### PR TITLE
Use `sys.version_info` to query interpreter version

### DIFF
--- a/server/src/common/pythonVersion.ts
+++ b/server/src/common/pythonVersion.ts
@@ -43,15 +43,19 @@ export function versionFromString(verString: string): PythonVersion | undefined 
     const majorVersion = parseInt(split[0], 10);
     const minorVersion = parseInt(split[1], 10);
 
-    if (isNaN(majorVersion) || isNaN(minorVersion)) {
+    return versionFromMajorMinor(majorVersion, minorVersion);
+}
+
+export function versionFromMajorMinor(major: number, minor: number): PythonVersion | undefined {
+    if (isNaN(major) || isNaN(minor)) {
         return undefined;
     }
 
-    if (majorVersion > 255 || minorVersion > 255) {
+    if (major > 255 || minor > 255) {
         return undefined;
     }
 
-    const value = majorVersion * 256 + minorVersion;
+    const value = major * 256 + minor;
     if (PythonVersion[value] === undefined) {
         return undefined;
     }


### PR DESCRIPTION
Syncing from Pylance.

Fixes the case where `python` points to Python 2, as Python 2's `--version` flag outputs via stderr. Parsing `--version` is not recommended by the Python docs in favor of `sys.version_info`. Do that instead as we already do for `sys.path`.