### PR TITLE
Don't add suggestions for 'with Y as [ ]'

### DIFF
--- a/packages/pyright-internal/src/languageService/completionProvider.ts
+++ b/packages/pyright-internal/src/languageService/completionProvider.ts
@@ -942,6 +942,18 @@ export class CompletionProvider {
             return undefined;
         }
 
+        // Are we within a "with Y as []"?
+        // Don't add any completion options.
+        if (
+            parseNode.parent &&
+            parseNode.parent.nodeType === ParseNodeType.WithItem &&
+            parseNode.parent.target &&
+            parseNode.parent.target.parent &&
+            parseNode.parent === parseNode.parent.target.parent
+        ) {
+            return undefined;
+        }
+
         const completionList = CompletionList.create();
 
         // Add call argument completions.

--- a/packages/pyright-internal/src/tests/fourslash/completions.with.fourslash.ts
+++ b/packages/pyright-internal/src/tests/fourslash/completions.with.fourslash.ts
@@ -1,0 +1,26 @@
+/// <reference path="fourslash.ts" />
+
+// @filename: test.py
+//// from unittest.mock import patch
+//// def some_func():
+////     pass
+//// with patch('some_func') as[|/*marker1*/|] a1:
+////     pass
+//// with patch('some_func') as   [|/*marker2*/|] a1:
+////     pass
+//// with patch('some_func') as a[|/*marker3*/|]2:
+////     pass
+//// with patch[|/*marker4*/|]('some_func'):
+////     pass
+
+// @ts-ignore
+await helper.verifyCompletion('exact', 'markdown', {
+    marker1: { completions: [] },
+    marker2: { completions: [] },
+    marker3: { completions: [] },
+});
+
+// @ts-ignore
+await helper.verifyCompletion('included', 'markdown', {
+    marker4: { completions: [{ label: 'patch', kind: Consts.CompletionItemKind.Variable }] },
+});


### PR DESCRIPTION
Pyright shouldn't attempt to provide suggestions after `with Y as [ ]`.

### Before
![Screen Shot 2020-11-16 at 14 31 13](https://user-images.githubusercontent.com/30130371/99258131-63957f00-2818-11eb-9672-6103f004fd49.png)

### After
<img width="479" alt="Screen Shot 2020-11-16 at 14 27 48" src="https://user-images.githubusercontent.com/30130371/99257828-e964fa80-2817-11eb-9e81-1a9219e7f886.png">

