### PR TITLE
Allow --watch usage with filespec

### DIFF
--- a/server/src/pyright.ts
+++ b/server/src/pyright.ts
@@ -38,7 +38,7 @@ function processArgs() {
         { name: 'stats' },
         { name: 'typeshed-path', alias: 't', type: String },
         { name: 'venv-path', alias: 'v', type: String },
-        { name: 'watch', alias: 'w' }
+        { name: 'watch', alias: 'w', type: Boolean }
     ];
 
     let args: CommandLineOptions;


### PR DESCRIPTION
If 'Boolean' is not specified, 'command-line-args' will set files list as a value of 'watch' property, not the 'files' property the code expects. Now 'pyright --watch *.py' correctly pass python files into the default 'files' property.