### PR TITLE
Fix completion after '#', fix parser crash on empty fstring expression

### DIFF
--- a/packages/pyright-internal/src/common/textRange.ts
+++ b/packages/pyright-internal/src/common/textRange.ts
@@ -41,6 +41,10 @@ export namespace TextRange {
         return position >= range.start && position < getEnd(range);
     }
 
+    export function overlaps(range: TextRange, position: number): boolean {
+        return position >= range.start && position <= getEnd(range);
+    }
+
     export function extend(range: TextRange, extension: TextRange | TextRange[] | undefined) {
         if (extension) {
             if (Array.isArray(extension)) {

--- a/packages/pyright-internal/src/parser/parser.ts
+++ b/packages/pyright-internal/src/parser/parser.ts
@@ -3426,7 +3426,7 @@ export class Parser {
 
     private _peekToken(count = 0): Token {
         if (this._tokenIndex + count < 0) {
-            this._tokenizerOutput!.tokens.getItemAt(0);
+            return this._tokenizerOutput!.tokens.getItemAt(0);
         }
 
         if (this._tokenIndex + count >= this._tokenizerOutput!.tokens.count) {

--- a/packages/pyright-internal/src/tests/fourslash/completions.autoimport.Lib.NotFound.fourslash.ts
+++ b/packages/pyright-internal/src/tests/fourslash/completions.autoimport.Lib.NotFound.fourslash.ts
@@ -9,4 +9,6 @@
 ////     pass
 
 // @ts-ignore
-await helper.verifyCompletion('included', 'markdown', { marker: { completions: [] } });
+await helper.verifyCompletion('excluded', 'markdown', {
+    marker: { completions: [{ label: 'Test', kind: undefined }] },
+});

--- a/packages/pyright-internal/src/tests/fourslash/completions.comment.fourslash.ts
+++ b/packages/pyright-internal/src/tests/fourslash/completions.comment.fourslash.ts
@@ -1,0 +1,28 @@
+/// <reference path="fourslash.ts" />
+
+// @filename: test.py
+//// msg = 'hello'
+//// [|/*marker1*/|]
+//// # msg.[|/*marker2*/|]
+//// [|/*marker3*/|]
+//// print('upper: ' + msg.up[|/*marker4*/|]per())
+//// print('#upper: ' + msg.up[|/*marker5*/|]per())
+////
+//// # msg.[|/*marker6*/|]
+//// [|/*marker7*/|]
+////
+
+// @ts-ignore
+await helper.verifyCompletion('exact', 'markdown', {
+    marker2: { completions: [] },
+    marker6: { completions: [] },
+});
+
+// @ts-ignore
+await helper.verifyCompletion('included', 'markdown', {
+    marker1: { completions: [{ label: 'msg', kind: Consts.CompletionItemKind.Variable }] },
+    marker3: { completions: [{ label: 'msg', kind: Consts.CompletionItemKind.Variable }] },
+    marker4: { completions: [{ label: 'upper', kind: Consts.CompletionItemKind.Method }] },
+    marker5: { completions: [{ label: 'upper', kind: Consts.CompletionItemKind.Method }] },
+    marker7: { completions: [{ label: 'msg', kind: Consts.CompletionItemKind.Variable }] },
+});

--- a/packages/pyright-internal/src/tests/harness/fourslash/testState.ts
+++ b/packages/pyright-internal/src/tests/harness/fourslash/testState.ts
@@ -910,7 +910,9 @@ export class TestState {
                     }
                 }
             } else {
-                assert.fail('Failed to get completions');
+                if (verifyMode !== 'exact' || expectedCompletions.length > 0) {
+                    assert.fail('Failed to get completions');
+                }
             }
 
             if (map[markerName].memberAccessInfo !== undefined && result?.memberAccessInfo !== undefined) {

--- a/packages/pyright-internal/src/tests/parser.test.ts
+++ b/packages/pyright-internal/src/tests/parser.test.ts
@@ -28,3 +28,10 @@ test('Sample1', () => {
     assert.equal(diagSink.fetchAndClear().length, 0);
     assert.equal(parseInfo.parseResults.parseTree.statements.length, 4);
 });
+
+test('FStringEmptyTuple', () => {
+    assert.doesNotThrow(() => {
+        const diagSink = new DiagnosticSink();
+        TestUtils.parseSampleFile('fstring6.py', diagSink);
+    });
+});

--- a/packages/pyright-internal/src/tests/samples/fstring6.py
+++ b/packages/pyright-internal/src/tests/samples/fstring6.py
@@ -1,0 +1,4 @@
+# This sample tests the parsing and analysis of f-strings with empty {}
+
+msg = "test"
+a = f"{}"


### PR DESCRIPTION
Rollup of:

- Fix completions after `#` character in line.
- Fix crash on parsing an empty fstring expression.