### PR TITLE
add missing newline in --help output

### DIFF
--- a/server/src/pyright.ts
+++ b/server/src/pyright.ts
@@ -231,7 +231,7 @@ function printUsage() {
         '  --createstub IMPORT              Create type stub file(s) for import\n' +
         '  --dependencies                   Emit import dependency information\n' +
         '  -h,--help                        Show this help message\n' +
-        '  --lib                            Use library code to infer types when stubs are missing' +
+        '  --lib                            Use library code to infer types when stubs are missing\n' +
         '  --outputjson                     Output results in JSON format\n' +
         '  -p,--project FILE OR DIRECTORY   Use the configuration file at this location\n' +
         '  --stats                          Print detailed performance stats\n' +


### PR DESCRIPTION
Currently the `--help` output looks like this:

```
pyright --help
Usage: pyright [options] files...
  Options:
  --createstub IMPORT              Create type stub file(s) for import
  --dependencies                   Emit import dependency information
  -h,--help                        Show this help message
  --lib                            Use library code to infer types when stubs are missing  --outputjson                     Output results in JSON format
  -p,--project FILE OR DIRECTORY   Use the configuration file at this location
  --stats                          Print detailed performance stats
  -t,--typeshed-path DIRECTORY     Use typeshed type stubs at this location
  -v,--venv-path DIRECTORY         Directory that contains virtual environments
  --verbose                        Emit verbose diagnostics
  --version                        Print Pyright version
  -w,--watch                       Continue to run and watch for changes
```