### PR TITLE
Don't show errors for other files by default

### DIFF
--- a/docs/settings.md
+++ b/docs/settings.md
@@ -20,7 +20,7 @@ The Pyright VS Code extension honors the following settings.
 
 **python.analysis.stubPath** [path]: Path to directory containing custom type stub files.
 
-**python.analysis.diagnosticMode** ["openFilesOnly", "workspace"]: Determines whether pyright analyzes (and reports errors for) all files in the workspace, as indicated by the config file. If this option is set to "openFilesOnly", pyright analyzes only open files.
+**python.analysis.diagnosticMode** ["openFilesOnly", "workspace"]: Determines whether pyright analyzes (and reports errors for) all files in the workspace, as indicated by the config file. If this option is set to "openFilesOnly", pyright analyzes only open files. If this option is set to "workspace", pyright will also analyze and show errors for files that are _not_ open.
 
 **python.analysis.diagnosticSeverityOverrides** [map]: Allows a user to override the severity levels for individual diagnostic rules. "reportXXX" rules in the type check diagnostics settings in [configuration](https://github.com/microsoft/pyright/blob/master/docs/configuration.md#type-check-diagnostics-settings) are supported. Use the rule name as a key and one of "error," "warning," "information," "true," "false," or "none" as value.
 

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -107,8 +107,9 @@ class PyrightServer extends LanguageServerBase {
                 serverSettings.disableOrganizeImports = !!pyrightSection.disableOrganizeImports;
                 serverSettings.typeCheckingMode = pyrightSection.typeCheckingMode;
             } else {
-                // Unless openFilesOnly is set explicitly, set it to true by default.
-                serverSettings.openFilesOnly = serverSettings.openFilesOnly ?? true;
+                // Unless openFilesOnly is set explicitly, set it to false by default.
+                // true analyses files that are _not_ currently open.
+                serverSettings.openFilesOnly = serverSettings.openFilesOnly ??  false;
                 serverSettings.useLibraryCodeForTypes = false;
                 serverSettings.disableLanguageServices = false;
                 serverSettings.disableOrganizeImports = false;


### PR DESCRIPTION
There's a setting to show errors for files _other_ than the files currently open. While I can't think of a scenario where this would make sense, I guess there are and some people find this desireable.

However, this is set to true by default as well. This results in pyright showing errors for files _other_ than the currently open file, which doesn't really make sense. Aside from being extremely confusing, it's quite orthogonal to what any other checker does too.

This change makes the default what any developer would expect: when opening a file, see errors for that file and not for other files.

It also documents what the alternative setting does, since it's not at all obvious.

(I was going to open a bug report thinking `pyright` was broken, but it seems its just an oversight in having the werid-case being the default, rather than the normal case).

Thanks for maintaining this, btw!