### PR TITLE
Output error description on analysis errors

### DIFF
--- a/server/src/analyzer/service.ts
+++ b/server/src/analyzer/service.ts
@@ -575,7 +575,7 @@ export class AnalyzerService {
                 }
             }
         } catch (err) {
-            this._console.log('Error performing analysis: ' + JSON.stringify(err));
+            this._console.log('Error performing analysis: ' + String(err));
 
             if (this._onCompletionCallback) {
                 this._onCompletionCallback({


### PR DESCRIPTION
'error' object is something like 'RangeError', it doesn't have any 'properties' in JSON sense and will yield a "{}" string. But it do have toString() method, so casting it to string will produce a meaningful error description.