### PR TITLE
Fixed bug whereby an assignment was not flagged as an error if the ta…

### DIFF
--- a/packages/pyright-internal/src/analyzer/checker.ts
+++ b/packages/pyright-internal/src/analyzer/checker.ts
@@ -820,7 +820,13 @@ export class Checker extends ParseTreeWalker {
                 if (
                     prevReturnType &&
                     returnType &&
-                    !this._evaluator.canAssignType(returnType, prevReturnType, new DiagnosticAddendum())
+                    !this._evaluator.canAssignType(
+                        returnType,
+                        prevReturnType,
+                        new DiagnosticAddendum(),
+                        /* typeVarMap */ undefined,
+                        CanAssignFlags.SkipSolveTypeVars
+                    )
                 ) {
                     const altNode = this._findNodeForOverload(node, prevOverload);
                     this._evaluator.addDiagnostic(

--- a/packages/pyright-internal/src/analyzer/typeVarMap.ts
+++ b/packages/pyright-internal/src/analyzer/typeVarMap.ts
@@ -52,7 +52,10 @@ export class TypeVarMap {
     }
 
     clone() {
-        const newTypeVarMap = new TypeVarMap(this._solveForScopes);
+        const newTypeVarMap = new TypeVarMap();
+        if (this._solveForScopes) {
+            newTypeVarMap._solveForScopes = [...this._solveForScopes];
+        }
 
         this._typeVarMap.forEach((value) => {
             newTypeVarMap.setTypeVar(value.typeVar, value.type, this.isNarrowable(value.typeVar));
@@ -89,7 +92,7 @@ export class TypeVarMap {
     }
 
     addSolveForScope(scopeId?: TypeVarScopeId) {
-        if (scopeId !== undefined) {
+        if (scopeId !== undefined && !this.hasSolveForScope(scopeId)) {
             if (!this._solveForScopes) {
                 this._solveForScopes = [];
             }

--- a/packages/pyright-internal/src/tests/samples/assignment8.py
+++ b/packages/pyright-internal/src/tests/samples/assignment8.py
@@ -31,6 +31,8 @@ my_obj = Foo.bar
 my_obj = Foo.baz
 my_obj = ()
 my_obj = lambda x: x
+
+# This should generate an error because _T has no meaning.
 my_obj = _T
 
 # This should generate an error because a is unbound.

--- a/packages/pyright-internal/src/tests/samples/classes2.py
+++ b/packages/pyright-internal/src/tests/samples/classes2.py
@@ -1,7 +1,17 @@
 # This sample tests the reportIncompatibleMethodOverride
 # configuration option.
 
-from typing import Any, Callable, Iterable, List, Sequence, TypeVar, Union
+from typing import (
+    Any,
+    Callable,
+    Generic,
+    Iterable,
+    List,
+    Optional,
+    Sequence,
+    TypeVar,
+    Union,
+)
 
 
 class ParentClass:
@@ -166,3 +176,20 @@ class Base1:
 class Base2(Base1):
     def submit(self, fn: Callable[..., _T2], *args: Any, **kwargs: Any) -> List[_T2]:
         return []
+
+
+class Foo:
+    pass
+
+
+_T2A = TypeVar("_T2A", bound=Foo)
+
+
+class ClassA(Generic[_T2A]):
+    def func1(self) -> Optional[_T2A]:
+        return None
+
+
+class ClassB(ClassA[_T2A]):
+    def func1(self) -> Optional[_T2A]:
+        return None

--- a/packages/pyright-internal/src/tests/samples/constructor2.py
+++ b/packages/pyright-internal/src/tests/samples/constructor2.py
@@ -108,7 +108,7 @@ def s11():
     t: Literal["Donkey[int]"] = reveal_type(a)
 
 
-def s12(p: Bear[_T1]) -> _T1:
+def s12(p: Bear[_T1]):
     a: Animal[Any, int] = p
     t: Literal["Bear[Any]"] = reveal_type(a)
 

--- a/packages/pyright-internal/src/tests/samples/constructor4.py
+++ b/packages/pyright-internal/src/tests/samples/constructor4.py
@@ -1,0 +1,25 @@
+# This sample tests that unspecified type parameters
+# for a class instance are "unknown".
+
+from collections import defaultdict
+from queue import Queue
+from typing import DefaultDict, List, Literal, Type, TypeVar
+
+val1 = Queue()
+t1: Literal["Queue[Unknown]"] = reveal_type(val1)
+
+val2 = list()
+t2: Literal["list[Unknown]"] = reveal_type(val2)
+
+_T = TypeVar("_T")
+
+
+def foo(value: Type[_T]) -> None:
+    val1: "DefaultDict[str, list[_T]]" = defaultdict(list)
+    t1: Literal["defaultdict[str, list[_T]]"] = reveal_type(val1)
+
+    val2: "DefaultDict[str, list[_T]]" = defaultdict(List[_T])
+    t2: Literal["defaultdict[str, list[_T]]"] = reveal_type(val2)
+
+    # This should generate an error because the type is incompatible.
+    val3: "DefaultDict[str, list[_T]]" = defaultdict(list[int])

--- a/packages/pyright-internal/src/tests/samples/enums1.py
+++ b/packages/pyright-internal/src/tests/samples/enums1.py
@@ -1,17 +1,19 @@
 # This sample tests the type checker's handling of Enum.
 
 from enum import Enum, IntEnum
-from typing import List
+from typing import List, Literal
 
 
 TestEnum1 = Enum("TestEnum1", "A B C D")
 TestEnum2 = IntEnum("TestEnum2", "AA BB CC DD")
+
 
 class TestEnum3(Enum):
     A = 0
     B = 1
     C = 2
     D = 3
+
 
 a = TestEnum1["A"]
 aa = TestEnum1.A
@@ -36,13 +38,11 @@ z = TestEnum3.Z
 
 
 # Test that enum classes are iterable.
-def requires_enum3_list(a: List[TestEnum3]):
-    return
-
 list1 = list(TestEnum3)
-requires_enum3_list(list1)
+t1: Literal["list[TestEnum3]"] = reveal_type(list1)
 
 list2 = [i for i in TestEnum3]
-requires_enum3_list(list2)
+t2: Literal["List[TestEnum3]"] = reveal_type(list2)
 
 num_items_in_enum3 = len(TestEnum3)
+t3: Literal["int"] = reveal_type(num_items_in_enum3)

--- a/packages/pyright-internal/src/tests/samples/genericTypes15.py
+++ b/packages/pyright-internal/src/tests/samples/genericTypes15.py
@@ -3,13 +3,11 @@
 # the "keys" method on "dict") based on the provided "self"
 # argument.
 
-# pyright: strict
-
-from typing import Dict
+from typing import Dict, Literal
 
 foo: Dict[str, str] = {}
 
 # This should not result in an "Unknown", so no
 # error should be generated.
 result = dict.keys(foo)
-
+t1: Literal["KeysView[Unknown]"] = reveal_type(result)

--- a/packages/pyright-internal/src/tests/samples/genericTypes20.py
+++ b/packages/pyright-internal/src/tests/samples/genericTypes20.py
@@ -6,9 +6,11 @@
 # no "unknown" types remaining in this file.
 # pyright: strict, reportUnknownParameterType=false
 
+from logging import Handler, NOTSET
 
-class Foo:
-    def __init__(self, a, b="hello"):
+class Foo(Handler):
+    def __init__(self, a, b="hello", level=NOTSET):
+        super().__init__(level)
         self._foo_a = a
         self._foo_b = b
 

--- a/packages/pyright-internal/src/tests/samples/genericTypes23.py
+++ b/packages/pyright-internal/src/tests/samples/genericTypes23.py
@@ -3,23 +3,25 @@
 
 from typing import Generic, TypeVar, Callable
 
-T = TypeVar('T', bound=float)
+T = TypeVar("T", bound=float)
+
 
 class Root(Generic[T]):
-    def __init__(self,_lambda:Callable[[T],T]):
+    def __init__(self, _lambda: Callable[[T], T]):
         self._lambda = _lambda
-    
+
     def call(self, val: T) -> T:
         return self._lambda(val)
+
 
 class Leaf(Root[T]):
     pass
 
-root_int: Root[int] = Root[int](lambda x: x<<2)
+
+root_int: Root[int] = Root[int](lambda x: x << 2)
 
 # This should generate an error.
 root_float: Root[float] = root_int
 
 # This should generate an error.
-root_float: Root[float] = Root[int](lambda x: x<<2) 
-
+root_float: Root[float] = Root[int](lambda x: x << 2)

--- a/packages/pyright-internal/src/tests/samples/genericTypes37.py
+++ b/packages/pyright-internal/src/tests/samples/genericTypes37.py
@@ -1,0 +1,28 @@
+# This sample verifies that the use of a bound TypeVar defined
+# by a generic class is not used inappropriately.
+
+from typing import Any, Generic, TypeVar
+
+
+class Bar:
+    ...
+
+
+_T = TypeVar("_T", bound=Bar)
+
+
+class Foo(Generic[_T]):
+    def func1(self, a: _T):
+        pass
+
+    def func2(self):
+        x: int = 3
+        # This should generate an error
+        self.func1(x)
+
+        y = Bar()
+        # This should generate an error
+        self.func1(y)
+
+        z: Any = 3
+        self.func1(z)

--- a/packages/pyright-internal/src/tests/samples/genericTypes38.py
+++ b/packages/pyright-internal/src/tests/samples/genericTypes38.py
@@ -1,0 +1,15 @@
+# This sample tests the handling of type variables
+# used within a generic class.
+
+from queue import Queue
+from typing import Generic, Optional, TypeVar
+
+_T = TypeVar("_T")
+
+
+class Foo(Generic[_T]):
+    def __init__(self):
+        self._queue: "Queue[Optional[_T]]" = Queue()
+
+    def publish(self, message: _T):
+        self._queue.put_nowait(message)

--- a/packages/pyright-internal/src/tests/samples/genericTypes39.py
+++ b/packages/pyright-internal/src/tests/samples/genericTypes39.py
@@ -1,0 +1,61 @@
+# This sample tests the handling of TypeVars defined by
+# a generic function.
+
+from typing import Callable, Iterable, TypeVar
+
+T = TypeVar("T")
+R = TypeVar("R")
+
+
+def do_something(
+    collection: Iterable[T], zero: R, f: Callable[[R, T], R]
+) -> Iterable[R]:
+    s = zero
+    yield s
+    for x in collection:
+        s = f(s, x)
+        yield s
+
+from typing import Dict, Generic, List, Tuple, TypeVar
+
+
+class Foo:
+    pass
+
+
+_T1 = TypeVar("_T1")
+_T2 = TypeVar("_T2", bound=Foo)
+_T2A = TypeVar("_T2A", bound=Foo)
+_T3 = TypeVar("_T3", Foo, int, str)
+
+
+class MyClass1(Generic[_T1]):
+    def __init__(self, a: _T1):
+        self._a: Dict[str, _T1] = {}
+        self._b: Tuple[_T1, ...] = (a, a, a)
+        self._c: Tuple[_T1, _T1] = (a, a)
+        self._d: List[_T1] = [a]
+
+
+class MyClass2(Generic[_T2]):
+    def __init__(self, a: _T2):
+        self._a: Dict[str, _T2] = {}
+        self._b: Tuple[_T2, ...] = (a, a, a)
+        self._c: Tuple[_T2, _T2] = (a, a)
+        self._d: List[_T2] = [a]
+
+
+class MyClass2A(Generic[_T2, _T2A]):
+    def __init__(self, a: _T2, b: _T2A):
+        self._a: Dict[str, _T2] = {"a": b}
+        self._b: Tuple[_T2, ...] = (a, a, a)
+        self._c: Tuple[_T2, _T2] = (a, a)
+        self._d: List[_T2] = [a]
+
+
+class MyClass3(Generic[_T3]):
+    def __init__(self, a: _T3):
+        self._a: Dict[str, _T3] = {}
+        self._b: Tuple[_T3, ...] = (a, a, a)
+        self._c: Tuple[_T3, _T3] = (a, a)
+        self._d: List[_T3] = [a]

--- a/packages/pyright-internal/src/tests/samples/genericTypes6.py
+++ b/packages/pyright-internal/src/tests/samples/genericTypes6.py
@@ -1,22 +1,49 @@
 # This sample tests the type checker's ability to do
 # TypeVar matching for both constrained TypeVars and unconstrained.
 
-from typing import TypeVar
+from typing import Generic, Literal, TypeVar
 
-S = TypeVar('S', str, bytes)
+S = TypeVar("S", str, bytes)
+
 
 def constrained(first: S, second: S) -> S:
     return first
 
+
 # This should generate an error because the two arguments
 # cannot satisfy the 'str' or 'bytes' constraint.
-result = constrained('a', b'abc')
+result = constrained("a", b"abc")
 
-T = TypeVar('T')
+T = TypeVar("T")
+
 
 def unconstrained(first: T, second: T) -> T:
     return first
 
+
 # This shouldn't generate an error because the TypeVar matching
 # logic is free to expand the type to a union of 'str' and 'bytes'.
-result = unconstrained('a', b'abc')
+result = unconstrained("a", b"abc")
+
+
+U = TypeVar("U", int, str)
+
+
+class Foo(Generic[U]):
+    def generic_func1(self, a: U, b: U = ..., **kwargs: U) -> U:
+        return b
+
+
+foo = Foo[str]()
+r1 = foo.generic_func1("hi")
+t1: Literal["str"] = reveal_type(r1)
+r2 = foo.generic_func1("hi", test="hi")
+t2: Literal["str"] = reveal_type(r2)
+
+# This should generate an error.
+r3 = foo.generic_func1("hi", test=3)
+t3: Literal["str"] = reveal_type(r3)
+
+# This should generate an error.
+r4 = foo.generic_func1("hi", 3)
+t4: Literal["str"] = reveal_type(r4)

--- a/packages/pyright-internal/src/tests/samples/memberAccess1.py
+++ b/packages/pyright-internal/src/tests/samples/memberAccess1.py
@@ -4,13 +4,18 @@
 from typing import Any, Generic, TypeVar, overload
 from functools import cached_property
 
-_T = TypeVar('_T')
+_T = TypeVar("_T")
+
 
 class Column(Generic[_T]):
     @overload
-    def __get__(self, instance: None, owner: Any) -> 'Column[_T]': ...
+    def __get__(self, instance: None, owner: Any) -> "Column[_T]":  # type: ignore
+        ...
+
     @overload
-    def __get__(self, instance: object, owner: Any) -> _T: ...
+    def __get__(self, instance: Any, owner: Any) -> _T:
+        ...
+
 
 class Foo:
     bar = Column[str]()
@@ -24,6 +29,7 @@ class Foo2:
     @cached_property
     def baz(self) -> int:
         return 3
+
 
 c: cached_property[int] = Foo2.baz
 d: int = Foo2().baz

--- a/packages/pyright-internal/src/tests/samples/memberAccess4.py
+++ b/packages/pyright-internal/src/tests/samples/memberAccess4.py
@@ -25,6 +25,7 @@ class B1(Mixin1):
 class C1(Mixin1):
     pass
 
+
 A1().do_stuff()
 
 # This should generate an error because B1 doesn't
@@ -45,10 +46,12 @@ class Mixin2:
     @classmethod
     def do_stuff(cls: Type[HasItemProtocol2]):
         pass
-    
+
+
 class A2(Mixin2):
     def must_have(self) -> None:
         pass
+
 
 class B2(Mixin2):
     pass
@@ -59,3 +62,13 @@ A2.do_stuff()
 # This should generate an error because B2 doesn't
 # match the protocol.
 B2.do_stuff()
+
+
+class Bar:
+    pass
+
+
+class Foo:
+    @staticmethod
+    def get_or_create(context: Bar):
+        return object.__getattribute__(context, "")

--- a/packages/pyright-internal/src/tests/samples/properties4.py
+++ b/packages/pyright-internal/src/tests/samples/properties4.py
@@ -1,17 +1,17 @@
 # This sample tests the handling of a property that's defined
 # with a generic type for the "self" parameter.
 
-from typing import TypeVar
+from typing import Literal, TypeVar
 
 
-_P = TypeVar('_P', bound=str)
+_P = TypeVar("_P", bound=str)
+
 
 class Foo(str):
     @property
-    def parent(self: _P) -> _P: ...
+    def parent(self: _P) -> _P:
+        ...
 
-def requires_foo(a: Foo):
-    pass
 
 p = Foo().parent
-requires_foo(p)
+t1: Literal["Foo"] = reveal_type(p)

--- a/packages/pyright-internal/src/tests/samples/typeVar3.py
+++ b/packages/pyright-internal/src/tests/samples/typeVar3.py
@@ -1,6 +1,6 @@
 # This sample tests various diagnostics related to TypeVar usage.
 
-from typing import Generic, List, TypeVar
+from typing import Generic, List, Optional, TypeVar
 
 
 _T = TypeVar("_T")
@@ -21,7 +21,7 @@ class OuterClass(Generic[_T]):
         my_var2: _T
 
 
-def func1(a: _T) -> _T:
+def func1(a: _T) -> Optional[_T]:
     # This should generate an error
     my_var: _S
 
@@ -36,4 +36,3 @@ a: _S = 3
 
 # This should generate an error.
 b: List[_T] = []
-

--- a/packages/pyright-internal/src/tests/samples/typeVar4.py
+++ b/packages/pyright-internal/src/tests/samples/typeVar4.py
@@ -2,7 +2,7 @@
 # covariant and contravariant TypeVars are used incorrectly
 # for method parameters and return types.
 
-from typing import Generic, List, TypeVar, Union
+from typing import Generic, List, Optional, TypeVar, Union
 
 _T = TypeVar("_T")
 _T_co = TypeVar("_T_co", covariant=True)
@@ -27,21 +27,21 @@ class Foo(Generic[_T, _T_co, _T_contra]):
     def func5(self, a: _T_contra):
         pass
 
-    def func6(self) -> _T:
+    def func6(self) -> Optional[_T]:
         pass
 
-    def func7(self) -> _T_co:
+    def func7(self) -> Optional[_T_co]:
         pass
 
     # This should generate an error because contravariant
     # TypeVars are not allowed for return parameters.
-    def func8(self) -> _T_contra:
+    def func8(self) -> Optional[_T_contra]:
         pass
 
     # This should generate an error because contravariant
     # TypeVars are not allowed for return parameters.
     def func9(self) -> Union[_T_contra, int]:
-        pass
+        return 3
 
     def func10(self) -> List[_T_contra]:
         return []

--- a/packages/pyright-internal/src/tests/typeEvaluator2.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator2.test.ts
@@ -63,7 +63,7 @@ test('Assignment7', () => {
 test('Assignment8', () => {
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['assignment8.py']);
 
-    TestUtils.validateResults(analysisResults, 1);
+    TestUtils.validateResults(analysisResults, 2);
 });
 
 test('AugmentedAssignment1', () => {
@@ -231,7 +231,7 @@ test('GenericTypes5', () => {
 test('GenericTypes6', () => {
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['genericTypes6.py']);
 
-    TestUtils.validateResults(analysisResults, 1);
+    TestUtils.validateResults(analysisResults, 3);
 });
 
 test('GenericTypes7', () => {
@@ -417,6 +417,24 @@ test('GenericTypes35', () => {
 
 test('GenericTypes36', () => {
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['genericTypes36.py']);
+
+    TestUtils.validateResults(analysisResults, 0);
+});
+
+test('GenericTypes37', () => {
+    const analysisResults = TestUtils.typeAnalyzeSampleFiles(['genericTypes37.py']);
+
+    TestUtils.validateResults(analysisResults, 2);
+});
+
+test('GenericTypes38', () => {
+    const analysisResults = TestUtils.typeAnalyzeSampleFiles(['genericTypes38.py']);
+
+    TestUtils.validateResults(analysisResults, 0);
+});
+
+test('GenericTypes39', () => {
+    const analysisResults = TestUtils.typeAnalyzeSampleFiles(['genericTypes38.py']);
 
     TestUtils.validateResults(analysisResults, 0);
 });
@@ -915,7 +933,7 @@ test('ParamSpec1', () => {
 
     configOptions.defaultPythonVersion = PythonVersion.V3_10;
     const results = TestUtils.typeAnalyzeSampleFiles(['paramSpec1.py'], configOptions);
-    TestUtils.validateResults(results, 7);
+    TestUtils.validateResults(results, 6);
 });
 
 test('ParamSpec2', () => {
@@ -981,7 +999,7 @@ test('TypeVar2', () => {
 test('TypeVar3', () => {
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['typeVar3.py']);
 
-    TestUtils.validateResults(analysisResults, 8);
+    TestUtils.validateResults(analysisResults, 7);
 });
 
 test('TypeVar4', () => {
@@ -1112,6 +1130,12 @@ test('Constructor3', () => {
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['constructor3.py']);
 
     TestUtils.validateResults(analysisResults, 0);
+});
+
+test('Constructor4', () => {
+    const analysisResults = TestUtils.typeAnalyzeSampleFiles(['constructor4.py']);
+
+    TestUtils.validateResults(analysisResults, 1);
 });
 
 test('ClassGetItem1', () => {


### PR DESCRIPTION
…rget type contains a type var and the source is concrete. This change generally makes the core type checker more strict about the use of type variables.