### PR TITLE
Add reference to PEP-561 for background information

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Pyright supports [configuration files](/docs/configuration.md) that provide gran
 * [PEP 484](https://www.python.org/dev/peps/pep-0484/) type hints including generics
 * [PEP 526](https://www.python.org/dev/peps/pep-0526/) syntax for variable annotations
 * [PEP 544](https://www.python.org/dev/peps/pep-0544/) structural subtyping
+* [PEP 561](https://www.python.org/dev/peps/pep-0561/) distributing and packaging type information
 * [PEP 589](https://www.python.org/dev/peps/pep-0589/) typed dictionaries
 * [PEP 591](https://www.python.org/dev/peps/pep-0591/) final qualifier
 * [PEP 593](https://www.python.org/dev/peps/pep-0593/) flexible variable annotations


### PR DESCRIPTION
PEP 561 - distributing and packaging type information for background provides useful background reading, including sample code for type annotations.

Addition is in order by PEP number, checked validity of Markdown by looking at "Preview changes" in GitHub.