### PR TITLE
Add python.analysis.autoImportCompletions to control auto-import completions

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -67,6 +67,12 @@
             "type": "object",
             "title": "Pyright",
             "properties": {
+                "python.analysis.autoImportCompletions": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Offer auto-import completions.",
+                    "scope": "resource"
+                },
                 "python.analysis.autoSearchPaths": {
                     "type": "boolean",
                     "default": true,

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -10,6 +10,8 @@ The Pyright VS Code extension honors the following settings.
 
 **pyright.useLibraryCodeForTypes** [boolean]: This setting is deprecated in favor of python.analysis.useLibraryCodeForTypes. It will be removed at a future time.
 
+**python.analysis.autoImportCompletions** [boolean]: Determines whether pyright offers auto-import completions.
+
 **python.analysis.autoSearchPaths** [boolean]: Determines whether pyright automatically adds common search paths like "src" if there are no execution environments defined in the config file.
 
 **python.analysis.diagnosticMode** ["openFilesOnly", "workspace"]: Determines whether pyright analyzes (and reports errors for) all files in the workspace, as indicated by the config file. If this option is set to "openFilesOnly", pyright analyzes only open files.

--- a/server/src/analyzer/service.ts
+++ b/server/src/analyzer/service.ts
@@ -504,6 +504,7 @@ export class AnalyzerService {
         configOptions.verboseOutput = !!commandLineOptions.verboseOutput;
         configOptions.checkOnlyOpenFiles = !!commandLineOptions.checkOnlyOpenFiles;
         configOptions.useLibraryCodeForTypes = !!commandLineOptions.useLibraryCodeForTypes;
+        configOptions.autoImportCompletions = !!commandLineOptions.autoImportCompletions;
 
         // If there was no stub path specified, use a default path.
         if (commandLineOptions.stubPath) {

--- a/server/src/backgroundAnalysisBase.ts
+++ b/server/src/backgroundAnalysisBase.ts
@@ -434,6 +434,7 @@ function createConfigOptionsFrom(jsonObject: any): ConfigOptions {
     configOptions.defaultPythonPlatform = jsonObject.defaultPythonPlatform;
     configOptions.diagnosticRuleSet = jsonObject.diagnosticRuleSet;
     configOptions.executionEnvironments = jsonObject.executionEnvironments;
+    configOptions.autoImportCompletions = jsonObject.autoImportCompletions;
     configOptions.include = jsonObject.include.map((f: any) => getFileSpec(f));
     configOptions.exclude = jsonObject.exclude.map((f: any) => getFileSpec(f));
     configOptions.ignore = jsonObject.ignore.map((f: any) => getFileSpec(f));

--- a/server/src/common/commandLineOptions.ts
+++ b/server/src/common/commandLineOptions.ts
@@ -100,4 +100,7 @@ export class CommandLineOptions {
 
     // Indicates diagnostic severity overrides
     diagnosticSeverityOverrides?: DiagnosticSeverityOverridesMap;
+
+    // Offer auto-import completions.
+    autoImportCompletions?: boolean;
 }

--- a/server/src/common/configOptions.ts
+++ b/server/src/common/configOptions.ts
@@ -488,6 +488,9 @@ export class ConfigOptions {
     // type information?
     useLibraryCodeForTypes: boolean;
 
+    // Offer auto-import completions.
+    autoImportCompletions = true;
+
     //---------------------------------------------------------------
     // Diagnostics Rule Set
 
@@ -1108,6 +1111,15 @@ export class ConfigOptions {
                         this.executionEnvironments.push(execEnv);
                     }
                 });
+            }
+        }
+
+        // Read the "autoImportCompletions" setting.
+        if (configObj.autoImportCompletions !== undefined) {
+            if (typeof configObj.autoImportCompletions !== 'boolean') {
+                console.info(`Config "autoImportCompletions" field must be true or false.`);
+            } else {
+                this.autoImportCompletions = configObj.autoImportCompletions;
             }
         }
     }

--- a/server/src/languageServerBase.ts
+++ b/server/src/languageServerBase.ts
@@ -95,6 +95,7 @@ export interface ServerSettings {
     watchForLibraryChanges?: boolean;
     diagnosticSeverityOverrides?: DiagnosticSeverityOverridesMap;
     logLevel?: LogLevel;
+    autoImportCompletions?: boolean;
 }
 
 export interface WorkspaceServiceInstance {

--- a/server/src/languageService/analyzerServiceExecutor.ts
+++ b/server/src/languageService/analyzerServiceExecutor.ts
@@ -44,6 +44,7 @@ function getEffectiveCommandLineOptions(
     commandLineOptions.checkOnlyOpenFiles = serverSettings.openFilesOnly;
     commandLineOptions.useLibraryCodeForTypes = serverSettings.useLibraryCodeForTypes;
     commandLineOptions.typeCheckingMode = serverSettings.typeCheckingMode;
+    commandLineOptions.autoImportCompletions = serverSettings.autoImportCompletions;
 
     if (!trackFiles) {
         commandLineOptions.watchForSourceChanges = false;

--- a/server/src/languageService/completionProvider.ts
+++ b/server/src/languageService/completionProvider.ts
@@ -592,7 +592,7 @@ export class CompletionProvider {
 
         // Add auto-import suggestions from other modules.
         // Ignore this check for privates, since they are not imported.
-        if (!priorWord.startsWith('_') && !this._itemToResolve) {
+        if (this._configOptions.autoImportCompletions && !priorWord.startsWith('_') && !this._itemToResolve) {
             this._getAutoImportCompletions(priorWord, completionList);
         }
 

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -63,6 +63,7 @@ class PyrightServer extends LanguageServerBase {
             typeCheckingMode: 'basic',
             diagnosticSeverityOverrides: {},
             logLevel: LogLevel.Info,
+            autoImportCompletions: true,
         };
 
         try {
@@ -115,6 +116,10 @@ class PyrightServer extends LanguageServerBase {
 
                 if (pythonAnalysisSection.typeCheckingMode !== undefined) {
                     serverSettings.typeCheckingMode = pythonAnalysisSection.typeCheckingMode;
+                }
+
+                if (pythonAnalysisSection.autoImportCompletions !== undefined) {
+                    serverSettings.autoImportCompletions = pythonAnalysisSection.autoImportCompletions;
                 }
             } else {
                 serverSettings.autoSearchPaths = true;

--- a/server/src/tests/fourslash/completions.autoimport.disabled.fourslash.ts
+++ b/server/src/tests/fourslash/completions.autoimport.disabled.fourslash.ts
@@ -1,0 +1,24 @@
+/// <reference path="fourslash.ts" />
+
+// @filename: mspythonconfig.json
+//// {
+////   "autoImportCompletions": false
+//// }
+
+// @filename: test1.py
+//// Test[|/*marker*/|]
+
+// @filename: test2.py
+//// class Test:
+////     pass
+
+// @ts-ignore
+await helper.verifyCompletion('excluded', {
+    marker: {
+        completions: [
+            {
+                label: 'Test',
+            },
+        ],
+    },
+});

--- a/server/src/tests/harness/fourslash/testLanguageService.ts
+++ b/server/src/tests/harness/fourslash/testLanguageService.ts
@@ -62,6 +62,7 @@ export class TestLanguageService implements LanguageServerInterface {
             openFilesOnly: this._workspace.serviceInstance.getConfigOptions().checkOnlyOpenFiles,
             useLibraryCodeForTypes: this._workspace.serviceInstance.getConfigOptions().useLibraryCodeForTypes,
             disableLanguageServices: this._workspace.disableLanguageServices,
+            autoImportCompletions: this._workspace.serviceInstance.getConfigOptions().autoImportCompletions,
         };
 
         return settings;


### PR DESCRIPTION
If `python.analysis.autoImportCompletions` is false, auto-import completions will be disabled. Quick-fixes are not affected (as they only appear on request, and VS Code offers more control over that UI via other settings).