### PR TITLE
Removed the notion of "low level file watcher" from FileSystem. Added…

### DIFF
--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -11,7 +11,7 @@
 
 import * as fs from 'fs';
 import * as path from 'path';
-import { commands, ExtensionContext, Position, Range, TextEditor, TextEditorEdit } from 'vscode';
+import { commands, ExtensionContext, Position, Range, TextEditor, TextEditorEdit, workspace } from 'vscode';
 import { LanguageClient, LanguageClientOptions, ServerOptions, TextEdit, TransportKind } from 'vscode-languageclient';
 
 import { Commands } from '../../server/src/commands/commands';
@@ -52,7 +52,14 @@ export function activate(context: ExtensionContext) {
         ],
         synchronize: {
             // Synchronize the setting section to the server.
-            configurationSection: ['python', 'pyright']
+            configurationSection: ['python', 'pyright'],
+
+            // Send file system change events within the workspace.
+            fileEvents: [
+                workspace.createFileSystemWatcher('**/pyrightconfig.json'),
+                workspace.createFileSystemWatcher('**/mspythonconfig.json'),
+                workspace.createFileSystemWatcher('**/*.{py,pyi,pyd}')
+            ]
         },
         connectionOptions: { cancellationStrategy: cancellationStrategy }
     };

--- a/server/src/analyzer/service.ts
+++ b/server/src/analyzer/service.ts
@@ -918,10 +918,7 @@ export class AnalyzerService {
                     this._console.log(`Adding fs watcher for library directories:\n ${watchList.join('\n')}`);
                 }
 
-                // Use fs.watch instead of chokidar, to avoid issue where chokidar locks up files
-                // when the virtual environment is located under the workspace folder (which breaks pip uninstall)
-                // Not sure why that happens with chokidar, if the watch path is outside the workspace it is fine.
-                this._libraryFileWatcher = this._fs.createLowLevelFileSystemWatcher(watchList, true, (event, path) => {
+                this._libraryFileWatcher = this._fs.createFileSystemWatcher(watchList, (event, path) => {
                     if (this._verboseOutput) {
                         this._console.log(`Received fs event '${event}' for path '${path}'`);
                     }

--- a/server/src/common/fileSystem.ts
+++ b/server/src/common/fileSystem.ts
@@ -16,11 +16,8 @@ import * as fs from 'fs';
 
 import { ConsoleInterface, NullConsole } from './console';
 
-export type FileWatcherEventHandler = (
-    eventName: 'add' | 'addDir' | 'change' | 'unlink' | 'unlinkDir',
-    path: string,
-    stats?: Stats
-) => void;
+export type FileWatcherEventType = 'add' | 'addDir' | 'change' | 'unlink' | 'unlinkDir';
+export type FileWatcherEventHandler = (eventName: FileWatcherEventType, path: string, stats?: Stats) => void;
 
 export interface FileWatcher {
     close(): void;
@@ -51,31 +48,31 @@ export interface FileSystem {
     unlinkSync(path: string): void;
     realpathSync(path: string): string;
     getModulePath(): string;
-    createLowLevelFileSystemWatcher(
-        paths: string[],
-        recursive?: boolean,
-        listener?: (event: string, filename: string) => void
-    ): FileWatcher;
     createFileSystemWatcher(paths: string[], listener: FileWatcherEventHandler): FileWatcher;
 }
 
-export function createFromRealFileSystem(console?: ConsoleInterface): FileSystem {
-    return new RealFileSystem(console ?? new NullConsole());
+export interface FileWatcherProvider {
+    createFileWatcher(paths: string[], listener: FileWatcherEventHandler): FileWatcher;
+}
+
+// Callers can specify a different file watcher provider if desired.
+// By default, we'll use the file watcher based on chokidar.
+export function createFromRealFileSystem(
+    console?: ConsoleInterface,
+    fileWatcherProvider?: FileWatcherProvider
+): FileSystem {
+    return new RealFileSystem(fileWatcherProvider ?? new ChokidarFileWatcherProvider(console ?? new NullConsole()));
 }
 
 const _isMacintosh = process.platform === 'darwin';
 const _isLinux = process.platform === 'linux';
 
-class LowLevelWatcher implements FileWatcher {
-    constructor(private paths: string[]) {}
-
-    close(): void {
-        this.paths.forEach(p => fs.unwatchFile(p));
-    }
-}
-
 class RealFileSystem implements FileSystem {
-    constructor(private _console: ConsoleInterface) {}
+    private _fileWatcherProvider: FileWatcherProvider;
+
+    constructor(fileWatcherProvider: FileWatcherProvider) {
+        this._fileWatcherProvider = fileWatcherProvider;
+    }
 
     existsSync(path: string) {
         return fs.existsSync(path);
@@ -107,9 +104,11 @@ class RealFileSystem implements FileSystem {
     statSync(path: string) {
         return fs.statSync(path);
     }
+
     unlinkSync(path: string) {
         fs.unlinkSync(path);
     }
+
     realpathSync(path: string) {
         return fs.realpathSync(path);
     }
@@ -121,23 +120,19 @@ class RealFileSystem implements FileSystem {
         return (global as any).__rootDirectory;
     }
 
-    createLowLevelFileSystemWatcher(
-        paths: string[],
-        recursive?: boolean,
-        listener?: (event: string, filename: string) => void
-    ): FileWatcher {
-        paths.forEach(p => {
-            fs.watch(p, { recursive: recursive }, listener);
-        });
-
-        return new LowLevelWatcher(paths);
-    }
-
     createFileSystemWatcher(paths: string[], listener: FileWatcherEventHandler): FileWatcher {
-        return this._createBaseFileSystemWatcher(paths).on('all', listener);
+        return this._fileWatcherProvider.createFileWatcher(paths, listener);
+    }
+}
+
+class ChokidarFileWatcherProvider implements FileWatcherProvider {
+    constructor(private _console: ConsoleInterface) {}
+
+    createFileWatcher(paths: string[], listener: FileWatcherEventHandler): FileWatcher {
+        return this._createFileSystemWatcher(paths).on('all', listener);
     }
 
-    private _createBaseFileSystemWatcher(paths: string[]): chokidar.FSWatcher {
+    private _createFileSystemWatcher(paths: string[]): chokidar.FSWatcher {
         // The following options are copied from VS Code source base. It also
         // uses chokidar for its file watching.
         const watcherOptions: chokidar.WatchOptions = {

--- a/server/src/languageServerBase.ts
+++ b/server/src/languageServerBase.ts
@@ -9,6 +9,7 @@
 
 import './common/extensions';
 
+import * as fs from 'fs';
 import {
     CancellationToken,
     CodeAction,
@@ -45,8 +46,14 @@ import { ConfigOptions } from './common/configOptions';
 import { ConsoleInterface } from './common/console';
 import { Diagnostic as AnalyzerDiagnostic, DiagnosticCategory } from './common/diagnostic';
 import { LanguageServiceExtension } from './common/extensibility';
-import { createFromRealFileSystem, FileSystem } from './common/fileSystem';
-import { convertPathToUri, convertUriToPath } from './common/pathUtils';
+import {
+    createFromRealFileSystem,
+    FileSystem,
+    FileWatcher,
+    FileWatcherEventHandler,
+    FileWatcherEventType
+} from './common/fileSystem';
+import { containsPath, convertPathToUri, convertUriToPath } from './common/pathUtils';
 import { Position } from './common/textRange';
 import { AnalyzerServiceExecutor } from './languageService/analyzerServiceExecutor';
 import { CompletionItemData } from './languageService/completionProvider';
@@ -90,6 +97,14 @@ export interface LanguageServerInterface {
     readonly fs: FileSystem;
 }
 
+interface InternalFileWatcher extends FileWatcher {
+    // Paths that are being watched within the workspace
+    workspacePaths: string[];
+
+    // Event handler to call
+    eventHandler: FileWatcherEventHandler;
+}
+
 export abstract class LanguageServerBase implements LanguageServerInterface {
     // Create a connection for the server. The connection type can be changed by the process's arguments
     protected _connection: IConnection = createConnection(this._GetConnectionOptions());
@@ -100,6 +115,9 @@ export abstract class LanguageServerBase implements LanguageServerInterface {
     // Tracks whether we're currently displaying progress.
     private _isDisplayingProgress = false;
 
+    // Tracks active file system watchers.
+    private _fileWatchers: InternalFileWatcher[] = [];
+
     // Global root path - the basis for all global settings.
     rootPath = '';
 
@@ -109,7 +127,7 @@ export abstract class LanguageServerBase implements LanguageServerInterface {
     constructor(private _productName: string, rootDirectory: string, private _extension?: LanguageServiceExtension) {
         this._connection.console.log(`${_productName} language server starting`);
         // virtual file system to be used. initialized to real file system by default. but can't be overwritten
-        this.fs = createFromRealFileSystem(this._connection.console);
+        this.fs = createFromRealFileSystem(this._connection.console, this);
 
         // Stash the base directory into a global variable.
         (global as any).__rootDirectory = rootDirectory;
@@ -206,6 +224,50 @@ export abstract class LanguageServerBase implements LanguageServerInterface {
         this._workspaceMap.forEach(workspace => {
             workspace.serviceInstance.restart();
         });
+    }
+
+    createFileWatcher(paths: string[], listener: FileWatcherEventHandler): FileWatcher {
+        // Capture "this" so we can reference it within the "close" method below.
+        const lsBase = this;
+
+        // Determine which paths are located within one or more workspaces.
+        // Those are already covered by existing file watchers handled by
+        // the client.
+        const workspacePaths: string[] = [];
+        const nonWorkspacePaths: string[] = [];
+        const workspaces = this._workspaceMap.getNonDefaultWorkspaces();
+
+        paths.forEach(path => {
+            if (workspaces.some(workspace => containsPath(workspace.rootPath, path))) {
+                workspacePaths.push(path);
+            } else {
+                nonWorkspacePaths.push(path);
+            }
+        });
+
+        // For any non-workspace paths, use the node file watcher.
+        const nodeWatchers = nonWorkspacePaths.map(path => {
+            return fs.watch(path, { recursive: true }, listener);
+        });
+
+        const fileWatcher: InternalFileWatcher = {
+            close() {
+                // Stop listening for workspace paths.
+                lsBase._fileWatchers = lsBase._fileWatchers.filter(watcher => watcher !== fileWatcher);
+
+                // Close the node watchers.
+                nodeWatchers.forEach(watcher => {
+                    watcher.close();
+                });
+            },
+            workspacePaths,
+            eventHandler: listener
+        };
+
+        // Record the file watcher.
+        this._fileWatchers.push(fileWatcher);
+
+        return fileWatcher;
     }
 
     private _setupConnection(): void {
@@ -505,6 +567,18 @@ export abstract class LanguageServerBase implements LanguageServerInterface {
             const filePath = convertUriToPath(params.textDocument.uri);
             const service = this._workspaceMap.getWorkspaceForFile(filePath).serviceInstance;
             service.setFileClosed(filePath);
+        });
+
+        this._connection.onDidChangeWatchedFiles(params => {
+            params.changes.forEach(change => {
+                const filePath = convertUriToPath(change.uri);
+                const eventType: FileWatcherEventType = change.type === 1 ? 'add' : 'change';
+                this._fileWatchers.forEach(watcher => {
+                    if (watcher.workspacePaths.some(dirPath => containsPath(dirPath, filePath))) {
+                        watcher.eventHandler(eventType, filePath);
+                    }
+                });
+            });
         });
 
         this._connection.onInitialized(() => {

--- a/server/src/tests/harness/vfs/filesystem.ts
+++ b/server/src/tests/harness/vfs/filesystem.ts
@@ -313,18 +313,6 @@ export class FileSystem {
         };
     }
 
-    createLowLevelFileSystemWatcher(
-        paths: string[],
-        recursive?: boolean,
-        listener?: (event: string, filename: string) => void
-    ): FileWatcher {
-        return {
-            close: () => {
-                /* left empty */
-            }
-        };
-    }
-
     getModulePath(): string {
         return MODULE_PATH;
     }

--- a/server/src/workspaceMap.ts
+++ b/server/src/workspaceMap.ts
@@ -13,6 +13,17 @@ export class WorkspaceMap extends Map<string, WorkspaceServiceInstance> {
         super();
     }
 
+    getNonDefaultWorkspaces(): WorkspaceServiceInstance[] {
+        const workspaces: WorkspaceServiceInstance[] = [];
+        this.forEach(workspace => {
+            if (workspace.rootPath) {
+                workspaces.push(workspace);
+            }
+        });
+
+        return workspaces;
+    }
+
     getWorkspaceForFile(filePath: string): WorkspaceServiceInstance {
         let bestRootPath: string | undefined;
         let bestInstance: WorkspaceServiceInstance | undefined;


### PR DESCRIPTION
… support for vscode client-base file watcher for files within all workspaces. Chokidar file watcher is no longer used for VS Code extension — only for the command-line version of Pyright.