### PR TITLE
Add severity level enum to package.json

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -95,7 +95,16 @@
                     "type": "object",
                     "default": {},
                     "description": "Allows a user to override the severity levels for individual diagnostics.",
-                    "scope": "resource"
+                    "scope": "resource",
+                    "additionalProperties": {
+                        "type": "string",
+                        "enum": [
+                            "none",
+                            "warning",
+                            "information",
+                            "error"
+                        ]
+                    }
                 },
                 "python.analysis.logLevel": {
                     "type": "string",


### PR DESCRIPTION
I'm working on making object settings editable from the GUI in vscode https://github.com/microsoft/vscode/issues/99635. The change in this PR would make the `diagnosticSeverityOverrides`  setting editable from the GUI. We can make it stricter by adding schemas for all of these options mentioned here: https://github.com/microsoft/pyright/blob/master/docs/configuration.md#type-check-diagnostics-settings.