### PR TITLE
Improve completion context detection, respect sig help doc kind, helpers

### DIFF
--- a/packages/pyright-internal/src/analyzer/binder.ts
+++ b/packages/pyright-internal/src/analyzer/binder.ts
@@ -2963,3 +2963,17 @@ export class YieldFinder extends ParseTreeWalker {
         return false;
     }
 }
+
+export class ReturnFinder extends ParseTreeWalker {
+    private _containsReturn = false;
+
+    checkContainsReturn(node: ParseNode) {
+        this.walk(node);
+        return this._containsReturn;
+    }
+
+    visitReturn(node: ReturnNode): boolean {
+        this._containsReturn = true;
+        return false;
+    }
+}

--- a/packages/pyright-internal/src/analyzer/parseTreeUtils.ts
+++ b/packages/pyright-internal/src/analyzer/parseTreeUtils.ts
@@ -550,7 +550,11 @@ export function getEnclosingClassOrFunction(node: ParseNode): FunctionNode | Cla
     return undefined;
 }
 
-export function getEnclosingSuiteOrModule(node: ParseNode): SuiteNode | ModuleNode | undefined {
+export function getEnclosingSuiteOrModule(
+    node: ParseNode,
+    stopAtFunction = false,
+    stopAtLambda = true
+): SuiteNode | ModuleNode | undefined {
     let curNode = node.parent;
     while (curNode) {
         if (curNode.nodeType === ParseNodeType.Suite) {
@@ -562,7 +566,15 @@ export function getEnclosingSuiteOrModule(node: ParseNode): SuiteNode | ModuleNo
         }
 
         if (curNode.nodeType === ParseNodeType.Lambda) {
-            return undefined;
+            if (stopAtLambda) {
+                return undefined;
+            }
+        }
+
+        if (curNode.nodeType === ParseNodeType.Function) {
+            if (stopAtFunction) {
+                return undefined;
+            }
         }
 
         curNode = curNode.parent;

--- a/packages/pyright-internal/src/analyzer/program.ts
+++ b/packages/pyright-internal/src/analyzer/program.ts
@@ -1330,6 +1330,7 @@ export class Program {
     getSignatureHelpForPosition(
         filePath: string,
         position: Position,
+        format: MarkupKind,
         token: CancellationToken
     ): SignatureHelpResults | undefined {
         return this._runEvaluatorWithCancellationToken(token, () => {
@@ -1344,6 +1345,7 @@ export class Program {
                 position,
                 this._lookUpImport,
                 this._evaluator!,
+                format,
                 token
             );
         });

--- a/packages/pyright-internal/src/analyzer/service.ts
+++ b/packages/pyright-internal/src/analyzer/service.ts
@@ -13,7 +13,6 @@ import {
     CancellationToken,
     CompletionItem,
     DocumentSymbol,
-    SymbolInformation,
 } from 'vscode-languageserver';
 import { TextDocumentContentChangeEvent } from 'vscode-languageserver-textdocument';
 import {
@@ -57,6 +56,7 @@ import { BackgroundAnalysisProgram, BackgroundAnalysisProgramFactory } from './b
 import { ImportedModuleDescriptor, ImportResolver, ImportResolverFactory } from './importResolver';
 import { MaxAnalysisTime } from './program';
 import { findPythonSearchPaths, getPythonPathFromPythonInterpreter } from './pythonPathUtils';
+import { TypeEvaluator } from './typeEvaluator';
 
 export const configFileNames = ['pyrightconfig.json', 'mspythonconfig.json'];
 
@@ -285,9 +285,10 @@ export class AnalyzerService {
     getSignatureHelpForPosition(
         filePath: string,
         position: Position,
+        format: MarkupKind,
         token: CancellationToken
     ): SignatureHelpResults | undefined {
-        return this._program.getSignatureHelpForPosition(filePath, position, token);
+        return this._program.getSignatureHelpForPosition(filePath, position, format, token);
     }
 
     getCompletionsForPosition(
@@ -307,6 +308,10 @@ export class AnalyzerService {
             this._backgroundAnalysisProgram.getIndexing(filePath),
             token
         );
+    }
+
+    getEvaluator(): TypeEvaluator | undefined {
+        return this._program.evaluator;
     }
 
     resolveCompletionItem(

--- a/packages/pyright-internal/src/analyzer/sourceFile.ts
+++ b/packages/pyright-internal/src/analyzer/sourceFile.ts
@@ -771,6 +771,7 @@ export class SourceFile {
         position: Position,
         importLookup: ImportLookup,
         evaluator: TypeEvaluator,
+        format: MarkupKind,
         token: CancellationToken
     ): SignatureHelpResults | undefined {
         // If we have no completed analysis job, there's nothing to do.
@@ -778,7 +779,13 @@ export class SourceFile {
             return undefined;
         }
 
-        return SignatureHelpProvider.getSignatureHelpForPosition(this._parseResults, position, evaluator, token);
+        return SignatureHelpProvider.getSignatureHelpForPosition(
+            this._parseResults,
+            position,
+            evaluator,
+            format,
+            token
+        );
     }
 
     getCompletionsForPosition(

--- a/packages/pyright-internal/src/analyzer/symbolUtils.ts
+++ b/packages/pyright-internal/src/analyzer/symbolUtils.ts
@@ -7,10 +7,9 @@
  * Collection of functions that operate on Symbol objects.
  */
 
-import { ParseNodeType } from '../parser/parseNodes';
 import { Declaration, DeclarationType } from './declaration';
 import { isFinalVariableDeclaration } from './declarationUtils';
-import { Symbol, SymbolTable } from './symbol';
+import { Symbol } from './symbol';
 
 export function getLastTypedDeclaredForSymbol(symbol: Symbol): Declaration | undefined {
     const typedDecls = symbol.getTypedDeclarations();

--- a/packages/pyright-internal/src/languageServerBase.ts
+++ b/packages/pyright-internal/src/languageServerBase.ts
@@ -173,6 +173,7 @@ export abstract class LanguageServerBase implements LanguageServerInterface {
     protected _hasHierarchicalDocumentSymbolCapability = false;
     protected _hoverContentFormat: MarkupKind = MarkupKind.PlainText;
     protected _completionDocFormat: MarkupKind = MarkupKind.PlainText;
+    protected _signatureDocFormat: MarkupKind = MarkupKind.PlainText;
     protected _supportsUnnecessaryDiagnosticTag = false;
     protected _defaultClientConfig: any;
 
@@ -589,6 +590,7 @@ export abstract class LanguageServerBase implements LanguageServerInterface {
             const signatureHelpResults = workspace.serviceInstance.getSignatureHelpForPosition(
                 filePath,
                 position,
+                this._signatureDocFormat,
                 token
             );
             if (!signatureHelpResults) {
@@ -606,7 +608,8 @@ export abstract class LanguageServerBase implements LanguageServerInterface {
                     );
                 }
 
-                const sigInfo = SignatureInformation.create(sig.label, sig.documentation, ...paramInfo);
+                const sigInfo = SignatureInformation.create(sig.label, undefined, ...paramInfo);
+                sigInfo.documentation = sig.documentation;
                 sigInfo.activeParameter = sig.activeParameter;
                 return sigInfo;
             });
@@ -933,6 +936,9 @@ export abstract class LanguageServerBase implements LanguageServerInterface {
         this._hoverContentFormat = this._getCompatibleMarkupKind(capabilities.textDocument?.hover?.contentFormat);
         this._completionDocFormat = this._getCompatibleMarkupKind(
             capabilities.textDocument?.completion?.completionItem?.documentationFormat
+        );
+        this._signatureDocFormat = this._getCompatibleMarkupKind(
+            capabilities.textDocument?.signatureHelp?.signatureInformation?.documentationFormat
         );
         const supportedDiagnosticTags = capabilities.textDocument?.publishDiagnostics?.tagSupport?.valueSet || [];
         this._supportsUnnecessaryDiagnosticTag = supportedDiagnosticTags.some(

--- a/packages/pyright-internal/src/languageService/referencesProvider.ts
+++ b/packages/pyright-internal/src/languageService/referencesProvider.ts
@@ -54,7 +54,7 @@ export class ReferencesResult {
     }
 }
 
-class FindReferencesTreeWalker extends ParseTreeWalker {
+export class FindReferencesTreeWalker extends ParseTreeWalker {
     private readonly _locationsFound: DocumentRange[] = [];
 
     constructor(
@@ -68,8 +68,8 @@ class FindReferencesTreeWalker extends ParseTreeWalker {
         super();
     }
 
-    findReferences() {
-        this.walk(this._parseResults.parseTree);
+    findReferences(rootNode = this._parseResults.parseTree) {
+        this.walk(rootNode);
 
         return this._locationsFound;
     }

--- a/packages/pyright-internal/src/parser/parseNodes.ts
+++ b/packages/pyright-internal/src/parser/parseNodes.ts
@@ -701,10 +701,16 @@ export interface ErrorNode extends ParseNodeBase {
     readonly nodeType: ParseNodeType.Error;
     readonly category: ErrorExpressionCategory;
     readonly child?: ExpressionNode;
+    readonly decorators?: DecoratorNode[];
 }
 
 export namespace ErrorNode {
-    export function create(initialRange: TextRange, category: ErrorExpressionCategory, child?: ExpressionNode) {
+    export function create(
+        initialRange: TextRange,
+        category: ErrorExpressionCategory,
+        child?: ExpressionNode,
+        decorators?: DecoratorNode[]
+    ) {
         const node: ErrorNode = {
             start: initialRange.start,
             length: initialRange.length,
@@ -712,11 +718,22 @@ export namespace ErrorNode {
             id: _nextNodeId++,
             category,
             child,
+            decorators,
         };
 
         if (child) {
             child.parent = node;
             extendRange(node, child);
+        }
+
+        if (decorators) {
+            decorators.forEach((decorator) => {
+                decorator.parent = node;
+            });
+
+            if (decorators.length > 0) {
+                extendRange(node, decorators[0]);
+            }
         }
 
         return node;

--- a/packages/pyright-internal/src/parser/parser.ts
+++ b/packages/pyright-internal/src/parser/parser.ts
@@ -720,7 +720,12 @@ export class Parser {
         const nameToken = this._getTokenIfIdentifier();
         if (!nameToken) {
             this._addError(Localizer.Diagnostic.expectedFunctionName(), defToken);
-            return ErrorNode.create(defToken, ErrorExpressionCategory.MissingFunctionParameterList);
+            return ErrorNode.create(
+                defToken,
+                ErrorExpressionCategory.MissingFunctionParameterList,
+                undefined,
+                decorators
+            );
         }
 
         if (!this._consumeTokenIfType(TokenType.OpenParenthesis)) {
@@ -728,7 +733,8 @@ export class Parser {
             return ErrorNode.create(
                 nameToken,
                 ErrorExpressionCategory.MissingFunctionParameterList,
-                NameNode.create(nameToken)
+                NameNode.create(nameToken),
+                decorators
             );
         }
 

--- a/packages/pyright-internal/src/tests/fourslash/completions.declNames.class.fourslash.ts
+++ b/packages/pyright-internal/src/tests/fourslash/completions.declNames.class.fourslash.ts
@@ -1,0 +1,35 @@
+/// <reference path="fourslash.ts" />
+
+// @filename: test.py
+//// class [|/*marker1*/|]
+////
+
+// @filename: test1.py
+//// class c[|/*marker2*/|]
+////
+
+// @filename: test2.py
+//// class c1[|/*marker3*/|]():
+////     pass
+////
+
+// @filename: test3.py
+//// class c1([|/*marker4*/|]):
+////     pass
+////
+
+{
+    helper.openFiles(helper.getMarkers().map((m) => m.fileName));
+
+    // @ts-ignore
+    await helper.verifyCompletion('exact', 'markdown', {
+        marker1: { completions: [] },
+        marker2: { completions: [] },
+        marker3: { completions: [] },
+    });
+
+    // @ts-ignore
+    await helper.verifyCompletion('included', 'markdown', {
+        marker4: { completions: [{ label: 'Exception', kind: Consts.CompletionItemKind.Class }] },
+    });
+}

--- a/packages/pyright-internal/src/tests/fourslash/completions.declNames.exception.fourslash.ts
+++ b/packages/pyright-internal/src/tests/fourslash/completions.declNames.exception.fourslash.ts
@@ -1,0 +1,18 @@
+/// <reference path="fourslash.ts" />
+
+// @filename: test.py
+//// try:
+////     pass
+//// except ZeroDivisionError as d[|/*marker1*/|]:
+////     pass
+////
+//// try:
+////     pass
+//// except ZeroDivisionError as [|/*marker2*/|]:
+////     pass
+
+// @ts-ignore
+await helper.verifyCompletion('exact', 'markdown', {
+    marker1: { completions: [] },
+    marker2: { completions: [] },
+});

--- a/packages/pyright-internal/src/tests/fourslash/completions.declNames.for.fourslash.ts
+++ b/packages/pyright-internal/src/tests/fourslash/completions.declNames.for.fourslash.ts
@@ -1,0 +1,30 @@
+/// <reference path="fourslash.ts" />
+
+// @filename: test1.py
+//// for [|/*marker1*/|]
+////
+
+// @filename: test2.py
+//// for c[|/*marker2*/|]
+////
+
+// @filename: test3.py
+//// for c1[|/*marker3*/|] in [1, 2]:
+////     pass
+////
+
+// @filename: test4.py
+//// [c for c[|/*marker4*/|] in [1, 2]]
+////
+
+{
+    helper.openFiles(helper.getMarkers().map((m) => m.fileName));
+
+    // @ts-ignore
+    await helper.verifyCompletion('exact', 'markdown', {
+        marker1: { completions: [{ label: 'in', kind: Consts.CompletionItemKind.Keyword }] },
+        marker2: { completions: [] },
+        marker3: { completions: [] },
+        marker4: { completions: [] },
+    });
+}

--- a/packages/pyright-internal/src/tests/fourslash/completions.declNames.importAlias.fourslash.ts
+++ b/packages/pyright-internal/src/tests/fourslash/completions.declNames.importAlias.fourslash.ts
@@ -1,0 +1,15 @@
+/// <reference path="fourslash.ts" />
+
+// @filename: test.py
+//// import os as o[|/*marker1*/|]
+//// import os as [|/*marker2*/|]
+//// from os import path as p[|/*marker3*/|]
+//// from os import path as [|/*marker4*/|]
+
+// @ts-ignore
+await helper.verifyCompletion('exact', 'markdown', {
+    marker1: { completions: [] },
+    marker2: { completions: [] },
+    marker3: { completions: [] },
+    marker4: { completions: [] },
+});

--- a/packages/pyright-internal/src/tests/fourslash/completions.declNames.lambda.fourslash.ts
+++ b/packages/pyright-internal/src/tests/fourslash/completions.declNames.lambda.fourslash.ts
@@ -1,0 +1,45 @@
+/// <reference path="fourslash.ts" />
+
+// @filename: test.py
+//// lambda [|/*marker1*/|]
+
+// @filename: test1.py
+//// lambda x[|/*marker2*/|]
+
+// @filename: test2.py
+//// lambda x[|/*marker3*/|]:
+
+// @filename: test3.py
+//// lambda x, [|/*marker4*/|]
+
+// @filename: test4.py
+//// lambda x, [|/*marker5*/|]:
+
+// @filename: test5.py
+//// lambda x, y[|/*marker6*/|]
+
+// @filename: test6.py
+//// lambda x, y[|/*marker7*/|]:
+
+// @filename: test7.py
+//// lambda x: [|/*marker8*/|]
+
+{
+    helper.openFiles(helper.getMarkers().map((m) => m.fileName));
+
+    // @ts-ignore
+    await helper.verifyCompletion('exact', 'markdown', {
+        marker1: { completions: [] },
+        marker2: { completions: [] },
+        marker3: { completions: [] },
+        marker4: { completions: [] },
+        marker5: { completions: [] },
+        marker6: { completions: [] },
+        marker7: { completions: [] },
+    });
+
+    // @ts-ignore
+    await helper.verifyCompletion('included', 'markdown', {
+        marker8: { completions: [{ label: 'str', kind: Consts.CompletionItemKind.Class }] },
+    });
+}

--- a/packages/pyright-internal/src/tests/fourslash/completions.declNames.method.fourslash.ts
+++ b/packages/pyright-internal/src/tests/fourslash/completions.declNames.method.fourslash.ts
@@ -1,0 +1,71 @@
+/// <reference path="fourslash.ts" />
+
+// @filename: test.py
+//// def [|/*marker1*/|]
+////
+//// def d[|/*marker2*/|]
+////
+//// def d1[|/*marker3*/|]():
+////     pass
+////
+//// async def [|/*marker4*/|]
+////
+//// async def a[|/*marker5*/|]
+////
+//// async def a1[|/*marker6*/|]():
+////     pass
+////
+//// def method(p[|/*marker7*/|]):
+////     pass
+//// def method(p:[|/*marker8*/|]):
+////     pass
+////
+//// def method(p, p2[|/*marker9*/|]):
+////     pass
+//// def method(p, p2:[|/*marker10*/|]):
+////     pass
+
+// @filename: test1.py
+//// class A:
+////     def a1[|/*marker11*/|]
+////
+////     def a2[|/*marker12*/|]():
+////         pass
+////
+////     def method(p[|/*marker13*/|]):
+////         pass
+////     def method(p:[|/*marker14*/|]):
+////         pass
+////
+////     def method(p, p2[|/*marker15*/|]):
+////         pass
+////     def method(p, p2:[|/*marker16*/|]):
+////         pass
+
+{
+    helper.openFiles(helper.getMarkers().map((m) => m.fileName));
+
+    // @ts-ignore
+    await helper.verifyCompletion('exact', 'markdown', {
+        marker1: { completions: [] },
+        marker2: { completions: [] },
+        marker3: { completions: [] },
+        marker4: { completions: [] },
+        marker5: { completions: [] },
+        marker6: { completions: [] },
+        marker7: { completions: [] },
+        marker9: { completions: [] },
+        marker11: { completions: [] },
+        marker12: { completions: [] },
+        marker13: { completions: [] },
+        marker15: { completions: [] },
+    });
+
+    // @ts-ignore
+    await helper.verifyCompletion('included', 'markdown', {
+        marker8: { completions: [{ label: 'str', kind: Consts.CompletionItemKind.Class }] },
+        marker10: { completions: [{ label: 'str', kind: Consts.CompletionItemKind.Class }] },
+        marker14: { completions: [{ label: 'str', kind: Consts.CompletionItemKind.Class }] },
+        marker16: { completions: [{ label: 'str', kind: Consts.CompletionItemKind.Class }] },
+    });
+}

--- a/packages/pyright-internal/src/tests/fourslash/completions.declNames.overload.fourslash.ts
+++ b/packages/pyright-internal/src/tests/fourslash/completions.declNames.overload.fourslash.ts
@@ -1,0 +1,115 @@
+/// <reference path="fourslash.ts" />
+
+// @filename: test1.py
+//// from typing import overload
+////
+//// class A:
+////     @overload
+////     def met[|/*marker1*/|]
+
+// @filename: test2.py
+//// from typing import overload
+////
+//// class A:
+////     @overload
+////     def met[|/*marker2*/|]()
+
+// @filename: test3.py
+//// from typing import overload
+////
+//// class A:
+////     @overload
+////     def met[|/*marker3*/|]():
+////         pass
+
+// @filename: test4.py
+//// from typing import overload
+////
+//// class A:
+////     @overload
+////     def method(self):
+////         pass
+////     @overload
+////     def met[|/*marker4*/|]
+
+// @filename: test5.py
+//// from typing import overload
+////
+//// class A:
+////     @overload
+////     def method(self):
+////         pass
+////     @overload
+////     def method2(self):
+////         pass
+////     @overload
+////     def met[|/*marker5*/|]
+
+// @filename: test6.py
+//// from typing import overload
+////
+//// class A:
+////     @overload
+////     def method(self):
+////         pass
+////     @overload
+////     def method2(self):
+////         pass
+////     @overload
+////     def diff[|/*marker6*/|]
+
+// @filename: test7.py
+//// from typing import overload
+////
+//// class A:
+////     @overload
+////     def method(self):
+////         pass
+////     @overload
+////     def method2(self):
+////         pass
+////
+//// class B(A):
+////     @overload
+////     def method3(self):
+////         pass
+////     @overload
+////     def met[|/*marker7*/|]
+
+// @filename: test8.py
+//// from typing import overload
+////
+//// class A:
+////     @overload
+////     def method(self):
+////         pass
+////     @overload
+////     def method[|/*marker8*/|](self, a):
+////         pass
+
+{
+    helper.openFiles(helper.getMarkers().map((m) => m.fileName));
+
+    // @ts-ignore
+    await helper.verifyCompletion('exact', 'markdown', {
+        marker1: { completions: [] },
+        marker2: { completions: [] },
+        marker3: { completions: [] },
+        marker4: { completions: [{ label: 'method', kind: Consts.CompletionItemKind.Method }] },
+        marker5: {
+            completions: [
+                { label: 'method', kind: Consts.CompletionItemKind.Method },
+                { label: 'method2', kind: Consts.CompletionItemKind.Method },
+            ],
+        },
+        marker6: { completions: [] },
+        marker7: {
+            completions: [
+                { label: 'method', kind: Consts.CompletionItemKind.Method },
+                { label: 'method2', kind: Consts.CompletionItemKind.Method },
+                { label: 'method3', kind: Consts.CompletionItemKind.Method },
+            ],
+        },
+        marker8: { completions: [{ label: 'method', kind: Consts.CompletionItemKind.Method }] },
+    });
+}

--- a/packages/pyright-internal/src/tests/fourslash/completions.declNames.topLevelOverload.fourslash.ts
+++ b/packages/pyright-internal/src/tests/fourslash/completions.declNames.topLevelOverload.fourslash.ts
@@ -1,0 +1,106 @@
+/// <reference path="fourslash.ts" />
+
+// @filename: test1.py
+//// from typing import overload
+////
+//// @overload
+//// def met[|/*marker1*/|]
+
+// @filename: test2.py
+//// from typing import overload
+////
+//// @overload
+//// def met[|/*marker2*/|]()
+
+// @filename: test3.py
+//// from typing import overload
+////
+//// @overload
+//// def met[|/*marker3*/|]():
+////     pass
+
+// @filename: test4.py
+//// from typing import overload
+////
+//// @overload
+//// def method(self):
+////     pass
+//// @overload
+//// def met[|/*marker4*/|]
+
+// @filename: test5.py
+//// from typing import overload
+////
+//// @overload
+//// def method(self):
+////     pass
+//// @overload
+//// def method2(self):
+////     pass
+//// @overload
+//// def met[|/*marker5*/|]
+
+// @filename: test6.py
+//// from typing import overload
+////
+//// @overload
+//// def method(self):
+////     pass
+//// @overload
+//// def method2(self):
+////     pass
+//// @overload
+//// def diff[|/*marker6*/|]
+
+// @filename: test7.py
+//// from typing import overload
+////
+//// @overload
+//// def method(self):
+////     pass
+//// @overload
+//// def method2(self):
+////     pass
+
+// @filename: test7-1.py
+//// from typing import overload
+//// from test7 import method, method2
+////
+//// @overload
+//// def method3(self):
+////     pass
+//// @overload
+//// def met[|/*marker7*/|]
+
+// @filename: test8.py
+//// from typing import overload
+////
+////  @overload
+////  def method(self):
+////      pass
+////  @overload
+////  def method[|/*marker8*/|](self, a):
+////      pass
+
+{
+    helper.openFiles(helper.getMarkers().map((m) => m.fileName));
+
+    // @ts-ignore
+    await helper.verifyCompletion('exact', 'markdown', {
+        marker1: { completions: [] },
+        marker2: { completions: [] },
+        marker3: { completions: [] },
+        marker4: { completions: [{ label: 'method', kind: Consts.CompletionItemKind.Function }] },
+        marker5: {
+            completions: [
+                { label: 'method', kind: Consts.CompletionItemKind.Function },
+                { label: 'method2', kind: Consts.CompletionItemKind.Function },
+            ],
+        },
+        marker6: { completions: [] },
+        marker7: {
+            completions: [{ label: 'method3', kind: Consts.CompletionItemKind.Function }],
+        },
+        marker8: { completions: [{ label: 'method', kind: Consts.CompletionItemKind.Function }] },
+    });
+}

--- a/packages/pyright-internal/src/tests/fourslash/completions.fourslash.ts
+++ b/packages/pyright-internal/src/tests/fourslash/completions.fourslash.ts
@@ -12,6 +12,7 @@
 ////     '''another function docs'''
 ////     pass
 //// some_fun[|/*marker3*/|]
+//// unknownVariable.[|/*marker4*/|]
 
 // @ts-ignore
 await helper.verifyCompletion('exact', 'markdown', {
@@ -31,4 +32,5 @@ await helper.verifyCompletion('exact', 'markdown', {
             },
         ],
     },
+    marker4: { completions: [] },
 });

--- a/packages/pyright-internal/src/tests/fourslash/completions.fstring.fourslash.ts
+++ b/packages/pyright-internal/src/tests/fourslash/completions.fstring.fourslash.ts
@@ -1,0 +1,21 @@
+/// <reference path="fourslash.ts" />
+
+// @filename: test.py
+//// msg = "gekki"
+////
+//// a = f"{[|/*marker1*/|]}"
+//// b = f"{msg.c[|/*marker2*/|]}"
+//// b = f"{msg.[|/*marker3*/|]}"
+
+// @ts-ignore
+await helper.verifyCompletion('included', 'markdown', {
+    marker1: {
+        completions: [{ label: 'msg', kind: Consts.CompletionItemKind.Variable }],
+    },
+    marker2: {
+        completions: [{ label: 'count', kind: Consts.CompletionItemKind.Method }],
+    },
+    marker3: {
+        completions: [{ label: 'capitalize', kind: Consts.CompletionItemKind.Method }],
+    },
+});

--- a/packages/pyright-internal/src/tests/fourslash/completions.parameters.fourslash.ts
+++ b/packages/pyright-internal/src/tests/fourslash/completions.parameters.fourslash.ts
@@ -1,0 +1,23 @@
+/// <reference path="fourslash.ts" />
+
+// @filename: test.py
+//// def Method(a, b, c):
+////     pass
+////
+//// Method([|/*marker1*/|]"[|/*marker2*/|]hello[|/*marker3*/|]"[|/*marker4*/|])
+
+// @ts-ignore
+await helper.verifyCompletion('included', 'markdown', {
+    marker1: {
+        completions: [{ label: 'a=', kind: Consts.CompletionItemKind.Variable }],
+    },
+    marker4: {
+        completions: [{ label: 'b=', kind: Consts.CompletionItemKind.Variable }],
+    },
+});
+
+// @ts-ignore
+await helper.verifyCompletion('exact', 'markdown', {
+    marker2: { completions: [] },
+    marker3: { completions: [] },
+});

--- a/packages/pyright-internal/src/tests/fourslash/completions.stringLiteral.fourslash.ts
+++ b/packages/pyright-internal/src/tests/fourslash/completions.stringLiteral.fourslash.ts
@@ -1,0 +1,37 @@
+/// <reference path="fourslash.ts" />
+
+// @filename: test.py
+//// import os
+//// from typing import Literal, TypedDict, Union
+////
+//// def method(a, b, c):
+////     pass
+////
+//// method("os.[|/*marker1*/|]")
+////
+//// class Movie(TypedDict):
+////     name: str
+////     age: int
+////
+//// m = Movie(name="hello", age=10)
+//// m["[|/*marker2*/|]"]
+////
+//// a: Union[Literal["hello"], Literal["hallo"]]
+//// a = "[|/*marker3*/|]"
+
+// @ts-ignore
+await helper.verifyCompletion('exact', 'markdown', {
+    marker1: { completions: [] },
+    marker2: {
+        completions: [
+            { label: '"name"', kind: Consts.CompletionItemKind.Text },
+            { label: '"age"', kind: Consts.CompletionItemKind.Text },
+        ],
+    },
+    marker3: {
+        completions: [
+            { label: '"hello"', kind: Consts.CompletionItemKind.Text },
+            { label: '"hallo"', kind: Consts.CompletionItemKind.Text },
+        ],
+    },
+});

--- a/packages/pyright-internal/src/tests/fourslash/fourslash.ts
+++ b/packages/pyright-internal/src/tests/fourslash/fourslash.ts
@@ -136,6 +136,8 @@ declare namespace _ {
         importName: string;
     }
 
+    type MarkupKind = 'markdown' | 'plaintext';
+
     interface Fourslash {
         getDocumentHighlightKind(m?: Marker): DocumentHighlightKind | undefined;
 
@@ -166,7 +168,8 @@ declare namespace _ {
 
         moveCaretRight(count: number): void;
 
-        openFile(indexOrName: number | string, content?: string): void;
+        openFile(indexOrName: number | string): void;
+        openFiles(indexOrNames: (number | string)[]): void;
 
         verifyDiagnostics(map?: { [marker: string]: { category: string; message: string } }): void;
         verifyCodeActions(
@@ -185,7 +188,7 @@ declare namespace _ {
         verifyHover(kind: string, map: { [marker: string]: string }): void;
         verifyCompletion(
             verifyMode: FourSlashCompletionVerificationMode,
-            docFormat: string,
+            docFormat: MarkupKind,
             map: {
                 [marker: string]: {
                     completions: FourSlashCompletionItem[];
@@ -198,17 +201,21 @@ declare namespace _ {
             },
             abbrMap?: { [abbr: string]: AbbreviationInfo }
         ): Promise<void>;
-        verifySignature(map: {
-            [marker: string]: {
-                noSig?: boolean;
-                signatures?: {
-                    label: string;
-                    parameters: string[];
-                }[];
-                activeParameters?: (number | undefined)[];
-                callHasParameters?: boolean;
-            };
-        }): void;
+        verifySignature(
+            docFormat: MarkupKind,
+            map: {
+                [marker: string]: {
+                    noSig?: boolean;
+                    signatures?: {
+                        label: string;
+                        parameters: string[];
+                        documentation?: string;
+                    }[];
+                    activeParameters?: (number | undefined)[];
+                    callHasParameters?: boolean;
+                };
+            }
+        ): void;
         verifyFindAllReferences(map: {
             [marker: string]: {
                 references: DocumentRange[];

--- a/packages/pyright-internal/src/tests/fourslash/signature.complicated.fourslash.ts
+++ b/packages/pyright-internal/src/tests/fourslash/signature.complicated.fourslash.ts
@@ -44,7 +44,7 @@
         },
     ];
 
-    helper.verifySignature({
+    helper.verifySignature('plaintext', {
         init: {
             signatures: xInitSignatures,
             activeParameters: [0],

--- a/packages/pyright-internal/src/tests/fourslash/signature.docstrings.fourslash.ts
+++ b/packages/pyright-internal/src/tests/fourslash/signature.docstrings.fourslash.ts
@@ -1,0 +1,43 @@
+/// <reference path="fourslash.ts" />
+
+// @filename: docstrings.py
+//// from typing import overload
+////
+//// def repeat(a: str, b: int) -> str:
+////    """Repeat the string ``a`` ``b`` times.
+////
+////    >>> repeat('foo', 3)
+////    'foofoofoo'
+////    """
+////
+////    return a * b
+////
+//// repeat([|/*marker1*/|])
+
+{
+    helper.verifySignature('plaintext', {
+        marker1: {
+            signatures: [
+                {
+                    label: '(a: str, b: int) -> str',
+                    parameters: ['a: str', 'b: int'],
+                    documentation: "Repeat the string ``a`` ``b`` times.\n\n>>> repeat('foo', 3)\n'foofoofoo'",
+                },
+            ],
+            activeParameters: [0],
+        },
+    });
+
+    helper.verifySignature('markdown', {
+        marker1: {
+            signatures: [
+                {
+                    label: '(a: str, b: int) -> str',
+                    parameters: ['a: str', 'b: int'],
+                    documentation: "Repeat the string `a` `b` times.\n\n```\n>>> repeat('foo', 3)\n'foofoofoo'\n```",
+                },
+            ],
+            activeParameters: [0],
+        },
+    });
+}

--- a/packages/pyright-internal/src/tests/fourslash/signature.overload.fourslash.ts
+++ b/packages/pyright-internal/src/tests/fourslash/signature.overload.fourslash.ts
@@ -38,7 +38,7 @@
         },
     ];
 
-    helper.verifySignature({
+    helper.verifySignature('plaintext', {
         o1: {
             signatures: overloadedSignatures,
             activeParameters: [undefined, 0, 0],

--- a/packages/pyright-internal/src/tests/fourslash/signature.simple.fourslash.ts
+++ b/packages/pyright-internal/src/tests/fourslash/signature.simple.fourslash.ts
@@ -21,7 +21,7 @@
         },
     ];
 
-    helper.verifySignature({
+    helper.verifySignature('plaintext', {
         s1: {
             signatures: simpleSignatures,
             activeParameters: [0],


### PR DESCRIPTION
Rollup of:

- Don't offer completions in contexts such as class names, function names, parameter names, etc. For functions with `@overload`, names will still be suggested for other functions to better aid in writing overloads.
- Respect the client's doc kind in signature help.
- Helper functions/types for extracting and checking nodes from text selections.