### PR TITLE
Added a new diagnostic rule called "reportInvalidTypeVarUse" that fla…

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -114,6 +114,8 @@ The following settings control pyright’s diagnostic output (warnings or errors
 
 **reportMissingTypeArgument** [boolean or string, optional]: Generate or suppress diagnostics when a generic class is used without providing explicit or implicit type arguments. The default value for this setting is 'none'.
 
+**reportInvalidTypeVarUse** [boolean or string, optional]: Generate or suppress diagnostics when a TypeVar is used inappropriately (e.g. if a TypeVar appears only once) within a generic function signature. The default value for this setting is 'none'.
+
 **reportCallInDefaultInitializer** [boolean or string, optional]: Generate or suppress diagnostics for function calls within a default value initialization expression. Such calls can mask expensive operations that are performed at module initialization time. The default value for this setting is 'none'.
 
 **reportUnnecessaryIsInstance** [boolean or string, optional]: Generate or suppress diagnostics for 'isinstance' or 'issubclass' calls where the result is statically determined to be always true or always false. Such calls are often indicative of a programming error. The default value for this setting is 'none'.

--- a/packages/pyright-internal/src/analyzer/checker.ts
+++ b/packages/pyright-internal/src/analyzer/checker.ts
@@ -348,6 +348,8 @@ export class Checker extends ParseTreeWalker {
 
         this._scopedNodes.push(node);
 
+        this._validateFunctionTypeVarUsage(node);
+
         if (functionTypeResult && functionTypeResult.decoratedType.category === TypeCategory.OverloadedFunction) {
             const overloads = functionTypeResult.decoratedType.overloads;
             if (overloads.length > 1) {
@@ -814,6 +816,55 @@ export class Checker extends ParseTreeWalker {
 
         // Don't explore further.
         return false;
+    }
+
+    // Verifies that each local type variable is used more than once.
+    private _validateFunctionTypeVarUsage(node: FunctionNode) {
+        // Skip this check entirely if it's disabled.
+        if (this._fileInfo.diagnosticRuleSet.reportInvalidTypeVarUse === 'none') {
+            return;
+        }
+
+        const localTypeVarUsage = new Map<string, NameNode[]>();
+
+        const nameWalker = new ParseTreeUtils.NameNodeWalker((nameNode) => {
+            const nameType = this._evaluator.getType(nameNode);
+            if (nameType && isTypeVar(nameType)) {
+                if (nameType.scopeId === this._evaluator.getScopeIdForNode(node)) {
+                    if (!localTypeVarUsage.has(nameType.details.name)) {
+                        localTypeVarUsage.set(nameType.details.name, [nameNode]);
+                    } else {
+                        localTypeVarUsage.get(nameType.details.name)!.push(nameNode);
+                    }
+                }
+            }
+        });
+
+        // Find all of the local type variables in signature.
+        node.parameters.forEach((param) => {
+            const annotation = param.typeAnnotation || param.typeAnnotationComment;
+            if (annotation) {
+                nameWalker.walk(annotation);
+            }
+        });
+
+        if (node.returnTypeAnnotation) {
+            nameWalker.walk(node.returnTypeAnnotation);
+        }
+
+        // Report errors for all local type variables that appear only once.
+        localTypeVarUsage.forEach((nameNodes) => {
+            if (nameNodes.length === 1) {
+                this._evaluator.addDiagnostic(
+                    this._fileInfo.diagnosticRuleSet.reportInvalidTypeVarUse,
+                    DiagnosticRule.reportInvalidTypeVarUse,
+                    Localizer.Diagnostic.typeVarUsedOnlyOnce().format({
+                        name: nameNodes[0].value,
+                    }),
+                    nameNodes[0]
+                );
+            }
+        });
     }
 
     private _validateOverloadConsistency(

--- a/packages/pyright-internal/src/analyzer/parseTreeUtils.ts
+++ b/packages/pyright-internal/src/analyzer/parseTreeUtils.ts
@@ -23,6 +23,7 @@ import {
     isExpressionNode,
     LambdaNode,
     ModuleNode,
+    NameNode,
     ParameterCategory,
     ParseNode,
     ParseNodeType,
@@ -1078,4 +1079,17 @@ export function isAssignmentToDefaultsFollowingNamedTuple(callNode: ParseNode): 
     }
 
     return false;
+}
+
+// This simple parse tree walker calls a callback function
+// for each NameNode it encounters.
+export class NameNodeWalker extends ParseTreeWalker {
+    constructor(private _callback: (node: NameNode) => void) {
+        super();
+    }
+
+    visitName(node: NameNode) {
+        this._callback(node);
+        return true;
+    }
 }

--- a/packages/pyright-internal/src/common/configOptions.ts
+++ b/packages/pyright-internal/src/common/configOptions.ts
@@ -195,6 +195,9 @@ export interface DiagnosticRuleSet {
     // Report usage of generic class without explicit type arguments?
     reportMissingTypeArgument: DiagnosticLevel;
 
+    // Report improper usage of type variables within function signatures?
+    reportInvalidTypeVarUse: DiagnosticLevel;
+
     // Report usage of function call within default value
     // initialization expression?
     reportCallInDefaultInitializer: DiagnosticLevel;
@@ -289,6 +292,7 @@ export function getDiagLevelDiagnosticRules() {
         DiagnosticRule.reportUnknownVariableType,
         DiagnosticRule.reportUnknownMemberType,
         DiagnosticRule.reportMissingTypeArgument,
+        DiagnosticRule.reportInvalidTypeVarUse,
         DiagnosticRule.reportCallInDefaultInitializer,
         DiagnosticRule.reportUnnecessaryIsInstance,
         DiagnosticRule.reportUnnecessaryCast,
@@ -353,6 +357,7 @@ export function getOffDiagnosticRuleSet(): DiagnosticRuleSet {
         reportUnknownVariableType: 'none',
         reportUnknownMemberType: 'none',
         reportMissingTypeArgument: 'none',
+        reportInvalidTypeVarUse: 'none',
         reportCallInDefaultInitializer: 'none',
         reportUnnecessaryIsInstance: 'none',
         reportUnnecessaryCast: 'none',
@@ -413,6 +418,7 @@ export function getBasicDiagnosticRuleSet(): DiagnosticRuleSet {
         reportUnknownVariableType: 'none',
         reportUnknownMemberType: 'none',
         reportMissingTypeArgument: 'none',
+        reportInvalidTypeVarUse: 'warning',
         reportCallInDefaultInitializer: 'none',
         reportUnnecessaryIsInstance: 'none',
         reportUnnecessaryCast: 'none',
@@ -473,6 +479,7 @@ export function getStrictDiagnosticRuleSet(): DiagnosticRuleSet {
         reportUnknownVariableType: 'error',
         reportUnknownMemberType: 'error',
         reportMissingTypeArgument: 'error',
+        reportInvalidTypeVarUse: 'error',
         reportCallInDefaultInitializer: 'none',
         reportUnnecessaryIsInstance: 'error',
         reportUnnecessaryCast: 'error',
@@ -1048,6 +1055,13 @@ export class ConfigOptions {
                 configObj.reportMissingTypeArgument,
                 DiagnosticRule.reportMissingTypeArgument,
                 defaultSettings.reportMissingTypeArgument
+            ),
+
+            // Read the "reportInvalidTypeVarUse" entry.
+            reportInvalidTypeVarUse: this._convertDiagnosticLevel(
+                configObj.reportInvalidTypeVarUse,
+                DiagnosticRule.reportInvalidTypeVarUse,
+                defaultSettings.reportInvalidTypeVarUse
             ),
 
             // Read the "reportCallInDefaultInitializer" entry.

--- a/packages/pyright-internal/src/common/diagnosticRules.ts
+++ b/packages/pyright-internal/src/common/diagnosticRules.ts
@@ -50,6 +50,7 @@ export enum DiagnosticRule {
     reportUnknownVariableType = 'reportUnknownVariableType',
     reportUnknownMemberType = 'reportUnknownMemberType',
     reportMissingTypeArgument = 'reportMissingTypeArgument',
+    reportInvalidTypeVarUse = 'reportInvalidTypeVarUse',
     reportCallInDefaultInitializer = 'reportCallInDefaultInitializer',
     reportUnnecessaryIsInstance = 'reportUnnecessaryIsInstance',
     reportUnnecessaryCast = 'reportUnnecessaryCast',

--- a/packages/pyright-internal/src/tests/samples/constructor2.py
+++ b/packages/pyright-internal/src/tests/samples/constructor2.py
@@ -108,7 +108,7 @@ def s11():
     t: Literal["Donkey[int]"] = reveal_type(a)
 
 
-def s12(p: Bear[_T1]):
+def s12(p: Bear[_T1], b: _T1):
     a: Animal[Any, int] = p
     t: Literal["Bear[Any]"] = reveal_type(a)
 

--- a/packages/pyright-internal/src/tests/samples/constructor4.py
+++ b/packages/pyright-internal/src/tests/samples/constructor4.py
@@ -14,7 +14,7 @@ t2: Literal["list[Unknown]"] = reveal_type(val2)
 _T = TypeVar("_T")
 
 
-def foo(value: Type[_T]) -> None:
+def foo(value: Type[_T], b: _T) -> None:
     val1: "DefaultDict[str, list[_T]]" = defaultdict(list)
     t1: Literal["defaultdict[str, list[_T]]"] = reveal_type(val1)
 

--- a/packages/pyright-internal/src/tests/samples/dataclass12.py
+++ b/packages/pyright-internal/src/tests/samples/dataclass12.py
@@ -21,12 +21,12 @@ class MapTreeNode(MapTreeLeaf[Key1, Value]):
     pass
 
 
-def add(key: Key2, value: Value):
-    return MapTreeNode(key=key, value=value)
+class Foo(Generic[Key2, Value]):
+    def add(self, key: Key2, value: Value):
+        return MapTreeNode(key=key, value=value)
 
-
-def test1(a: int, b: str):
-    v1 = add(a, b)
-    t1: Literal["MapTreeNode[int, str]"] = reveal_type(v1)
-    t1_key: Literal["int"] = reveal_type(v1.key)
-    t1_value: Literal["str"] = reveal_type(v1.value)
+    def test1(self, a: int, b: str):
+        v1 = self.add(a, b)
+        t1: Literal["MapTreeNode[int, str]"] = reveal_type(v1)
+        t1_key: Literal["int"] = reveal_type(v1.key)
+        t1_value: Literal["str"] = reveal_type(v1.value)

--- a/packages/pyright-internal/src/tests/samples/genericTypes46.py
+++ b/packages/pyright-internal/src/tests/samples/genericTypes46.py
@@ -11,13 +11,13 @@ def func(a: Union[int, float]):
 _T1 = TypeVar("_T1", int, float)
 
 
-def func1(a: _T1):
+def func1(a: _T1, b: _T1):
     return func(a)
 
 
 _T2 = TypeVar("_T2", int, float, complex)
 
 
-def func2(a: _T2):
+def func2(a: _T2, b: _T2):
     # This should generate an error.
     return func(a)

--- a/packages/pyright-internal/src/tests/samples/isinstance4.py
+++ b/packages/pyright-internal/src/tests/samples/isinstance4.py
@@ -35,7 +35,7 @@ def get_type_of_object(object: Union[Callable[..., Any], CustomClass]):
 _T = TypeVar("_T", bound=CustomClass)
 
 
-def func(cls: Type[_T]):
+def func(cls: Type[_T], val: _T):
     if issubclass(cls, CustomClass):
         t1: Literal["Type[CustomClass]"] = reveal_type(cls)
     else:

--- a/packages/pyright-internal/src/tests/samples/typeAlias11.py
+++ b/packages/pyright-internal/src/tests/samples/typeAlias11.py
@@ -40,7 +40,7 @@ HttpHandler = Callable[
 
 async def run_async(
     ctx: Context[TSource],
-    handler: HttpHandler[TNext, TResult, TError, TSource],
+    handler: HttpHandler[str, TResult, TError, TSource],
 ) -> Result[TResult, TError]:
     result = Result[TResult, TError]()
 

--- a/packages/pyright-internal/src/tests/samples/typeVar5.py
+++ b/packages/pyright-internal/src/tests/samples/typeVar5.py
@@ -9,7 +9,7 @@ _T1 = TypeVar("_T1")
 _T2 = TypeVar("_T2")
 
 
-class ClassA(Generic[_T1]):
+class ClassA(Generic[_T1, _T2]):
     async def func1(self, a: _T1):
         # This should generate an error.
         _ = a.temp

--- a/packages/pyright-internal/src/tests/samples/typeVar7.py
+++ b/packages/pyright-internal/src/tests/samples/typeVar7.py
@@ -39,7 +39,7 @@ _T1 = TypeVar("_T1", Foo, Bar)
 _T2 = TypeVar("_T2", Foo, Bar, str)
 
 
-class ClassA(Generic[_T1]):
+class ClassA(Generic[_T1, _T2]):
     async def func1(self, a: _T1) -> _T1:
         _ = a.var1
 

--- a/packages/pyright-internal/src/tests/samples/typeVar9.py
+++ b/packages/pyright-internal/src/tests/samples/typeVar9.py
@@ -1,0 +1,50 @@
+# This sample tests the reporting of incorrect TypeVar usage within
+# a generic function. A TypeVar must appear at least twice to be
+# considered legitimate.
+
+# pyright: reportInvalidTypeVarUse=true
+
+from typing import Dict, Generic, List, TypeVar
+
+
+_T = TypeVar("_T")
+_S = TypeVar("_S")
+
+
+class Foo(Generic[_T]):
+    def m1(self, v1: _T) -> None:
+        ...
+
+    # This should generate an error because _S
+    # is a local typeVar and appears only once.
+    def m2(self, v1: _S) -> None:
+        ...
+
+    # This should generate an error because _S
+    # is a local typeVar and appears only once.
+    def m3(self, v1: _T) -> _S:
+        ...
+
+
+# This should generate an error because _T
+# is a local typeVar and appears only once.
+def f1(self, v1: _T) -> None:
+    ...
+
+
+def f2(self, v1: _T, v2: List[_T]) -> None:
+    ...
+
+
+def f3(self, v1: _T) -> _T:
+    ...
+
+
+def f4(self) -> Dict[_T, _T]:
+    ...
+
+
+# This should generate an error because _T
+# is a local typeVar and appears only once.
+def f5(self) -> List[_T]:
+    ...

--- a/packages/pyright-internal/src/tests/typeEvaluator2.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator2.test.ts
@@ -1073,7 +1073,7 @@ test('ParamSpec4', () => {
 
     configOptions.defaultPythonVersion = PythonVersion.V3_10;
     const results = TestUtils.typeAnalyzeSampleFiles(['paramSpec4.py'], configOptions);
-    TestUtils.validateResults(results, 5);
+    TestUtils.validateResults(results, 5, 2);
 });
 
 test('ParamSpec5', () => {
@@ -1135,7 +1135,7 @@ test('TypeVar6', () => {
 test('TypeVar7', () => {
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['typeVar7.py']);
 
-    TestUtils.validateResults(analysisResults, 22);
+    TestUtils.validateResults(analysisResults, 22, 2);
 });
 
 test('TypeVar8', () => {

--- a/packages/pyright-internal/src/tests/typeEvaluator2.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator2.test.ts
@@ -1144,6 +1144,12 @@ test('TypeVar8', () => {
     TestUtils.validateResults(analysisResults, 2);
 });
 
+test('TypeVar9', () => {
+    const analysisResults = TestUtils.typeAnalyzeSampleFiles(['typeVar9.py']);
+
+    TestUtils.validateResults(analysisResults, 4);
+});
+
 test('Annotated1', () => {
     const configOptions = new ConfigOptions('.');
 

--- a/packages/vscode-pyright/package.json
+++ b/packages/vscode-pyright/package.json
@@ -488,6 +488,17 @@
                                 "error"
                             ]
                         },
+                        "reportInvalidTypeVarUse": {
+                            "type": "string",
+                            "description": "Diagnostics for improper use of type variables in a function signature.",
+                            "default": "warning",
+                            "enum": [
+                                "none",
+                                "information",
+                                "warning",
+                                "error"
+                            ]
+                        },
                         "reportCallInDefaultInitializer": {
                             "type": "string",
                             "description": "Diagnostics for function calls within a default value initialization expression. Such calls can mask expensive operations that are performed at module initialization time.",

--- a/packages/vscode-pyright/schemas/pyrightconfig.schema.json
+++ b/packages/vscode-pyright/schemas/pyrightconfig.schema.json
@@ -327,6 +327,12 @@
       "title": "Controls reporting generic class reference with missing type arguments",
       "default": "none"
     },
+    "reportInvalidTypeVarUse": {
+      "$id": "#/properties/reportInvalidTypeVarUse",
+      "$ref": "#/definitions/diagnostic",
+      "title": "Controls reporting improper use of type variables within function signatures",
+      "default": "warning"
+    },
     "reportCallInDefaultInitializer": {
       "$id": "#/properties/reportCallInDefaultInitializer",
       "$ref": "#/definitions/diagnostic",


### PR DESCRIPTION
…gs errors when TypeVars are used incorrectly. In particular, it flags the use of a single instance of a TypeVar within a generic function signature.