### PR TITLE
Fix for missing docstrings in completions on a property where only the getter has documentation 

### DIFF
--- a/packages/pyright-internal/src/analyzer/typeDocStringUtils.ts
+++ b/packages/pyright-internal/src/analyzer/typeDocStringUtils.ts
@@ -8,7 +8,13 @@
  * the source file.
  */
 
-import { ClassDeclaration, DeclarationBase, DeclarationType, FunctionDeclaration } from '../analyzer/declaration';
+import {
+    ClassDeclaration,
+    Declaration,
+    DeclarationBase,
+    DeclarationType,
+    FunctionDeclaration,
+} from '../analyzer/declaration';
 import * as ParseTreeUtils from '../analyzer/parseTreeUtils';
 import { isStubFile, SourceMapper } from '../analyzer/sourceMapper';
 import { ClassType, FunctionType, ModuleType, OverloadedFunctionType } from '../analyzer/types';
@@ -79,6 +85,21 @@ export function getFunctionDocStringFromDeclaration(resolvedDecl: FunctionDeclar
     if (!docString && isStubFile(resolvedDecl.path)) {
         const implDecls = sourceMapper.findFunctionDeclarations(resolvedDecl);
         docString = _getFunctionOrClassDeclDocString(implDecls);
+    }
+    return docString;
+}
+
+export function getFunctionDocStringFromDeclarations(declarations: Declaration[], sourceMapper: SourceMapper) {
+    let docString = undefined;
+    if (declarations?.length > 0) {
+        for (const decl of declarations) {
+            if (decl.type === DeclarationType.Function) {
+                docString = getFunctionDocStringFromDeclaration(decl, sourceMapper);
+            }
+            if (docString) {
+                break;
+            }
+        }
     }
     return docString;
 }

--- a/packages/pyright-internal/src/languageService/completionProvider.ts
+++ b/packages/pyright-internal/src/languageService/completionProvider.ts
@@ -31,6 +31,7 @@ import { getLastTypedDeclaredForSymbol } from '../analyzer/symbolUtils';
 import {
     getClassDocString,
     getFunctionDocStringFromDeclaration,
+    getFunctionDocStringFromDeclarations,
     getFunctionDocStringFromType,
     getModuleDocString,
     getOverloadedFunctionDocStrings,
@@ -1659,6 +1660,13 @@ export class CompletionProvider {
                             } else if (primaryDecl.type === DeclarationType.Function) {
                                 // @property functions
                                 documentation = getFunctionDocStringFromDeclaration(primaryDecl, this._sourceMapper);
+                                if (documentation === undefined) {
+                                    // if the setter was undocumented check the getter
+                                    documentation = getFunctionDocStringFromDeclarations(
+                                        symbol.getDeclarations(),
+                                        this._sourceMapper
+                                    );
+                                }
                             }
 
                             if (this._format === MarkupKind.Markdown) {

--- a/packages/pyright-internal/src/tests/fourslash/completions.propertyDocStrings.fourslash.ts
+++ b/packages/pyright-internal/src/tests/fourslash/completions.propertyDocStrings.fourslash.ts
@@ -1,0 +1,64 @@
+/// <reference path="fourslash.ts" />
+
+// @filename: mspythonconfig.json
+//// {
+////   "useLibraryCodeForTypes": true
+//// }
+
+// @filename: test.py
+//// class ClassWithGetterDocs(object):
+////     def __init__(self, length):
+////         self._length = length
+////
+////     @property
+////     def length(self):
+////         """
+////         read property doc
+////         """
+////         return self._length
+////
+////     @length.setter
+////     def length(self, value):
+////         pass
+////
+//// one = ClassWithGetterDocs(3)
+//// one.lengt[|/*marker1*/|]
+////
+//// class ClassWithSetterDocs(object):
+////     def __init__(self, length):
+////         self._length = length
+////
+////     @property
+////     def length(self):
+////         return self._length
+////
+////     @length.setter
+////     def length(self, value):
+////         """
+////         setter property doc
+////         """
+////         pass
+////
+//// two = ClassWithSetterDocs(3)
+//// two.lengt[|/*marker2*/|]
+// @ts-ignore
+await helper.verifyCompletion('included', 'markdown', {
+    marker1: {
+        completions: [
+            {
+                label: 'length',
+                kind: Consts.CompletionItemKind.Property,
+                documentation: '```python\nlength: Unknown (property)\n```\n---\nread property doc',
+            },
+        ],
+    },
+    marker2: {
+        completions: [
+            {
+                label: 'length',
+                kind: Consts.CompletionItemKind.Property,
+                documentation: '```python\nlength: Unknown (property)\n```\n---\nsetter property doc',
+            },
+        ],
+    },
+});


### PR DESCRIPTION
Fix for missing docs in completion list due to only checking the setter for docs because its definition comes after the getter. This primary declaration logic comes from overloads were the doc strings are using on the last function. Now if the setter is missing a doc string we check the other declarations until we find a doc string.

During onHover we always look at the first declaration which would be the getter.

this._addResultsForDeclaration(format, sourceMapper, results.parts, declarations[0], node, evaluator);

in hoverProvider.ts

before 
![image](https://user-images.githubusercontent.com/1946977/104045955-315b2a80-5194-11eb-9587-8637052950dd.png)

after
![image](https://user-images.githubusercontent.com/1946977/104045987-3d46ec80-5194-11eb-947f-b1f3b9b95f63.png)

better aligns with Hover
![image](https://user-images.githubusercontent.com/1946977/104046026-4f288f80-5194-11eb-9486-a3de544328d3.png)
