### PR TITLE
Run install:all in style checker, fix desynced package-lock.json

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -64,7 +64,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-node-
 
-      - run: npm install
+      - run: npm run install:all
 
       - name: Check diff after npm install
         run: git diff --exit-code --name-only

--- a/packages/pyright/package-lock.json
+++ b/packages/pyright/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "pyright",
-    "version": "1.1.63",
+    "version": "1.1.65",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {


### PR DESCRIPTION
I made a mistake in the pipeline; `lerna bootstrap` won't always refresh `package-lock.json` when bootstrapping. The style check should have been running `install:all` to ensure that `package-lock.json` is touched if out of date.

This PR should fail the first run (as I missed one of the `package-lock.json` files in my original PR), but I will fix it in a second commit; making sure I'm correct.