### PR TITLE
Fix import message template, add to LS extension, print LS version, auto-import improvements

### DIFF
--- a/server/src/analyzer/checker.ts
+++ b/server/src/analyzer/checker.ts
@@ -1020,7 +1020,7 @@ export class Checker extends ParseTreeWalker {
                                 this._fileInfo,
                                 this._fileInfo.diagnosticRuleSet.reportUnusedImport,
                                 DiagnosticRule.reportUnusedImport,
-                                Localizer.Diagnostic.unaccessedImport().format({ importName: multipartName }),
+                                Localizer.Diagnostic.unaccessedImport().format({ name: multipartName }),
                                 textRange
                             );
                             return;
@@ -1041,7 +1041,7 @@ export class Checker extends ParseTreeWalker {
                 }
 
                 if (nameNode) {
-                    message = Localizer.Diagnostic.unaccessedImport().format({ importName: nameNode.value });
+                    message = Localizer.Diagnostic.unaccessedImport().format({ name: nameNode.value });
                 }
                 break;
 

--- a/server/src/analyzer/service.ts
+++ b/server/src/analyzer/service.ts
@@ -170,8 +170,14 @@ export class AnalyzerService {
         return this._program.getBoundSourceFile(path)?.getParseResults();
     }
 
-    getAutoImports(filePath: string, range: Range, similarityLimit: number, token: CancellationToken) {
-        return this._program.getAutoImports(filePath, range, similarityLimit, token);
+    getAutoImports(
+        filePath: string,
+        range: Range,
+        similarityLimit: number,
+        nameMap: Map<string, string> | undefined,
+        token: CancellationToken
+    ) {
+        return this._program.getAutoImports(filePath, range, similarityLimit, nameMap, token);
     }
 
     getDefinitionForPosition(

--- a/server/src/analyzer/sourceFile.ts
+++ b/server/src/analyzer/sourceFile.ts
@@ -561,6 +561,7 @@ export class SourceFile {
     }
 
     getDeclarationForPosition(
+        sourceMapper: SourceMapper,
         position: Position,
         evaluator: TypeEvaluator,
         token: CancellationToken
@@ -571,6 +572,7 @@ export class SourceFile {
         }
 
         return ReferencesProvider.getDeclarationForPosition(
+            sourceMapper,
             this._parseResults,
             this._filePath,
             position,

--- a/server/src/analyzer/sourceMapper.ts
+++ b/server/src/analyzer/sourceMapper.ts
@@ -30,24 +30,14 @@ export class SourceMapper {
         return sourceFiles.map((sf) => sf.getParseResults()?.parseTree).filter(_isDefined);
     }
 
-    public findDeclaration(stubDecl: Declaration): Declaration | undefined {
+    public findDeclarations(stubDecl: Declaration): Declaration[] {
         if (stubDecl.type === DeclarationType.Class) {
-            const decls = this.findClassDeclarations(stubDecl);
-            if (decls.length > 0) {
-                return decls[0];
-            } else {
-                return undefined;
-            }
+            return this.findClassDeclarations(stubDecl);
         } else if (stubDecl.type === DeclarationType.Function) {
-            const decls = this.findFunctionDeclarations(stubDecl);
-            if (decls.length > 0) {
-                return decls[0];
-            } else {
-                return undefined;
-            }
+            return this.findFunctionDeclarations(stubDecl);
         }
 
-        return undefined;
+        return [];
     }
 
     public findClassDeclarations(stubDecl: ClassDeclaration): ClassDeclaration[] {

--- a/server/src/analyzer/typeDocStringUtils.ts
+++ b/server/src/analyzer/typeDocStringUtils.ts
@@ -66,14 +66,19 @@ export function getClassDocString(
     return docString;
 }
 
-export function getFunctionDocString(type: FunctionType, sourceMapper: SourceMapper) {
+export function getFunctionDocStringFromType(type: FunctionType, sourceMapper: SourceMapper) {
     let docString = type.details.docString;
-    if (!docString) {
-        const decl = type.details.declaration;
-        if (decl && isStubFile(decl.path)) {
-            const implDecls = sourceMapper.findFunctionDeclarations(decl);
-            docString = _getFunctionOrClassDeclDocString(implDecls);
-        }
+    if (!docString && type.details.declaration) {
+        docString = getFunctionDocStringFromDeclaration(type.details.declaration, sourceMapper);
+    }
+    return docString;
+}
+
+export function getFunctionDocStringFromDeclaration(resolvedDecl: FunctionDeclaration, sourceMapper: SourceMapper) {
+    let docString = _getFunctionOrClassDeclDocString([resolvedDecl]);
+    if (!docString && isStubFile(resolvedDecl.path)) {
+        const implDecls = sourceMapper.findFunctionDeclarations(resolvedDecl);
+        docString = _getFunctionOrClassDeclDocString(implDecls);
     }
     return docString;
 }

--- a/server/src/common/extensibility.ts
+++ b/server/src/common/extensibility.ts
@@ -16,6 +16,7 @@ export interface LanguageServiceExtension {
 }
 
 export interface CompletionListExtension {
+    // Extension updates completion list provided by the application.
     updateCompletionList(
         sourceList: CompletionList,
         ast: ModuleNode,
@@ -24,4 +25,13 @@ export interface CompletionListExtension {
         options: ConfigOptions,
         token: CancellationToken
     ): Promise<CompletionList>;
+
+    // Prefix to tell extension commands from others.
+    // For example, 'myextension'. Command name then
+    // should be 'myextension.command'.
+    readonly commandPrefix: string;
+
+    // Extension executes command attached to commited
+    // completion list item, if any.
+    executeCommand(command: string, args: any[] | undefined, token: CancellationToken): Promise<void>;
 }

--- a/server/src/languageServerBase.ts
+++ b/server/src/languageServerBase.ts
@@ -161,11 +161,12 @@ export abstract class LanguageServerBase implements LanguageServerInterface {
     constructor(
         private _productName: string,
         rootDirectory: string,
+        version: string,
         private _extension?: LanguageServiceExtension,
         private _maxAnalysisTimeInForeground?: MaxAnalysisTime,
         supportedCommands?: string[]
     ) {
-        this._connection.console.log(`${_productName} language server starting`);
+        this._connection.console.log(`${_productName} language server ${version && version + ' '}starting`);
         this.fs = createFromRealFileSystem(this._connection.console, this);
 
         // Set the working directory to a known location within

--- a/server/src/languageService/autoImporter.ts
+++ b/server/src/languageService/autoImporter.ts
@@ -17,7 +17,7 @@ import {
     ImportGroup,
     ImportStatements,
 } from '../analyzer/importStatementUtils';
-import { SourceFile } from '../analyzer/sourceFile';
+import { SourceFileInfo } from '../analyzer/program';
 import { SymbolTable } from '../analyzer/symbol';
 import { Symbol } from '../analyzer/symbol';
 import * as SymbolNameUtils from '../analyzer/symbolNameUtils';
@@ -33,14 +33,14 @@ export type ModuleSymbolMap = Map<string, SymbolTable>;
 
 // Build a map of all modules within this program and the module-
 // level scope that contains the symbol table for the module.
-export function buildModuleSymbolsMap(files: SourceFile[], token: CancellationToken): ModuleSymbolMap {
+export function buildModuleSymbolsMap(files: SourceFileInfo[], token: CancellationToken): ModuleSymbolMap {
     const moduleSymbolMap = new Map<string, SymbolTable>();
 
     files.forEach((file) => {
         throwIfCancellationRequested(token);
-        const symbolTable = file.getModuleSymbolTable();
+        const symbolTable = file.sourceFile.getModuleSymbolTable();
         if (symbolTable) {
-            moduleSymbolMap.set(file.getFilePath(), symbolTable);
+            moduleSymbolMap.set(file.sourceFile.getFilePath(), symbolTable);
         }
     });
 
@@ -48,10 +48,12 @@ export function buildModuleSymbolsMap(files: SourceFile[], token: CancellationTo
 }
 
 export interface AutoImportResult {
+    isImportFrom: boolean;
     name: string;
     symbol?: Symbol;
     source: string;
     edits: TextEditAction[];
+    alias?: string;
 }
 
 export class AutoImporter {
@@ -63,7 +65,13 @@ export class AutoImporter {
         private _moduleSymbolMap: ModuleSymbolMap
     ) {}
 
-    getAutoImportCandidates(word: string, similarityLimit: number, excludes: string[], token: CancellationToken) {
+    getAutoImportCandidates(
+        word: string,
+        similarityLimit: number,
+        excludes: string[],
+        aliasName: string | undefined,
+        token: CancellationToken
+    ) {
         const results: AutoImportResult[] = [];
 
         const importStatements = getTopLevelImports(this._parseResults.parseTree);
@@ -128,10 +136,18 @@ export class AutoImporter {
                     importStatements,
                     filePath,
                     importSource,
-                    importGroup
+                    importGroup,
+                    aliasName
                 );
 
-                results.push({ name, symbol, source: importSource, edits: autoImportTextEdits });
+                results.push({
+                    name,
+                    symbol,
+                    source: importSource,
+                    edits: autoImportTextEdits,
+                    isImportFrom: true,
+                    alias: aliasName,
+                });
             });
 
             // See if this file should be offered as an implicit import.
@@ -139,15 +155,41 @@ export class AutoImporter {
             const initPathPy = combinePaths(fileDir, '__init__.py');
             const initPathPyi = initPathPy + 'i';
 
+            const isStubFile = filePath.endsWith('.pyi');
+            const hasInit = this._moduleSymbolMap.has(initPathPy) || this._moduleSymbolMap.has(initPathPyi);
+
             // If the current file is in a directory that also contains an "__init__.py[i]"
             // file, we can use that directory name as an implicit import target.
-            if (!this._moduleSymbolMap.has(initPathPy) && !this._moduleSymbolMap.has(initPathPyi)) {
+            // Or if the file is a stub file, we can use it as import target.
+            if (!isStubFile && !hasInit) {
                 return;
             }
 
-            const name = stripFileExtension(getFileName(filePath));
-            const moduleNameAndType = this._getModuleNameAndTypeFromFilePath(getDirectoryPath(filePath));
-            const importSource = moduleNameAndType.moduleName;
+            let importNamePart: string | undefined;
+            let name: string;
+            let importSource: string;
+            let moduleNameAndType: ModuleNameAndType;
+
+            if (hasInit) {
+                importNamePart = stripFileExtension(getFileName(filePath));
+                moduleNameAndType = this._getModuleNameAndTypeFromFilePath(getDirectoryPath(filePath));
+                importSource = moduleNameAndType.moduleName;
+
+                // See if we can import module as "import xxx"
+                if (importNamePart === '__init__') {
+                    importNamePart = undefined;
+                    name = importSource;
+                } else {
+                    name = importNamePart;
+                }
+            } else {
+                // We don't have init.py[i] but this file is a stub file.
+                // See whether we can import it as "import xx"
+                importNamePart = undefined;
+                moduleNameAndType = this._getModuleNameAndTypeFromFilePath(filePath);
+                name = importSource = moduleNameAndType.moduleName;
+            }
+
             if (!importSource) {
                 return;
             }
@@ -164,20 +206,32 @@ export class AutoImporter {
 
             const importGroup = this._getImportGroupFromModuleNameAndType(moduleNameAndType);
             const autoImportTextEdits = this._getTextEditsForAutoImportByFilePath(
-                name,
+                importNamePart,
                 importStatements,
                 filePath,
                 importSource,
-                importGroup
+                importGroup,
+                aliasName
             );
 
-            results.push({ name, symbol: undefined, source: importSource, edits: autoImportTextEdits });
+            results.push({
+                name: name,
+                alias: aliasName,
+                symbol: undefined,
+                source: importSource,
+                edits: autoImportTextEdits,
+                isImportFrom: !!importNamePart,
+            });
         });
 
         return results;
     }
 
     private _isSimilar(word: string, name: string, similarityLimit: number) {
+        if (similarityLimit === 1) {
+            return word === name;
+        }
+
         return word.length > 2
             ? StringUtils.computeCompletionSimilarity(word, name) > similarityLimit
             : word.length > 0 && name.startsWith(word);
@@ -215,16 +269,24 @@ export class AutoImporter {
     }
 
     private _getTextEditsForAutoImportByFilePath(
-        symbolName: string,
+        symbolName: string | undefined,
         importStatements: ImportStatements,
         filePath: string,
         moduleName: string,
-        importGroup: ImportGroup
+        importGroup: ImportGroup,
+        aliasName: string | undefined
     ): TextEditAction[] {
-        // Does an 'import from' statement already exist? If so, we'll reuse it.
-        const importStatement = importStatements.mapByFilePath.get(filePath);
-        if (importStatement && importStatement.node.nodeType === ParseNodeType.ImportFrom) {
-            return getTextEditsForAutoImportSymbolAddition(symbolName, importStatement, this._parseResults);
+        if (symbolName) {
+            // Does an 'import from' statement already exist? If so, we'll reuse it.
+            const importStatement = importStatements.mapByFilePath.get(filePath);
+            if (importStatement && importStatement.node.nodeType === ParseNodeType.ImportFrom) {
+                return getTextEditsForAutoImportSymbolAddition(
+                    symbolName,
+                    importStatement,
+                    this._parseResults,
+                    aliasName
+                );
+            }
         }
 
         return getTextEditsForAutoImportInsertion(
@@ -232,7 +294,8 @@ export class AutoImporter {
             importStatements,
             moduleName,
             importGroup,
-            this._parseResults
+            this._parseResults,
+            aliasName
         );
     }
 }

--- a/server/src/languageService/completionProvider.ts
+++ b/server/src/languageService/completionProvider.ts
@@ -30,7 +30,8 @@ import * as SymbolNameUtils from '../analyzer/symbolNameUtils';
 import { getLastTypedDeclaredForSymbol } from '../analyzer/symbolUtils';
 import {
     getClassDocString,
-    getFunctionDocString,
+    getFunctionDocStringFromDeclaration,
+    getFunctionDocStringFromType,
     getModuleDocString,
     getOverloadedFunctionDocStrings,
 } from '../analyzer/typeDocStringUtils';
@@ -843,6 +844,7 @@ export class CompletionProvider {
             priorWord,
             similarityLimit,
             completionList.items.filter((i) => !i.data?.autoImport).map((i) => i.label),
+            undefined,
             this._cancellationToken
         )) {
             if (result.symbol) {
@@ -863,7 +865,7 @@ export class CompletionProvider {
                     completionList,
                     result.name,
                     '',
-                    `Auto-import from ${result.source}`,
+                    result.isImportFrom ? `Auto-import from ${result.source}` : `Auto-import ${result.source}`,
                     undefined,
                     result.edits
                 );
@@ -1086,13 +1088,16 @@ export class CompletionProvider {
                             } else if (type.category === TypeCategory.Class) {
                                 documentation = getClassDocString(type, primaryDecl, this._sourceMapper);
                             } else if (type.category === TypeCategory.Function) {
-                                documentation = getFunctionDocString(type, this._sourceMapper);
+                                documentation = getFunctionDocStringFromType(type, this._sourceMapper);
                             } else if (type.category === TypeCategory.OverloadedFunction) {
                                 documentation = getOverloadedFunctionDocStrings(
                                     type,
                                     primaryDecl,
                                     this._sourceMapper
                                 ).find((doc) => doc);
+                            } else if (primaryDecl.type === DeclarationType.Function) {
+                                // @property functions
+                                documentation = getFunctionDocStringFromDeclaration(primaryDecl, this._sourceMapper);
                             }
 
                             let markdownString = '```python\n' + typeDetail + '\n```\n';

--- a/server/src/languageService/definitionProvider.ts
+++ b/server/src/languageService/definitionProvider.ts
@@ -55,12 +55,14 @@ export class DefinitionProvider {
                         });
 
                         if (isStubFile(resolvedDecl.path)) {
-                            const implDecl = sourceMapper.findDeclaration(resolvedDecl);
-                            if (implDecl && implDecl.path) {
-                                this._addIfUnique(definitions, {
-                                    path: implDecl.path,
-                                    range: implDecl.range,
-                                });
+                            const implDecls = sourceMapper.findDeclarations(resolvedDecl);
+                            for (const implDecl of implDecls) {
+                                if (implDecl && implDecl.path) {
+                                    this._addIfUnique(definitions, {
+                                        path: implDecl.path,
+                                        range: implDecl.range,
+                                    });
+                                }
                             }
                         }
                     }

--- a/server/src/localization/localize.ts
+++ b/server/src/localization/localize.ts
@@ -542,7 +542,7 @@ export namespace Localizer {
         export const unaccessedFunction = () =>
             new ParameterizedString<{ name: string }>(getRawString('Diagnostic.unaccessedFunction'));
         export const unaccessedImport = () =>
-            new ParameterizedString<{ importName: string }>(getRawString('Diagnostic.unaccessedImport'));
+            new ParameterizedString<{ name: string }>(getRawString('Diagnostic.unaccessedImport'));
         export const unaccessedSymbol = () =>
             new ParameterizedString<{ name: string }>(getRawString('Diagnostic.unaccessedSymbol'));
         export const unaccessedVariable = () =>

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -23,7 +23,8 @@ class PyrightServer extends LanguageServerBase {
     private _controller: CommandController;
 
     constructor() {
-        super('Pyright', getDirectoryPath(__dirname), undefined, maxAnalysisTimeInForeground);
+        const version = require('../package.json').version || '';
+        super('Pyright', getDirectoryPath(__dirname), version, undefined, maxAnalysisTimeInForeground);
 
         this._controller = new CommandController(this);
     }

--- a/server/src/tests/fourslash/completions.autoimport.topLevel.fourslash.ts
+++ b/server/src/tests/fourslash/completions.autoimport.topLevel.fourslash.ts
@@ -1,0 +1,47 @@
+/// <reference path="fourslash.ts" />
+
+// @filename: test1.py
+//// os[|/*marker1*/|]
+
+// @filename: test2.py
+//// sys[|/*marker2*/|]
+
+// @filename: test3.py
+//// import os
+//// import sys
+//// a = os.path
+//// b = sys.path
+
+helper.openFile('/test1.py');
+
+// @ts-ignore
+await helper.verifyCompletion('included', {
+    marker1: {
+        completions: [
+            {
+                label: 'os',
+                documentation: {
+                    kind: 'markdown',
+                    value: 'Auto-import os\n\n```python\nos\n```\n',
+                },
+            },
+        ],
+    },
+});
+
+helper.openFile('/test2.py');
+
+// @ts-ignore
+await helper.verifyCompletion('included', {
+    marker2: {
+        completions: [
+            {
+                label: 'sys',
+                documentation: {
+                    kind: 'markdown',
+                    value: 'Auto-import sys\n\n```python\nsys\n```\n',
+                },
+            },
+        ],
+    },
+});

--- a/server/src/tests/fourslash/completions.libCodeAndStub.fourslash.ts
+++ b/server/src/tests/fourslash/completions.libCodeAndStub.fourslash.ts
@@ -5,23 +5,41 @@
 ////   "useLibraryCodeForTypes": true
 //// }
 
+// @filename: test.py
+//// import testLib
+//// obj = testLib.[|/*marker1*/Validator|]()
+//// obj.is[|/*marker2*/|]
+//// obj.read[|/*marker3*/|]
+
 // @filename: testLib/__init__.py
 // @library: true
 //// class Validator:
 ////     '''The validator class'''
 ////     def is_valid(self, text):
 ////         '''Checks if the input string is valid.'''
-////         return true
+////         return True
+////     @property
+////     def read_only_prop(self):
+////         '''The read-only property.'''
+////         return True
+////     @property
+////     def read_write_prop(self):
+////         '''The read-write property.'''
+////         return True
+////     @read_write_prop.setter
+////     def read_write_prop(self, val):
+////         pass
 
 // @filename: testLib/__init__.pyi
 // @library: true
 //// class Validator:
 ////     def is_valid(self, text: str) -> bool: ...
-
-// @filename: test.py
-//// import testLib
-//// obj = testLib.[|/*marker1*/Validator|]()
-//// obj.is[|/*marker2*/|]
+////     @property
+////     def read_only_prop(self) -> bool: ...
+////     @property
+////     def read_write_prop(self) -> bool: ...
+////     @read_write_prop.setter
+////     def read_write_prop(self, val: bool): ...
 
 // @ts-ignore
 await helper.verifyCompletion('included', {
@@ -44,6 +62,24 @@ await helper.verifyCompletion('included', {
                     kind: 'markdown',
                     value:
                         '```python\nis_valid: (self: Validator, text: str) -> bool\n```\n---\nChecks if the input string is valid.',
+                },
+            },
+        ],
+    },
+    marker3: {
+        completions: [
+            {
+                label: 'read_only_prop',
+                documentation: {
+                    kind: 'markdown',
+                    value: '```python\nread_only_prop: bool\n```\n---\nThe read-only property.',
+                },
+            },
+            {
+                label: 'read_write_prop',
+                documentation: {
+                    kind: 'markdown',
+                    value: '```python\nread_write_prop: bool\n```\n---\nThe read-write property.',
                 },
             },
         ],

--- a/server/src/tests/fourslash/completions.libCodeNoStub.fourslash.ts
+++ b/server/src/tests/fourslash/completions.libCodeNoStub.fourslash.ts
@@ -5,18 +5,31 @@
 ////   "useLibraryCodeForTypes": true
 //// }
 
+// @filename: test.py
+//// import testLib
+//// obj = testLib.[|/*marker1*/Validator|]()
+//// obj.is[|/*marker2*/|]
+//// obj.read[|/*marker3*/|]
+
 // @filename: testLib/__init__.py
 // @library: true
 //// class Validator:
 ////     '''The validator class'''
 ////     def is_valid(self, text: str) -> bool:
 ////         '''Checks if the input string is valid.'''
-////         return true
-
-// @filename: test.py
-//// import testLib
-//// obj = testLib.[|/*marker1*/Validator|]()
-//// obj.is[|/*marker2*/|]
+////         return True
+////     @property
+////     def read_only_prop(self) -> bool:
+////         '''The read-only property.'''
+////         return True
+////     @property
+////     def read_write_prop(self) -> bool:
+////         '''The read-write property.'''
+////         return True
+////     @read_write_prop.setter
+////     def read_write_prop(self, val: bool):
+////         '''The read-write property.'''
+////         pass
 
 // @ts-ignore
 await helper.verifyCompletion('included', {
@@ -39,6 +52,24 @@ await helper.verifyCompletion('included', {
                     kind: 'markdown',
                     value:
                         '```python\nis_valid: (self: Validator, text: str) -> bool\n```\n---\nChecks if the input string is valid.',
+                },
+            },
+        ],
+    },
+    marker3: {
+        completions: [
+            {
+                label: 'read_only_prop',
+                documentation: {
+                    kind: 'markdown',
+                    value: '```python\nread_only_prop: bool\n```\n---\nThe read-only property.',
+                },
+            },
+            {
+                label: 'read_write_prop',
+                documentation: {
+                    kind: 'markdown',
+                    value: '```python\nread_write_prop: bool\n```\n---\nThe read-write property.',
                 },
             },
         ],

--- a/server/src/tests/fourslash/completions.localCode.fourslash.ts
+++ b/server/src/tests/fourslash/completions.localCode.fourslash.ts
@@ -1,31 +1,25 @@
 /// <reference path="fourslash.ts" />
 
-// @filename: mspythonconfig.json
-//// {
-////   "useLibraryCodeForTypes": true
-//// }
-
 // @filename: test.py
 //// import testLib
 //// obj = testLib.[|/*marker1*/Validator|]()
 //// obj.is[|/*marker2*/|]
 //// obj.read[|/*marker3*/|]
 
-// @filename: testLib/__init__.pyi
-// @library: true
+// @filename: testLib/__init__.py
 //// class Validator:
 ////     '''The validator class'''
 ////     def is_valid(self, text: str) -> bool:
 ////         '''Checks if the input string is valid.'''
-////         pass
+////         return True
 ////     @property
 ////     def read_only_prop(self) -> bool:
 ////         '''The read-only property.'''
-////         pass
+////         return True
 ////     @property
 ////     def read_write_prop(self) -> bool:
 ////         '''The read-write property.'''
-////         pass
+////         return True
 ////     @read_write_prop.setter
 ////     def read_write_prop(self, val: bool):
 ////         '''The read-write property.'''

--- a/server/src/tests/fourslash/findDefinitions.sourceAndStub.outerClassPropertyReadOnly.fourslash.ts
+++ b/server/src/tests/fourslash/findDefinitions.sourceAndStub.outerClassPropertyReadOnly.fourslash.ts
@@ -1,0 +1,31 @@
+/// <reference path="fourslash.ts" />
+
+// @filename: testLib1/__init__.py
+// @library: true
+//// class Test1:
+////     @property
+////     def [|P|](self):
+////         return ''
+
+// @filename: typings/testLib1/__init__.pyi
+//// class Test1:
+////     @property
+////     def [|P|](self) -> str: ...
+
+// @filename: test.py
+//// import testLib1
+////
+//// a = testLib1.Test1()
+//// a.[|/*marker*/P|]
+
+{
+    const ranges = helper.getRanges().filter((r) => !r.marker);
+
+    helper.verifyFindDefinitions({
+        marker: {
+            definitions: ranges.map((r) => {
+                return { path: r.fileName, range: helper.convertPositionRange(r) };
+            }),
+        },
+    });
+}

--- a/server/src/tests/fourslash/findDefinitions.sourceAndStub.outerClassPropertyReadWrite.fourslash.ts
+++ b/server/src/tests/fourslash/findDefinitions.sourceAndStub.outerClassPropertyReadWrite.fourslash.ts
@@ -1,0 +1,36 @@
+/// <reference path="fourslash.ts" />
+
+// @filename: testLib1/__init__.py
+// @library: true
+//// class Test1:
+////     @property
+////     def [|P|](self):
+////         return ''
+////     @P.setter
+////     def [|P|](self, a):
+////         pass
+
+// @filename: typings/testLib1/__init__.pyi
+//// class Test1:
+////     @property
+////     def [|P|](self) -> str: ...
+////     @P.setter
+////     def [|P|](self, a: str): ...
+
+// @filename: test.py
+//// import testLib1
+////
+//// a = testLib1.Test1()
+//// a.[|/*marker*/P|]
+
+{
+    const ranges = helper.getRanges().filter((r) => !r.marker);
+
+    helper.verifyFindDefinitions({
+        marker: {
+            definitions: ranges.map((r) => {
+                return { path: r.fileName, range: helper.convertPositionRange(r) };
+            }),
+        },
+    });
+}

--- a/server/src/tests/fourslash/findallreferences.classPropertyReadWrite.ts
+++ b/server/src/tests/fourslash/findallreferences.classPropertyReadWrite.ts
@@ -1,0 +1,39 @@
+/// <reference path="fourslash.ts" />
+
+// @filename: testLib1/__init__.py
+//// class Test1:
+////     @property
+////     def [|P|](self):
+////         return ''
+////     @[|P|].setter
+////     def [|P|](self, a):
+////         pass
+
+// @filename: test.py
+//// from testLib1 import Test1
+////
+//// a = Test1()
+//// a.[|/*marker*/P|] = ''
+//// val = a.[|P|]
+
+// @filename: test2.py
+//// from testLib1 import Test1
+////
+//// b = Test1()
+//// func(b)
+////
+//// def func(t: Test1):
+////     t.[|P|] = ''
+////     print(t.[|P|])
+
+{
+    const ranges = helper.getRanges();
+
+    helper.verifyFindAllReferences({
+        marker: {
+            references: ranges.map((r) => {
+                return { path: r.fileName, range: helper.convertPositionRange(r) };
+            }),
+        },
+    });
+}

--- a/server/src/tests/fourslash/findallreferences.parameter.fourslash.ts
+++ b/server/src/tests/fourslash/findallreferences.parameter.fourslash.ts
@@ -1,0 +1,24 @@
+/// <reference path="fourslash.ts" />
+
+// @filename: test.py
+//// def func([|/*marker*/a|]):
+////     print([|a|])
+////
+//// a = 40
+//// func(a)
+
+// @filename: test2.py
+//// a = 50
+//// print(a)
+
+{
+    const ranges = helper.getRanges();
+
+    helper.verifyFindAllReferences({
+        marker: {
+            references: ranges.map((r) => {
+                return { path: r.fileName, range: helper.convertPositionRange(r) };
+            }),
+        },
+    });
+}

--- a/server/src/tests/fourslash/findallreferences.sourceAndStub.class.fourslash.ts
+++ b/server/src/tests/fourslash/findallreferences.sourceAndStub.class.fourslash.ts
@@ -1,0 +1,33 @@
+/// <reference path="fourslash.ts" />
+
+// @filename: testLib1/__init__.py
+// @library: true
+//// class [|Test1|]:
+////    def M(self, a):
+////     pass
+
+// @filename: typings/testLib1/__init__.pyi
+//// class [|Test1|]:
+////     def M(self, a: str): ...
+
+// @filename: test.py
+//// from testLib1 import [|Test1|]
+////
+//// a = [|/*marker*/Test1|]()
+
+// @filename: test2.py
+//// from testLib1 import [|Test1|]
+////
+//// b = [|Test1|]()
+
+{
+    const ranges = helper.getRanges();
+
+    helper.verifyFindAllReferences({
+        marker: {
+            references: ranges.map((r) => {
+                return { path: r.fileName, range: helper.convertPositionRange(r) };
+            }),
+        },
+    });
+}

--- a/server/src/tests/fourslash/findallreferences.sourceAndStub.classMethod.fourslash.ts
+++ b/server/src/tests/fourslash/findallreferences.sourceAndStub.classMethod.fourslash.ts
@@ -1,0 +1,37 @@
+/// <reference path="fourslash.ts" />
+
+// @filename: testLib1/__init__.py
+// @library: true
+//// class Test1:
+////    def [|M|](self, a):
+////     pass
+
+// @filename: typings/testLib1/__init__.pyi
+//// class Test1:
+////     def [|M|](self, a: str): ...
+
+// @filename: test.py
+//// from testLib1 import Test1
+////
+//// Test1().[|/*marker*/M|]('')
+
+// @filename: test2.py
+//// from testLib1 import Test1
+////
+//// b = Test1()
+//// func(b)
+////
+//// def func(t: Test1):
+////     t.[|M|]('')
+
+{
+    const ranges = helper.getRanges();
+
+    helper.verifyFindAllReferences({
+        marker: {
+            references: ranges.map((r) => {
+                return { path: r.fileName, range: helper.convertPositionRange(r) };
+            }),
+        },
+    });
+}

--- a/server/src/tests/fourslash/findallreferences.sourceAndStub.classPropertyReadOnly.fourslash.ts
+++ b/server/src/tests/fourslash/findallreferences.sourceAndStub.classPropertyReadOnly.fourslash.ts
@@ -1,0 +1,40 @@
+/// <reference path="fourslash.ts" />
+
+// @filename: testLib1/__init__.py
+// @library: true
+//// class Test1:
+////     @property
+////     def [|P|](self):
+////         return ''
+
+// @filename: typings/testLib1/__init__.pyi
+//// class Test1:
+////     @property
+////     def [|P|](self) -> str: ...
+
+// @filename: test.py
+//// from testLib1 import Test1
+////
+//// a = Test1()
+//// val = a.[|/*marker*/P|]
+
+// @filename: test2.py
+//// from testLib1 import Test1
+////
+//// b = Test1()
+//// func(b)
+////
+//// def func(t: Test1):
+////     print(t.[|P|])
+
+{
+    const ranges = helper.getRanges();
+
+    helper.verifyFindAllReferences({
+        marker: {
+            references: ranges.map((r) => {
+                return { path: r.fileName, range: helper.convertPositionRange(r) };
+            }),
+        },
+    });
+}

--- a/server/src/tests/fourslash/findallreferences.sourceAndStub.classPropertyReadWrite.fourslash.skip.ts
+++ b/server/src/tests/fourslash/findallreferences.sourceAndStub.classPropertyReadWrite.fourslash.skip.ts
@@ -1,0 +1,48 @@
+/// <reference path="fourslash.ts" />
+
+// @filename: testLib1/__init__.py
+// @library: true
+//// class Test1:
+////     @property
+////     def [|P|](self):
+////         return ''
+////     # bug: these next 2 missing from results - disabling test until this is fixed, it actually works in the product
+////     @[|P|].setter
+////     def [|P|](self, a):
+////         pass
+
+// @filename: typings/testLib1/__init__.pyi
+//// class Test1:
+////     @property
+////     def [|P|](self) -> str: ...
+////     @[|P|].setter
+////     def [|P|](self, a: str): ...
+
+// @filename: test.py
+//// from testLib1 import Test1
+////
+//// a = Test1()
+//// a.[|/*marker*/P|] = ''
+//// val = a.[|P|]
+
+// @filename: test2.py
+//// from testLib1 import Test1
+////
+//// b = Test1()
+//// func(b)
+////
+//// def func(t: Test1):
+////     t.[|P|] = ''
+////     print(t.[|P|])
+
+{
+    const ranges = helper.getRanges();
+
+    helper.verifyFindAllReferences({
+        marker: {
+            references: ranges.map((r) => {
+                return { path: r.fileName, range: helper.convertPositionRange(r) };
+            }),
+        },
+    });
+}

--- a/server/src/tests/fourslash/findallreferences.sourceAndStub.function.fourslash.ts
+++ b/server/src/tests/fourslash/findallreferences.sourceAndStub.function.fourslash.ts
@@ -1,0 +1,35 @@
+/// <reference path="fourslash.ts" />
+
+// @filename: testLib1/__init__.py
+// @library: true
+//// def [|func1|](a):
+////     pass
+
+// @filename: typings/testLib1/__init__.pyi
+//// def [|func1|](a: str): ...
+
+// @filename: test.py
+//// from testLib1 import [|func1|]
+////
+//// [|/*marker*/func1|]('')
+
+// @filename: test2.py
+//// import testLib1
+////
+//// def func1(t: str):
+////     pass
+////
+//// func1('')
+//// testLib1.[|func1|]('')
+
+{
+    const ranges = helper.getRanges();
+
+    helper.verifyFindAllReferences({
+        marker: {
+            references: ranges.map((r) => {
+                return { path: r.fileName, range: helper.convertPositionRange(r) };
+            }),
+        },
+    });
+}

--- a/server/src/tests/fourslash/findallreferences.variable.fourslash.ts
+++ b/server/src/tests/fourslash/findallreferences.variable.fourslash.ts
@@ -1,0 +1,24 @@
+/// <reference path="fourslash.ts" />
+
+// @filename: test.py
+//// def func(a):
+////     print(a)
+////
+//// [|/*marker*/a|] = 40
+//// func([|a|])
+
+// @filename: test2.py
+//// a = 50
+//// print(a)
+
+{
+    const ranges = helper.getRanges();
+
+    helper.verifyFindAllReferences({
+        marker: {
+            references: ranges.map((r) => {
+                return { path: r.fileName, range: helper.convertPositionRange(r) };
+            }),
+        },
+    });
+}

--- a/server/src/tests/fourslash/hover.libCodeAndStub.fourslash.ts
+++ b/server/src/tests/fourslash/hover.libCodeAndStub.fourslash.ts
@@ -11,22 +11,54 @@
 ////     '''The validator class'''
 ////     def is_valid(self, text):
 ////         '''Checks if the input string is valid.'''
-////         return true
+////         return True
+////     @property
+////     def read_only_prop(self):
+////         '''The read-only property.'''
+////         return True
+////     @property
+////     def read_write_prop(self):
+////         '''The read-write property.'''
+////         return True
+////     @read_write_prop.setter
+////     def read_write_prop(self, val):
+////         pass
 
 // @filename: testLib/__init__.pyi
 // @library: true
 //// class Validator:
 ////     def is_valid(self, text: str) -> bool: ...
+////     @property
+////     def read_only_prop(self) -> bool: ...
+////     @property
+////     def read_write_prop(self) -> bool: ...
+////     @read_write_prop.setter
+////     def read_write_prop(self, val: bool): ...
 
 // @filename: test.py
 //// import testLib
 //// obj = testLib.[|/*marker1*/Validator|]()
 //// obj.[|/*marker2*/is_valid|]('')
+//// obj.[|/*marker3*/read_only_prop|]
+//// r = obj.[|/*marker4*/read_write_prop|]
+//// obj.[|/*marker5*/read_write_prop|] = r
 
 helper.verifyHover({
     marker1: { value: '```python\n(class) Validator\n```\nThe validator class', kind: 'markdown' },
     marker2: {
         value: '```python\n(method) is_valid: (text: str) -> bool\n```\nChecks if the input string is valid.',
+        kind: 'markdown',
+    },
+    marker3: {
+        value: '```python\n(property) read_only_prop: bool\n```\nThe read-only property.',
+        kind: 'markdown',
+    },
+    marker4: {
+        value: '```python\n(property) read_write_prop: bool\n```\nThe read-write property.',
+        kind: 'markdown',
+    },
+    marker5: {
+        value: '```python\n(property) read_write_prop: bool\n```\nThe read-write property.',
         kind: 'markdown',
     },
 });

--- a/server/src/tests/fourslash/hover.libCodeNoStub.fourslash.ts
+++ b/server/src/tests/fourslash/hover.libCodeNoStub.fourslash.ts
@@ -11,17 +11,43 @@
 ////     '''The validator class'''
 ////     def is_valid(self, text: str) -> bool:
 ////         '''Checks if the input string is valid.'''
-////         return true
+////         return True
+////     @property
+////     def read_only_prop(self) -> bool:
+////         '''The read-only property.'''
+////         return True
+////     @property
+////     def read_write_prop(self) -> bool:
+////         '''The read-write property.'''
+////         return True
+////     @read_write_prop.setter
+////     def read_write_prop(self, val: bool):
+////         pass
 
 // @filename: test.py
 //// import testLib
 //// obj = testLib.[|/*marker1*/Validator|]()
 //// obj.[|/*marker2*/is_valid|]('')
+//// obj.[|/*marker3*/read_only_prop|]
+//// r = obj.[|/*marker4*/read_write_prop|]
+//// obj.[|/*marker5*/read_write_prop|] = r
 
 helper.verifyHover({
     marker1: { value: '```python\n(class) Validator\n```\nThe validator class', kind: 'markdown' },
     marker2: {
         value: '```python\n(method) is_valid: (text: str) -> bool\n```\nChecks if the input string is valid.',
+        kind: 'markdown',
+    },
+    marker3: {
+        value: '```python\n(property) read_only_prop: bool\n```\nThe read-only property.',
+        kind: 'markdown',
+    },
+    marker4: {
+        value: '```python\n(property) read_write_prop: bool\n```\nThe read-write property.',
+        kind: 'markdown',
+    },
+    marker5: {
+        value: '```python\n(property) read_write_prop: bool\n```\nThe read-write property.',
         kind: 'markdown',
     },
 });

--- a/server/src/tests/fourslash/hover.libStub.fourslash.ts
+++ b/server/src/tests/fourslash/hover.libStub.fourslash.ts
@@ -12,16 +12,42 @@
 ////     def is_valid(self, text: str) -> bool:
 ////         '''Checks if the input string is valid.'''
 ////         pass
+////     @property
+////     def read_only_prop(self) -> bool:
+////         '''The read-only property.'''
+////         pass
+////     @property
+////     def read_write_prop(self) -> bool:
+////         '''The read-write property.'''
+////         pass
+////     @read_write_prop.setter
+////     def read_write_prop(self, val: bool):
+////         pass
 
 // @filename: test.py
 //// import testLib
 //// obj = testLib.[|/*marker1*/Validator|]()
 //// obj.[|/*marker2*/is_valid|]('')
+//// obj.[|/*marker3*/read_only_prop|]
+//// r = obj.[|/*marker4*/read_write_prop|]
+//// obj.[|/*marker5*/read_write_prop|] = r
 
 helper.verifyHover({
     marker1: { value: '```python\n(class) Validator\n```\nThe validator class', kind: 'markdown' },
     marker2: {
         value: '```python\n(method) is_valid: (text: str) -> bool\n```\nChecks if the input string is valid.',
+        kind: 'markdown',
+    },
+    marker3: {
+        value: '```python\n(property) read_only_prop: bool\n```\nThe read-only property.',
+        kind: 'markdown',
+    },
+    marker4: {
+        value: '```python\n(property) read_write_prop: bool\n```\nThe read-write property.',
+        kind: 'markdown',
+    },
+    marker5: {
+        value: '```python\n(property) read_write_prop: bool\n```\nThe read-write property.',
         kind: 'markdown',
     },
 });

--- a/server/src/tests/fourslash/rename.library.sourceAndStub.fourslash.ts
+++ b/server/src/tests/fourslash/rename.library.sourceAndStub.fourslash.ts
@@ -1,0 +1,33 @@
+/// <reference path="fourslash.ts" />
+
+// @filename: mspythonconfig.json
+//// {
+////   "useLibraryCodeForTypes": true
+//// }
+
+// @filename: testLib1/__init__.py
+// @library: true
+//// class Test1:
+////    def M(self, a):
+////     pass
+
+// @filename: typings/testLib1/__init__.pyi
+//// class Test1:
+////    def M(self, a: Test1): ...
+
+// @filename: test.py
+//// from testLib1 import Test1
+////
+//// a = [|/*marker*/Test1|]()
+
+// @filename: test2.py
+//// from testLib1 import Test1
+////
+//// b = Test1()
+
+helper.verifyRename({
+    marker: {
+        newName: 'NewTest1',
+        changes: [],
+    },
+});

--- a/server/src/tests/fourslash/rename.multipleDecl.fourslash.ts
+++ b/server/src/tests/fourslash/rename.multipleDecl.fourslash.ts
@@ -1,30 +1,21 @@
 /// <reference path="fourslash.ts" />
 
-// @filename: mspythonconfig.json
-//// {
-////   "useLibraryCodeForTypes": true
-//// }
-
 // @filename: foo/__init__.py
-// @library: true
 //// class Foo:
 ////    pass
 
 // @filename: test.py
 //// import foo
-//// import os as [|foo|]
 //// [|/*marker*/foo|] = 3
 //// def [|foo|](): pass
 
-{
-    const ranges = helper.getRanges();
+const ranges = helper.getRanges();
 
-    helper.verifyRename({
-        marker: {
-            newName: 'foo1',
-            changes: ranges.map((r) => {
-                return { filePath: r.fileName, range: helper.convertPositionRange(r), replacementText: 'foo1' };
-            }),
-        },
-    });
-}
+helper.verifyRename({
+    marker: {
+        newName: 'foo1',
+        changes: ranges.map((r) => {
+            return { filePath: r.fileName, range: helper.convertPositionRange(r), replacementText: 'foo1' };
+        }),
+    },
+});

--- a/server/src/tests/fourslash/rename.sourceAndStub.fourslash.ts
+++ b/server/src/tests/fourslash/rename.sourceAndStub.fourslash.ts
@@ -1,0 +1,37 @@
+/// <reference path="fourslash.ts" />
+
+// @filename: testLib1/__init__.py
+//// class Test1:
+////    def [|M|](self, a):
+////     pass
+
+// @filename: testLib1/__init__.pyi
+//// class Test1:
+////     def [|M|](self, a: str): ...
+
+// @filename: test.py
+//// from testLib1 import Test1
+////
+//// Test1().[|[|/*marker*/M|]|]('')
+
+// @filename: test2.py
+//// from testLib1 import Test1
+////
+//// b = Test1()
+//// func(b)
+////
+//// def func(t: Test1):
+////     t.[|M|]('')
+
+{
+    const ranges = helper.getRanges().filter((r) => !r.marker);
+
+    helper.verifyRename({
+        marker: {
+            newName: 'M2',
+            changes: ranges.map((r) => {
+                return { filePath: r.fileName, range: helper.convertPositionRange(r), replacementText: 'M2' };
+            }),
+        },
+    });
+}

--- a/server/src/tests/harness/fourslash/testState.ts
+++ b/server/src/tests/harness/fourslash/testState.ts
@@ -796,8 +796,13 @@ export class TestState {
         this._analyze();
 
         for (const marker of this.getMarkers()) {
+            const markerName = this.getMarkerName(marker);
+            if (!map[markerName]) {
+                continue;
+            }
+
             const filePath = marker.fileName;
-            const expectedCompletions = map[this.getMarkerName(marker)].completions;
+            const expectedCompletions = map[markerName].completions;
             const completionPosition = this._convertOffsetToPosition(filePath, marker.position);
 
             const result = await this.program.getCompletionsForPosition(
@@ -946,7 +951,7 @@ export class TestState {
             const position = this._convertOffsetToPosition(fileName, marker.position);
             const actual = this.program.getReferencesForPosition(fileName, position, true, CancellationToken.None);
 
-            assert.equal(expected.length, actual?.length ?? 0);
+            assert.equal(actual?.length ?? 0, expected.length);
 
             for (const r of expected) {
                 assert.equal(actual?.filter((d) => this._deepEqual(d, r)).length, 1);
@@ -974,7 +979,7 @@ export class TestState {
             const position = this._convertOffsetToPosition(fileName, marker.position);
             const actual = this.program.getDefinitionsForPosition(fileName, position, CancellationToken.None);
 
-            assert.equal(expected.length, actual?.length ?? 0);
+            assert.equal(actual?.length ?? 0, expected.length);
 
             for (const r of expected) {
                 assert.equal(actual?.filter((d) => this._deepEqual(d, r)).length, 1);
@@ -1008,7 +1013,7 @@ export class TestState {
                 CancellationToken.None
             );
 
-            assert.equal(expected.changes.length, actual?.length ?? 0);
+            assert.equal(actual?.length ?? 0, expected.changes.length);
 
             for (const c of expected.changes) {
                 assert.equal(actual?.filter((e) => this._deepEqual(e, c)).length, 1);


### PR DESCRIPTION
Rollup of:

- Fix the import message template
- Tweak LS extension interface
- Print LS version on startup
- Improve auto-import completions for package names
- Improve find-all-references/rename for stub+source case