### PR TITLE
Extensibility updates in threading and fourslash, add completion context

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -4,7 +4,7 @@ Pyright offers flexible configuration options specified in a JSON-formatted text
 
 Relative paths specified within the config file are relative to the config file’s location. Paths with shell variables (including `~`) are not supported.
 
-## Master Pyright Config Options
+## Main Pyright Config Options
 
 **include** [array of paths, optional]: Paths of directories or files that should be included. If no paths are specified, pyright defaults to the directory that contains the config file. Paths may contain wildcard characters ** (a directory or multiple levels of directories), * (a sequence of zero or more characters), or ? (a single character). If no include paths are specified, the root path for the workspace is assumed.
 

--- a/packages/pyright-internal/src/analyzer/backgroundAnalysisProgram.ts
+++ b/packages/pyright-internal/src/analyzer/backgroundAnalysisProgram.ts
@@ -264,3 +264,12 @@ export class BackgroundAnalysisProgram {
         }
     }
 }
+
+export type BackgroundAnalysisProgramFactory = (
+    console: ConsoleInterface,
+    configOptions: ConfigOptions,
+    importResolver: ImportResolver,
+    extension?: LanguageServiceExtension,
+    backgroundAnalysis?: BackgroundAnalysisBase,
+    maxAnalysisTime?: MaxAnalysisTime
+) => BackgroundAnalysisProgram;

--- a/packages/pyright-internal/src/analyzer/program.ts
+++ b/packages/pyright-internal/src/analyzer/program.ts
@@ -8,13 +8,7 @@
  * and all of their recursive imports.
  */
 
-import {
-    CancellationToken,
-    CompletionItem,
-    CompletionList,
-    DocumentSymbol,
-    SymbolInformation,
-} from 'vscode-languageserver';
+import { CancellationToken, CompletionItem, DocumentSymbol, SymbolInformation } from 'vscode-languageserver';
 import {
     CallHierarchyIncomingCall,
     CallHierarchyItem,
@@ -51,6 +45,7 @@ import {
     ModuleSymbolMap,
 } from '../languageService/autoImporter';
 import { CallHierarchyProvider } from '../languageService/callHierarchyProvider';
+import { CompletionResults } from '../languageService/completionProvider';
 import { IndexResults } from '../languageService/documentSymbolProvider';
 import { HoverResults } from '../languageService/hoverProvider';
 import { ReferencesResult } from '../languageService/referencesProvider';
@@ -147,6 +142,10 @@ export class Program {
         this._importResolver = initialImportResolver;
         this._configOptions = initialConfigOptions;
         this._createNewEvaluator();
+    }
+
+    get evaluator(): TypeEvaluator | undefined {
+        return this._evaluator;
     }
 
     setConfigOptions(configOptions: ConfigOptions) {
@@ -1251,13 +1250,13 @@ export class Program {
         workspacePath: string,
         libraryMap: Map<string, IndexResults> | undefined,
         token: CancellationToken
-    ): Promise<CompletionList | undefined> {
+    ): Promise<CompletionResults | undefined> {
         const sourceFileInfo = this._sourceFileMap.get(filePath);
         if (!sourceFileInfo) {
             return undefined;
         }
 
-        let completionList = this._runEvaluatorWithCancellationToken(token, () => {
+        const completionResult = this._runEvaluatorWithCancellationToken(token, () => {
             this._bindFile(sourceFileInfo);
 
             const execEnv = this._configOptions.findExecEnvironment(filePath);
@@ -1275,8 +1274,8 @@ export class Program {
             );
         });
 
-        if (!completionList || !this._extension?.completionListExtension) {
-            return completionList;
+        if (!completionResult?.completionList || !this._extension?.completionListExtension) {
+            return completionResult;
         }
 
         const pr = sourceFileInfo.sourceFile.getParseResults();
@@ -1284,8 +1283,8 @@ export class Program {
         if (pr?.parseTree && content) {
             const offset = convertPositionToOffset(position, pr.tokenizerOutput.lines);
             if (offset !== undefined) {
-                completionList = await this._extension.completionListExtension.updateCompletionList(
-                    completionList,
+                completionResult.completionList = await this._extension.completionListExtension.updateCompletionList(
+                    completionResult.completionList,
                     pr.parseTree,
                     content,
                     offset,
@@ -1295,7 +1294,7 @@ export class Program {
             }
         }
 
-        return completionList;
+        return completionResult;
     }
 
     resolveCompletionItem(

--- a/packages/pyright-internal/src/analyzer/sourceFile.ts
+++ b/packages/pyright-internal/src/analyzer/sourceFile.ts
@@ -10,7 +10,6 @@
 import {
     CancellationToken,
     CompletionItem,
-    CompletionList,
     DocumentHighlight,
     DocumentSymbol,
     SymbolInformation,
@@ -33,6 +32,7 @@ import { DocumentRange, getEmptyRange, Position, TextRange } from '../common/tex
 import { TextRangeCollection } from '../common/textRangeCollection';
 import { timingStats } from '../common/timing';
 import { ModuleSymbolMap } from '../languageService/autoImporter';
+import { CompletionResults } from '../languageService/completionProvider';
 import { CompletionItemData, CompletionProvider } from '../languageService/completionProvider';
 import { DefinitionProvider } from '../languageService/definitionProvider';
 import { DocumentHighlightProvider } from '../languageService/documentHighlightProvider';
@@ -777,7 +777,7 @@ export class SourceFile {
         libraryMap: Map<string, IndexResults> | undefined,
         moduleSymbolsCallback: () => ModuleSymbolMap,
         token: CancellationToken
-    ): CompletionList | undefined {
+    ): CompletionResults | undefined {
         // If we have no completed analysis job, there's nothing to do.
         if (!this._parseResults) {
             return undefined;

--- a/packages/pyright-internal/src/languageService/completionProvider.ts
+++ b/packages/pyright-internal/src/languageService/completionProvider.ts
@@ -44,6 +44,8 @@ import {
     isNone,
     isObject,
     isTypeVar,
+    isUnbound,
+    isUnknown,
     ObjectType,
     Type,
     TypeBase,
@@ -51,6 +53,7 @@ import {
 } from '../analyzer/types';
 import {
     doForSubtypes,
+    getDeclaringModulesForType,
     getMembersForClass,
     getMembersForModule,
     isProperty,
@@ -174,6 +177,18 @@ export interface CompletionItemData {
     symbolId?: number;
 }
 
+// ModuleContext attempts to gather info for unknown types
+export interface ModuleContext {
+    lastKnownModule?: string;
+    lastKnownMemberName?: string;
+    unknownMemberName?: string;
+}
+
+export interface CompletionResults {
+    completionList: CompletionList | undefined;
+    moduleContext?: ModuleContext;
+}
+
 interface RecentCompletionInfo {
     label: string;
     autoImportText: string;
@@ -209,7 +224,7 @@ export class CompletionProvider {
         private _cancellationToken: CancellationToken
     ) {}
 
-    getCompletionsForPosition(): CompletionList | undefined {
+    getCompletionsForPosition(): CompletionResults | undefined {
         const offset = convertPositionToOffset(this._position, this._parseResults.tokenizerOutput.lines);
         if (offset === undefined) {
             return undefined;
@@ -412,7 +427,7 @@ export class CompletionProvider {
         priorWord: string,
         priorText: string,
         postText: string
-    ): CompletionList | undefined {
+    ): CompletionResults | undefined {
         // Is the error due to a missing member access name? If so,
         // we can evaluate the left side of the member access expression
         // to determine its type and offer suggestions based on it.
@@ -451,15 +466,15 @@ export class CompletionProvider {
         return undefined;
     }
 
-    private _createSingleKeywordCompletionList(keyword: string): CompletionList {
+    private _createSingleKeywordCompletionList(keyword: string): CompletionResults {
         const completionItem = CompletionItem.create(keyword);
         completionItem.kind = CompletionItemKind.Keyword;
         completionItem.sortText = this._makeSortText(SortCategory.LikelyKeyword, keyword);
-
-        return CompletionList.create([completionItem]);
+        const completionList = CompletionList.create([completionItem]);
+        return { completionList };
     }
 
-    private _getMethodOverrideCompletions(partialName: NameNode): CompletionList | undefined {
+    private _getMethodOverrideCompletions(partialName: NameNode): CompletionResults | undefined {
         const enclosingClass = ParseTreeUtils.getEnclosingClass(partialName, true);
         if (!enclosingClass) {
             return undefined;
@@ -498,7 +513,7 @@ export class CompletionProvider {
             }
         });
 
-        return completionList;
+        return { completionList };
     }
 
     private _printMethodSignature(node: FunctionNode): string {
@@ -536,10 +551,14 @@ export class CompletionProvider {
         return methodSignature;
     }
 
-    private _getMemberAccessCompletions(leftExprNode: ExpressionNode, priorWord: string): CompletionList | undefined {
+    private _getMemberAccessCompletions(
+        leftExprNode: ExpressionNode,
+        priorWord: string
+    ): CompletionResults | undefined {
         const leftType = this._evaluator.getType(leftExprNode);
         const symbolTable = new Map<string, Symbol>();
         const completionList = CompletionList.create();
+        let lastKnownModule: ModuleContext | undefined;
 
         if (leftType) {
             doForSubtypes(leftType, (subtype) => {
@@ -575,11 +594,65 @@ export class CompletionProvider {
             const objectThrough: ObjectType | undefined = leftType && isObject(leftType) ? leftType : undefined;
             this._addSymbolsForSymbolTable(symbolTable, (_) => true, priorWord, objectThrough, completionList);
 
-            // const moduleNamesForType = getDeclaringModulesForType(leftType);
-            // TODO - log modules to telemetry.
+            // If we dont know this type, look for a module we should stub
+            if (!leftType || isUnknown(leftType) || isUnbound(leftType)) {
+                lastKnownModule = this._getLastKnownModule(leftExprNode, leftType);
+            }
         }
 
-        return completionList;
+        return { completionList, moduleContext: lastKnownModule };
+    }
+
+    private _getLastKnownModule(leftExprNode: ExpressionNode, leftType: Type | undefined): ModuleContext | undefined {
+        let curNode: ExpressionNode | undefined = leftExprNode;
+        let curType: Type | undefined = leftType;
+        let unknownMemberName: string | undefined =
+            leftExprNode.nodeType === ParseNodeType.MemberAccess ? leftExprNode?.memberName.value : undefined;
+
+        // Walk left of the expression scope till we find a known type. A.B.Unknown.<-- return B.
+        while (curNode) {
+            if (curNode.nodeType === ParseNodeType.Call || curNode.nodeType === ParseNodeType.MemberAccess) {
+                // Move left
+                curNode = curNode.leftExpression;
+
+                // First time in the loop remember the name of the unknown type.
+                if (unknownMemberName === undefined) {
+                    unknownMemberName =
+                        curNode.nodeType === ParseNodeType.MemberAccess ? curNode?.memberName.value ?? '' : '';
+                }
+            } else {
+                curNode = undefined;
+            }
+
+            if (curNode) {
+                curType = this._evaluator.getType(curNode);
+
+                // Breakout if we found a known type.
+                if (curType !== undefined && !isUnknown(curType) && !isUnbound(curType)) {
+                    break;
+                }
+            }
+        }
+
+        const context: ModuleContext = {};
+        if (curType && !isUnknown(curType) && !isUnbound(curType) && curNode) {
+            const moduleNamesForType = getDeclaringModulesForType(curType);
+
+            // For union types we only care about non 'typing' modules.
+            context.lastKnownModule = moduleNamesForType.find((n) => n !== 'typing');
+
+            if (curNode.nodeType === ParseNodeType.MemberAccess) {
+                context.lastKnownMemberName = curNode.memberName.value;
+            } else if (curNode.nodeType === ParseNodeType.Name && isClass(curType)) {
+                context.lastKnownMemberName = curType.details.name;
+            } else if (curNode.nodeType === ParseNodeType.Name && isObject(curType)) {
+                context.lastKnownMemberName = curType.classType.details.name;
+            }
+
+            context.unknownMemberName = unknownMemberName;
+        }
+
+        return context;
     }
 
     private _getStatementCompletions(
@@ -587,7 +660,7 @@ export class CompletionProvider {
         priorWord: string,
         priorText: string,
         postText: string
-    ): CompletionList | undefined {
+    ): CompletionResults | undefined {
         // For now, use the same logic for expressions and statements.
         return this._getExpressionCompletions(parseNode, priorWord, priorText, postText);
     }
@@ -597,7 +670,7 @@ export class CompletionProvider {
         priorWord: string,
         priorText: string,
         postText: string
-    ): CompletionList | undefined {
+    ): CompletionResults | undefined {
         // If the user typed a "." as part of a number, don't present
         // any completion options.
         if (parseNode.nodeType === ParseNodeType.Number) {
@@ -643,7 +716,7 @@ export class CompletionProvider {
             }
         }
 
-        return completionList;
+        return { completionList };
     }
 
     private _addCallArgumentCompletions(
@@ -732,7 +805,7 @@ export class CompletionProvider {
         priorWord: string,
         priorText: string,
         postText: string
-    ): CompletionList | undefined {
+    ): CompletionResults | undefined {
         let parentNode: ParseNode | undefined = parseNode.parent;
         if (!parentNode || parentNode.nodeType !== ParseNodeType.StringList || parentNode.strings.length > 1) {
             return undefined;
@@ -784,7 +857,7 @@ export class CompletionProvider {
             this._addCallArgumentCompletions(parseNode, priorWord, priorText, postText, completionList);
         }
 
-        return completionList;
+        return { completionList };
     }
 
     // Given a string of text that precedes the current insertion point,
@@ -926,7 +999,10 @@ export class CompletionProvider {
         }
     }
 
-    private _getImportFromCompletions(importFromNode: ImportFromNode, priorWord: string): CompletionList | undefined {
+    private _getImportFromCompletions(
+        importFromNode: ImportFromNode,
+        priorWord: string
+    ): CompletionResults | undefined {
         // Don't attempt to provide completions for "from X import *".
         if (importFromNode.isWildcardImport) {
             return undefined;
@@ -965,7 +1041,7 @@ export class CompletionProvider {
             }
         });
 
-        return completionList;
+        return { completionList };
     }
 
     private _findMatchingKeywords(keywordList: string[], partialMatch: string): string[] {
@@ -1443,7 +1519,7 @@ export class CompletionProvider {
         }
     }
 
-    private _getImportModuleCompletions(node: ModuleNameNode): CompletionList {
+    private _getImportModuleCompletions(node: ModuleNameNode): CompletionResults {
         const execEnvironment = this._configOptions.findExecEnvironment(this._filePath);
         const moduleDescriptor: ImportedModuleDescriptor = {
             leadingDots: node.leadingDots,
@@ -1483,6 +1559,6 @@ export class CompletionProvider {
             completionItem.sortText = this._makeSortText(SortCategory.ImportModuleName, completionName);
         });
 
-        return completionList;
+        return { completionList };
     }
 }

--- a/packages/pyright-internal/src/tests/fourslash/completions.moduleContext.UnknownMemberOnInstance.fourslash.ts
+++ b/packages/pyright-internal/src/tests/fourslash/completions.moduleContext.UnknownMemberOnInstance.fourslash.ts
@@ -1,0 +1,17 @@
+/// <reference path="fourslash.ts" />
+
+// @filename: test.py
+//// class Model:
+////     pass
+////
+//// def some_func1(a: Model):
+////     x = a.unknownName.[|/*marker1*/|]
+////     pass
+
+// @ts-ignore
+await helper.verifyCompletion('included', {
+    marker1: {
+        completions: [],
+        moduleContext: { lastKnownModule: 'test', lastKnownMemberName: 'Model', unknownMemberName: 'unknownName' },
+    },
+});

--- a/packages/pyright-internal/src/tests/fourslash/completions.moduleContext.UnknownStaticFunctionOnClass.fourslash.ts
+++ b/packages/pyright-internal/src/tests/fourslash/completions.moduleContext.UnknownStaticFunctionOnClass.fourslash.ts
@@ -1,0 +1,57 @@
+/// <reference path="fourslash.ts" />
+
+// @filename: test.py
+//// class Model:
+////     @staticmethod
+////     def foo( value ):
+////         return value
+////
+////
+//// x = Model.foo(unknownValue).[|/*marker1*/|]
+////     pass
+////
+//// y = Model.unknownMember.[|/*marker2*/|]
+////     pass
+////
+//// def some_func1(a: Model):
+////     x = a.unknownMember.[|/*marker3*/|]
+////     pass
+////
+//// Model.unknownValue.[|/*marker4*/|]
+////
+//// UnkownModel.unknownValue.[|/*marker5*/|]
+
+// @ts-ignore
+await helper.verifyCompletion('included', {
+    // tests: _getLastKnownModule():  if (curNode.nodeType === ParseNodeType.MemberAccess && curNode.memberName)
+    marker1: {
+        completions: [],
+        moduleContext: { lastKnownModule: 'test', lastKnownMemberName: 'foo', unknownMemberName: 'foo' },
+    },
+    // tests: _getLastKnownModule():  else if (curNode.nodeType === ParseNodeType.Name && isClass(curType))
+    marker2: {
+        completions: [],
+        moduleContext: {
+            lastKnownModule: 'test',
+            lastKnownMemberName: 'Model',
+            unknownMemberName: 'unknownMember',
+        },
+    },
+    // tests: _getLastKnownModule(): else if (curNode.nodeType === ParseNodeType.Name && isObject(curType))
+    marker3: {
+        completions: [],
+        moduleContext: {
+            lastKnownModule: 'test',
+            lastKnownMemberName: 'Model',
+            unknownMemberName: 'unknownMember',
+        },
+    },
+    marker4: {
+        completions: [],
+        moduleContext: { lastKnownModule: 'test', lastKnownMemberName: 'Model', unknownMemberName: 'unknownValue' },
+    },
+    marker5: {
+        completions: [],
+        moduleContext: {},
+    },
+});

--- a/packages/pyright-internal/src/tests/fourslash/completions.moduleContext.libCodeNoStub.fourslash.ts
+++ b/packages/pyright-internal/src/tests/fourslash/completions.moduleContext.libCodeNoStub.fourslash.ts
@@ -1,0 +1,30 @@
+/// <reference path="fourslash.ts" />
+
+// @filename: mspythonconfig.json
+//// {
+////   "useLibraryCodeForTypes": true
+//// }
+
+// @filename: test.py
+//// import testnumpy
+//// obj = testnumpy.random.randint("foo").[|/*marker1*/|]
+
+// @filename: testnumpy/__init__.py
+// @library: true
+//// from . import random
+
+// @filename: testnumpy/random/__init__.py
+// @library: true
+//// __all__ = ['randint']
+
+// @ts-ignore
+await helper.verifyCompletion('included', {
+    marker1: {
+        completions: [],
+        moduleContext: {
+            lastKnownModule: 'testnumpy',
+            lastKnownMemberName: 'random',
+            unknownMemberName: 'randint',
+        },
+    },
+});

--- a/packages/pyright-internal/src/tests/fourslash/fourslash.ts
+++ b/packages/pyright-internal/src/tests/fourslash/fourslash.ts
@@ -154,6 +154,11 @@ declare namespace _ {
             map: {
                 [marker: string]: {
                     completions: FourSlashCompletionItem[];
+                    moduleContext?: {
+                        lastKnownModule?: string;
+                        lastKnownMemberName?: string;
+                        unknownMemberName?: string;
+                    };
                 };
             }
         ): Promise<void>;

--- a/packages/vscode-pyright/package.json
+++ b/packages/vscode-pyright/package.json
@@ -82,7 +82,7 @@
                 },
                 "python.analysis.stubPath": {
                     "type": "string",
-                    "default": "",
+                    "default": "typings",
                     "description": "Path to directory containing custom type stub files.",
                     "scope": "resource"
                 },


### PR DESCRIPTION
Rollup of:

- Update the background thread implementation for extensibility.
- Add a "context" to completion results, for use in analyzing which stubs would improve completion.
- Make fourslash test state overridable for extensibility.
- Refactor workspace server instance to allow adding extra settings.
- Display default stubPath in VS Code UI.