### PR TITLE
Add new entrypoint for pyright-langserver

### DIFF
--- a/langserver.index.js
+++ b/langserver.index.js
@@ -3,4 +3,4 @@
 // Stash the base directory into a global variable.
 global.__rootDirectory = __dirname + '/dist/';
 
-require('./dist/pyright');
+require('./dist/pyright-langserver');

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     },
     "main": "index.js",
     "bin": {
-        "pyright": "index.js"
+        "pyright": "index.js",
+        "pyright-langserver": "langserver.index.js"
     }
 }

--- a/server/package.json
+++ b/server/package.json
@@ -10,7 +10,7 @@
         "start:serverProd": "npm i && npm run build:serverProd",
         "build": "npm run build:serverProd && npm run build:serverDebug && npm run build:cli",
         "build:serverDebug": "tsc && npm run installServer",
-        "build:serverProd": "npm run installServer && webpack --config webpack.config-server.js",
+        "build:serverProd": "npm run installServer && webpack --config webpack.config-extension.js",
         "installServer": "node ./customInstallServerIntoExtension.js ../client ./package.json ./tsconfig.json ./package-lock.json",
         "build:cli": "node ./copyTypeshedFallback.js && npm run eslint && webpack --config webpack.config-cli.js",
         "eslint": "eslint src/**/*.ts",

--- a/server/webpack.config-cli.js
+++ b/server/webpack.config-cli.js
@@ -1,5 +1,5 @@
 /**
- * webpack.config-pyright.js
+ * webpack.config-cli.js
  * Copyright: Microsoft 2018
  *
  * Configuration for webpack to bundle the javascript into a single file
@@ -11,11 +11,14 @@
 const path = require('path');
 
 module.exports = {
-    entry: './src/pyright.ts',
+    entry: {
+        'pyright': './src/pyright.ts',
+        'pyright-langserver': './src/server.ts'
+    },
     mode: 'development',
     target: 'node',
     output: {
-        filename: 'pyright.js',
+        filename: '[name].js',
         path: path.resolve(__dirname, '../dist'),
     },
     resolve: {

--- a/server/webpack.config-extension.js
+++ b/server/webpack.config-extension.js
@@ -1,5 +1,5 @@
 /**
- * webpack.config-server.js
+ * webpack.config-extension.js
  * Copyright: Microsoft 2018
  *
  * Configuration for webpack to bundle the javascript into a single file


### PR DESCRIPTION
- As discussed in #99. This PR adds a new executable `pyright-langserver` that is installed when `npm install -g pyright` is done. This would make it easy to be utilized by other editors.