### PR TITLE
Improve except suggestions

### DIFF
--- a/packages/pyright-internal/src/languageService/completionProvider.ts
+++ b/packages/pyright-internal/src/languageService/completionProvider.ts
@@ -991,6 +991,16 @@ export class CompletionProvider {
             }
         }
 
+        if (parseNode.parent?.nodeType === ParseNodeType.Except) {
+            const completionItems: CompletionItem[] = [];
+            completionList.items.forEach((item) => {
+                if (item.label !== 'NotImplemented') {
+                    completionItems.push(item);
+                }
+            });
+            completionList.items = completionItems;
+        }
+
         return { completionList };
     }
 

--- a/packages/pyright-internal/src/tests/fourslash/completions.NotImplemented.fourslash.ts
+++ b/packages/pyright-internal/src/tests/fourslash/completions.NotImplemented.fourslash.ts
@@ -1,0 +1,12 @@
+/// <reference path="fourslash.ts" />
+
+// @filename: test.py
+//// try:
+////     pass
+//// except NotImplemented[|/*marker1*/|]:
+////     pass
+
+// @ts-ignore
+await helper.verifyCompletion('exact', 'markdown', {
+    marker1: { completions: [{ label: 'NotImplementedError', kind: Consts.CompletionItemKind.Class }] },
+});


### PR DESCRIPTION
Don't include `NotImplemented` in except suggestions. It should be `except NotImplementedError`.
This is a common beginner mistake.
See: https://github.com/microsoft/pylance-release/issues/563

--
The change works as intended, but it doesn't feel right. Maybe there is another position to insert this check. Ideally that would also allow us to also check every other suggestion if it inherits from `BaseException`.