### PR TITLE
made reportMissingTypeStub diagnostics warning by default and some refactoring around code actions.

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -44,7 +44,7 @@ The following settings control pyright’s diagnostic output (warnings or errors
 
 **reportMissingImports** [boolean or string, optional]: Generate or suppress diagnostics for imports that have no corresponding imported python file or type stub file. The default value for this setting is 'none', although pyright can do a much better job of static type checking if type stub files are provided for all imports.
 
-**reportMissingTypeStubs** [boolean or string, optional]: Generate or suppress diagnostics for imports that have no corresponding type stub file (either a typeshed file or a custom type stub). The type checker requires type stubs to do its best job at analysis. The default value for this setting is 'none', although pyright can do a much better job of static type checking if type stub files are provided for all imports.
+**reportMissingTypeStubs** [boolean or string, optional]: Generate or suppress diagnostics for imports that have no corresponding type stub file (either a typeshed file or a custom type stub). The type checker requires type stubs to do its best job at analysis. The default value for this setting is 'warning'. Note that there is a corresponding quick fix for this diagnostics that let you generate custom type stub to improve editing experiences.
 
 **reportImportCycles** [boolean or string, optional]: Generate or suppress diagnostics for cyclical import chains. These are not errors in Python, but they do slow down type analysis and often hint at architectural layering issues. Generally, they should be avoided. The default value for this setting is 'none'. Note that there are import cycles in the typeshed stdlib typestub files that are ignored by this setting.
 

--- a/server/src/common/configOptions.ts
+++ b/server/src/common/configOptions.ts
@@ -275,7 +275,7 @@ export function getDefaultDiagnosticSettings(): DiagnosticSettings {
         enableTypeIgnoreComments: true,
         reportTypeshedErrors: 'none',
         reportMissingImports: 'error',
-        reportMissingTypeStubs: 'none',
+        reportMissingTypeStubs: 'warning',
         reportImportCycles: 'none',
         reportUnusedImport: 'none',
         reportUnusedClass: 'none',

--- a/server/src/languageService/codeActionProvider.ts
+++ b/server/src/languageService/codeActionProvider.ts
@@ -1,0 +1,61 @@
+/*
+ * codeActionProvider.ts
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT license.
+ */
+
+import { CodeAction, CodeActionKind, Command } from 'vscode-languageserver';
+import { Commands } from '../commands/commands';
+import { AddMissingOptionalToParamAction, CreateTypeStubFileAction } from '../common/diagnostic';
+import { Range } from '../common/textRange';
+import { WorkspaceServiceInstance } from '../languageServerBase';
+
+export class CodeActionProvider {
+    static getCodeActionsForPosition(workspace: WorkspaceServiceInstance, filePath: string, range: Range) {
+        const sortImportsCodeAction = CodeAction.create(
+            'Organize Imports', Command.create('Organize Imports', Commands.orderImports),
+            CodeActionKind.SourceOrganizeImports);
+        const codeActions: CodeAction[] = [sortImportsCodeAction];
+
+        if (!workspace.disableLanguageServices) {
+            const diags = workspace.serviceInstance.getDiagnosticsForRange(filePath, range);
+            const typeStubDiag = diags.find(d => {
+                const actions = d.getActions();
+                return actions && actions.find(a => a.action === Commands.createTypeStub);
+            });
+
+            if (typeStubDiag) {
+                const action = typeStubDiag.getActions()!.find(
+                    a => a.action === Commands.createTypeStub) as CreateTypeStubFileAction;
+                if (action) {
+                    const createTypeStubAction = CodeAction.create(
+                        `Create Type Stub For ‘${ action.moduleName }’`,
+                        Command.create('Create Type Stub', Commands.createTypeStub,
+                            workspace.rootPath, action.moduleName),
+                        CodeActionKind.QuickFix);
+                    codeActions.push(createTypeStubAction);
+                }
+            }
+
+            const addOptionalDiag = diags.find(d => {
+                const actions = d.getActions();
+                return actions && actions.find(a => a.action === Commands.addMissingOptionalToParam);
+            });
+
+            if (addOptionalDiag) {
+                const action = addOptionalDiag.getActions()!.find(
+                    a => a.action === Commands.addMissingOptionalToParam) as AddMissingOptionalToParamAction;
+                if (action) {
+                    const addMissingOptionalAction = CodeAction.create(
+                        `Add 'Optional' to type annotation`,
+                        Command.create(`Add 'Optional' to type annotation`, Commands.addMissingOptionalToParam,
+                            action.offsetOfTypeNode),
+                        CodeActionKind.QuickFix);
+                    codeActions.push(addMissingOptionalAction);
+                }
+            }
+        }
+
+        return codeActions;
+    }
+}

--- a/server/src/languageService/definitionProvider.ts
+++ b/server/src/languageService/definitionProvider.ts
@@ -12,8 +12,8 @@
 
 import * as ParseTreeUtils from '../analyzer/parseTreeUtils';
 import { TypeEvaluator } from '../analyzer/typeEvaluator';
-import { Position, DocumentRange, rangesAreEqual } from '../common/textRange';
 import { convertPositionToOffset } from '../common/positionUtils';
+import { DocumentRange, Position, rangesAreEqual } from '../common/textRange';
 import { ParseNodeType } from '../parser/parseNodes';
 import { ParseResults } from '../parser/parser';
 

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -4,12 +4,23 @@
  * Implements pyright language server.
  */
 
+import * as fs from 'fs';
+import * as path from 'path';
 import { isArray } from 'util';
+import { CodeAction, CodeActionParams, Command, ExecuteCommandParams } from 'vscode-languageserver';
+import { CommandController } from './commands/commandController';
+import * as debug from './common/debug';
+import { convertUriToPath, getDirectoryPath, normalizeSlashes } from './common/pathUtils';
 import { LanguageServerBase, ServerSettings, WorkspaceServiceInstance } from './languageServerBase';
+import { CodeActionProvider } from './languageService/codeActionProvider';
 
 class Server extends LanguageServerBase {
+    private _controller: CommandController;
+
     constructor() {
-        super('Pyright');
+        debug.assert(fs.existsSync(path.join(__dirname, 'typeshed-fallback')), 'Unable to locate typeshed fallback folder.');
+        super('Pyright', getDirectoryPath(__dirname));
+        this._controller = new CommandController(this);
     }
 
     async getSettings(workspace: WorkspaceServiceInstance): Promise<ServerSettings> {
@@ -17,15 +28,15 @@ class Server extends LanguageServerBase {
         try {
             const pythonSection = await this.getConfiguration(workspace, 'python');
             if (pythonSection) {
-                serverSettings.pythonPath = pythonSection.pythonPath;
-                serverSettings.venvPath = pythonSection.venvPath;
+                serverSettings.pythonPath = normalizeSlashes(pythonSection.pythonPath);
+                serverSettings.venvPath = normalizeSlashes(pythonSection.venvPath);
             }
 
             const pythonAnalysisSection = await this.getConfiguration(workspace, 'python.analysis');
             if (pythonAnalysisSection) {
                 const typeshedPaths = pythonAnalysisSection.typeshedPaths;
                 if (typeshedPaths && isArray(typeshedPaths) && typeshedPaths.length > 0) {
-                    serverSettings.typeshedPath = typeshedPaths[0];
+                    serverSettings.typeshedPath = normalizeSlashes(typeshedPaths[0]);
                 }
             }
 
@@ -40,9 +51,21 @@ class Server extends LanguageServerBase {
                 serverSettings.disableLanguageServices = false;
             }
         } catch (error) {
-            this.console.log(`Error reading settings: ${error}`);
+            this.console.log(`Error reading settings: ${ error }`);
         }
         return serverSettings;
+    }
+
+    protected executeCommand(cmdParams: ExecuteCommandParams): Promise<any> {
+        return this._controller.execute(cmdParams);
+    }
+
+    protected async executeCodeAction(params: CodeActionParams): Promise<(Command | CodeAction)[] | undefined | null> {
+        this.recordUserInteractionTime();
+
+        const filePath = convertUriToPath(params.textDocument.uri);
+        const workspace = this.workspaceMap.getWorkspaceForFile(filePath);
+        return CodeActionProvider.getCodeActionsForPosition(workspace, filePath, params.range);
     }
 }
 


### PR DESCRIPTION
user will now see squiggle on third party library on import statement if it doesn't have a typestub.

this will also enable corresponding "create type stub" code action to light up. when invoked, "generated typestub" can improve user's editing experience.