### PR TITLE
Fixed a bug in the handling of wildcard imports

### DIFF
--- a/packages/pyright-internal/src/analyzer/symbolUtils.ts
+++ b/packages/pyright-internal/src/analyzer/symbolUtils.ts
@@ -63,10 +63,7 @@ export function getNamesInDunderAll(symbolTable: SymbolTable): string[] | undefi
                             listEntryNode.strings.length === 1 &&
                             listEntryNode.strings[0].nodeType === ParseNodeType.String
                         ) {
-                            const entryName = listEntryNode.strings[0].value;
-                            if (symbolTable.get(entryName)) {
-                                namesToImport.push(entryName);
-                            }
+                            namesToImport.push(listEntryNode.strings[0].value);
                         }
                     });
 

--- a/packages/pyright-internal/src/tests/fourslash/import.wildcard.fourslash.ts
+++ b/packages/pyright-internal/src/tests/fourslash/import.wildcard.fourslash.ts
@@ -1,0 +1,27 @@
+/// <reference path="fourslash.ts" />
+
+// @filename: testpkg/py.typed
+// @library: true
+////
+
+// @filename: testpkg/__init__.py
+// @library: true
+//// __all__ = ["submod"]
+//// def foo():
+////    return
+
+// @filename: testpkg/submod.py
+// @library: true
+//// def test_func():
+////     print("hi")
+
+// @filename: .src/test.py
+//// # pyright: reportWildcardImportFromLibrary=false
+//// from testpkg import *
+//// submod.test_func()
+//// [|/*marker*/foo|]()
+
+// @ts-ignore
+await helper.verifyDiagnostics({
+    marker: { category: 'error', message: `"foo" is not defined` },
+});


### PR DESCRIPTION
Fixed a bug in the handling of wildcard imports when a dunder all symbol is present in the target and the dunder all array refers to an implicitly-imported submodule.