### PR TITLE
Expand type alias for completion provider

### DIFF
--- a/packages/pyright-internal/src/languageService/completionProvider.ts
+++ b/packages/pyright-internal/src/languageService/completionProvider.ts
@@ -39,6 +39,7 @@ import { CallSignatureInfo, TypeEvaluator } from '../analyzer/typeEvaluator';
 import {
     ClassType,
     FunctionType,
+    getTypeAliasInfo,
     isClass,
     isModule,
     isNone,
@@ -1493,11 +1494,19 @@ export class CompletionProvider {
                             switch (primaryDecl.type) {
                                 case DeclarationType.Intrinsic:
                                 case DeclarationType.Variable:
-                                case DeclarationType.Parameter:
-                                    typeDetail =
-                                        name + ': ' + this._evaluator.printType(type, /* expandTypeAlias */ false);
+                                case DeclarationType.Parameter: {
+                                    let expandTypeAlias = false;
+                                    if (type && TypeBase.isInstantiable(type)) {
+                                        const typeAliasInfo = getTypeAliasInfo(type);
+                                        if (typeAliasInfo) {
+                                            if (typeAliasInfo.aliasName === name) {
+                                                expandTypeAlias = true;
+                                            }
+                                        }
+                                    }
+                                    typeDetail = name + ': ' + this._evaluator.printType(type, expandTypeAlias);
                                     break;
-
+                                }
                                 case DeclarationType.Function: {
                                     const functionType = detail.objectThrough
                                         ? this._evaluator.bindFunctionToClassOrObject(detail.objectThrough, type, false)

--- a/packages/pyright-internal/src/tests/fourslash/completions.typeAlias.fourslash.ts
+++ b/packages/pyright-internal/src/tests/fourslash/completions.typeAlias.fourslash.ts
@@ -1,0 +1,29 @@
+/// <reference path="fourslash.ts" />
+
+// @filename: test.py
+//// AliasT = list[int]
+//// x: AliasT[|/*marker1*/|]
+//// y: AliasT = []
+//// y[|/*marker2*/|]
+
+// @ts-ignore
+await helper.verifyCompletion('includes', 'markdown', {
+    marker1: {
+        completions: [
+            {
+                label: 'AliasT',
+                kind: Consts.CompletionItemKind.Variable,
+                documentation: '```python\nAliasT: Type[list[int]]\n```\n',
+            },
+        ],
+    },
+    marker2: {
+        completions: [
+            {
+                label: 'y',
+                kind: Consts.CompletionItemKind.Variable,
+                documentation: '```python\ny: AliasT\n```\n',
+            },
+        ],
+    },
+});


### PR DESCRIPTION
Match type alias from completion provider with hover provider. The type alias will only be expanded if the completion item is the alias itself to preserve readability.

See: https://github.com/microsoft/pylance-release/issues/562

 https://github.com/microsoft/pyright/blob/51ad4c20df30bae7acbdd23fdb04ab88cda7b3f5/packages/pyright-internal/src/languageService/hoverProvider.ts#L161-L174

<img width="862" alt="Screen Shot 2020-11-16 at 00 06 32" src="https://user-images.githubusercontent.com/30130371/99199468-a5ceaa00-279f-11eb-82fb-ef6cb44daa2f.png">

<img width="794" alt="Screen Shot 2020-11-16 at 00 08 14" src="https://user-images.githubusercontent.com/30130371/99199496-d57db200-279f-11eb-93c5-aaf0be7a0252.png">