### PR TITLE
Fix paths when unset, fix tmpdir, other visual tweaks

### DIFF
--- a/packages/pyright-internal/src/analyzer/pythonPathUtils.ts
+++ b/packages/pyright-internal/src/analyzer/pythonPathUtils.ts
@@ -235,3 +235,8 @@ export function getPythonPathFromPythonInterpreter(
 
     return result;
 }
+
+export function isPythonBinary(p: string): boolean {
+    p = p.trim();
+    return p === 'python' || p === 'python3';
+}

--- a/packages/pyright-internal/src/analyzer/service.ts
+++ b/packages/pyright-internal/src/analyzer/service.ts
@@ -26,7 +26,7 @@ import { BackgroundAnalysisBase } from '../backgroundAnalysisBase';
 import { createBackgroundThreadCancellationTokenSource } from '../common/cancellationUtils';
 import { CommandLineOptions } from '../common/commandLineOptions';
 import { ConfigOptions } from '../common/configOptions';
-import { ConsoleInterface, StandardConsole } from '../common/console';
+import { ConsoleInterface, log, LogLevel, StandardConsole } from '../common/console';
 import { Diagnostic } from '../common/diagnostic';
 import { FileEditAction, TextEditAction } from '../common/editAction';
 import { LanguageServiceExtension } from '../common/extensibility';
@@ -614,16 +614,14 @@ export class AnalyzerService {
                 importFailureInfo
             ).paths;
             if (pythonPaths.length === 0) {
-                if (configOptions.verboseOutput) {
-                    this._console.error(`No search paths found for configured python interpreter.`);
-                }
+                const logLevel = configOptions.verboseOutput ? LogLevel.Error : LogLevel.Log;
+                log(this._console, logLevel, `No search paths found for configured python interpreter.`);
             } else {
-                if (configOptions.verboseOutput) {
-                    this._console.info(`Search paths found for configured python interpreter:`);
-                    pythonPaths.forEach((path) => {
-                        this._console.info(`  ${path}`);
-                    });
-                }
+                const logLevel = configOptions.verboseOutput ? LogLevel.Info : LogLevel.Log;
+                log(this._console, logLevel, `Search paths found for configured python interpreter:`);
+                pythonPaths.forEach((path) => {
+                    log(this._console, logLevel, `  ${path}`);
+                });
             }
 
             if (configOptions.verboseOutput) {

--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -2295,7 +2295,7 @@ export function createTypeEvaluator(importLookup: ImportLookup, evaluatorOptions
     function isNodeReachable(node: ParseNode): boolean {
         const flowNode = AnalyzerNodeInfo.getFlowNode(node);
         if (!flowNode) {
-            return true;
+            return false;
         }
 
         return isFlowNodeReachable(flowNode);

--- a/packages/pyright-internal/src/common/pathUtils.ts
+++ b/packages/pyright-internal/src/common/pathUtils.ts
@@ -892,11 +892,6 @@ export function isFileSystemCaseSensitive(fs: FileSystem) {
 export function isFileSystemCaseSensitiveInternal(fs: FileSystem) {
     let filePath: string | undefined = undefined;
     try {
-        // Make sure tmp dir exists.
-        if (!fs.existsSync(fs.tmpdir())) {
-            fs.mkdirSync(fs.tmpdir(), { recursive: true });
-        }
-
         // Make unique file name.
         let name: string;
         let mangledFilePath: string;

--- a/packages/pyright-internal/src/languageService/analyzerServiceExecutor.ts
+++ b/packages/pyright-internal/src/languageService/analyzerServiceExecutor.ts
@@ -7,7 +7,7 @@
  * Runs the analyzer service of a given workspace service instance
  * with a specified set of options.
  */
-
+import { isPythonBinary } from '../analyzer/pythonPathUtils';
 import { CommandLineOptions } from '../common/commandLineOptions';
 import { combinePaths, normalizePath } from '../common/pathUtils';
 import { ServerSettings, WorkspaceServiceInstance } from '../languageServerBase';
@@ -66,7 +66,7 @@ function getEffectiveCommandLineOptions(
         // The Python VS Code extension treats the value "python" specially. This means
         // the local python interpreter should be used rather than interpreting the
         // setting value as a path to the interpreter. We'll simply ignore it in this case.
-        if (serverSettings.pythonPath.trim() !== 'python') {
+        if (!isPythonBinary(serverSettings.pythonPath)) {
             commandLineOptions.pythonPath = combinePaths(
                 workspaceRootPath || languageServiceRootPath,
                 normalizePath(_expandPathVariables(languageServiceRootPath, serverSettings.pythonPath))

--- a/packages/pyright-internal/src/languageService/completionProvider.ts
+++ b/packages/pyright-internal/src/languageService/completionProvider.ts
@@ -999,8 +999,8 @@ export class CompletionProvider {
                     undefined,
                     '',
                     result.source
-                        ? `Auto-import\n\n\`\`\`\nfrom ${result.source} import ${result.name}\n\`\`\``
-                        : `Auto-import\n\n\`\`\`\nimport ${result.name}\n\`\`\``,
+                        ? `\`\`\`\nfrom ${result.source} import ${result.name}\n\`\`\``
+                        : `\`\`\`\nimport ${result.name}\n\`\`\``,
                     undefined,
                     result.edits
                 );
@@ -1325,7 +1325,7 @@ export class CompletionProvider {
 
             let autoImportText: string | undefined;
             if (autoImportSource) {
-                autoImportText = `Auto-import\n\n\`\`\`\nfrom ${autoImportSource} import ${name}\n\`\`\``;
+                autoImportText = `\`\`\`\nfrom ${autoImportSource} import ${name}\n\`\`\``;
             }
 
             this._addNameToCompletionList(
@@ -1387,6 +1387,7 @@ export class CompletionProvider {
                 // Force auto-import entries to the end.
                 completionItem.sortText = this._makeSortText(SortCategory.AutoImport, name, autoImportText);
                 completionItemData.autoImportText = autoImportText;
+                completionItem.detail = 'Auto-import';
             } else if (SymbolNameUtils.isDunderName(name)) {
                 // Force dunder-named symbols to appear after all other symbols.
                 completionItem.sortText = this._makeSortText(SortCategory.DunderSymbol, name);

--- a/packages/pyright-internal/src/languageService/hoverProvider.ts
+++ b/packages/pyright-internal/src/languageService/hoverProvider.ts
@@ -271,7 +271,10 @@ export class HoverProvider {
         const classText = `${node.value}(${functionParts[0].join(', ')})`;
 
         this._addResultsPart(parts, '(class) ' + classText, true);
-        this._addDocumentationPartForType(sourceMapper, parts, initMethodType, declaration);
+        const addedDoc = this._addDocumentationPartForType(sourceMapper, parts, initMethodType, declaration);
+        if (!addedDoc) {
+            this._addDocumentationPartForType(sourceMapper, parts, classType, declaration);
+        }
         return true;
     }
 
@@ -298,7 +301,7 @@ export class HoverProvider {
         parts: HoverTextPart[],
         type: Type,
         resolvedDecl: DeclarationBase | undefined
-    ) {
+    ): boolean {
         const docStrings: (string | undefined)[] = [];
 
         if (isModule(type)) {
@@ -314,11 +317,15 @@ export class HoverProvider {
             docStrings.push(getFunctionDocStringFromDeclaration(resolvedDecl as FunctionDeclaration, sourceMapper));
         }
 
+        let addedDoc = false;
         for (const docString of docStrings) {
             if (docString) {
+                addedDoc = true;
                 this._addDocumentationResultsPart(parts, docString);
             }
         }
+
+        return addedDoc;
     }
 
     private static _addDocumentationResultsPart(parts: HoverTextPart[], docString?: string) {

--- a/packages/pyright-internal/src/tests/fourslash/completions.autoimport.Lib.Found.Type.fourslash.ts
+++ b/packages/pyright-internal/src/tests/fourslash/completions.autoimport.Lib.Found.Type.fourslash.ts
@@ -19,8 +19,9 @@ await helper.verifyCompletion('included', {
                 label: 'Test',
                 documentation: {
                     kind: 'markdown',
-                    value: 'Auto-import\n\n```\nfrom testLib import Test\n```',
+                    value: '```\nfrom testLib import Test\n```',
                 },
+                detail: 'Auto-import',
             },
         ],
     },

--- a/packages/pyright-internal/src/tests/fourslash/completions.autoimport.Lib.Found.duplication.fourslash.ts
+++ b/packages/pyright-internal/src/tests/fourslash/completions.autoimport.Lib.Found.duplication.fourslash.ts
@@ -33,8 +33,9 @@ await helper.verifyCompletion('included', {
                 label: 'test1',
                 documentation: {
                     kind: 'markdown',
-                    value: 'Auto-import\n\n```\nfrom testLib import test1\n```',
+                    value: '```\nfrom testLib import test1\n```',
                 },
+                detail: 'Auto-import',
             },
         ],
     },

--- a/packages/pyright-internal/src/tests/fourslash/completions.autoimport.fourslash.ts
+++ b/packages/pyright-internal/src/tests/fourslash/completions.autoimport.fourslash.ts
@@ -15,8 +15,9 @@ await helper.verifyCompletion('included', {
                 label: 'Test',
                 documentation: {
                     kind: 'markdown',
-                    value: 'Auto-import\n\n```\nfrom test2 import Test\n```',
+                    value: '```\nfrom test2 import Test\n```',
                 },
+                detail: 'Auto-import',
             },
         ],
     },

--- a/packages/pyright-internal/src/tests/fourslash/completions.autoimport.shadow.fourslash.ts
+++ b/packages/pyright-internal/src/tests/fourslash/completions.autoimport.shadow.fourslash.ts
@@ -37,8 +37,9 @@ await helper.verifyCompletion('exact', {
                 label: 'MyShadow',
                 documentation: {
                     kind: 'markdown',
-                    value: 'Auto-import\n\n```\nfrom testLib import MyShadow\n```',
+                    value: '```\nfrom testLib import MyShadow\n```',
                 },
+                detail: 'Auto-import',
             },
         ],
     },

--- a/packages/pyright-internal/src/tests/fourslash/completions.autoimport.topLevel.fourslash.ts
+++ b/packages/pyright-internal/src/tests/fourslash/completions.autoimport.topLevel.fourslash.ts
@@ -22,8 +22,9 @@ await helper.verifyCompletion('included', {
                 label: 'os',
                 documentation: {
                     kind: 'markdown',
-                    value: 'Auto-import\n\n```\nimport os\n```',
+                    value: '```\nimport os\n```',
                 },
+                detail: 'Auto-import',
             },
         ],
     },
@@ -39,8 +40,9 @@ await helper.verifyCompletion('included', {
                 label: 'sys',
                 documentation: {
                     kind: 'markdown',
-                    value: 'Auto-import\n\n```\nimport sys\n```',
+                    value: '```\nimport sys\n```',
                 },
+                detail: 'Auto-import',
             },
         ],
     },

--- a/packages/pyright-internal/src/tests/fourslash/fourslash.ts
+++ b/packages/pyright-internal/src/tests/fourslash/fourslash.ts
@@ -28,6 +28,7 @@ declare namespace _ {
         label: string;
         insertionText?: string;
         documentation?: { kind: string; value: string };
+        detail?: string;
     }
 
     interface TextRange {

--- a/packages/pyright-internal/src/tests/fourslash/hover.classNoInit.fourslash.ts
+++ b/packages/pyright-internal/src/tests/fourslash/hover.classNoInit.fourslash.ts
@@ -1,0 +1,14 @@
+/// <reference path="fourslash.ts" />
+
+// @filename: test.py
+//// class Something:
+////     '''This is a test.'''
+////
+////     def __init__(self, text: str) -> None:
+////         self.text = text
+////
+//// [|/*marker1*/Something|]()
+
+helper.verifyHover({
+    marker1: { value: '```python\n(class) Something(text: str)\n```\nThis is a test.', kind: 'markdown' },
+});

--- a/packages/pyright-internal/src/tests/harness/fourslash/testState.ts
+++ b/packages/pyright-internal/src/tests/harness/fourslash/testState.ts
@@ -863,6 +863,7 @@ export class TestState {
 
                         const actual: CompletionItem = result.completionList.items[actualIndex];
                         assert.equal(actual.label, expected.label);
+                        assert.equal(actual.detail, expected.detail);
                         if (expectedCompletions[i].documentation !== undefined) {
                             if (actual.documentation === undefined) {
                                 this.program.resolveCompletionItem(filePath, actual, undefined, CancellationToken.None);

--- a/packages/pyright-internal/src/tests/harness/vfs/filesystem.ts
+++ b/packages/pyright-internal/src/tests/harness/vfs/filesystem.ts
@@ -321,6 +321,7 @@ export class TestFileSystem implements FileSystem {
     }
 
     tmpdir(): string {
+        this.mkdirpSync('/tmp');
         return pathUtil.normalizeSlashes('/tmp');
     }
 


### PR DESCRIPTION
Rollup of:

- Fix pythonPath and other path configuration when not defined. My previous fix here didn't check for a value before resolving the path (the old code assigned without resolving, so undefined remained undefined). Would have been caught had it not been for the type of the returned being `any`.
- Print search paths in trace log mode.
- Fix tmpdir on systems with shared temporary folders and multiple processes.
- Move "Auto-import" text to "details" property so it shows in the completion list.
- Show the class doc for constructor calls when the constructor has no docstring. Other doc fetches are non-calls and would have returned the class docs anyway.
- Fix `isNodeReachable` helper to not return true on missing nodes (fixes semantic highlight issues).