### PR TITLE
Fix progress reporter type, auto-import/symbol changes, worker thread updates, improve auto-import tooltips

### DIFF
--- a/server/src/analyzer/aliasDeclarationUtils.ts
+++ b/server/src/analyzer/aliasDeclarationUtils.ts
@@ -1,0 +1,80 @@
+/*
+ * aliasDeclarationUtils.ts
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT license.
+ *
+ * Helper functions around alias declarations.
+ */
+
+import { ImportLookup, ImportLookupResult } from './analyzerFileInfo';
+import { Declaration, DeclarationType } from './declaration';
+import { Symbol } from './symbol';
+
+// If the specified declaration is an alias declaration that points to a symbol,
+// it resolves the alias and looks up the symbol, then returns the first declaration
+// associated with that symbol. It does this recursively if necessary. If a symbol
+// lookup fails, undefined is returned. If resolveLocalNames is true, the method
+// resolves aliases through local renames ("as" clauses found in import statements).
+export function resolveAliasDeclaration(
+    importLookup: ImportLookup,
+    declaration: Declaration,
+    resolveLocalNames: boolean
+): Declaration | undefined {
+    let curDeclaration: Declaration | undefined = declaration;
+    const alreadyVisited: Declaration[] = [];
+
+    while (true) {
+        if (curDeclaration.type !== DeclarationType.Alias) {
+            return curDeclaration;
+        }
+
+        if (!curDeclaration.symbolName) {
+            return curDeclaration;
+        }
+
+        // If we are not supposed to follow local alias names and this
+        // is a local name, don't continue to follow the alias.
+        if (!resolveLocalNames && curDeclaration.usesLocalName) {
+            return curDeclaration;
+        }
+
+        let lookupResult: ImportLookupResult | undefined;
+        if (curDeclaration.path) {
+            lookupResult = importLookup(curDeclaration.path);
+            if (!lookupResult) {
+                return undefined;
+            }
+        }
+
+        const symbol: Symbol | undefined = lookupResult
+            ? lookupResult.symbolTable.get(curDeclaration.symbolName)
+            : undefined;
+        if (!symbol) {
+            if (curDeclaration.submoduleFallback) {
+                return resolveAliasDeclaration(importLookup, curDeclaration.submoduleFallback, resolveLocalNames);
+            }
+            return undefined;
+        }
+
+        // Prefer declarations with specified types. If we don't have any of those,
+        // fall back on declarations with inferred types.
+        let declarations = symbol.getTypedDeclarations();
+        if (declarations.length === 0) {
+            declarations = symbol.getDeclarations();
+
+            if (declarations.length === 0) {
+                return undefined;
+            }
+        }
+
+        // Prefer the last declaration in the list. This ensures that
+        // we use all of the overloads if it's an overloaded function.
+        curDeclaration = declarations[declarations.length - 1];
+
+        // Make sure we don't follow a circular list indefinitely.
+        if (alreadyVisited.find((decl) => decl === curDeclaration)) {
+            return declaration;
+        }
+        alreadyVisited.push(curDeclaration);
+    }
+}

--- a/server/src/analyzer/analysis.ts
+++ b/server/src/analyzer/analysis.ts
@@ -74,10 +74,7 @@ export function analyzeProgram(
             return false;
         }
 
-        const message: string =
-            (e.stack ? e.stack.toString() : undefined) ||
-            (typeof e.message === 'string' ? e.message : undefined) ||
-            JSON.stringify(e);
+        const message = debug.getErrorString(e);
         console.error('Error performing analysis: ' + message);
 
         callback({

--- a/server/src/analyzer/declarationUtils.ts
+++ b/server/src/analyzer/declarationUtils.ts
@@ -84,3 +84,26 @@ export function isExplicitTypeAliasDeclaration(decl: Declaration) {
 export function isPossibleTypeAliasDeclaration(decl: Declaration) {
     return decl.type === DeclarationType.Variable && !!decl.typeAliasName;
 }
+
+export function getNameFromDeclaration(declaration: Declaration) {
+    switch (declaration.type) {
+        case DeclarationType.Alias:
+            return declaration.symbolName;
+
+        case DeclarationType.Class:
+        case DeclarationType.Function:
+            return declaration.node.name.value;
+
+        case DeclarationType.Parameter:
+            return declaration.node.name?.value;
+
+        case DeclarationType.Variable:
+            return declaration.node.nodeType === ParseNodeType.Name ? declaration.node.value : undefined;
+
+        case DeclarationType.Intrinsic:
+        case DeclarationType.SpecialBuiltInClass:
+            return undefined;
+    }
+
+    throw new Error(`Shouldn't reach here`);
+}

--- a/server/src/analyzer/pythonPathUtils.ts
+++ b/server/src/analyzer/pythonPathUtils.ts
@@ -29,6 +29,9 @@ interface PythonPathResult {
 
 const cachedSearchPaths = new Map<string, PythonPathResult>();
 
+export const stdLibFolderName = 'stdlib';
+export const thirdPartyFolderName = 'third_party';
+
 export function getTypeShedFallbackPath(fs: FileSystem) {
     let moduleDirectory = fs.getModulePath();
     if (!moduleDirectory) {
@@ -53,7 +56,7 @@ export function getTypeShedFallbackPath(fs: FileSystem) {
 }
 
 export function getTypeshedSubdirectory(typeshedPath: string, isStdLib: boolean) {
-    return combinePaths(typeshedPath, isStdLib ? 'stdlib' : 'third_party');
+    return combinePaths(typeshedPath, isStdLib ? stdLibFolderName : thirdPartyFolderName);
 }
 
 export function findPythonSearchPaths(

--- a/server/src/analyzer/symbolUtils.ts
+++ b/server/src/analyzer/symbolUtils.ts
@@ -7,9 +7,10 @@
  * Collection of functions that operate on Symbol objects.
  */
 
+import { ParseNodeType } from '../parser/parseNodes';
 import { Declaration, DeclarationType } from './declaration';
 import { isFinalVariableDeclaration } from './declarationUtils';
-import { Symbol } from './symbol';
+import { Symbol, SymbolTable } from './symbol';
 
 export function getLastTypedDeclaredForSymbol(symbol: Symbol): Declaration | undefined {
     const typedDecls = symbol.getTypedDeclarations();
@@ -38,4 +39,42 @@ export function isTypedDictMemberAccessedThroughIndex(symbol: Symbol): boolean {
 
 export function isFinalVariable(symbol: Symbol): boolean {
     return symbol.getDeclarations().some((decl) => isFinalVariableDeclaration(decl));
+}
+
+export function getNamesInDunderAll(symbolTable: SymbolTable): string[] | undefined {
+    const namesToImport: string[] = [];
+
+    const allSymbol = symbolTable.get('__all__');
+    if (allSymbol) {
+        const decls = allSymbol.getDeclarations();
+
+        // For now, we handle only the case where __all__ is defined
+        // through a simple assignment. Some libraries use more complex
+        // logic like __all__.extend(X) or __all__ += X. We'll punt on
+        // those for now.
+        if (decls.length === 1 && decls[0].type === DeclarationType.Variable) {
+            const firstDecl = decls[0];
+            if (firstDecl.node.parent && firstDecl.node.parent.nodeType === ParseNodeType.Assignment) {
+                const expr = firstDecl.node.parent.rightExpression;
+                if (expr.nodeType === ParseNodeType.List) {
+                    expr.entries.forEach((listEntryNode) => {
+                        if (
+                            listEntryNode.nodeType === ParseNodeType.StringList &&
+                            listEntryNode.strings.length === 1 &&
+                            listEntryNode.strings[0].nodeType === ParseNodeType.String
+                        ) {
+                            const entryName = listEntryNode.strings[0].value;
+                            if (symbolTable.get(entryName)) {
+                                namesToImport.push(entryName);
+                            }
+                        }
+                    });
+
+                    return namesToImport;
+                }
+            }
+        }
+    }
+
+    return undefined;
 }

--- a/server/src/analyzer/typeEvaluator.ts
+++ b/server/src/analyzer/typeEvaluator.ts
@@ -69,7 +69,8 @@ import {
 } from '../parser/parseNodes';
 import { ParseOptions, Parser } from '../parser/parser';
 import { KeywordType, OperatorType, StringTokenFlags, Token, TokenType } from '../parser/tokenizerTypes';
-import { AnalyzerFileInfo, ImportLookup, ImportLookupResult } from './analyzerFileInfo';
+import * as DeclarationUtils from './aliasDeclarationUtils';
+import { AnalyzerFileInfo, ImportLookup } from './analyzerFileInfo';
 import * as AnalyzerNodeInfo from './analyzerNodeInfo';
 import {
     createKeyForReference,
@@ -12290,63 +12291,7 @@ export function createTypeEvaluator(importLookup: ImportLookup, printTypeFlags: 
     // lookup fails, undefined is returned. If resolveLocalNames is true, the method
     // resolves aliases through local renames ("as" clauses found in import statements).
     function resolveAliasDeclaration(declaration: Declaration, resolveLocalNames: boolean): Declaration | undefined {
-        let curDeclaration: Declaration | undefined = declaration;
-        const alreadyVisited: Declaration[] = [];
-
-        while (true) {
-            if (curDeclaration.type !== DeclarationType.Alias) {
-                return curDeclaration;
-            }
-
-            if (!curDeclaration.symbolName) {
-                return curDeclaration;
-            }
-
-            // If we are not supposed to follow local alias names and this
-            // is a local name, don't continue to follow the alias.
-            if (!resolveLocalNames && curDeclaration.usesLocalName) {
-                return curDeclaration;
-            }
-
-            let lookupResult: ImportLookupResult | undefined;
-            if (curDeclaration.path) {
-                lookupResult = importLookup(curDeclaration.path);
-                if (!lookupResult) {
-                    return undefined;
-                }
-            }
-
-            const symbol: Symbol | undefined = lookupResult
-                ? lookupResult.symbolTable.get(curDeclaration.symbolName)
-                : undefined;
-            if (!symbol) {
-                if (curDeclaration.submoduleFallback) {
-                    return resolveAliasDeclaration(curDeclaration.submoduleFallback, resolveLocalNames);
-                }
-                return undefined;
-            }
-
-            // Prefer declarations with specified types. If we don't have any of those,
-            // fall back on declarations with inferred types.
-            let declarations = symbol.getTypedDeclarations();
-            if (declarations.length === 0) {
-                declarations = symbol.getDeclarations();
-
-                if (declarations.length === 0) {
-                    return undefined;
-                }
-            }
-
-            // Prefer the last declaration in the list. This ensures that
-            // we use all of the overloads if it's an overloaded function.
-            curDeclaration = declarations[declarations.length - 1];
-
-            // Make sure we don't follow a circular list indefinitely.
-            if (alreadyVisited.find((decl) => decl === curDeclaration)) {
-                return declaration;
-            }
-            alreadyVisited.push(curDeclaration);
-        }
+        return DeclarationUtils.resolveAliasDeclaration(importLookup, declaration, resolveLocalNames);
     }
 
     // Returns the type of the symbol. If the type is explicitly declared, that type

--- a/server/src/backgroundAnalysis.ts
+++ b/server/src/backgroundAnalysis.ts
@@ -14,7 +14,7 @@ import { ConsoleInterface } from './common/console';
 
 export class BackgroundAnalysis extends BackgroundAnalysisBase {
     constructor(console: ConsoleInterface) {
-        super();
+        super(console);
 
         const initialData: InitializationData = {
             rootDirectory: (global as any).__rootDirectory as string,
@@ -23,7 +23,7 @@ export class BackgroundAnalysis extends BackgroundAnalysisBase {
 
         // this will load this same file in BG thread and start listener
         const worker = new Worker(__filename, { workerData: initialData });
-        this.setup(worker, console);
+        this.setup(worker);
     }
 }
 

--- a/server/src/backgroundThreadBase.ts
+++ b/server/src/backgroundThreadBase.ts
@@ -1,0 +1,135 @@
+/*
+ * backgroundThreadBase.ts
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT license.
+ *
+ * base class for background worker thread.
+ */
+
+import { MessagePort, parentPort } from 'worker_threads';
+
+import { OperationCanceledException, setCancellationFolderName } from './common/cancellationUtils';
+import { ConfigOptions } from './common/configOptions';
+import { LogLevel } from './common/console';
+import * as debug from './common/debug';
+import { createFromRealFileSystem, FileSystem } from './common/fileSystem';
+import { FileSpec } from './common/pathUtils';
+
+export class BackgroundThreadBase {
+    protected fs: FileSystem;
+
+    protected constructor(data: InitializationData) {
+        setCancellationFolderName(data.cancellationFolderName);
+
+        // Stash the base directory into a global variable.
+        (global as any).__rootDirectory = data.rootDirectory;
+
+        this.fs = createFromRealFileSystem(this.getConsole());
+    }
+
+    protected log(level: LogLevel, msg: string) {
+        parentPort?.postMessage({ requestType: 'log', data: { level: level, message: msg } });
+    }
+
+    protected getConsole() {
+        return {
+            log: (msg: string) => {
+                this.log(LogLevel.Log, msg);
+            },
+            info: (msg: string) => {
+                this.log(LogLevel.Info, msg);
+            },
+            warn: (msg: string) => {
+                this.log(LogLevel.Warn, msg);
+            },
+            error: (msg: string) => {
+                this.log(LogLevel.Error, msg);
+            },
+            // We always generate logs in the background. For the foreground,
+            // we'll decide decide based on user setting whether.
+            level: LogLevel.Log,
+        };
+    }
+}
+
+export function createConfigOptionsFrom(jsonObject: any): ConfigOptions {
+    const configOptions = new ConfigOptions(jsonObject.projectRoot);
+    const getFileSpec = (fileSpec: any): FileSpec => {
+        return { wildcardRoot: fileSpec.wildcardRoot, regExp: new RegExp(fileSpec.regExp.source) };
+    };
+
+    configOptions.pythonPath = jsonObject.pythonPath;
+    configOptions.typeshedPath = jsonObject.typeshedPath;
+    configOptions.stubPath = jsonObject.stubPath;
+    configOptions.autoExcludeVenv = jsonObject.autoExcludeVenv;
+    configOptions.verboseOutput = jsonObject.verboseOutput;
+    configOptions.checkOnlyOpenFiles = jsonObject.checkOnlyOpenFiles;
+    configOptions.useLibraryCodeForTypes = jsonObject.useLibraryCodeForTypes;
+    configOptions.internalTestMode = jsonObject.internalTestMode;
+    configOptions.venvPath = jsonObject.venvPath;
+    configOptions.defaultVenv = jsonObject.defaultVenv;
+    configOptions.defaultPythonVersion = jsonObject.defaultPythonVersion;
+    configOptions.defaultPythonPlatform = jsonObject.defaultPythonPlatform;
+    configOptions.diagnosticRuleSet = jsonObject.diagnosticRuleSet;
+    configOptions.executionEnvironments = jsonObject.executionEnvironments;
+    configOptions.autoImportCompletions = jsonObject.autoImportCompletions;
+    configOptions.include = jsonObject.include.map((f: any) => getFileSpec(f));
+    configOptions.exclude = jsonObject.exclude.map((f: any) => getFileSpec(f));
+    configOptions.ignore = jsonObject.ignore.map((f: any) => getFileSpec(f));
+    configOptions.strict = jsonObject.strict.map((f: any) => getFileSpec(f));
+
+    return configOptions;
+}
+
+export function run(code: () => any, port: MessagePort) {
+    try {
+        const result = code();
+        port.postMessage({ kind: 'ok', data: result });
+    } catch (e) {
+        if (OperationCanceledException.is(e)) {
+            port.postMessage({ kind: 'cancelled', data: e.message });
+            return;
+        }
+
+        port.postMessage({ kind: 'failed', data: `Exception: ${e.message} in ${e.stack}` });
+    }
+}
+
+export function getBackgroundWaiter<T>(port: MessagePort): Promise<T> {
+    return new Promise((resolve, reject) => {
+        port.on('message', (m: RequestResponse) => {
+            switch (m.kind) {
+                case 'ok':
+                    resolve(m.data);
+                    break;
+
+                case 'cancelled':
+                    reject(new OperationCanceledException());
+                    break;
+
+                case 'failed':
+                    reject(m.data);
+                    break;
+
+                default:
+                    debug.fail(`unknown kind ${m.kind}`);
+            }
+        });
+    });
+}
+
+export interface InitializationData {
+    rootDirectory: string;
+    cancellationFolderName?: string;
+    runner?: string;
+}
+
+export interface RequestResponse {
+    kind: 'ok' | 'failed' | 'cancelled';
+    data: any;
+}
+
+export interface LogData {
+    level: LogLevel;
+    message: string;
+}

--- a/server/src/common/cancellationUtils.ts
+++ b/server/src/common/cancellationUtils.ts
@@ -261,8 +261,8 @@ export function getCancellationStrategyFromArgv(argv: string[]): CancellationStr
     }
 }
 
-let analysisId = 0;
-export function createAnalysisCancellationTokenSource() {
+let cancellationSourceId = 0;
+export function createBackgroundThreadCancellationTokenSource(): AbstractCancellationTokenSource {
     if (!cancellationFolderName) {
         // File-based cancellation is not used.
         // Return regular cancellation token source.
@@ -270,7 +270,7 @@ export function createAnalysisCancellationTokenSource() {
     }
 
     return new FileBasedCancellationTokenSource(
-        getCancellationFilePath(cancellationFolderName, `analysis-${String(analysisId++)}`),
+        getCancellationFilePath(cancellationFolderName, `source-${String(cancellationSourceId++)}`),
         true
     );
 }

--- a/server/src/common/debug.ts
+++ b/server/src/common/debug.ts
@@ -98,6 +98,14 @@ export function formatEnum(value = 0, enumObject: any, isFlags?: boolean) {
     return value.toString();
 }
 
+export function getErrorString(error: any): string {
+    return (
+        (error.stack ? error.stack.toString() : undefined) ||
+        (typeof error.message === 'string' ? error.message : undefined) ||
+        JSON.stringify(error)
+    );
+}
+
 function getEnumMembers(enumObject: any) {
     const result: [number, string][] = [];
     for (const name of Object.keys(enumObject)) {

--- a/server/src/common/fileSystem.ts
+++ b/server/src/common/fileSystem.ts
@@ -223,6 +223,11 @@ class ChokidarFileWatcherProvider implements FileWatcherProvider {
             interval: 1000, // while not used in normal cases, if any error causes chokidar to fallback to polling, increase its intervals
             binaryInterval: 1000,
             disableGlobbing: true, // fix https://github.com/Microsoft/vscode/issues/4586
+            awaitWriteFinish: {
+                // this will make sure we re-scan files once file changes are written to disk
+                stabilityThreshold: 1000,
+                pollInterval: 1000,
+            },
         };
 
         if (_isMacintosh) {

--- a/server/src/languageServerBase.ts
+++ b/server/src/languageServerBase.ts
@@ -129,6 +129,12 @@ export interface LanguageServerInterface {
     readonly fs: FileSystem;
 }
 
+// This is a subset of the LSP Connection, defined to not expose the LSP library
+// in the public interface.
+export interface ProgressReporterConnection {
+    sendNotification: (method: string, params?: any) => void;
+}
+
 export interface ServerOptions {
     productName: string;
     rootDirectory: string;
@@ -137,7 +143,7 @@ export interface ServerOptions {
     maxAnalysisTimeInForeground?: MaxAnalysisTime;
     supportedCommands?: string[];
     supportedCodeActions?: string[];
-    progressReporterFactory?: (connection: Connection) => ProgressReporter;
+    progressReporterFactory?: (connection: ProgressReporterConnection) => ProgressReporter;
 }
 
 interface InternalFileWatcher extends FileWatcher {

--- a/server/src/languageService/documentSymbolProvider.ts
+++ b/server/src/languageService/documentSymbolProvider.ts
@@ -11,147 +11,116 @@
 import { CancellationToken, DocumentSymbol, Location, SymbolInformation, SymbolKind } from 'vscode-languageserver';
 import { URI } from 'vscode-uri';
 
+import { resolveAliasDeclaration } from '../analyzer/aliasDeclarationUtils';
+import { ImportLookup } from '../analyzer/analyzerFileInfo';
 import * as AnalyzerNodeInfo from '../analyzer/analyzerNodeInfo';
-import { Declaration, DeclarationType } from '../analyzer/declaration';
-import * as ParseTreeUtils from '../analyzer/parseTreeUtils';
-import { ParseTreeWalker } from '../analyzer/parseTreeWalker';
-import { getLastTypedDeclaredForSymbol } from '../analyzer/symbolUtils';
+import { AliasDeclaration, Declaration, DeclarationType } from '../analyzer/declaration';
+import { getNameFromDeclaration } from '../analyzer/declarationUtils';
+import { getLastTypedDeclaredForSymbol, getNamesInDunderAll } from '../analyzer/symbolUtils';
 import { TypeEvaluator } from '../analyzer/typeEvaluator';
 import { isProperty } from '../analyzer/typeUtils';
 import { throwIfCancellationRequested } from '../common/cancellationUtils';
 import { convertOffsetsToRange } from '../common/positionUtils';
 import * as StringUtils from '../common/stringUtils';
-import { ClassNode, FunctionNode, ListComprehensionNode, ModuleNode, ParseNode } from '../parser/parseNodes';
+import { Range } from '../common/textRange';
 import { ParseResults } from '../parser/parser';
+
+export interface IndexAliasData {
+    readonly originalName: string;
+    readonly modulePath: string;
+}
+
+export interface IndexSymbolData {
+    readonly name: string;
+    readonly alias: IndexAliasData | undefined;
+    readonly externallyVisible: boolean;
+    readonly kind: SymbolKind;
+    readonly range: Range;
+    readonly selectionRange: Range;
+    readonly children: IndexSymbolData[];
+}
+
+export interface IndexResults {
+    readonly privateOrProtected: boolean;
+    readonly symbols: IndexSymbolData[];
+}
+
+export function includeAliasDeclarationInIndex(declaration: AliasDeclaration): boolean {
+    return declaration.usesLocalName && !!declaration.symbolName && declaration.path.length > 0;
+}
+
+export function getIndexAliasData(
+    importLookup: ImportLookup | undefined,
+    declaration: AliasDeclaration
+): IndexAliasData | undefined {
+    if (!declaration.symbolName) {
+        return undefined;
+    }
+
+    const aliasData = { originalName: declaration.symbolName!, modulePath: declaration.path };
+    if (!importLookup) {
+        return aliasData;
+    }
+
+    const resolved = resolveAliasDeclaration(importLookup, declaration, true);
+    const nameValue = resolved ? getNameFromDeclaration(resolved) : undefined;
+    if (!nameValue || resolved!.path.length <= 0) {
+        return aliasData;
+    }
+
+    return { originalName: nameValue, modulePath: resolved!.path };
+}
 
 // We'll use a somewhat-arbitrary cutoff value here to determine
 // whether it's sufficiently similar.
 const similarityLimit = 0.5;
 
-class FindSymbolTreeWalker extends ParseTreeWalker {
-    private _filePath: string;
-    private _parseResults: ParseResults;
-    private _symbolResults: SymbolInformation[];
-    private _query: string;
-    private _evaluator: TypeEvaluator;
-    private _cancellationToken: CancellationToken;
-
-    constructor(
+export class DocumentSymbolProvider {
+    static addSymbolsForDocument(
+        indexResults: IndexResults | undefined,
+        parseResults: ParseResults | undefined,
         filePath: string,
-        parseResults: ParseResults,
-        symbolInfoResults: SymbolInformation[],
         query: string,
-        evaluator: TypeEvaluator,
+        symbolList: SymbolInformation[],
         token: CancellationToken
     ) {
-        super();
-        this._filePath = filePath;
-        this._parseResults = parseResults;
-        this._symbolResults = symbolInfoResults;
-        this._query = query;
-        this._evaluator = evaluator;
-        this._cancellationToken = token;
-    }
-
-    findSymbols() {
-        this.walk(this._parseResults.parseTree);
-    }
-
-    visitModule(node: ModuleNode) {
-        this._addSymbolInformationForScope(node, '');
-        return true;
-    }
-
-    visitClass(node: ClassNode) {
-        const className = node.name.value;
-        this._addSymbolInformationForScope(node, className);
-        return true;
-    }
-
-    visitFunction(node: FunctionNode) {
-        const functionName = node.name.value;
-        let containerName = functionName;
-        const containingClass = ParseTreeUtils.getEnclosingClass(node, true);
-        if (containingClass) {
-            containerName = containingClass.name.value + '.' + functionName;
-        }
-        this._addSymbolInformationForScope(node, containerName);
-        return true;
-    }
-
-    visitListComprehension(node: ListComprehensionNode) {
-        this._addSymbolInformationForScope(node);
-        return true;
-    }
-
-    private _addSymbolInformationForScope(node: ParseNode, containerName?: string) {
-        throwIfCancellationRequested(this._cancellationToken);
-
-        const scope = AnalyzerNodeInfo.getScope(node);
-        if (!scope) {
+        if (!indexResults && !parseResults) {
             return;
         }
 
-        const symbolTable = scope.symbolTable;
-        symbolTable.forEach((symbol, name) => {
-            if (!symbol.isIgnoredForProtocolMatch()) {
-                // Prefer declarations with a defined type.
-                let decl = getLastTypedDeclaredForSymbol(symbol);
-
-                // Fall back to declarations without a type.
-                if (!decl && symbol.hasDeclarations()) {
-                    decl = symbol.getDeclarations()[0];
-                }
-
-                if (decl) {
-                    this._addSymbolInformationFromDeclaration(name, decl, containerName);
-                }
-            }
-        });
+        const indexSymbolData =
+            indexResults?.symbols ?? DocumentSymbolProvider.indexSymbols(parseResults!, false, token);
+        appendWorkspaceSymbolsRecursive(indexSymbolData, filePath, query, '', symbolList, token);
     }
 
-    private _addSymbolInformationFromDeclaration(name: string, declaration: Declaration, containerName?: string) {
-        if (declaration.path !== this._filePath) {
+    static addHierarchicalSymbolsForDocument(
+        indexResults: IndexResults | undefined,
+        parseResults: ParseResults | undefined,
+        symbolList: DocumentSymbol[],
+        token: CancellationToken
+    ) {
+        if (!indexResults && !parseResults) {
             return;
         }
 
-        if (this._query !== undefined) {
-            const similarity = StringUtils.computeCompletionSimilarity(this._query, name);
-            if (similarity < similarityLimit) {
-                return;
-            }
-        }
+        const indexSymbolData =
+            indexResults?.symbols ?? DocumentSymbolProvider.indexSymbols(parseResults!, false, token);
+        appendDocumentSymbolsRecursive(indexSymbolData, symbolList, token);
+    }
 
-        const resolvedSymbol = this._evaluator.resolveAliasDeclaration(declaration, /* resolveLocalNames */ true);
-        if (!resolvedSymbol) {
-            return;
-        }
+    static indexSymbols(
+        parseResults: ParseResults,
+        importSymbolsOnly: boolean,
+        token: CancellationToken
+    ): IndexSymbolData[] {
+        const indexSymbolData: IndexSymbolData[] = [];
+        collectSymbolIndexData(parseResults, parseResults.parseTree, importSymbolsOnly, indexSymbolData, token);
 
-        const location: Location = {
-            uri: URI.file(this._filePath).toString(),
-            range: declaration.range,
-        };
-
-        const symbolKind = getSymbolKind(name, declaration, this._evaluator);
-        if (symbolKind === undefined) {
-            return;
-        }
-
-        const symbolInfo: SymbolInformation = {
-            name,
-            kind: symbolKind,
-            location,
-        };
-
-        if (containerName) {
-            symbolInfo.containerName = containerName;
-        }
-
-        this._symbolResults.push(symbolInfo);
+        return indexSymbolData;
     }
 }
 
-function getSymbolKind(name: string, declaration: Declaration, evaluator: TypeEvaluator): SymbolKind | undefined {
+function getSymbolKind(name: string, declaration: Declaration, evaluator?: TypeEvaluator): SymbolKind | undefined {
     let symbolKind: SymbolKind;
     switch (declaration.type) {
         case DeclarationType.Class:
@@ -161,7 +130,7 @@ function getSymbolKind(name: string, declaration: Declaration, evaluator: TypeEv
 
         case DeclarationType.Function:
             if (declaration.isMethod) {
-                const declType = evaluator.getTypeForDeclaration(declaration);
+                const declType = evaluator?.getTypeForDeclaration(declaration);
                 if (declType && isProperty(declType)) {
                     symbolKind = SymbolKind.Property;
                 } else {
@@ -198,11 +167,89 @@ function getSymbolKind(name: string, declaration: Declaration, evaluator: TypeEv
     return symbolKind;
 }
 
-function getDocumentSymbolsRecursive(
-    node: AnalyzerNodeInfo.ScopedNode,
-    docSymbolResults: DocumentSymbol[],
+function appendWorkspaceSymbolsRecursive(
+    indexSymbolData: IndexSymbolData[],
+    filePath: string,
+    query: string,
+    container: string,
+    symbolList: SymbolInformation[],
+    token: CancellationToken
+) {
+    throwIfCancellationRequested(token);
+
+    for (const symbolData of indexSymbolData) {
+        if (symbolData.alias) {
+            continue;
+        }
+
+        const similarity = StringUtils.computeCompletionSimilarity(query, symbolData.name);
+        if (similarity >= similarityLimit) {
+            const location: Location = {
+                uri: URI.file(filePath).toString(),
+                range: symbolData.selectionRange,
+            };
+
+            const symbolInfo: SymbolInformation = {
+                name: symbolData.name,
+                kind: symbolData.kind,
+                containerName: container.length > 0 ? container : undefined,
+                location,
+            };
+
+            symbolList.push(symbolInfo);
+        }
+
+        appendWorkspaceSymbolsRecursive(
+            symbolData.children,
+            filePath,
+            query,
+            getContainerName(container, symbolData.name),
+            symbolList,
+            token
+        );
+    }
+
+    function getContainerName(container: string, name: string) {
+        if (container.length > 0) {
+            return `${container}.${name}`;
+        }
+
+        return name;
+    }
+}
+
+function appendDocumentSymbolsRecursive(
+    indexSymbolData: IndexSymbolData[],
+    symbolList: DocumentSymbol[],
+    token: CancellationToken
+) {
+    throwIfCancellationRequested(token);
+
+    for (const symbolData of indexSymbolData) {
+        if (symbolData.alias) {
+            continue;
+        }
+
+        const children: DocumentSymbol[] = [];
+        appendDocumentSymbolsRecursive(symbolData.children, children, token);
+
+        const symbolInfo: DocumentSymbol = {
+            name: symbolData.name,
+            kind: symbolData.kind,
+            range: symbolData.range,
+            selectionRange: symbolData.selectionRange,
+            children: children,
+        };
+
+        symbolList.push(symbolInfo);
+    }
+}
+
+function collectSymbolIndexData(
     parseResults: ParseResults,
-    evaluator: TypeEvaluator,
+    node: AnalyzerNodeInfo.ScopedNode,
+    autoImportMode: boolean,
+    indexSymbolData: IndexSymbolData[],
     token: CancellationToken
 ) {
     throwIfCancellationRequested(token);
@@ -212,47 +259,86 @@ function getDocumentSymbolsRecursive(
         return;
     }
 
+    // Build __all__ map for regular python file to reduce candidate in autoImportMode.
+    const file = AnalyzerNodeInfo.getFileInfo(parseResults.parseTree);
+    let allNameTable: Set<string> | undefined;
+    if (autoImportMode && !file?.isStubFile) {
+        allNameTable = new Set<string>(getNamesInDunderAll(scope.symbolTable) ?? []);
+    }
+
     const symbolTable = scope.symbolTable;
     symbolTable.forEach((symbol, name) => {
-        if (!symbol.isIgnoredForProtocolMatch()) {
-            // Prefer declarations with a defined type.
-            let decl = getLastTypedDeclaredForSymbol(symbol);
+        if (symbol.isIgnoredForProtocolMatch()) {
+            return;
+        }
 
-            // Fall back to declarations without a type.
-            if (!decl && symbol.hasDeclarations()) {
-                decl = symbol.getDeclarations()[0];
+        if (allNameTable && !allNameTable.has(name)) {
+            // if allNameTable exists, then name must exist in the table.
+            return;
+        }
+
+        // Prefer declarations with a defined type.
+        let declaration = getLastTypedDeclaredForSymbol(symbol);
+
+        // Fall back to declarations without a type.
+        if (!declaration && symbol.hasDeclarations()) {
+            declaration = symbol.getDeclarations()[0];
+        }
+
+        if (!declaration) {
+            return;
+        }
+
+        if (DeclarationType.Alias === declaration.type) {
+            if (declaration.path.length <= 0) {
+                return;
             }
 
-            if (decl) {
-                getDocumentSymbolRecursive(name, decl, evaluator, parseResults, docSymbolResults, token);
+            if (!allNameTable && !includeAliasDeclarationInIndex(declaration)) {
+                // For import alias, we only put the alias in the index if it is the form of
+                // "from x import y as z" or the alias is explicitly listed in __all__
+                return;
             }
         }
+
+        collectSymbolIndexDataForName(
+            parseResults,
+            declaration,
+            autoImportMode,
+            !symbol.isExternallyHidden(),
+            name,
+            indexSymbolData,
+            token
+        );
     });
 }
 
-function getDocumentSymbolRecursive(
-    name: string,
-    declaration: Declaration,
-    evaluator: TypeEvaluator,
+function collectSymbolIndexDataForName(
     parseResults: ParseResults,
-    docSymbolResults: DocumentSymbol[],
+    declaration: Declaration,
+    autoImportMode: boolean,
+    externallyVisible: boolean,
+    name: string,
+    indexSymbolData: IndexSymbolData[],
     token: CancellationToken
 ) {
-    if (declaration.type === DeclarationType.Alias) {
+    if (autoImportMode && !externallyVisible) {
         return;
     }
 
-    const symbolKind = getSymbolKind(name, declaration, evaluator);
+    const symbolKind = getSymbolKind(name, declaration);
     if (symbolKind === undefined) {
         return;
     }
 
     const selectionRange = declaration.range;
     let range = selectionRange;
-    const children: DocumentSymbol[] = [];
+    const children: IndexSymbolData[] = [];
 
     if (declaration.type === DeclarationType.Class || declaration.type === DeclarationType.Function) {
-        getDocumentSymbolsRecursive(declaration.node, children, parseResults, evaluator, token);
+        if (!autoImportMode) {
+            collectSymbolIndexData(parseResults, declaration.node, false, children, token);
+        }
 
         const nameRange = convertOffsetsToRange(
             declaration.node.start,
@@ -262,36 +348,18 @@ function getDocumentSymbolRecursive(
         range = nameRange;
     }
 
-    const symbolInfo: DocumentSymbol = {
+    const data: IndexSymbolData = {
         name,
+        alias:
+            DeclarationType.Alias === declaration.type
+                ? getIndexAliasData(AnalyzerNodeInfo.getFileInfo(parseResults.parseTree)?.importLookup, declaration)
+                : undefined,
+        externallyVisible,
         kind: symbolKind,
         range,
         selectionRange,
         children,
     };
 
-    docSymbolResults.push(symbolInfo);
-}
-
-export class DocumentSymbolProvider {
-    static addSymbolsForDocument(
-        symbolList: SymbolInformation[],
-        query: string,
-        filePath: string,
-        parseResults: ParseResults,
-        evaluator: TypeEvaluator,
-        token: CancellationToken
-    ) {
-        const symbolTreeWalker = new FindSymbolTreeWalker(filePath, parseResults, symbolList, query, evaluator, token);
-        symbolTreeWalker.findSymbols();
-    }
-
-    static addHierarchicalSymbolsForDocument(
-        symbolList: DocumentSymbol[],
-        parseResults: ParseResults,
-        evaluator: TypeEvaluator,
-        token: CancellationToken
-    ) {
-        getDocumentSymbolsRecursive(parseResults.parseTree, symbolList, parseResults, evaluator, token);
-    }
+    indexSymbolData.push(data);
 }

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -11,7 +11,6 @@ import {
     CodeActionKind,
     CodeActionParams,
     Command,
-    Connection,
     ExecuteCommandParams,
 } from 'vscode-languageserver/node';
 import { isMainThread } from 'worker_threads';
@@ -25,7 +24,12 @@ import { LogLevel } from './common/console';
 import { isDebugMode, isString } from './common/core';
 import { convertUriToPath, getDirectoryPath, normalizeSlashes } from './common/pathUtils';
 import { ProgressReporter } from './common/progressReporter';
-import { LanguageServerBase, ServerSettings, WorkspaceServiceInstance } from './languageServerBase';
+import {
+    LanguageServerBase,
+    ProgressReporterConnection,
+    ServerSettings,
+    WorkspaceServiceInstance,
+} from './languageServerBase';
 import { CodeActionProvider } from './languageService/codeActionProvider';
 
 const maxAnalysisTimeInForeground = { openFilesTimeInMs: 50, noOpenFilesTimeInMs: 200 };
@@ -178,7 +182,7 @@ class PyrightServer extends LanguageServerBase {
     }
 }
 
-function reporterFactory(connection: Connection): ProgressReporter {
+function reporterFactory(connection: ProgressReporterConnection): ProgressReporter {
     return {
         isEnabled(data: AnalysisResults): boolean {
             return true;

--- a/server/src/tests/fourslash/completions.autoimport.Lib.Found.Type.fourslash.ts
+++ b/server/src/tests/fourslash/completions.autoimport.Lib.Found.Type.fourslash.ts
@@ -19,7 +19,7 @@ await helper.verifyCompletion('included', {
                 label: 'Test',
                 documentation: {
                     kind: 'markdown',
-                    value: 'Auto-import from testLib\n\n',
+                    value: 'Auto-import\n\n```\nfrom testLib import Test\n```',
                 },
             },
         ],

--- a/server/src/tests/fourslash/completions.autoimport.Lib.Found.duplication.fourslash.ts
+++ b/server/src/tests/fourslash/completions.autoimport.Lib.Found.duplication.fourslash.ts
@@ -33,7 +33,7 @@ await helper.verifyCompletion('included', {
                 label: 'test1',
                 documentation: {
                     kind: 'markdown',
-                    value: 'Auto-import from testLib\n\n```python\ntest1\n```\n',
+                    value: 'Auto-import\n\n```\nfrom testLib import test1\n```',
                 },
             },
         ],

--- a/server/src/tests/fourslash/completions.autoimport.fourslash.ts
+++ b/server/src/tests/fourslash/completions.autoimport.fourslash.ts
@@ -15,7 +15,7 @@ await helper.verifyCompletion('included', {
                 label: 'Test',
                 documentation: {
                     kind: 'markdown',
-                    value: 'Auto-import from test2\n\n',
+                    value: 'Auto-import\n\n```\nfrom test2 import Test\n```',
                 },
             },
         ],

--- a/server/src/tests/fourslash/completions.autoimport.shadow.fourslash.ts
+++ b/server/src/tests/fourslash/completions.autoimport.shadow.fourslash.ts
@@ -37,7 +37,7 @@ await helper.verifyCompletion('exact', {
                 label: 'MyShadow',
                 documentation: {
                     kind: 'markdown',
-                    value: 'Auto-import from testLib\n\n',
+                    value: 'Auto-import\n\n```\nfrom testLib import MyShadow\n```',
                 },
             },
         ],

--- a/server/src/tests/fourslash/completions.autoimport.topLevel.fourslash.ts
+++ b/server/src/tests/fourslash/completions.autoimport.topLevel.fourslash.ts
@@ -22,7 +22,7 @@ await helper.verifyCompletion('included', {
                 label: 'os',
                 documentation: {
                     kind: 'markdown',
-                    value: 'Auto-import os\n\n```python\nos\n```\n',
+                    value: 'Auto-import\n\n```\nimport os\n```',
                 },
             },
         ],
@@ -39,7 +39,7 @@ await helper.verifyCompletion('included', {
                 label: 'sys',
                 documentation: {
                     kind: 'markdown',
-                    value: 'Auto-import sys\n\n```python\nsys\n```\n',
+                    value: 'Auto-import\n\n```\nimport sys\n```',
                 },
             },
         ],

--- a/server/src/tests/harness/fourslash/fourSlashTypes.ts
+++ b/server/src/tests/harness/fourslash/fourSlashTypes.ts
@@ -12,6 +12,8 @@ export const enum GlobalMetadataOptionNames {
     projectRoot = 'projectroot',
     ignoreCase = 'ignorecase',
     typeshed = 'typeshed',
+    indexer = 'indexer',
+    indexerWithoutStdLib = 'indexerwithoutstdlib',
 }
 
 /** Any option name not belong to this will become global option */

--- a/server/src/tests/harness/fourslash/testLanguageService.ts
+++ b/server/src/tests/harness/fourslash/testLanguageService.ts
@@ -28,6 +28,9 @@ import { HostSpecificFeatures } from './testState';
 
 export class TestFeatures implements HostSpecificFeatures {
     importResolverFactory: ImportResolverFactory = AnalyzerService.createImportResolver;
+    runIndexer(workspace: WorkspaceServiceInstance, noStdLib: boolean): void {
+        /* empty */
+    }
     getCodeActionsForPosition(
         workspace: WorkspaceServiceInstance,
         filePath: string,


### PR DESCRIPTION
- Fixes an issue with the types on the progress reporter; the vscode-jsonrpc library can't be a part of the public API.
- Many changes to the auto-import / symbol search system.
- Infrastructure improvements for worker threads.
- Improved auto-import tooltips to display the code that would be inserted (e.g. `from foo import bar` or `import foobar`).