### PR TITLE
fix: reportMissingModuleSource default none

### DIFF
--- a/packages/vscode-pyright/package.json
+++ b/packages/vscode-pyright/package.json
@@ -130,7 +130,7 @@
                         "reportMissingModuleSource": {
                             "type": "string",
                             "description": "Diagnostics for imports that have no corresponding source file. This happens when a type stub is found, but the module source file was not found, indicating that the code may fail at runtime when using this execution environment. Type checking will be done using the type stub.",
-                            "default": "warning",
+                            "default": "none",
                             "enum": [
                                 "none",
                                 "information",


### PR DESCRIPTION
schema default is none https://github.com/microsoft/pyright/blob/58a349b50e5212d29ab1606f8f3cb8b6557c7aa5/packages/vscode-pyright/schemas/pyrightconfig.schema.json#L138-L142