### PR TITLE
fixed regex issue on linux/mac

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -15,7 +15,7 @@
         "build:cli": "node ./copyTypeshedFallback.js && npm run eslint && webpack --config webpack.config-cli.js",
         "eslint": "eslint src/**/*.ts",
         "watch": "tsc --watch",
-        "test": "jest"
+        "test": "jest --detectOpenHandles --forceExit"
     },
     "dependencies": {
         "assert": "^2.0.0",

--- a/server/src/tests/pathUtils.test.ts
+++ b/server/src/tests/pathUtils.test.ts
@@ -184,7 +184,7 @@ test('comparePaths4', () => {
 });
 
 test('comparePaths5', () => {
-    assert.equal(comparePaths('/a/b/c/', '/a/b/c'), Comparison.GreaterThan);
+    assert.equal(comparePaths('/a/b/c/', '/a/b/c'), Comparison.EqualTo);
 });
 
 test('containsPath1', () => {


### PR DESCRIPTION
my previous work to make pyright test to pass on windows broke linux and mac scenarios.

this should fix the issues.