### PR TITLE
Expand variables in paths early

### DIFF
--- a/packages/pyright-internal/src/server.ts
+++ b/packages/pyright-internal/src/server.ts
@@ -52,6 +52,24 @@ class PyrightServer extends LanguageServerBase {
         this._controller = new CommandController(this);
     }
 
+    // Expands certain predefined variables supported within VS Code settings.
+    // Ideally, VS Code would provide an API for doing this expansion, but
+    // it doesn't. We'll handle the most common variables here as a convenience.
+    _expandPathVariables(rootPath: string, value: string): string {
+        const regexp = /\$\{(.*?)\}/g;
+        return value.replace(regexp, (match: string, name: string) => {
+            const trimmedName = name.trim();
+            if (trimmedName === 'workspaceFolder') {
+                return rootPath;
+            }
+            if (trimmedName === 'env:HOME' && process.env.HOME !== undefined) {
+                return process.env.HOME;
+            }
+
+            return match;
+        });
+    }
+
     async getSettings(workspace: WorkspaceServiceInstance): Promise<ServerSettings> {
         const serverSettings: ServerSettings = {
             watchForSourceChanges: true,
@@ -71,12 +89,19 @@ class PyrightServer extends LanguageServerBase {
             if (pythonSection) {
                 const pythonPath = pythonSection.pythonPath;
                 if (pythonPath && isString(pythonPath) && !isPythonBinary(pythonPath)) {
-                    serverSettings.pythonPath = resolvePaths(workspace.rootPath, pythonPath);
+                    serverSettings.pythonPath = resolvePaths(
+                        workspace.rootPath,
+                        this._expandPathVariables(workspace.rootPath, pythonPath)
+                    );
                 }
 
                 const venvPath = pythonSection.venvPath;
+
                 if (venvPath && isString(venvPath)) {
-                    serverSettings.venvPath = resolvePaths(workspace.rootPath, venvPath);
+                    serverSettings.venvPath = resolvePaths(
+                        workspace.rootPath,
+                        this._expandPathVariables(workspace.rootPath, venvPath)
+                    );
                 }
             }
 
@@ -92,7 +117,10 @@ class PyrightServer extends LanguageServerBase {
 
                 const stubPath = pythonAnalysisSection.stubPath;
                 if (stubPath && isString(stubPath)) {
-                    serverSettings.stubPath = resolvePaths(workspace.rootPath, stubPath);
+                    serverSettings.stubPath = resolvePaths(
+                        workspace.rootPath,
+                        this._expandPathVariables(workspace.rootPath, stubPath)
+                    );
                 }
 
                 const diagnosticSeverityOverrides = pythonAnalysisSection.diagnosticSeverityOverrides;

--- a/packages/pyright-internal/src/server.ts
+++ b/packages/pyright-internal/src/server.ts
@@ -55,7 +55,7 @@ class PyrightServer extends LanguageServerBase {
     // Expands certain predefined variables supported within VS Code settings.
     // Ideally, VS Code would provide an API for doing this expansion, but
     // it doesn't. We'll handle the most common variables here as a convenience.
-    _expandPathVariables(rootPath: string, value: string): string {
+    protected expandPathVariables(rootPath: string, value: string): string {
         const regexp = /\$\{(.*?)\}/g;
         return value.replace(regexp, (match: string, name: string) => {
             const trimmedName = name.trim();
@@ -91,7 +91,7 @@ class PyrightServer extends LanguageServerBase {
                 if (pythonPath && isString(pythonPath) && !isPythonBinary(pythonPath)) {
                     serverSettings.pythonPath = resolvePaths(
                         workspace.rootPath,
-                        this._expandPathVariables(workspace.rootPath, pythonPath)
+                        this.expandPathVariables(workspace.rootPath, pythonPath)
                     );
                 }
 
@@ -100,7 +100,7 @@ class PyrightServer extends LanguageServerBase {
                 if (venvPath && isString(venvPath)) {
                     serverSettings.venvPath = resolvePaths(
                         workspace.rootPath,
-                        this._expandPathVariables(workspace.rootPath, venvPath)
+                        this.expandPathVariables(workspace.rootPath, venvPath)
                     );
                 }
             }
@@ -119,7 +119,7 @@ class PyrightServer extends LanguageServerBase {
                 if (stubPath && isString(stubPath)) {
                     serverSettings.stubPath = resolvePaths(
                         workspace.rootPath,
-                        this._expandPathVariables(workspace.rootPath, stubPath)
+                        this.expandPathVariables(workspace.rootPath, stubPath)
                     );
                 }
 


### PR DESCRIPTION
Variables can be used in paths (`${workspaceFolder}` or `${env:HOME}`)
but they were already being resolved to absolute paths before expanding
the variables, which made the expansions not do the "right" thing.

This commit changes it to expand the variables early, in the server
constructor.

Relates to #1267