### PR TITLE
Streaming references/symbols, analysis error, indexing changes

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -26,11 +26,15 @@ jobs:
         with:
           node-version: ${{ env.NODE_VERSION }}
 
+      # Don't cache on Windows; the cache ends up being very large and
+      # the Windows implementation of the cache task uses a much slower archiver.
       - name: Get npm cache directory
+        if: runner.os != 'Windows'
         id: npm-cache
         run: |
           echo "::set-output name=dir::$(npm config get cache)"
       - uses: actions/cache@v2
+        if: runner.os != 'Windows'
         with:
           path: ${{ steps.npm-cache.outputs.dir }}
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}

--- a/packages/pyright-internal/src/analyzer/analysis.ts
+++ b/packages/pyright-internal/src/analyzer/analysis.ts
@@ -28,6 +28,7 @@ export interface AnalysisResults {
     fatalErrorOccurred: boolean;
     configParseErrorOccurred: boolean;
     elapsedTime: number;
+    error?: Error;
 }
 
 export type AnalysisCompleteCallback = (results: AnalysisResults) => void;
@@ -85,6 +86,7 @@ export function analyzeProgram(
             fatalErrorOccurred: true,
             configParseErrorOccurred: false,
             elapsedTime: 0,
+            error: debug.getSerializableError(e),
         });
     }
 

--- a/packages/pyright-internal/src/analyzer/program.ts
+++ b/packages/pyright-internal/src/analyzer/program.ts
@@ -47,9 +47,9 @@ import {
 } from '../languageService/autoImporter';
 import { CallHierarchyProvider } from '../languageService/callHierarchyProvider';
 import { CompletionResults } from '../languageService/completionProvider';
-import { IndexResults } from '../languageService/documentSymbolProvider';
+import { IndexOptions, IndexResults, WorkspaceSymbolCallback } from '../languageService/documentSymbolProvider';
 import { HoverResults } from '../languageService/hoverProvider';
-import { ReferencesResult } from '../languageService/referencesProvider';
+import { ReferenceCallback, ReferencesResult } from '../languageService/referencesProvider';
 import { SignatureHelpResults } from '../languageService/signatureHelpProvider';
 import { ImportLookupResult } from './analyzerFileInfo';
 import * as AnalyzerNodeInfo from './analyzerNodeInfo';
@@ -142,10 +142,10 @@ export class Program {
         initialConfigOptions: ConfigOptions,
         console?: ConsoleInterface,
         private _extension?: LanguageServiceExtension,
-        logPrefix = 'FG'
+        logTracker?: LogTracker
     ) {
         this._console = console || new StandardConsole();
-        this._logTracker = new LogTracker(console, logPrefix);
+        this._logTracker = logTracker ?? new LogTracker(console, 'FG');
         this._importResolver = initialImportResolver;
         this._configOptions = initialConfigOptions;
         this._createNewEvaluator();
@@ -436,19 +436,24 @@ export class Program {
             return;
         }
 
+        let count = 0;
         return this._runEvaluatorWithCancellationToken(token, () => {
             // Go through all workspace files to create indexing data.
-            // This will cause all files in the workspace to be parsed and bound. We might
-            // need to drop some of those parse tree and binding info once indexing is done
-            // if it didn't exist before.
+            // This will cause all files in the workspace to be parsed and bound. But
+            // _handleMemoryHighUsage will make sure we don't OOM
             for (const sourceFileInfo of this._sourceFileList) {
                 if (!this._isUserCode(sourceFileInfo)) {
                     continue;
                 }
 
                 this._bindFile(sourceFileInfo);
-                const results = sourceFileInfo.sourceFile.index(false, token);
+                const results = sourceFileInfo.sourceFile.index({ indexingForAutoImportMode: false }, token);
                 if (results) {
+                    if (++count > 2000) {
+                        this._console.warn(`Workspace indexing has hit its upper limit: 2000 files`);
+                        return;
+                    }
+
                     callback(sourceFileInfo.sourceFile.getFilePath(), results);
                 }
 
@@ -658,12 +663,12 @@ export class Program {
         return this._evaluator;
     }
 
-    private _parseFile(fileToParse: SourceFileInfo) {
+    private _parseFile(fileToParse: SourceFileInfo, content?: string) {
         if (!this._isFileNeeded(fileToParse) || !fileToParse.sourceFile.isParseRequired()) {
             return;
         }
 
-        if (fileToParse.sourceFile.parse(this._configOptions, this._importResolver)) {
+        if (fileToParse.sourceFile.parse(this._configOptions, this._importResolver, content)) {
             this._parsedFileCount++;
             this._updateSourceFileImports(fileToParse, this._configOptions);
         }
@@ -683,12 +688,12 @@ export class Program {
 
     // Binds the specified file and all of its dependencies, recursively. If
     // it runs out of time, it returns true. If it completes, it returns false.
-    private _bindFile(fileToAnalyze: SourceFileInfo): void {
+    private _bindFile(fileToAnalyze: SourceFileInfo, content?: string): void {
         if (!this._isFileNeeded(fileToAnalyze) || !fileToAnalyze.sourceFile.isBindingRequired()) {
             return;
         }
 
-        this._parseFile(fileToAnalyze);
+        this._parseFile(fileToAnalyze, content);
 
         // We need to parse and bind the builtins import first.
         let builtinsScope: Scope | undefined;
@@ -737,9 +742,16 @@ export class Program {
 
     // Build a map of all modules within this program and the module-
     // level scope that contains the symbol table for the module.
-    private _buildModuleSymbolsMap(sourceFileToExclude: SourceFileInfo, token: CancellationToken): ModuleSymbolMap {
+    private _buildModuleSymbolsMap(
+        sourceFileToExclude: SourceFileInfo,
+        userFileOnly: boolean,
+        token: CancellationToken
+    ): ModuleSymbolMap {
+        // If we have library map, always use the map for library symbols.
         return buildModuleSymbolsMap(
-            this._sourceFileList.filter((s) => s !== sourceFileToExclude),
+            this._sourceFileList.filter(
+                (s) => s !== sourceFileToExclude && (userFileOnly ? this._isUserCode(s) : true)
+            ),
             token
         );
     }
@@ -972,9 +984,9 @@ export class Program {
             }
 
             const writtenWord = fileContents.substr(textRange.start, textRange.length);
-            const map = this._buildModuleSymbolsMap(sourceFileInfo, token);
+            const map = this._buildModuleSymbolsMap(sourceFileInfo, !!libraryMap, token);
             const autoImporter = new AutoImporter(
-                this._configOptions,
+                this._configOptions.findExecEnvironment(filePath),
                 this._importResolver,
                 parseTree,
                 range.start,
@@ -1084,16 +1096,17 @@ export class Program {
         });
     }
 
-    getReferencesForPosition(
+    reportReferencesForPosition(
         filePath: string,
         position: Position,
         includeDeclaration: boolean,
+        reporter: ReferenceCallback,
         token: CancellationToken
-    ): DocumentRange[] | undefined {
-        return this._runEvaluatorWithCancellationToken(token, () => {
+    ) {
+        this._runEvaluatorWithCancellationToken(token, () => {
             const sourceFileInfo = this._getSourceFileInfoFromPath(filePath);
             if (!sourceFileInfo) {
-                return undefined;
+                return;
             }
 
             const invokedFromUserFile = this._isUserCode(sourceFileInfo);
@@ -1104,11 +1117,12 @@ export class Program {
                 this._createSourceMapper(execEnv),
                 position,
                 this._evaluator!,
+                reporter,
                 token
             );
 
             if (!referencesResult) {
-                return undefined;
+                return;
             }
 
             // Do we need to do a global search as well?
@@ -1155,19 +1169,18 @@ export class Program {
                             continue;
                         }
 
-                        const tempResult: ReferencesResult = {
-                            requiresGlobalSearch: referencesResult.requiresGlobalSearch,
-                            nodeAtOffset: referencesResult.nodeAtOffset,
-                            symbolName: referencesResult.symbolName,
-                            declarations: referencesResult.declarations,
-                            locations: [],
-                        };
+                        const tempResult = new ReferencesResult(
+                            referencesResult.requiresGlobalSearch,
+                            referencesResult.nodeAtOffset,
+                            referencesResult.symbolName,
+                            referencesResult.declarations
+                        );
 
                         declFileInfo.sourceFile.addReferences(tempResult, includeDeclaration, this._evaluator!, token);
                         for (const loc of tempResult.locations) {
                             // Include declarations only. And throw away any references
                             if (loc.path === decl.path && doesRangeContain(decl.range, loc.range)) {
-                                referencesResult.locations.push(loc);
+                                referencesResult.addLocations(loc);
                             }
                         }
                     }
@@ -1175,13 +1188,11 @@ export class Program {
             } else {
                 sourceFileInfo.sourceFile.addReferences(referencesResult, includeDeclaration, this._evaluator!, token);
             }
-
-            return referencesResult.locations;
         });
     }
 
-    getFileIndex(filePath: string, importSymbolsOnly: boolean, token: CancellationToken): IndexResults | undefined {
-        if (importSymbolsOnly) {
+    getFileIndex(filePath: string, options: IndexOptions, token: CancellationToken): IndexResults | undefined {
+        if (options.indexingForAutoImportMode) {
             // Memory optimization. We only want to hold onto symbols
             // usable outside when importSymbolsOnly is on.
             const name = stripFileExtension(getFileName(filePath));
@@ -1198,8 +1209,26 @@ export class Program {
                 return undefined;
             }
 
-            this._bindFile(sourceFileInfo);
-            return sourceFileInfo.sourceFile.index(importSymbolsOnly, token);
+            let content: string | undefined = undefined;
+            if (
+                options.indexingForAutoImportMode &&
+                !sourceFileInfo.sourceFile.isStubFile() &&
+                sourceFileInfo.sourceFile.getClientVersion() === null
+            ) {
+                try {
+                    // Perf optimization. if py file doesn't contain __all__
+                    // No need to parse and bind.
+                    content = this._fs.readFileSync(filePath, 'utf8');
+                    if (content.indexOf('__all__') < 0) {
+                        return undefined;
+                    }
+                } catch (error) {
+                    content = undefined;
+                }
+            }
+
+            this._bindFile(sourceFileInfo, content);
+            return sourceFileInfo.sourceFile.index(options, token);
         });
     }
 
@@ -1217,8 +1246,8 @@ export class Program {
         });
     }
 
-    addSymbolsForWorkspace(symbolList: SymbolInformation[], query: string, token: CancellationToken) {
-        return this._runEvaluatorWithCancellationToken(token, () => {
+    reportSymbolsForWorkspace(query: string, reporter: WorkspaceSymbolCallback, token: CancellationToken) {
+        this._runEvaluatorWithCancellationToken(token, () => {
             // Don't do a search if the query is empty. We'll return
             // too many results in this case.
             if (!query) {
@@ -1236,7 +1265,10 @@ export class Program {
                     this._bindFile(sourceFileInfo);
                 }
 
-                sourceFileInfo.sourceFile.addSymbolsForDocument(symbolList, query, token);
+                const symbolList = sourceFileInfo.sourceFile.getSymbolsForDocument(query, token);
+                if (symbolList.length > 0) {
+                    reporter(symbolList);
+                }
 
                 // This operation can consume significant memory, so check
                 // for situations where we need to discard the type cache.
@@ -1334,7 +1366,7 @@ export class Program {
                 this._evaluator!,
                 this._createSourceMapper(execEnv, /* mapCompiled */ true),
                 libraryMap,
-                () => this._buildModuleSymbolsMap(sourceFileInfo, token),
+                () => this._buildModuleSymbolsMap(sourceFileInfo, !!libraryMap, token),
                 token
             );
         });
@@ -1384,7 +1416,7 @@ export class Program {
                 this._evaluator!,
                 this._createSourceMapper(execEnv, /* mapCompiled */ true),
                 libraryMap,
-                () => this._buildModuleSymbolsMap(sourceFileInfo, token),
+                () => this._buildModuleSymbolsMap(sourceFileInfo, !!libraryMap, token),
                 completionItem,
                 token
             );
@@ -1410,6 +1442,7 @@ export class Program {
                 this._createSourceMapper(execEnv),
                 position,
                 this._evaluator!,
+                undefined,
                 token
             );
 
@@ -1472,6 +1505,7 @@ export class Program {
             this._createSourceMapper(execEnv),
             position,
             this._evaluator!,
+            undefined,
             token
         );
 
@@ -1508,6 +1542,7 @@ export class Program {
             this._createSourceMapper(execEnv),
             position,
             this._evaluator!,
+            undefined,
             token
         );
 
@@ -1563,6 +1598,7 @@ export class Program {
             this._createSourceMapper(execEnv),
             position,
             this._evaluator!,
+            undefined,
             token
         );
 

--- a/packages/pyright-internal/src/analyzer/service.ts
+++ b/packages/pyright-internal/src/analyzer/service.ts
@@ -46,8 +46,9 @@ import {
 import { DocumentRange, Position, Range } from '../common/textRange';
 import { timingStats } from '../common/timing';
 import { CompletionResults } from '../languageService/completionProvider';
-import { IndexResults } from '../languageService/documentSymbolProvider';
+import { IndexResults, WorkspaceSymbolCallback } from '../languageService/documentSymbolProvider';
 import { HoverResults } from '../languageService/hoverProvider';
+import { ReferenceCallback } from '../languageService/referencesProvider';
 import { SignatureHelpResults } from '../languageService/signatureHelpProvider';
 import { AnalysisCompleteCallback } from './analysis';
 import { BackgroundAnalysisProgram, BackgroundAnalysisProgramFactory } from './backgroundAnalysisProgram';
@@ -244,21 +245,22 @@ export class AnalyzerService {
         return this._program.getDefinitionsForPosition(filePath, position, token);
     }
 
-    getReferencesForPosition(
+    reportReferencesForPosition(
         filePath: string,
         position: Position,
         includeDeclaration: boolean,
+        reporter: ReferenceCallback,
         token: CancellationToken
-    ): DocumentRange[] | undefined {
-        return this._program.getReferencesForPosition(filePath, position, includeDeclaration, token);
+    ) {
+        this._program.reportReferencesForPosition(filePath, position, includeDeclaration, reporter, token);
     }
 
     addSymbolsForDocument(filePath: string, symbolList: DocumentSymbol[], token: CancellationToken) {
         this._program.addSymbolsForDocument(filePath, symbolList, token);
     }
 
-    addSymbolsForWorkspace(symbolList: SymbolInformation[], query: string, token: CancellationToken) {
-        this._program.addSymbolsForWorkspace(symbolList, query, token);
+    reportSymbolsForWorkspace(query: string, reporter: WorkspaceSymbolCallback, token: CancellationToken) {
+        this._program.reportSymbolsForWorkspace(query, reporter, token);
     }
 
     getHoverForPosition(filePath: string, position: Position, token: CancellationToken): HoverResults | undefined {

--- a/packages/pyright-internal/src/analyzer/staticExpressions.ts
+++ b/packages/pyright-internal/src/analyzer/staticExpressions.ts
@@ -8,7 +8,7 @@
  * (parse node trees).
  */
 
-import { ExecutionEnvironment } from '../common/configOptions';
+import { ExecutionEnvironment, PythonPlatform } from '../common/configOptions';
 import { ExpressionNode, NumberNode, ParseNodeType, TupleNode } from '../parser/parseNodes';
 import { KeywordType, OperatorType } from '../parser/tokenizerTypes';
 
@@ -220,11 +220,11 @@ function _isOsNameInfoExpression(node: ExpressionNode): boolean {
 }
 
 function _getExpectedPlatformNameFromPlatform(execEnv: ExecutionEnvironment): string | undefined {
-    if (execEnv.pythonPlatform === 'Darwin') {
+    if (execEnv.pythonPlatform === PythonPlatform.Darwin) {
         return 'darwin';
-    } else if (execEnv.pythonPlatform === 'Windows') {
+    } else if (execEnv.pythonPlatform === PythonPlatform.Windows) {
         return 'win32';
-    } else if (execEnv.pythonPlatform === 'Linux') {
+    } else if (execEnv.pythonPlatform === PythonPlatform.Linux) {
         return 'linux';
     }
 
@@ -232,11 +232,11 @@ function _getExpectedPlatformNameFromPlatform(execEnv: ExecutionEnvironment): st
 }
 
 function _getExpectedOsNameFromPlatform(execEnv: ExecutionEnvironment): string | undefined {
-    if (execEnv.pythonPlatform === 'Darwin') {
+    if (execEnv.pythonPlatform === PythonPlatform.Darwin) {
         return 'posix';
-    } else if (execEnv.pythonPlatform === 'Windows') {
+    } else if (execEnv.pythonPlatform === PythonPlatform.Windows) {
         return 'nt';
-    } else if (execEnv.pythonPlatform === 'Linux') {
+    } else if (execEnv.pythonPlatform === PythonPlatform.Linux) {
         return 'posix';
     }
 

--- a/packages/pyright-internal/src/backgroundAnalysisBase.ts
+++ b/packages/pyright-internal/src/backgroundAnalysisBase.ts
@@ -32,6 +32,7 @@ import { Diagnostic } from './common/diagnostic';
 import { FileDiagnostics } from './common/diagnosticSink';
 import { LanguageServiceExtension } from './common/extensibility';
 import { FileSystem } from './common/fileSystem';
+import { LogTracker } from './common/logTracker';
 import { Range } from './common/textRange';
 import { IndexResults } from './languageService/documentSymbolProvider';
 
@@ -252,12 +253,13 @@ export class BackgroundAnalysisRunnerBase extends BackgroundThreadBase {
 
         this._configOptions = new ConfigOptions(data.rootDirectory);
         this._importResolver = this.createImportResolver(this.fs, this._configOptions);
+        const console = this.getConsole();
         this._program = new Program(
             this._importResolver,
             this._configOptions,
-            this.getConsole(),
+            console,
             this._extension,
-            `BG(${threadId})`
+            new LogTracker(console, `BG(${threadId})`)
         );
     }
 

--- a/packages/pyright-internal/src/common/configOptions.ts
+++ b/packages/pyright-internal/src/common/configOptions.ts
@@ -31,6 +31,12 @@ import {
     versionToString,
 } from './pythonVersion';
 
+export enum PythonPlatform {
+    Darwin = 'Darwin',
+    Windows = 'Windows',
+    Linux = 'Linux',
+}
+
 export class ExecutionEnvironment {
     // Default to "." which indicates every file in the project.
     constructor(root: string, defaultPythonVersion?: PythonVersion, defaultPythonPlatform?: string) {
@@ -1224,11 +1230,11 @@ export class ConfigOptions {
         }
 
         if (process.platform === 'darwin') {
-            this.defaultPythonPlatform = 'Darwin';
+            this.defaultPythonPlatform = PythonPlatform.Darwin;
         } else if (process.platform === 'linux') {
-            this.defaultPythonPlatform = 'Linux';
+            this.defaultPythonPlatform = PythonPlatform.Linux;
         } else if (process.platform === 'win32') {
-            this.defaultPythonPlatform = 'Windows';
+            this.defaultPythonPlatform = PythonPlatform.Windows;
         }
 
         if (this.defaultPythonPlatform !== undefined) {

--- a/packages/pyright-internal/src/common/debug.ts
+++ b/packages/pyright-internal/src/common/debug.ts
@@ -7,7 +7,7 @@
  */
 
 import { stableSort } from './collectionUtils';
-import { AnyFunction, compareValues, hasProperty } from './core';
+import { AnyFunction, compareValues, hasProperty, isString } from './core';
 
 export function assert(
     expression: boolean,
@@ -104,6 +104,25 @@ export function getErrorString(error: any): string {
         (typeof error.message === 'string' ? error.message : undefined) ||
         JSON.stringify(error)
     );
+}
+
+export function getSerializableError(error: any): Error | undefined {
+    if (!error) {
+        return undefined;
+    }
+
+    const exception = JSON.stringify(error);
+    if (exception.length > 2) {
+        // Given error object is JSON.stringify serializable. Use it as it is
+        // to preserve properties.
+        return error;
+    }
+
+    // Convert error to JSON.stringify serializable Error shape.
+    const name = error.name ? (isString(error.name) ? error.name : 'noname') : 'noname';
+    const message = error.message ? (isString(error.message) ? error.message : 'nomessage') : 'nomessage';
+    const stack = error.stack ? (isString(error.stack) ? error.stack : undefined) : undefined;
+    return { name, message, stack };
 }
 
 function getEnumMembers(enumObject: any) {

--- a/packages/pyright-internal/src/common/pathUtils.ts
+++ b/packages/pyright-internal/src/common/pathUtils.ts
@@ -914,3 +914,14 @@ export function isFileSystemCaseSensitiveInternal(fs: FileSystem) {
         }
     }
 }
+
+export function getLibraryPathWithoutExtension(libraryFilePath: string) {
+    let filePathWithoutExtension = stripFileExtension(libraryFilePath);
+
+    // Strip off the '/__init__' if it's present.
+    if (filePathWithoutExtension.endsWith('__init__')) {
+        filePathWithoutExtension = filePathWithoutExtension.substr(0, filePathWithoutExtension.length - 9);
+    }
+
+    return filePathWithoutExtension;
+}

--- a/packages/pyright-internal/src/common/pythonVersion.ts
+++ b/packages/pyright-internal/src/common/pythonVersion.ts
@@ -71,3 +71,23 @@ export function versionFromMajorMinor(major: number, minor: number): PythonVersi
 export function is3x(version: PythonVersion): boolean {
     return version >> 8 === 3;
 }
+
+export function getPythonVersionStrings(pythonVersion: PythonVersion) {
+    const versionStrings: string[] = [];
+
+    let minorVersion = pythonVersion & 0xff;
+    while (true) {
+        const pythonVersionString =
+            minorVersion > 0 ? versionToString(0x300 + minorVersion) : minorVersion === 0 ? '3' : '2and3';
+        versionStrings.push(pythonVersionString);
+
+        // We use -1 to indicate "2and3", which is searched after "3.0".
+        if (minorVersion === -1) {
+            break;
+        }
+
+        minorVersion--;
+    }
+
+    return versionStrings;
+}

--- a/packages/pyright-internal/src/common/timing.ts
+++ b/packages/pyright-internal/src/common/timing.ts
@@ -39,8 +39,11 @@ export class TimingStat {
             this.isTiming = true;
             const duration = new Duration();
             callback();
-            this.totalTime += duration.getDurationInMilliseconds();
+            const elapsedTime = duration.getDurationInMilliseconds();
+            this.totalTime += elapsedTime;
             this.isTiming = false;
+
+            return elapsedTime;
         }
     }
 

--- a/packages/pyright-internal/src/languageService/completionProvider.ts
+++ b/packages/pyright-internal/src/languageService/completionProvider.ts
@@ -965,7 +965,7 @@ export class CompletionProvider {
     private _getAutoImportCompletions(priorWord: string, completionList: CompletionList) {
         const moduleSymbolMap = this._moduleSymbolsCallback();
         const autoImporter = new AutoImporter(
-            this._configOptions,
+            this._configOptions.findExecEnvironment(this._filePath),
             this._importResolver,
             this._parseResults,
             this._position,

--- a/packages/pyright-internal/src/tests/harness/fourslash/testState.ts
+++ b/packages/pyright-internal/src/tests/harness/fourslash/testState.ts
@@ -1006,7 +1006,15 @@ export class TestState {
             const expected = map[name].references;
 
             const position = this.convertOffsetToPosition(fileName, marker.position);
-            const actual = this.program.getReferencesForPosition(fileName, position, true, CancellationToken.None);
+
+            const actual: DocumentRange[] = [];
+            this.program.reportReferencesForPosition(
+                fileName,
+                position,
+                true,
+                (locs) => actual.push(...locs),
+                CancellationToken.None
+            );
 
             assert.equal(actual?.length ?? 0, expected.length);
 

--- a/packages/pyright/package.json
+++ b/packages/pyright/package.json
@@ -19,7 +19,7 @@
     "scripts": {
         "build": "webpack --mode production --progress",
         "clean": "shx rm -rf ./dist ./out README.md",
-        "prepublishOnly": "npm run clean && shx cp ../../README.md . && npm run build",
+        "prepack": "npm run clean && shx cp ../../README.md . && npm run build",
         "webpack": "webpack --mode development --progress"
     },
     "devDependencies": {


### PR DESCRIPTION
Rollup of:

- Improve performance of validation workflow on Windows.
- Support streaming clients for references and workspace symbols (work reporters). This is VS, but VS Code in the future.
- Include analysis error in analysis result.
- Changes to support improved indexing performance in Pylance.