### PR TITLE
Improve type inference of context manager that swallow exceptions

### DIFF
--- a/server/src/analyzer/binder.ts
+++ b/server/src/analyzer/binder.ts
@@ -86,6 +86,7 @@ import {
     FlowPostFinally,
     FlowPreFinallyGate,
     FlowWildcardImport,
+    FlowWithStatement,
     getUniqueFlowNodeId,
     isCodeFlowSupportedForReference,
 } from './codeFlow';
@@ -1366,6 +1367,7 @@ export class Binder extends ParseTreeWalker {
         });
 
         this.walk(node.suite);
+        this._createFlowPostWithStatement(node);
 
         return false;
     }
@@ -1941,6 +1943,16 @@ export class Binder extends ParseTreeWalker {
         }
 
         AnalyzerNodeInfo.setFlowNode(node, this._currentFlowNode);
+    }
+
+    private _createFlowPostWithStatement(node: WithNode) {
+        const flowNode: FlowWithStatement = {
+            flags: FlowFlags.PostWithStatement,
+            id: getUniqueFlowNodeId(),
+            node,
+            antecedent: this._currentFlowNode,
+        };
+        this._currentFlowNode = flowNode;
     }
 
     private _isCodeUnreachable() {

--- a/server/src/analyzer/codeFlow.ts
+++ b/server/src/analyzer/codeFlow.ts
@@ -21,6 +21,7 @@ import {
     MemberAccessNode,
     NameNode,
     ParseNodeType,
+    WithNode,
 } from '../parser/parseNodes';
 
 export enum FlowFlags {
@@ -37,6 +38,7 @@ export enum FlowFlags {
     PreFinallyGate = 1 << 11, // Injected edge that links pre-finally label and pre-try flow
     PostFinally = 1 << 12, // Injected edge that links post-finally flow with the rest of the graph
     AssignmentAlias = 1 << 13, // Assigned symbol is aliased to another symbol with the same name
+    PostWithStatement = 1 << 15, // Track code after a "with" block.
 }
 
 let _nextFlowNodeId = 1;
@@ -94,6 +96,13 @@ export interface FlowCondition extends FlowNode {
 // the code flow and making subsequent code unreachable.
 export interface FlowCall extends FlowNode {
     node: CallNode;
+    antecedent: FlowNode;
+}
+
+// Record calls to context managers, which may suppress exceptions,
+// thus affecting the code following and making it reachable.
+export interface FlowWithStatement extends FlowNode {
+    node: WithNode;
     antecedent: FlowNode;
 }
 

--- a/server/src/parser/parseNodes.ts
+++ b/server/src/parser/parseNodes.ts
@@ -543,16 +543,22 @@ export interface WithItemNode extends ParseNodeBase {
     readonly nodeType: ParseNodeType.WithItem;
     expression: ExpressionNode;
     target?: ExpressionNode;
+
+    // The exitExpression is a copy of the expression
+    // node. We use it as a place to hang the result type
+    // of __(a)exit__.
+    exitExpression: ExpressionNode;
 }
 
 export namespace WithItemNode {
-    export function create(expression: ExpressionNode) {
+    export function create(expression: ExpressionNode, exitExpression: ExpressionNode) {
         const node: WithItemNode = {
             start: expression.start,
             length: expression.length,
             nodeType: ParseNodeType.WithItem,
             id: _nextNodeId++,
             expression,
+            exitExpression,
         };
 
         expression.parent = node;

--- a/server/src/parser/parser.ts
+++ b/server/src/parser/parser.ts
@@ -941,7 +941,12 @@ export class Parser {
     // with_item: test ['as' expr]
     private _parseWithItem(): WithItemNode {
         const expr = this._parseTestExpression(true);
-        const itemNode = WithItemNode.create(expr);
+
+        // Make a shallow copy of the expression but give it a new ID.
+        const exitExpr = Object.assign({}, expr);
+        exitExpr.id = getNextNodeId();
+
+        const itemNode = WithItemNode.create(expr, exitExpr);
 
         if (this._consumeTokenIfKeyword(KeywordType.As)) {
             itemNode.target = this._parseExpression(false);

--- a/server/src/tests/checker.test.ts
+++ b/server/src/tests/checker.test.ts
@@ -782,6 +782,30 @@ test('With2', () => {
     validateResults(analysisResults, 3);
 });
 
+test('With3', () => {
+    const analysisResults = TestUtils.typeAnalyzeSampleFiles(['with3.py']);
+
+    validateResults(analysisResults, 0);
+});
+
+test('With4', () => {
+    const analysisResults = TestUtils.typeAnalyzeSampleFiles(['with4.py']);
+
+    validateResults(analysisResults, 4);
+});
+
+test('With5', () => {
+    const analysisResults = TestUtils.typeAnalyzeSampleFiles(['with5.py']);
+
+    validateResults(analysisResults, 0);
+});
+
+test('With6', () => {
+    const analysisResults = TestUtils.typeAnalyzeSampleFiles(['with6.py']);
+
+    validateResults(analysisResults, 5);
+});
+
 test('ForLoops1', () => {
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['forLoops1.py']);
 

--- a/server/src/tests/samples/with3.py
+++ b/server/src/tests/samples/with3.py
@@ -1,0 +1,110 @@
+# This sample tests for context manager that might suppress exceptions.
+
+from contextlib import contextmanager, suppress
+from typing import Any, Iterator, Optional
+
+from typing_extensions import Literal
+
+
+class DoesNotSuppress1:
+    def __enter__(self) -> int:
+        ...
+
+    def __exit__(
+        self, exctype: object, excvalue: object, traceback: object
+    ) -> Optional[bool]:
+        ...
+
+
+class DoesNotSuppress2:
+    def __enter__(self) -> int:
+        ...
+
+    def __exit__(
+        self, exctype: object, excvalue: object, traceback: object
+    ) -> Literal[False]:
+        ...
+
+
+class DoesNotSuppress3:
+    def __enter__(self) -> int:
+        ...
+
+    def __exit__(self, exctype: object, excvalue: object, traceback: object) -> Any:
+        ...
+
+
+class DoesNotSuppress4:
+    def __enter__(self) -> int:
+        ...
+
+    def __exit__(self, exctype: object, excvalue: object, traceback: object) -> None:
+        ...
+
+
+@contextmanager
+def simple() -> Iterator[int]:
+    yield 3
+
+
+def cond() -> bool:
+    ...
+
+
+def test_no_suppress_1a() -> int:
+    with DoesNotSuppress1():
+        return 3
+
+    return "str"  # not an error because it's unreachable
+
+
+def test_no_suppress_1b() -> int:
+    with DoesNotSuppress1():
+        if cond():
+            return 3
+        else:
+            return 3
+
+    return "str"  # not an error because it's unreachable
+
+
+def test_no_suppress_2() -> int:
+    with DoesNotSuppress2():
+        return 3
+
+    return "str"  # not an error because it's unreachable
+
+
+def test_no_suppress_3() -> int:
+    with DoesNotSuppress3():
+        return 3
+
+    return "str"  # not an error because it's unreachable
+
+
+def test_no_suppress_4() -> int:
+    with DoesNotSuppress4():
+        return 3
+
+    return "str"  # not an error because it's unreachable
+
+
+def test_no_suppress_5() -> int:
+    with simple():
+        return 3
+
+    return "str"  # not an error because it's unreachable
+
+
+def test_contextlib_suppress():
+    with suppress(KeyError):
+        raise KeyError
+
+    return 5
+
+
+def require_int(val: int):
+    pass
+
+
+require_int(test_contextlib_suppress())

--- a/server/src/tests/samples/with4.py
+++ b/server/src/tests/samples/with4.py
@@ -1,0 +1,69 @@
+from typing import Optional
+
+from typing_extensions import Literal
+
+
+class DoesNotSuppress:
+    def __enter__(self) -> int:
+        ...
+
+    def __exit__(
+        self, exctype: object, excvalue: object, traceback: object
+    ) -> Optional[bool]:
+        ...
+
+
+class Suppresses1:
+    def __enter__(self) -> int:
+        ...
+
+    def __exit__(self, exctype: object, excvalue: object, traceback: object) -> bool:
+        ...
+
+
+class Suppresses2:
+    def __enter__(self) -> int:
+        ...
+
+    def __exit__(
+        self, exctype: object, excvalue: object, traceback: object
+    ) -> Literal[True]:
+        ...
+
+
+def cond() -> bool:
+    ...
+
+
+def noop() -> None:
+    ...
+
+
+def test_suppress_1a() -> int:  # error missing return value
+    with Suppresses1():
+        return 3
+
+    noop()
+
+
+def test_suppress_1b() -> int:  # error missing return value
+    with Suppresses1():
+        if cond():
+            return 3
+        else:
+            return 3
+    noop()
+
+
+def test_suppress_2() -> int:  # error missing return value
+    with Suppresses2():
+        return 3
+
+    noop()
+
+
+def test_mix() -> int:  # error missing return value
+    with DoesNotSuppress(), Suppresses1(), DoesNotSuppress():
+        return 3
+
+    noop()

--- a/server/src/tests/samples/with5.py
+++ b/server/src/tests/samples/with5.py
@@ -1,0 +1,98 @@
+from contextlib import asynccontextmanager
+from typing import Any, AsyncIterator, Optional
+
+from typing_extensions import Literal
+
+
+class DoesNotSuppress1:
+    async def __aenter__(self) -> int:
+        ...
+
+    async def __aexit__(
+        self, exctype: object, excvalue: object, traceback: object
+    ) -> Optional[bool]:
+        ...
+
+
+class DoesNotSuppress2:
+    async def __aenter__(self) -> int:
+        ...
+
+    async def __aexit__(
+        self, exctype: object, excvalue: object, traceback: object
+    ) -> Literal[False]:
+        ...
+
+
+class DoesNotSuppress3:
+    async def __aenter__(self) -> int:
+        ...
+
+    async def __aexit__(
+        self, exctype: object, excvalue: object, traceback: object
+    ) -> Any:
+        ...
+
+
+class DoesNotSuppress4:
+    async def __aenter__(self) -> int:
+        ...
+
+    async def __aexit__(
+        self, exctype: object, excvalue: object, traceback: object
+    ) -> None:
+        ...
+
+
+@asynccontextmanager
+async def simple() -> AsyncIterator[int]:
+    yield 3
+
+
+def cond() -> bool:
+    ...
+
+
+async def test_no_suppress_1a() -> int:
+    async with DoesNotSuppress1():
+        return 3
+
+    return "str"  # not an error because it's unreachable
+
+
+async def test_no_suppress_1b() -> int:
+    async with DoesNotSuppress1():
+        if cond():
+            return 3
+        else:
+            return 3
+
+    return "str"  # not an error because it's unreachable
+
+
+async def test_no_suppress_2() -> int:
+    async with DoesNotSuppress2():
+        return 3
+
+    return "str"  # not an error because it's unreachable
+
+
+async def test_no_suppress_3() -> int:
+    async with DoesNotSuppress3():
+        return 3
+
+    return "str"  # not an error because it's unreachable
+
+
+async def test_no_suppress_4() -> int:
+    async with DoesNotSuppress4():
+        return 3
+
+    return "str"  # not an error because it's unreachable
+
+
+async def test_no_suppress_5() -> int:
+    async with simple():
+        return 3
+
+    return "str"  # not an error because it's unreachable

--- a/server/src/tests/samples/with6.py
+++ b/server/src/tests/samples/with6.py
@@ -1,0 +1,74 @@
+from typing import Optional
+
+from typing_extensions import Literal
+
+
+class DoesNotSuppress:
+    async def __aenter__(self) -> int:
+        ...
+
+    async def __aexit__(
+        self, exctype: object, excvalue: object, traceback: object
+    ) -> Optional[bool]:
+        ...
+
+
+class Suppresses1:
+    async def __aenter__(self) -> int:
+        ...
+
+    async def __aexit__(
+        self, exctype: object, excvalue: object, traceback: object
+    ) -> bool:
+        ...
+
+
+class Suppresses2:
+    async def __aenter__(self) -> int:
+        ...
+
+    async def __aexit__(
+        self, exctype: object, excvalue: object, traceback: object
+    ) -> Literal[True]:
+        ...
+
+
+def cond() -> bool:
+    ...
+
+
+def noop() -> None:
+    ...
+
+
+async def test_suppress_1() -> int:  # error missing return value
+    async with Suppresses1():
+        return 3
+    noop()
+
+
+async def test_suppress_exception() -> int:  # error missing return value
+    async with Suppresses1():
+        raise KeyError
+    noop()
+
+
+async def test_suppress_2() -> int:  # error missing return value
+    async with Suppresses1():
+        if cond():
+            return 3
+        else:
+            return 3
+    noop()
+
+
+async def test_suppress_3() -> int:  # error missing return value
+    async with Suppresses2():
+        return 3
+    noop()
+
+
+async def test_mix() -> int:  # error missing return value
+    async with DoesNotSuppress(), Suppresses1(), DoesNotSuppress():
+        return 3
+    noop()


### PR DESCRIPTION
This fixes #764 

The [typeshed](https://github.com/python/typeshed/blob/master/CONTRIBUTING.md#stub-file-coding-style) has this to say:
> When adding type annotations for context manager classes, annotate
the return type of `__exit__` as bool only if the context manager
sometimes suppresses exceptions -- if it sometimes returns `True`
at runtime. If the context manager never suppresses exceptions,
have the return type be either `None` or `Optional[bool]`. If you
are not sure whether exceptions are suppressed or not or if the
context manager is meant to be subclassed, pick `Optional[bool]`.
See https://github.com/python/mypy/issues/7214 for more details.

This PR makes `pyright` follow the statement above, by adding additional code flow analysis to track `with` blocks and check the return type of the context managers.

The tests are based on https://github.com/python/mypy/pull/7317 but have been modified to more closely resemble the tests in this repo.