### PR TITLE
Add sample of vev configuration in docs.configuration

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -62,6 +62,7 @@ The following is an example of a pyright config file:
       "src/typestubs"
   ],
   "typingsPath": "src/typestubs",
+  "venvPath": "/home/foo/.venvs",
 
   "reportTypeshedErrors": false,
   "reportMissingImports": true,
@@ -83,7 +84,8 @@ The following is an example of a pyright config file:
       "pythonVersion": "3.0",
       "extraPaths": [
         "src/backend"
-      ]
+      ],
+      "venv": "venv_bar"
     },
     {
       "root": "src/tests",


### PR DESCRIPTION
I added some lines to docs.configuration because there is no sample configuration of venv.

I was stuck at the configuration of venv, so I think this sample will help the users.