### PR TITLE
Synchronize package.json dependencies, tweak signature help parameter indexing

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1221,9 +1221,9 @@
             "dev": true
         },
         "@types/node": {
-            "version": "13.9.5",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-13.9.5.tgz",
-            "integrity": "sha512-hkzMMD3xu6BrJpGVLeQ3htQQNAcOrJjX7WFmtK8zWQpz2UJf13LCFF2ALA7c9OVdvc2vQJeDdjfR35M0sBCxvw==",
+            "version": "13.11.1",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-13.11.1.tgz",
+            "integrity": "sha512-eWQGP3qtxwL8FGneRrC5DwrJLGN4/dH1clNTuLfN81HCrxVtxRjygDTUoZJ5ASlDEeo0ppYFQjQIlXhtXpOn6g==",
             "dev": true
         },
         "@types/prettier": {
@@ -1254,25 +1254,25 @@
             "dev": true
         },
         "@typescript-eslint/eslint-plugin": {
-            "version": "2.25.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-2.25.0.tgz",
-            "integrity": "sha512-W2YyMtjmlrOjtXc+FtTelVs9OhuR6OlYc4XKIslJ8PUJOqgYYAPRJhAqkYRQo3G4sjvG8jSodsNycEn4W2gHUw==",
+            "version": "2.27.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-2.27.0.tgz",
+            "integrity": "sha512-/my+vVHRN7zYgcp0n4z5A6HAK7bvKGBiswaM5zIlOQczsxj/aiD7RcgD+dvVFuwFaGh5+kM7XA6Q6PN0bvb1tw==",
             "dev": true,
             "requires": {
-                "@typescript-eslint/experimental-utils": "2.25.0",
+                "@typescript-eslint/experimental-utils": "2.27.0",
                 "functional-red-black-tree": "^1.0.1",
                 "regexpp": "^3.0.0",
                 "tsutils": "^3.17.1"
             }
         },
         "@typescript-eslint/experimental-utils": {
-            "version": "2.25.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-2.25.0.tgz",
-            "integrity": "sha512-0IZ4ZR5QkFYbaJk+8eJ2kYeA+1tzOE1sBjbwwtSV85oNWYUBep+EyhlZ7DLUCyhMUGuJpcCCFL0fDtYAP1zMZw==",
+            "version": "2.27.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-2.27.0.tgz",
+            "integrity": "sha512-vOsYzjwJlY6E0NJRXPTeCGqjv5OHgRU1kzxHKWJVPjDYGbPgLudBXjIlc+OD1hDBZ4l1DLbOc5VjofKahsu9Jw==",
             "dev": true,
             "requires": {
                 "@types/json-schema": "^7.0.3",
-                "@typescript-eslint/typescript-estree": "2.25.0",
+                "@typescript-eslint/typescript-estree": "2.27.0",
                 "eslint-scope": "^5.0.0",
                 "eslint-utils": "^2.0.0"
             },
@@ -1289,21 +1289,21 @@
             }
         },
         "@typescript-eslint/parser": {
-            "version": "2.25.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-2.25.0.tgz",
-            "integrity": "sha512-mccBLaBSpNVgp191CP5W+8U1crTyXsRziWliCqzj02kpxdjKMvFHGJbK33NroquH3zB/gZ8H511HEsJBa2fNEg==",
+            "version": "2.27.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-2.27.0.tgz",
+            "integrity": "sha512-HFUXZY+EdwrJXZo31DW4IS1ujQW3krzlRjBrFRrJcMDh0zCu107/nRfhk/uBasO8m0NVDbBF5WZKcIUMRO7vPg==",
             "dev": true,
             "requires": {
                 "@types/eslint-visitor-keys": "^1.0.0",
-                "@typescript-eslint/experimental-utils": "2.25.0",
-                "@typescript-eslint/typescript-estree": "2.25.0",
+                "@typescript-eslint/experimental-utils": "2.27.0",
+                "@typescript-eslint/typescript-estree": "2.27.0",
                 "eslint-visitor-keys": "^1.1.0"
             }
         },
         "@typescript-eslint/typescript-estree": {
-            "version": "2.25.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-2.25.0.tgz",
-            "integrity": "sha512-VUksmx5lDxSi6GfmwSK7SSoIKSw9anukWWNitQPqt58LuYrKalzsgeuignbqnB+rK/xxGlSsCy8lYnwFfB6YJg==",
+            "version": "2.27.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-2.27.0.tgz",
+            "integrity": "sha512-t2miCCJIb/FU8yArjAvxllxbTiyNqaXJag7UOpB5DVoM3+xnjeOngtqlJkLRnMtzaRcJhe3CIR9RmL40omubhg==",
             "dev": true,
             "requires": {
                 "debug": "^4.1.1",
@@ -7477,9 +7477,9 @@
             }
         },
         "regexpp": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.0.0.tgz",
-            "integrity": "sha512-Z+hNr7RAVWxznLPuA7DIh8UNX1j9CDrUQxskw9IrBE1Dxue2lyXT+shqEIeLUjrokxIP8CMy1WkjgG3rTsd5/g==",
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.1.0.tgz",
+            "integrity": "sha512-ZOIzd8yVsQQA7j8GCSlPGXwg5PfmA1mrq0JP4nGhh54LaKN3xdai/vHUDu74pKwV8OxseMS65u2NImosQcSD0Q==",
             "dev": true
         },
         "remove-trailing-separator": {
@@ -8862,17 +8862,17 @@
             "integrity": "sha512-mwLDojZkbmpizSJSmp690oa9FB9jig18SIDGZeBCvFc2/LYSRvMm/WwWtMBJuJ1MfFh7rZXfQige4Uje5Z9NzA=="
         },
         "vscode-languageserver": {
-            "version": "6.2.0-next.1",
-            "resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-6.2.0-next.1.tgz",
-            "integrity": "sha512-bSCxOgEIr9rgycjjRK/NWwzawVY/RAB1feR2KegpauSKcpzCRJEJ7VA5VeQrRZKUPhbXkootnLMwDdrjjm2s2g==",
+            "version": "6.2.0-next.2",
+            "resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-6.2.0-next.2.tgz",
+            "integrity": "sha512-UCXULa/RmT2zxcb6auNezl9ZIPwYHS15+a0XzybrpT2+xA0RbHEYQCsIQkTRYjGv8cm3yS9iPJMmxLilP+y1Xw==",
             "requires": {
-                "vscode-languageserver-protocol": "3.16.0-next.1"
+                "vscode-languageserver-protocol": "3.16.0-next.2"
             }
         },
         "vscode-languageserver-protocol": {
-            "version": "3.16.0-next.1",
-            "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.16.0-next.1.tgz",
-            "integrity": "sha512-3+sttjSNVJ9O4Kl8P/Xm3kwDVGXNltHTNcEVosXFmWUzPCkDOfkw4AmFmA6WTvXUY37uJ0vh7T1KQcfBmdydgg==",
+            "version": "3.16.0-next.2",
+            "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.16.0-next.2.tgz",
+            "integrity": "sha512-atmkGT/W6tF0cx4SaWFYtFs2UeSeC28RPiap9myv2YZTaTCFvTBEPNWrU5QRKfkyM0tbgtGo6T3UCQ8tkDpjzA==",
             "requires": {
                 "vscode-jsonrpc": "5.1.0-next.1",
                 "vscode-languageserver-types": "3.16.0-next.1"

--- a/server/package.json
+++ b/server/package.json
@@ -25,7 +25,7 @@
         "command-line-args": "^5.1.1",
         "leven": "^3.1.0",
         "typescript-char": "^0.0.0",
-        "vscode-languageserver": "^6.2.0-next.1",
+        "vscode-languageserver": "^6.2.0-next.2",
         "vscode-uri": "^2.1.1"
     },
     "devDependencies": {
@@ -34,9 +34,9 @@
         "@types/command-line-args": "^5.0.0",
         "@types/fs-extra": "^8.1.0",
         "@types/jest": "^25.1.4",
-        "@types/node": "^13.9.5",
-        "@typescript-eslint/eslint-plugin": "^2.25.0",
-        "@typescript-eslint/parser": "^2.25.0",
+        "@types/node": "^13.11.1",
+        "@typescript-eslint/eslint-plugin": "^2.27.0",
+        "@typescript-eslint/parser": "^2.27.0",
         "eslint": "^6.8.0",
         "eslint-config-prettier": "^6.10.1",
         "fs-extra": "^8.1.0",

--- a/server/src/languageServerBase.ts
+++ b/server/src/languageServerBase.ts
@@ -465,8 +465,11 @@ export abstract class LanguageServerBase implements LanguageServerInterface {
                 }),
                 activeSignature:
                     signatureHelpResults.activeSignature !== undefined ? signatureHelpResults.activeSignature : null,
+                // -1 is out of bounds but is legal within the LSP (should be treated as undefined).
+                // It produces a better result in VS Code by preventing it from highlighting the first parameter
+                // when no parameter works (as the LSP client converts null into zero).
                 activeParameter:
-                    signatureHelpResults.activeParameter !== undefined ? signatureHelpResults.activeParameter : null,
+                    signatureHelpResults.activeParameter !== undefined ? signatureHelpResults.activeParameter : -1,
             };
         });
 


### PR DESCRIPTION
Rollup to fix the version mismatches between the packages and prevent VS Code from highlighting the first parameter when no parameter is specified as active (as the LSP client converts `null` to `0` rather than an out-of-bounds value).