### PR TITLE
Declare severity overrides for VS Code UI, fix up some configuration pulling code

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -11,9 +11,9 @@
             "dev": true
         },
         "@types/vscode": {
-            "version": "1.46.0",
-            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.46.0.tgz",
-            "integrity": "sha512-8m9wPEB2mcRqTWNKs9A9Eqs8DrQZt0qNFO8GkxBOnyW6xR//3s77SoMgb/nY1ctzACsZXwZj3YRTDsn4bAoaUw==",
+            "version": "1.47.0",
+            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.47.0.tgz",
+            "integrity": "sha512-nJA37ykkz9FYA0ZOQUSc3OZnhuzEW2vUhUEo4MiduUo82jGwwcLfyvmgd/Q7b0WrZAAceojGhZybg319L24bTA==",
             "dev": true
         },
         "ansi-styles": {

--- a/client/package.json
+++ b/client/package.json
@@ -13,7 +13,7 @@
         "url": "https://github.com/Microsoft/pyright"
     },
     "engines": {
-        "vscode": "^1.46.0"
+        "vscode": "^1.47.0"
     },
     "keywords": [
         "python"
@@ -103,14 +103,436 @@
                     "default": {},
                     "description": "Allows a user to override the severity levels for individual diagnostics.",
                     "scope": "resource",
-                    "additionalProperties": {
-                        "type": "string",
-                        "enum": [
-                            "none",
-                            "warning",
-                            "information",
-                            "error"
-                        ]
+                    "properties": {
+                        "reportGeneralTypeIssues": {
+                            "type": "string",
+                            "description": "Diagnostics for general type inconsistencies, unsupported operations, argument/parameter mismatches, etc. Covers all of the basic type-checking rules not covered by other rules. Does not include syntax errors.",
+                            "default": "error",
+                            "enum": [
+                                "none",
+                                "information",
+                                "warning",
+                                "error"
+                            ]
+                        },
+                        "reportMissingImports": {
+                            "type": "string",
+                            "description": "Diagnostics for imports that have no corresponding imported python file or type stub file.",
+                            "default": "warning",
+                            "enum": [
+                                "none",
+                                "information",
+                                "warning",
+                                "error"
+                            ]
+                        },
+                        "reportMissingModuleSource": {
+                            "type": "string",
+                            "description": "Diagnostics for imports that have no corresponding source file. This happens when a type stub is found, but the module source file was not found, indicating that the code may fail at runtime when using this execution environment. Type checking will be done using the type stub.",
+                            "default": "warning",
+                            "enum": [
+                                "none",
+                                "information",
+                                "warning",
+                                "error"
+                            ]
+                        },
+                        "reportMissingTypeStubs": {
+                            "type": "string",
+                            "description": "Diagnostics for imports that have no corresponding type stub file (either a typeshed file or a custom type stub). The type checker requires type stubs to do its best job at analysis.",
+                            "default": "warning",
+                            "enum": [
+                                "none",
+                                "information",
+                                "warning",
+                                "error"
+                            ]
+                        },
+                        "reportImportCycles": {
+                            "type": "string",
+                            "description": "Diagnostics for cyclical import chains. These are not errors in Python, but they do slow down type analysis and often hint at architectural layering issues. Generally, they should be avoided.",
+                            "default": "warning",
+                            "enum": [
+                                "none",
+                                "information",
+                                "warning",
+                                "error"
+                            ]
+                        },
+                        "reportUnusedImport": {
+                            "type": "string",
+                            "description": "Diagnostics for an imported symbol that is not referenced within that file.",
+                            "default": "information",
+                            "enum": [
+                                "none",
+                                "information",
+                                "warning",
+                                "error"
+                            ]
+                        },
+                        "reportUnusedClass": {
+                            "type": "string",
+                            "description": "Diagnostics for a class with a private name (starting with an underscore) that is not accessed.",
+                            "default": "information",
+                            "enum": [
+                                "none",
+                                "information",
+                                "warning",
+                                "error"
+                            ]
+                        },
+                        "reportUnusedFunction": {
+                            "type": "string",
+                            "description": "Diagnostics for a function or method with a private name (starting with an underscore) that is not accessed.",
+                            "default": "information",
+                            "enum": [
+                                "none",
+                                "information",
+                                "warning",
+                                "error"
+                            ]
+                        },
+                        "reportUnusedVariable": {
+                            "type": "string",
+                            "description": "Diagnostics for a variable that is not accessed.",
+                            "default": "information",
+                            "enum": [
+                                "none",
+                                "information",
+                                "warning",
+                                "error"
+                            ]
+                        },
+                        "reportDuplicateImport": {
+                            "type": "string",
+                            "description": "Diagnostics for an imported symbol or module that is imported more than once.",
+                            "default": "warning",
+                            "enum": [
+                                "none",
+                                "information",
+                                "warning",
+                                "error"
+                            ]
+                        },
+                        "reportOptionalSubscript": {
+                            "type": "string",
+                            "description": "Diagnostics for an attempt to subscript (index) a variable with an Optional type.",
+                            "default": "warning",
+                            "enum": [
+                                "none",
+                                "information",
+                                "warning",
+                                "error"
+                            ]
+                        },
+                        "reportOptionalMemberAccess": {
+                            "type": "string",
+                            "description": "Diagnostics for an attempt to access a member of a variable with an Optional type.",
+                            "default": "warning",
+                            "enum": [
+                                "none",
+                                "information",
+                                "warning",
+                                "error"
+                            ]
+                        },
+                        "reportOptionalCall": {
+                            "type": "string",
+                            "description": "Diagnostics for an attempt to call a variable with an Optional type.",
+                            "default": "warning",
+                            "enum": [
+                                "none",
+                                "information",
+                                "warning",
+                                "error"
+                            ]
+                        },
+                        "reportOptionalIterable": {
+                            "type": "string",
+                            "description": "Diagnostics for an attempt to use an Optional type as an iterable value (e.g. within a for statement).",
+                            "default": "warning",
+                            "enum": [
+                                "none",
+                                "information",
+                                "warning",
+                                "error"
+                            ]
+                        },
+                        "reportOptionalContextManager": {
+                            "type": "string",
+                            "description": "Diagnostics for an attempt to use an Optional type as a context manager (as a parameter to a with statement).",
+                            "default": "warning",
+                            "enum": [
+                                "none",
+                                "information",
+                                "warning",
+                                "error"
+                            ]
+                        },
+                        "reportOptionalOperand": {
+                            "type": "string",
+                            "description": "Diagnostics for an attempt to use an Optional type as an operand to a binary or unary operator (like '+', '==', 'or', 'not').",
+                            "default": "warning",
+                            "enum": [
+                                "none",
+                                "information",
+                                "warning",
+                                "error"
+                            ]
+                        },
+                        "reportUntypedFunctionDecorator": {
+                            "type": "string",
+                            "description": "Diagnostics for function decorators that have no type annotations. These obscure the function type, defeating many type analysis features.",
+                            "default": "warning",
+                            "enum": [
+                                "none",
+                                "information",
+                                "warning",
+                                "error"
+                            ]
+                        },
+                        "reportUntypedClassDecorator": {
+                            "type": "string",
+                            "description": "Diagnostics for class decorators that have no type annotations. These obscure the class type, defeating many type analysis features.",
+                            "default": "warning",
+                            "enum": [
+                                "none",
+                                "information",
+                                "warning",
+                                "error"
+                            ]
+                        },
+                        "reportUntypedBaseClass": {
+                            "type": "string",
+                            "description": "Diagnostics for base classes whose type cannot be determined statically. These obscure the class type, defeating many type analysis features.",
+                            "default": "warning",
+                            "enum": [
+                                "none",
+                                "information",
+                                "warning",
+                                "error"
+                            ]
+                        },
+                        "reportUntypedNamedTuple": {
+                            "type": "string",
+                            "description": "Diagnostics when “namedtuple” is used rather than “NamedTuple”. The former contains no type information, whereas the latter does.",
+                            "default": "warning",
+                            "enum": [
+                                "none",
+                                "information",
+                                "warning",
+                                "error"
+                            ]
+                        },
+                        "reportPrivateUsage": {
+                            "type": "string",
+                            "description": "Diagnostics for incorrect usage of private or protected variables or functions. Protected class members begin with a single underscore _ and can be accessed only by subclasses. Private class members begin with a double underscore but do not end in a double underscore and can be accessed only within the declaring class. Variables and functions declared outside of a class are considered private if their names start with either a single or double underscore, and they cannot be accessed outside of the declaring module.",
+                            "default": "warning",
+                            "enum": [
+                                "none",
+                                "information",
+                                "warning",
+                                "error"
+                            ]
+                        },
+                        "reportConstantRedefinition": {
+                            "type": "string",
+                            "description": "Diagnostics for attempts to redefine variables whose names are all-caps with underscores and numerals.",
+                            "default": "warning",
+                            "enum": [
+                                "none",
+                                "information",
+                                "warning",
+                                "error"
+                            ]
+                        },
+                        "reportIncompatibleMethodOverride": {
+                            "type": "string",
+                            "description": "Diagnostics for methods that override a method of the same name in a base class in an incompatible manner (wrong number of parameters, incompatible parameter types, or incompatible return type).",
+                            "default": "warning",
+                            "enum": [
+                                "none",
+                                "information",
+                                "warning",
+                                "error"
+                            ]
+                        },
+                        "reportIncompatibleVariableOverride": {
+                            "type": "string",
+                            "description": "Diagnostics for overrides in subclasses that redefine a variable in an incompatible way.",
+                            "default": "warning",
+                            "enum": [
+                                "none",
+                                "information",
+                                "warning",
+                                "error"
+                            ]
+                        },
+                        "reportInvalidStringEscapeSequence": {
+                            "type": "string",
+                            "description": "Diagnostics for invalid escape sequences used within string literals. The Python specification indicates that such sequences will generate a syntax error in future versions.",
+                            "default": "warning",
+                            "enum": [
+                                "none",
+                                "information",
+                                "warning",
+                                "error"
+                            ]
+                        },
+                        "reportUnknownParameterType": {
+                            "type": "string",
+                            "description": "Diagnostics for input or return parameters for functions or methods that have an unknown type.",
+                            "default": "warning",
+                            "enum": [
+                                "none",
+                                "information",
+                                "warning",
+                                "error"
+                            ]
+                        },
+                        "reportUnknownArgumentType": {
+                            "type": "string",
+                            "description": "Diagnostics for call arguments for functions or methods that have an unknown type.",
+                            "default": "warning",
+                            "enum": [
+                                "none",
+                                "information",
+                                "warning",
+                                "error"
+                            ]
+                        },
+                        "reportUnknownLambdaType": {
+                            "type": "string",
+                            "description": "Diagnostics for input or return parameters for lambdas that have an unknown type.",
+                            "default": "warning",
+                            "enum": [
+                                "none",
+                                "information",
+                                "warning",
+                                "error"
+                            ]
+                        },
+                        "reportUnknownVariableType": {
+                            "type": "string",
+                            "description": "Diagnostics for variables that have an unknown type..",
+                            "default": "warning",
+                            "enum": [
+                                "none",
+                                "information",
+                                "warning",
+                                "error"
+                            ]
+                        },
+                        "reportUnknownMemberType": {
+                            "type": "string",
+                            "description": "Diagnostics for class or instance variables that have an unknown type.",
+                            "default": "warning",
+                            "enum": [
+                                "none",
+                                "information",
+                                "warning",
+                                "error"
+                            ]
+                        },
+                        "reportCallInDefaultInitializer": {
+                            "type": "string",
+                            "description": "Diagnostics for function calls within a default value initialization expression. Such calls can mask expensive operations that are performed at module initialization time.",
+                            "default": "information",
+                            "enum": [
+                                "none",
+                                "information",
+                                "warning",
+                                "error"
+                            ]
+                        },
+                        "reportUnnecessaryIsInstance": {
+                            "type": "string",
+                            "description": "Diagnostics for 'isinstance' or 'issubclass' calls where the result is statically determined to be always true or always false. Such calls are often indicative of a programming error.",
+                            "default": "information",
+                            "enum": [
+                                "none",
+                                "information",
+                                "warning",
+                                "error"
+                            ]
+                        },
+                        "reportUnnecessaryCast": {
+                            "type": "string",
+                            "description": "Diagnostics for 'cast' calls that are statically determined to be unnecessary. Such calls are sometimes indicative of a programming error.",
+                            "default": "information",
+                            "enum": [
+                                "none",
+                                "information",
+                                "warning",
+                                "error"
+                            ]
+                        },
+                        "reportAssertAlwaysTrue": {
+                            "type": "string",
+                            "description": "Diagnostics for 'assert' statement that will provably always assert. This can be indicative of a programming error.",
+                            "default": "information",
+                            "enum": [
+                                "none",
+                                "information",
+                                "warning",
+                                "error"
+                            ]
+                        },
+                        "reportSelfClsParameterName": {
+                            "type": "string",
+                            "description": "Diagnostics for a missing or misnamed “self” parameter in instance methods and “cls” parameter in class methods. Instance methods in metaclasses (classes that derive from “type”) are allowed to use “cls” for instance methods.",
+                            "default": "information",
+                            "enum": [
+                                "none",
+                                "information",
+                                "warning",
+                                "error"
+                            ]
+                        },
+                        "reportImplicitStringConcatenation": {
+                            "type": "string",
+                            "description": "Diagnostics for two or more string literals that follow each other, indicating an implicit concatenation. This is considered a bad practice and often masks bugs such as missing commas.",
+                            "default": "warning",
+                            "enum": [
+                                "none",
+                                "information",
+                                "warning",
+                                "error"
+                            ]
+                        },
+                        "reportInvalidStubStatement": {
+                            "type": "string",
+                            "description": "Diagnostics for type stub statements that do not conform to PEP 484",
+                            "default": "warning",
+                            "enum": [
+                                "none",
+                                "information",
+                                "warning",
+                                "error"
+                            ]
+                        },
+                        "reportUndefinedVariable": {
+                            "type": "string",
+                            "description": "Diagnostics for a missing or misnamed “self” parameter in instance methods and “cls” parameter in class methods. Instance methods in metaclasses (classes that derive from “type”) are allowed to use “cls” for instance methods.",
+                            "default": "warning",
+                            "enum": [
+                                "none",
+                                "information",
+                                "warning",
+                                "error"
+                            ]
+                        },
+                        "reportUnboundVariable": {
+                            "type": "string",
+                            "description": "Diagnostics for unbound and possibly unbound variables.",
+                            "default": "information",
+                            "enum": [
+                                "none",
+                                "information",
+                                "warning",
+                                "error"
+                            ]
+                        }
                     }
                 },
                 "python.analysis.logLevel": {
@@ -192,7 +614,7 @@
         "build": "tsc -p ./"
     },
     "devDependencies": {
-        "@types/vscode": "^1.46.0",
+        "@types/vscode": "^1.47.0",
         "typescript": "^3.9.5",
         "vsce": "^1.77.0"
     },

--- a/server/src/common/diagnosticRules.ts
+++ b/server/src/common/diagnosticRules.ts
@@ -8,7 +8,9 @@
  * that can be enabled or disabled in the configuration.
  */
 
-export const enum DiagnosticRule {
+// Not const enum since keys need to be inspected in tests
+// to match declaration of user-visible settings in package.json
+export enum DiagnosticRule {
     strictListInference = 'strictListInference',
     strictDictionaryInference = 'strictDictionaryInference',
     strictParameterNoneValue = 'strictParameterNoneValue',

--- a/server/src/languageServerBase.ts
+++ b/server/src/languageServerBase.ts
@@ -236,9 +236,8 @@ export abstract class LanguageServerBase implements LanguageServerInterface {
 
     abstract async getSettings(workspace: WorkspaceServiceInstance): Promise<ServerSettings>;
 
-    protected getConfiguration(workspace: WorkspaceServiceInstance, section: string) {
+    protected async getConfiguration(scopeUri: string | undefined, section: string) {
         if (this._hasConfigurationCapability) {
-            const scopeUri = workspace.rootUri ? workspace.rootUri : undefined;
             const item: ConfigurationItem = {
                 scopeUri,
                 section,

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -67,13 +67,13 @@ class PyrightServer extends LanguageServerBase {
         };
 
         try {
-            const pythonSection = await this.getConfiguration(workspace, 'python');
+            const pythonSection = await this.getConfiguration(workspace.rootUri, 'python');
             if (pythonSection) {
                 serverSettings.pythonPath = normalizeSlashes(pythonSection.pythonPath);
                 serverSettings.venvPath = normalizeSlashes(pythonSection.venvPath);
             }
 
-            const pythonAnalysisSection = await this.getConfiguration(workspace, 'python.analysis');
+            const pythonAnalysisSection = await this.getConfiguration(workspace.rootUri, 'python.analysis');
             if (pythonAnalysisSection) {
                 const typeshedPaths = pythonAnalysisSection.typeshedPaths;
                 if (typeshedPaths && isArray(typeshedPaths) && typeshedPaths.length > 0) {
@@ -125,7 +125,7 @@ class PyrightServer extends LanguageServerBase {
                 serverSettings.autoSearchPaths = true;
             }
 
-            const pyrightSection = await this.getConfiguration(workspace, 'pyright');
+            const pyrightSection = await this.getConfiguration(workspace.rootUri, 'pyright');
             if (pyrightSection) {
                 if (pyrightSection.openFilesOnly !== undefined) {
                     serverSettings.openFilesOnly = !!pyrightSection.openFilesOnly;

--- a/server/src/tests/diagnosticOverrides.test.ts
+++ b/server/src/tests/diagnosticOverrides.test.ts
@@ -1,0 +1,104 @@
+/*
+ * diagnosticOverrides.test.ts
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT license.
+ *
+ * Tests to verify consistentcy between declarations of diagnostic
+ * overrides in code and in the configuration schema.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+import { DiagnosticRule } from '../common/diagnosticRules';
+
+describe('Diagnostic overrides', () => {
+    test('Compare DiagnosticRule to pyrightconfig.schema.json', () => {
+        const schemasFolder = path.resolve(__dirname, '..', '..', '..', 'client', 'schemas');
+        const schemaJson = path.join(schemasFolder, 'pyrightconfig.schema.json');
+        const jsonString = fs.readFileSync(schemaJson, { encoding: 'utf-8' });
+        const json = JSON.parse(jsonString);
+
+        expect(json.definitions?.diagnostic?.anyOf).toBeDefined();
+        const anyOf = json.definitions?.diagnostic?.anyOf;
+
+        expect(Array.isArray(anyOf));
+        expect(anyOf).toHaveLength(2);
+
+        expect(anyOf[0].type).toEqual('boolean');
+        expect(anyOf[1].type).toEqual('string');
+
+        const enumValues = anyOf[1].enum;
+        expect(Array.isArray(enumValues));
+        expect(enumValues).toHaveLength(4);
+        expect(enumValues[0]).toEqual('none');
+        expect(enumValues[1]).toEqual('information');
+        expect(enumValues[2]).toEqual('warning');
+        expect(enumValues[3]).toEqual('error');
+
+        expect(json.properties).toBeDefined();
+        const overrideNamesInJson = Object.keys(json.properties).filter((n) => n.startsWith('report'));
+
+        for (const propName of overrideNamesInJson) {
+            const p = json.properties[propName];
+
+            expect(p['$id']).toEqual(`#/properties/${propName}`);
+            expect(p['$ref']).toEqual(`#/definitions/diagnostic`);
+            expect(p.title).toBeDefined();
+            expect(p.title.length).toBeGreaterThan(0);
+            expect(p.default).toBeDefined();
+            expect(enumValues).toContain(p.default);
+        }
+
+        const overrideNamesInCode = Object.values(DiagnosticRule).filter((x) => x.startsWith('report'));
+
+        for (const n of overrideNamesInJson) {
+            expect(overrideNamesInCode).toContain(n);
+        }
+        for (const n of overrideNamesInCode) {
+            expect(overrideNamesInJson).toContain(n);
+        }
+    });
+    test('Compare DiagnosticRule to package.json', () => {
+        const extensionRoot = path.resolve(__dirname, '..', '..', '..', 'client');
+        const packageJson = path.join(extensionRoot, 'package.json');
+        const jsonString = fs.readFileSync(packageJson, { encoding: 'utf-8' });
+        const json = JSON.parse(jsonString);
+
+        expect(json.contributes?.configuration?.properties).toBeDefined();
+        const overrides = json.contributes?.configuration?.properties['python.analysis.diagnosticSeverityOverrides'];
+        expect(overrides).toBeDefined();
+        const props = overrides.properties;
+        expect(props).toBeDefined();
+
+        const overrideNamesInJson = Object.keys(props);
+        for (const propName of overrideNamesInJson) {
+            const p = props[propName];
+
+            expect(p.type).toEqual('string');
+            expect(p.description).toBeDefined();
+            expect(p.description.length).toBeGreaterThan(0);
+            expect(p.default).toBeDefined();
+
+            expect(p.enum).toBeDefined();
+            expect(Array.isArray(p.enum));
+            expect(p.enum).toHaveLength(4);
+
+            expect(p.enum[0]).toEqual('none');
+            expect(p.enum[1]).toEqual('information');
+            expect(p.enum[2]).toEqual('warning');
+            expect(p.enum[3]).toEqual('error');
+
+            expect(p.enum).toContain(p.default);
+        }
+
+        const overrideNamesInCode = Object.values(DiagnosticRule).filter((x) => x.startsWith('report'));
+
+        for (const n of overrideNamesInJson) {
+            expect(overrideNamesInCode).toContain(n);
+        }
+        for (const n of overrideNamesInCode) {
+            expect(overrideNamesInJson).toContain(n);
+        }
+    });
+});


### PR DESCRIPTION
- Use the new VS Code object setting schema support to declare in the UI which settings are available, their options, and their descriptions. This raises the minimum VS Code version to 1.47, and ensures this list is always up to date and synced with the enum and pyrightconfigschema.

![image](https://user-images.githubusercontent.com/5341706/89934337-491e8a80-dbc5-11ea-81d8-378d08443728.png)

- Update configuration querying code to support querying top-level settings (the `undefined` scope) in Pylance.