### PR TITLE
server.ts: Use __rootDirectory from entrypoint if available

### DIFF
--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -36,9 +36,13 @@ class PyrightServer extends LanguageServerBase {
     constructor() {
         // eslint-disable-next-line @typescript-eslint/no-var-requires
         const version = require('../package.json').version || '';
+
+        // When executed from CLI command (pyright-langserver), __rootDirectory is already defined
+        // When executed from VSCode extension, rootDirectory should parent directory of (__dirname = ./client/server)
+        const rootDirectory = (global as any).__rootDirectory || getDirectoryPath(__dirname);
         super({
             productName: 'Pyright',
-            rootDirectory: getDirectoryPath(__dirname),
+            rootDirectory,
             version,
             maxAnalysisTimeInForeground,
             progressReporterFactory: reporterFactory,


### PR DESCRIPTION
The previous PR (#810 ) for adding an entrypoint for `pyright-langserver` had a problem, the `__rootDirectory` was not calculated incorrectly.

