### PR TITLE
Improving error messages for expected TypeDicts

### DIFF
--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -8201,15 +8201,18 @@ export function createTypeEvaluator(importLookup: ImportLookup, evaluatorOptions
             expectedType = matchingSubtype;
         }
 
-        const expectedDiagAddendum = new DiagnosticAddendum();
+        let expectedDiagAddendum = undefined; 
         if (expectedType) {
+            expectedDiagAddendum = new DiagnosticAddendum();
             const result = getTypeFromDictionaryExpected(node, expectedType, expectedDiagAddendum);
             if (result) {
                 return result;
             }
         }
 
-        return getTypeFromDictionaryInferred(node, /* forceStrict */ !!expectedType)!;
+        let result = getTypeFromDictionaryInferred(node, /* forceStrict */ !!expectedType)!;
+        result = { ...result, expectedTypeDiagAddendum: expectedDiagAddendum };
+        return result;
     }
 
     // Attempts to infer the type of a dictionary statement. If an expectedType

--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -8201,7 +8201,7 @@ export function createTypeEvaluator(importLookup: ImportLookup, evaluatorOptions
             expectedType = matchingSubtype;
         }
 
-        let expectedDiagAddendum = undefined; 
+        let expectedDiagAddendum = undefined;
         if (expectedType) {
             expectedDiagAddendum = new DiagnosticAddendum();
             const result = getTypeFromDictionaryExpected(node, expectedType, expectedDiagAddendum);
@@ -8374,9 +8374,8 @@ export function createTypeEvaluator(importLookup: ImportLookup, evaluatorOptions
                         }
                     }
                 }
-                
+
                 let valueTypeResult: TypeResult;
-                let valueType: Type;
 
                 if (
                     expectedTypedDictEntries &&
@@ -8393,11 +8392,11 @@ export function createTypeEvaluator(importLookup: ImportLookup, evaluatorOptions
                     valueTypeResult = getTypeOfExpression(entryNode.valueExpression, expectedValueType);
                 }
 
-                if(expectedDiagAddendum && valueTypeResult.expectedTypeDiagAddendum) {
-                    expectedDiagAddendum.addAddendum(valueTypeResult.expectedTypeDiagAddendum)
+                if (expectedDiagAddendum && valueTypeResult.expectedTypeDiagAddendum) {
+                    expectedDiagAddendum.addAddendum(valueTypeResult.expectedTypeDiagAddendum);
                 }
 
-                valueType = valueTypeResult.type;
+                const valueType = valueTypeResult.type;
 
                 if (!limitEntryCount || index < maxEntriesToUseForInference) {
                     keyTypes.push(keyType);


### PR DESCRIPTION
When TypedDict is an expected value, but the Dict expression does not fulfill the requirements, the generated error message does not provide enough information to narrow down the error.

```python
from typing import TypedDict, Dict

Movie = TypedDict("Movie", name=str, year=int)
move: Movie = {
    "name": "M",
    "year": "5"
    # this should generate an error about year
}

class Inner(TypedDict, total=False):
    inner_key: Dict[str, 'Inner']
    something: str

a: Inner = {
    "inner_key": {
        "akey": {
            "inner_key": {
                "bkey": {
                    "something": 22
                    # this should generate an error about "something"
                }
            }
        }
    }
}

```

Before this change:
```
  4:15 - error: Expression of type "dict[str, str]" cannot be assigned to declared type "Movie"
    "dict[str, str]" is incompatible with "Movie" (reportGeneralTypeIssues)
  14:12 - error: Expression of type "dict[str, dict[str, dict[str, dict[str, dict[str, int]]]]]" cannot be assigned to declared type "Inner"
    "dict[str, dict[str, dict[str, dict[str, dict[str, int]]]]]" is incompatible with "Inner" (reportGeneralTypeIssues)
```

After this change:
```
  4:15 - error: Expression of type "dict[str, str]" cannot be assigned to declared type "Movie"
    Type "Literal['5']" is not assignable to field "year" (reportGeneralTypeIssues)
  14:12 - error: Expression of type "dict[str, dict[str, dict[str, dict[str, dict[str, int]]]]]" cannot be assigned to declared type "Inner"
    Type "dict[str, dict[str, dict[str, dict[str, int]]]]" is not assignable to field "inner_key"
      Type "dict[str, dict[str, int]]" is not assignable to field "inner_key"
        Type "Literal[22]" is not assignable to field "something" (reportGeneralTypeIssues)
```

Ground work had been done in the commit: https://github.com/microsoft/pyright/commit/dc033502ee7df5471e527397c5733e85f9b6fa43. But it may have regressed somewhere along the line.

All tests are passing. Feel free to let me know if you have suggestions. I would also like to work on to see if we can report the errors at a more a narrowed down levels than all at the outer expression.

PS: Thanks for this project. It has been an invaluable resource.

