### PR TITLE
Fix typos in methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Pyright is a work in progress. The following functionality is not yet finished. 
 * Validate parameters for magic functions
 * Validate that overridden methods in subclass have same signature as base class methods
 * Verify that exception classes inherit from base Exception
-* Validate await / async consitency
+* Validate await / async consistency
 * Flag assignments to read-only values (None, True, False, __debug__) as errors
 * Revamp support for properties - model with Descriptor protocol, detect missing setter
 * Add numeric codes to diagnostics and a configuration mechanism for disabling errors by code

--- a/server/src/analyzer/parseTreeWalker.ts
+++ b/server/src/analyzer/parseTreeWalker.ts
@@ -58,7 +58,7 @@ export class ParseTreeWalker {
                 return this.visitAssignment(node as AssignmentNode);
 
             case ParseNodeType.AugmentedAssignment:
-                return this.visitAgumentedAssignment(node as AugmentedAssignemtnExpressionNode);
+                return this.visitAugmentedAssignment(node as AugmentedAssignemtnExpressionNode);
 
             case ParseNodeType.Await:
                 return this.visitAwait(node as AwaitExpressionNode);
@@ -97,7 +97,7 @@ export class ParseTreeWalker {
                 return this.visitDictionaryKeyEntry(node as DictionaryKeyEntryNode);
 
             case ParseNodeType.DictionaryExpandEntry:
-                return this.visitDictionarExpandEntry(node as DictionaryExpandEntryNode);
+                return this.visitDictionaryExpandEntry(node as DictionaryExpandEntryNode);
 
             case ParseNodeType.If:
                 return this.visitIf(node as IfNode);
@@ -245,7 +245,7 @@ export class ParseTreeWalker {
         return true;
     }
 
-    visitAgumentedAssignment(node: AugmentedAssignemtnExpressionNode) {
+    visitAugmentedAssignment(node: AugmentedAssignemtnExpressionNode) {
         return true;
     }
 
@@ -297,7 +297,7 @@ export class ParseTreeWalker {
         return true;
     }
 
-    visitDictionarExpandEntry(node: DictionaryExpandEntryNode) {
+    visitDictionaryExpandEntry(node: DictionaryExpandEntryNode) {
         return true;
     }
 


### PR DESCRIPTION
Sorry, missed one typo in the README file and noticed while preparing this pull request that is a bit trickier than the previous one.

It changes the name of two methods. Used the IDE to alter the methods and find their usages, but not quite sure if that's enough to guarantee I am not breaking anything else.

`npm run build` passed locally FWIW

Thanks