### PR TITLE
Mention ALE in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,9 @@ For rich Python editing and debugging capabilities with Visual Studio Code, be s
 You can install the latest-published version of the Pyright VS Code extension directly from VS Code. Simply open the extensions panel and search for `pyright`.
 
 ### Vim
-For vim/neovim users, you can install [coc-pyright](https://github.com/fannheyward/coc-pyright), Pyright extension for coc.nvim.
+For vim/neovim users, you can install [coc-pyright](https://github.com/fannheyward/coc-pyright), the Pyright extension for coc.nvim.
+
+Alternatively, [ALE](https://github.com/dense-analysis/ale) will automatically check your code with Pyright, without requiring any additional configuration.
 
 ### Sublime Text
 For sublime text users, you can install the [LSP-pyright](https://github.com/sublimelsp/LSP-pyright) plugin from [package control](https://packagecontrol.io/packages/LSP-pyright).


### PR DESCRIPTION
ALE has out-of-the-box support for Pyright, and the ALE project is firmly committed to making Pyright support work with no or very little configuration on the Vim side.

I am the author of ALE, and I use Pyright every day at work now. If anything ever goes wrong with Pyright support, I'll be fixing it pretty quickly.

Thank you for making what I view as being the _definitive_ Python language server. :+1: 