### PR TITLE
Implemented support for incremental text changes LSP

### DIFF
--- a/server/src/analyzer/program.ts
+++ b/server/src/analyzer/program.ts
@@ -13,7 +13,8 @@ import {
     CompletionItem,
     CompletionList,
     DocumentSymbol,
-    SymbolInformation
+    SymbolInformation,
+    TextDocumentContentChangeEvent
 } from 'vscode-languageserver';
 
 import { throwIfCancellationRequested } from '../common/cancellationUtils';
@@ -202,7 +203,7 @@ export class Program {
         return sourceFile;
     }
 
-    setFileOpened(filePath: string, version: number | null, contents: string) {
+    setFileOpened(filePath: string, version: number | null, contents: TextDocumentContentChangeEvent[]) {
         let sourceFileInfo = this._sourceFileMap.get(filePath);
         if (!sourceFileInfo) {
             const sourceFile = new SourceFile(this._fs, filePath, false, false, this._console);
@@ -235,7 +236,7 @@ export class Program {
         const sourceFileInfo = this._sourceFileMap.get(filePath);
         if (sourceFileInfo) {
             sourceFileInfo.isOpenByClient = false;
-            sourceFileInfo.sourceFile.setClientVersion(null, '');
+            sourceFileInfo.sourceFile.setClientVersion(null, [{ text: '' }]);
 
             if (this._configOptions.checkOnlyOpenFiles) {
                 // Reset the diagnostic version so we force an update

--- a/server/src/analyzer/service.ts
+++ b/server/src/analyzer/service.ts
@@ -13,7 +13,8 @@ import {
     CompletionItem,
     CompletionList,
     DocumentSymbol,
-    SymbolInformation
+    SymbolInformation,
+    TextDocumentContentChangeEvent
 } from 'vscode-languageserver';
 
 import { getGlobalCancellationToken, OperationCanceledException } from '../common/cancellationUtils';
@@ -156,11 +157,11 @@ export class AnalyzerService {
     }
 
     setFileOpened(path: string, version: number | null, contents: string) {
-        this._program.setFileOpened(path, version, contents);
+        this._program.setFileOpened(path, version, [{ text: contents }]);
         this._scheduleReanalysis(false);
     }
 
-    updateOpenFileContents(path: string, version: number | null, contents: string) {
+    updateOpenFileContents(path: string, version: number | null, contents: TextDocumentContentChangeEvent[]) {
         this._program.setFileOpened(path, version, contents);
         this._program.markFilesDirty([path]);
         this._scheduleReanalysis(false);

--- a/server/src/common/positionUtils.ts
+++ b/server/src/common/positionUtils.ts
@@ -56,3 +56,30 @@ export function convertPositionToOffset(position: Position, lines: TextRangeColl
 
     return lines.getItemAt(position.line).start + position.character;
 }
+
+export function getLinesFromText(text: string): TextRangeCollection<TextRange> {
+    const lines: TextRange[] = [];
+
+    let prevLineStart = 0;
+    let curOffset = 0;
+    while (curOffset < text.length) {
+        const curChar = text.charCodeAt(curOffset);
+        curOffset++;
+
+        if (curChar === 0xd) {
+            if (curOffset < text.length && text.charCodeAt(curOffset) === 0xa) {
+                curOffset++;
+            }
+
+            lines.push({ start: prevLineStart, length: curOffset - prevLineStart });
+            prevLineStart = curOffset;
+        } else if (curChar === 0xa) {
+            lines.push({ start: prevLineStart, length: curOffset - prevLineStart });
+            prevLineStart = curOffset;
+        }
+    }
+
+    lines.push({ start: prevLineStart, length: curOffset - prevLineStart });
+
+    return new TextRangeCollection<TextRange>(lines);
+}

--- a/server/src/languageServerBase.ts
+++ b/server/src/languageServerBase.ts
@@ -221,9 +221,9 @@ export abstract class LanguageServerBase implements LanguageServerInterface {
 
                 return {
                     capabilities: {
-                        // Tell the client that the server works in FULL text document
-                        // sync mode (as opposed to incremental).
-                        textDocumentSync: TextDocumentSyncKind.Full,
+                        // Tell the client that the server works in incremental text document
+                        // sync mode.
+                        textDocumentSync: TextDocumentSyncKind.Incremental,
                         definitionProvider: true,
                         referencesProvider: true,
                         documentSymbolProvider: true,
@@ -473,7 +473,7 @@ export abstract class LanguageServerBase implements LanguageServerInterface {
 
             const filePath = convertUriToPath(params.textDocument.uri);
             const service = this._workspaceMap.getWorkspaceForFile(filePath).serviceInstance;
-            service.updateOpenFileContents(filePath, params.textDocument.version, params.contentChanges[0].text);
+            service.updateOpenFileContents(filePath, params.textDocument.version, params.contentChanges);
         });
 
         this._connection.onDidCloseTextDocument(params => {

--- a/server/src/tests/harness/fourslash/testState.ts
+++ b/server/src/tests/harness/fourslash/testState.ts
@@ -328,7 +328,7 @@ export class TestState {
         fileToOpen.fileName = normalizeSlashes(fileToOpen.fileName);
         this.activeFile = fileToOpen;
 
-        this.program.setFileOpened(this.activeFile.fileName, 1, fileToOpen.content);
+        this.program.setFileOpened(this.activeFile.fileName, 1, [{ text: fileToOpen.content }]);
     }
 
     printCurrentFileState(showWhitespace: boolean, makeCaretVisible: boolean) {


### PR DESCRIPTION
I implemented support for incremental text changes. Unfortunately, I think this is going to be slower and more expensive than the alternative because incremental changes are specified in terms of lines/columns rather than file offsets. That means the code needs to scan the old file contents to break it into lines, then insert the text change.

My inclination is to discard this change and stick with "full" text updates. Python source files are typically are, at most, several K in size. Passing the entire contents is cheap.