### PR TITLE
Be consistent on log messages, using file location instead of URI as in other methods

### DIFF
--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -187,10 +187,10 @@ _connection.onDidChangeTextDocument(params => {
 });
 
 _connection.onDidCloseTextDocument(params => {
-    _connection.console.log(`${params.textDocument.uri} closed.`);
+    let filePath = _convertUriToPath(params.textDocument.uri);
+    _connection.console.log(`${filePath} closed.`);
 
-    _analyzerService.setFileClosed(
-        _convertUriToPath(params.textDocument.uri));
+    _analyzerService.setFileClosed(filePath);
 });
 
 function _convertUriToPath(uri: string): string {


### PR DESCRIPTION
Hello,

There seems to be some inconsistency with the log messages. In the VSCode output, I can see that when I open a file the server is printing

`/home/kinow/Development/python/workspace/cylc/lib/cylc/network/__init__.py opened.`

But when I close it, it says:

`file:///home/kinow/Development/python/workspace/cylc/lib/cylc/network/__init__.py closed.`

This change uses the same method used in other `on____()` methods, for the close event, creating a log message more similar to open/change/etc.

Cheers
Bruno