### PR TITLE
Added support for py.typed files to distinguish between packages that…

### DIFF
--- a/packages/pyright-internal/src/analyzer/binder.ts
+++ b/packages/pyright-internal/src/analyzer/binder.ts
@@ -278,7 +278,7 @@ export class Binder extends ParseTreeWalker {
                 );
             } else {
                 // Source found, but type stub is missing
-                if (!importResult.isStubFile && importResult.importType === ImportType.ThirdParty) {
+                if (!importResult.isStubFile && importResult.importType === ImportType.ThirdParty && !importResult.isPyTypedPresent) {
                     const diagnostic = this._addDiagnostic(
                         this._fileInfo.diagnosticRuleSet.reportMissingTypeStubs,
                         DiagnosticRule.reportMissingTypeStubs,

--- a/packages/pyright-internal/src/analyzer/binder.ts
+++ b/packages/pyright-internal/src/analyzer/binder.ts
@@ -278,7 +278,11 @@ export class Binder extends ParseTreeWalker {
                 );
             } else {
                 // Source found, but type stub is missing
-                if (!importResult.isStubFile && importResult.importType === ImportType.ThirdParty && !importResult.isPyTypedPresent) {
+                if (
+                    !importResult.isStubFile &&
+                    importResult.importType === ImportType.ThirdParty &&
+                    !importResult.isPyTypedPresent
+                ) {
                     const diagnostic = this._addDiagnostic(
                         this._fileInfo.diagnosticRuleSet.reportMissingTypeStubs,
                         DiagnosticRule.reportMissingTypeStubs,

--- a/packages/pyright-internal/src/analyzer/importResolver.ts
+++ b/packages/pyright-internal/src/analyzer/importResolver.ts
@@ -795,7 +795,7 @@ export class ImportResolver {
                     importFailureInfo
                 );
 
-                if (typingsImport && typingsImport.isImportFound) {
+                if (typingsImport.isImportFound) {
                     // We will treat typings files as "local" rather than "third party".
                     typingsImport.importType = ImportType.Local;
                     typingsImport.isLocalTypingsFile = true;
@@ -818,7 +818,7 @@ export class ImportResolver {
             /* useStubPackage */ undefined,
             allowPyi
         );
-        if (localImport && localImport.isImportFound && !localImport.isNamespacePackage) {
+        if (localImport.isImportFound && !localImport.isNamespacePackage) {
             return localImport;
         }
         bestResultSoFar = localImport;
@@ -835,7 +835,7 @@ export class ImportResolver {
                 /* useStubPackage */ undefined,
                 allowPyi
             );
-            if (localImport && localImport.isImportFound) {
+            if (localImport.isImportFound) {
                 return localImport;
             }
 
@@ -1022,7 +1022,7 @@ export class ImportResolver {
                     importName,
                     importFailureInfo
                 );
-                if (importInfo && importInfo.isImportFound) {
+                if (importInfo.isImportFound) {
                     importInfo.importType = isStdLib ? ImportType.BuiltIn : ImportType.ThirdParty;
                     return importInfo;
                 }
@@ -1151,10 +1151,6 @@ export class ImportResolver {
 
         // Now try to match the module parts from the current directory location.
         const absImport = this.resolveAbsoluteImport(curDir, moduleDescriptor, importName, importFailureInfo);
-        if (!absImport) {
-            return undefined;
-        }
-
         return this._filterImplicitImports(absImport, moduleDescriptor.importedSymbols);
     }
 

--- a/packages/pyright-internal/src/analyzer/importResult.ts
+++ b/packages/pyright-internal/src/analyzer/importResult.ts
@@ -73,4 +73,11 @@ export interface ImportResult {
     // If resolved from a type hint (.pyi), then store the import result
     // from .py here.
     nonStubImportResult?: ImportResult;
+
+    // Is there a "py.typed" file (as described in PEP 561) present in
+    // the package that was used to resolve the import?
+    isPyTypedPresent?: boolean;
+
+    // The directory of the package, if found.
+    packageDirectory?: string;
 }


### PR DESCRIPTION
… claim to have inlined types versus those that don't. Also added support for "partial" stub packages (a "-stub" package that has a py.typed file that includes the line "partial\n" as described in PEP 561).