### PR TITLE
Introducing customBuiltins in pyright config file

### DIFF
--- a/client/schemas/pyrightconfig.schema.json
+++ b/client/schemas/pyrightconfig.schema.json
@@ -72,6 +72,17 @@
       ],
       "pattern": "^(.*)$"
     },
+    "customBuiltins": {
+      "$id": "#/properties/customBuiltins",
+      "type": "array",
+      "title": "A list of custom builtins to add to the builtins export list",
+      "items": {
+        "$id": "#/properties/customBuiltins/items",
+        "type": "string",
+        "title": "Item of the builtins.pyi file that will be available without imports",
+        "pattern": "^(.*)$"
+      }
+    },
     "strictListInference": {
       "$id": "#/properties/strictListInference",
       "type": "boolean",

--- a/server/src/analyzer/sourceFile.ts
+++ b/server/src/analyzer/sourceFile.ts
@@ -677,8 +677,7 @@ export class SourceFile {
 
                 const fileInfo = this._buildFileInfo(configOptions, importLookup, builtinsScope);
                 AnalyzerNodeInfo.setFileInfo(this._parseResults!.parseTree, fileInfo);
-
-                const binder = new Binder(fileInfo);
+                const binder = new Binder(fileInfo, configOptions);
                 this._isBindingInProgress = true;
                 this._binderResults = binder.bindModule(this._parseResults!.parseTree);
 

--- a/server/src/common/configOptions.ts
+++ b/server/src/common/configOptions.ts
@@ -315,6 +315,11 @@ export class ConfigOptions {
     // Path to custom typings (stub) modules.
     typingsPath?: string;
 
+    // A list of custom builtins to add to the builtins export list.
+    // Can be combined with typeshedPath to use a custom builtins.pyi
+    // and access a variable without importing it
+    customBuiltins: string[];
+
     // A list of file specs to include in the analysis. Can contain
     // directories, in which case all "*.py" files within those directories
     // are included.
@@ -716,6 +721,23 @@ export class ConfigOptions {
                 console.log(`Config "typingsPath" field must contain a string.`);
             } else {
                 this.typingsPath = normalizePath(combinePaths(this.projectRoot, configObj.typingsPath));
+            }
+        }
+
+        // Read the "customBuiltins".
+        this.customBuiltins = [];
+        if (configObj.customBuiltins !== undefined) {
+            if (!Array.isArray(configObj.customBuiltins)) {
+                console.log(`Config "customBuiltins" field must contain an array.`);
+            } else {
+              const builtinList = configObj.customBuiltins as string[];
+              builtinList.forEach((builtin, index) => {
+                  if (typeof builtin !== 'string') {
+                      console.log(`Index ${ index } of "builtinsList" array should be a string.`);
+                  } else {
+                      this.customBuiltins.push(builtin);
+                  }
+              });
             }
         }
 

--- a/server/src/tests/testUtils.ts
+++ b/server/src/tests/testUtils.ts
@@ -93,7 +93,7 @@ export function buildAnalyzerFileInfo(filePath: string, parseResults: ParseResul
 }
 
 export function bindSampleFile(fileName: string,
-        configOptions = new ConfigOptions('.')): FileAnalysisResult {
+    configOptions = new ConfigOptions('.')): FileAnalysisResult {
 
     const diagSink = new DiagnosticSink();
     const filePath = resolveSampleFilePath(fileName);
@@ -101,7 +101,7 @@ export function bindSampleFile(fileName: string,
     const parseResults = parseSampleFile(fileName, diagSink, execEnvironment);
 
     const fileInfo = buildAnalyzerFileInfo(filePath, parseResults, configOptions);
-    const binder = new Binder(fileInfo);
+    const binder = new Binder(fileInfo, configOptions);
     binder.bindModule(parseResults.parseTree);
 
     // Walk the AST to verify internal consistency.


### PR DESCRIPTION
In specific cases it is useful to add custom builtins to get auto completion and type checking without importing a module.