### PR TITLE
Support detecting multiple site-packages directories in venvs

### DIFF
--- a/packages/pyright-internal/src/analyzer/pythonPathUtils.ts
+++ b/packages/pyright-internal/src/analyzer/pythonPathUtils.ts
@@ -59,6 +59,39 @@ export function getTypeshedSubdirectory(typeshedPath: string, isStdLib: boolean)
     return combinePaths(typeshedPath, isStdLib ? stdLibFolderName : thirdPartyFolderName);
 }
 
+function checkVenvPath(fs: FileSystem, libPath: string, importFailureInfo: string[]): string | undefined {
+    if (fs.existsSync(libPath)) {
+        importFailureInfo.push(`Found path '${libPath}'; looking for ${pathConsts.sitePackages}`);
+    } else {
+        importFailureInfo.push(`Did not find '${libPath}'`);
+        return undefined;
+    }
+
+    const sitePackagesPath = combinePaths(libPath, pathConsts.sitePackages);
+    if (fs.existsSync(sitePackagesPath)) {
+        importFailureInfo.push(`Found path '${sitePackagesPath}'`);
+        return sitePackagesPath;
+    } else {
+        importFailureInfo.push(`Did not find '${sitePackagesPath}', so looking for python subdirectory`);
+    }
+
+    // We didn't find a site-packages directory directly in the lib
+    // directory. Scan for a "python*" directory instead.
+    const entries = getFileSystemEntries(fs, libPath);
+    for (let i = 0; i < entries.directories.length; i++) {
+        const dirName = entries.directories[i];
+        if (dirName.startsWith('python')) {
+            const dirPath = combinePaths(libPath, dirName, pathConsts.sitePackages);
+            if (fs.existsSync(dirPath)) {
+                importFailureInfo.push(`Found path '${dirPath}'`);
+                return dirPath;
+            } else {
+                importFailureInfo.push(`Path '${dirPath}' is not a valid directory`);
+            }
+        }
+    }
+}
+
 export function findPythonSearchPaths(
     fs: FileSystem,
     configOptions: ConfigOptions,
@@ -69,59 +102,30 @@ export function findPythonSearchPaths(
 ): string[] | undefined {
     importFailureInfo.push('Finding python search paths');
 
-    let venvPath: string | undefined;
-    if (venv !== undefined) {
-        if (configOptions.venvPath) {
-            venvPath = combinePaths(configOptions.venvPath, venv);
-        }
-    } else if (configOptions.defaultVenv) {
-        if (configOptions.venvPath) {
-            venvPath = combinePaths(configOptions.venvPath, configOptions.defaultVenv);
-        }
-    }
+    if (configOptions.venvPath !== undefined && (venv !== undefined || configOptions.defaultVenv)) {
+        const venvDir = venv !== undefined ? venv : configOptions.defaultVenv;
+        const venvPath = combinePaths(configOptions.venvPath, venvDir);
 
-    if (venvPath) {
-        let libPath = combinePaths(venvPath, pathConsts.lib);
-        if (fs.existsSync(libPath)) {
-            importFailureInfo.push(`Found path '${libPath}'; looking for ${pathConsts.sitePackages}`);
+        const foundPaths: string[] = [];
+
+        [pathConsts.lib, pathConsts.lib64, pathConsts.Lib].forEach((libPath) => {
+            const ret = checkVenvPath(fs, combinePaths(venvPath, libPath), importFailureInfo);
+            if (ret) {
+                foundPaths.push(ret);
+            }
+        });
+
+        if (foundPaths.length > 0) {
+            importFailureInfo.push(`Found the following '${pathConsts.sitePackages}' dirs`);
+            foundPaths.forEach((path) => {
+                importFailureInfo.push(`  ${path}`);
+            });
+            return foundPaths;
         } else {
-            importFailureInfo.push(`Did not find '${libPath}'; trying 'Lib' instead`);
-            libPath = combinePaths(venvPath, 'Lib');
-            if (fs.existsSync(libPath)) {
-                importFailureInfo.push(`Found path '${libPath}'; looking for ${pathConsts.sitePackages}`);
-            } else {
-                importFailureInfo.push(`Did not find '${libPath}'`);
-                libPath = '';
-            }
+            importFailureInfo.push(
+                `Did not find any '${pathConsts.sitePackages}' dirs. Falling back on python interpreter.`
+            );
         }
-
-        if (libPath) {
-            const sitePackagesPath = combinePaths(libPath, pathConsts.sitePackages);
-            if (fs.existsSync(sitePackagesPath)) {
-                importFailureInfo.push(`Found path '${sitePackagesPath}'`);
-                return [sitePackagesPath];
-            } else {
-                importFailureInfo.push(`Did not find '${sitePackagesPath}', so looking for python subdirectory`);
-            }
-
-            // We didn't find a site-packages directory directly in the lib
-            // directory. Scan for a "python*" directory instead.
-            const entries = getFileSystemEntries(fs, libPath);
-            for (let i = 0; i < entries.directories.length; i++) {
-                const dirName = entries.directories[i];
-                if (dirName.startsWith('python')) {
-                    const dirPath = combinePaths(libPath, dirName, pathConsts.sitePackages);
-                    if (fs.existsSync(dirPath)) {
-                        importFailureInfo.push(`Found path '${dirPath}'`);
-                        return [dirPath];
-                    } else {
-                        importFailureInfo.push(`Path '${dirPath}' is not a valid directory`);
-                    }
-                }
-            }
-        }
-
-        importFailureInfo.push(`Did not find '${pathConsts.sitePackages}'. Falling back on python interpreter.`);
     }
 
     // Fall back on the python interpreter.

--- a/packages/pyright-internal/src/analyzer/pythonPathUtils.ts
+++ b/packages/pyright-internal/src/analyzer/pythonPathUtils.ts
@@ -121,11 +121,11 @@ export function findPythonSearchPaths(
                 importFailureInfo.push(`  ${path}`);
             });
             return foundPaths;
-        } else {
-            importFailureInfo.push(
-                `Did not find any '${pathConsts.sitePackages}' dirs. Falling back on python interpreter.`
-            );
         }
+
+        importFailureInfo.push(
+            `Did not find any '${pathConsts.sitePackages}' dirs. Falling back on python interpreter.`
+        );
     }
 
     // Fall back on the python interpreter.

--- a/packages/pyright-internal/src/common/pathConsts.ts
+++ b/packages/pyright-internal/src/common/pathConsts.ts
@@ -8,5 +8,7 @@
 
 export const typeshedFallback = 'typeshed-fallback';
 export const lib = 'lib';
+export const lib64 = 'lib64';
+export const Lib = 'Lib';
 export const sitePackages = 'site-packages';
 export const src = 'src';


### PR DESCRIPTION
On Red Hat derived systems, Python's `purelib` and `platlib` are set to `<prefix>/lib` and `<prefix>/lib64` respectively. This means that Python packages are installed to either of those directories depending on whether they contain native libraries or not (as I understand it). This distinction is also present in pipenv's virtualenvs. See:

```
$  . /home/truls/.local/share/virtualenvs/pyright-test-Fm_xQ9MX/bin/activate
(pyright-test) truls@dhcp-111-236 ~/foo/pyright-test $ python
Python 3.9.0 (default, Oct  6 2020, 00:00:00) 
[GCC 10.2.1 20200826 (Red Hat 10.2.1-3)] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import sysconfig
>>> sysconfig.get_path('purelib')
'/home/truls/.local/share/virtualenvs/pyright-test-Fm_xQ9MX/lib/python3.9/site-packages'
>>> sysconfig.get_path('platlib')
'/home/truls/.local/share/virtualenvs/pyright-test-Fm_xQ9MX/lib64/python3.9/site-packages'
>>> 
```

The current virtualenv include path detection logic in pyright returns only the first extant `site-packages` directory it finds. This is insufficient for discovering the full include path for virtualenvs where packages may be installed in both the `lib` and `lib64` directories. This PR changes the virtualenv include path detection logic so that it returns all of the extant `site-packages` dirs it finds in the `lib`, `lib64` or `Lib` directories.
