### PR TITLE
Don't make super calls in base class methods

### DIFF
--- a/packages/pyright-internal/src/analyzer/parseTreeWalker.ts
+++ b/packages/pyright-internal/src/analyzer/parseTreeWalker.ts
@@ -212,7 +212,7 @@ export class ParseTreeWalker {
 
             case ParseNodeType.Error:
                 if (this.visitError(node)) {
-                    return [node.child];
+                    return [node.child, ...(node.decorators ?? [])];
                 }
                 break;
 

--- a/packages/pyright-internal/src/analyzer/program.ts
+++ b/packages/pyright-internal/src/analyzer/program.ts
@@ -50,7 +50,7 @@ import {
     ModuleSymbolMap,
 } from '../languageService/autoImporter';
 import { CallHierarchyProvider } from '../languageService/callHierarchyProvider';
-import { AbbreviationMap, CompletionResults } from '../languageService/completionProvider';
+import { AbbreviationMap, CompletionOptions, CompletionResults } from '../languageService/completionProvider';
 import { IndexOptions, IndexResults, WorkspaceSymbolCallback } from '../languageService/documentSymbolProvider';
 import { HoverResults } from '../languageService/hoverProvider';
 import { ReferenceCallback, ReferencesResult } from '../languageService/referencesProvider';
@@ -1358,7 +1358,7 @@ export class Program {
         filePath: string,
         position: Position,
         workspacePath: string,
-        format: MarkupKind,
+        options: CompletionOptions,
         nameMap: AbbreviationMap | undefined,
         libraryMap: Map<string, IndexResults> | undefined,
         token: CancellationToken
@@ -1382,7 +1382,7 @@ export class Program {
                         this._importResolver,
                         this._lookUpImport,
                         this._evaluator!,
-                        format,
+                        options,
                         this._createSourceMapper(execEnv, /* mapCompiled */ true),
                         nameMap,
                         libraryMap,
@@ -1422,7 +1422,7 @@ export class Program {
     resolveCompletionItem(
         filePath: string,
         completionItem: CompletionItem,
-        format: MarkupKind,
+        options: CompletionOptions,
         token: CancellationToken
     ) {
         return this._runEvaluatorWithCancellationToken(token, () => {
@@ -1439,7 +1439,7 @@ export class Program {
                 this._importResolver,
                 this._lookUpImport,
                 this._evaluator!,
-                format,
+                options,
                 this._createSourceMapper(execEnv, /* mapCompiled */ true),
                 completionItem,
                 token

--- a/packages/pyright-internal/src/analyzer/service.ts
+++ b/packages/pyright-internal/src/analyzer/service.ts
@@ -46,7 +46,7 @@ import {
 } from '../common/pathUtils';
 import { DocumentRange, Position, Range } from '../common/textRange';
 import { timingStats } from '../common/timing';
-import { AbbreviationMap, CompletionResults } from '../languageService/completionProvider';
+import { AbbreviationMap, CompletionOptions, CompletionResults } from '../languageService/completionProvider';
 import { IndexResults, WorkspaceSymbolCallback } from '../languageService/documentSymbolProvider';
 import { HoverResults } from '../languageService/hoverProvider';
 import { ReferenceCallback } from '../languageService/referencesProvider';
@@ -295,7 +295,7 @@ export class AnalyzerService {
         filePath: string,
         position: Position,
         workspacePath: string,
-        format: MarkupKind,
+        options: CompletionOptions,
         nameMap: AbbreviationMap | undefined,
         token: CancellationToken
     ): Promise<CompletionResults | undefined> {
@@ -303,7 +303,7 @@ export class AnalyzerService {
             filePath,
             position,
             workspacePath,
-            format,
+            options,
             nameMap,
             this._backgroundAnalysisProgram.getIndexing(filePath),
             token
@@ -317,10 +317,10 @@ export class AnalyzerService {
     resolveCompletionItem(
         filePath: string,
         completionItem: CompletionItem,
-        format: MarkupKind,
+        options: CompletionOptions,
         token: CancellationToken
     ) {
-        this._program.resolveCompletionItem(filePath, completionItem, format, token);
+        this._program.resolveCompletionItem(filePath, completionItem, options, token);
     }
 
     performQuickAction(

--- a/packages/pyright-internal/src/analyzer/sourceFile.ts
+++ b/packages/pyright-internal/src/analyzer/sourceFile.ts
@@ -33,7 +33,7 @@ import { DocumentRange, getEmptyRange, Position, TextRange } from '../common/tex
 import { TextRangeCollection } from '../common/textRangeCollection';
 import { timingStats } from '../common/timing';
 import { ModuleSymbolMap } from '../languageService/autoImporter';
-import { AbbreviationMap, CompletionResults } from '../languageService/completionProvider';
+import { AbbreviationMap, CompletionOptions, CompletionResults } from '../languageService/completionProvider';
 import { CompletionItemData, CompletionProvider } from '../languageService/completionProvider';
 import { DefinitionProvider } from '../languageService/definitionProvider';
 import { DocumentHighlightProvider } from '../languageService/documentHighlightProvider';
@@ -795,7 +795,7 @@ export class SourceFile {
         importResolver: ImportResolver,
         importLookup: ImportLookup,
         evaluator: TypeEvaluator,
-        format: MarkupKind,
+        options: CompletionOptions,
         sourceMapper: SourceMapper,
         nameMap: AbbreviationMap | undefined,
         libraryMap: Map<string, IndexResults> | undefined,
@@ -824,7 +824,7 @@ export class SourceFile {
             configOptions,
             importLookup,
             evaluator,
-            format,
+            options,
             sourceMapper,
             {
                 nameMap,
@@ -842,7 +842,7 @@ export class SourceFile {
         importResolver: ImportResolver,
         importLookup: ImportLookup,
         evaluator: TypeEvaluator,
-        format: MarkupKind,
+        options: CompletionOptions,
         sourceMapper: SourceMapper,
         completionItem: CompletionItem,
         token: CancellationToken
@@ -863,7 +863,7 @@ export class SourceFile {
             configOptions,
             importLookup,
             evaluator,
-            format,
+            options,
             sourceMapper,
             undefined,
             token

--- a/packages/pyright-internal/src/common/textRange.ts
+++ b/packages/pyright-internal/src/common/textRange.ts
@@ -41,6 +41,10 @@ export namespace TextRange {
         return position >= range.start && position < getEnd(range);
     }
 
+    export function containsRange(range: TextRange, span: TextRange): boolean {
+        return span.start >= range.start && getEnd(span) <= getEnd(range);
+    }
+
     export function overlaps(range: TextRange, position: number): boolean {
         return position >= range.start && position <= getEnd(range);
     }

--- a/packages/pyright-internal/src/languageServerBase.ts
+++ b/packages/pyright-internal/src/languageServerBase.ts
@@ -167,6 +167,7 @@ export abstract class LanguageServerBase implements LanguageServerInterface {
     protected _hasWindowProgressCapability = false;
     protected _hoverContentFormat: MarkupKind = MarkupKind.PlainText;
     protected _completionDocFormat: MarkupKind = MarkupKind.PlainText;
+    protected _completionSupportsSnippet = false;
     protected _signatureDocFormat: MarkupKind = MarkupKind.PlainText;
     protected _supportsUnnecessaryDiagnosticTag = false;
     protected _defaultClientConfig: any;
@@ -663,7 +664,7 @@ export abstract class LanguageServerBase implements LanguageServerInterface {
                 workspace.serviceInstance.resolveCompletionItem(
                     completionItemData.filePath,
                     params,
-                    this._completionDocFormat,
+                    this.getCompletionOptions(),
                     token
                 );
             }
@@ -893,7 +894,7 @@ export abstract class LanguageServerBase implements LanguageServerInterface {
             filePath,
             position,
             workspacePath,
-            this._completionDocFormat,
+            this.getCompletionOptions(),
             undefined,
             token
         );
@@ -903,6 +904,10 @@ export abstract class LanguageServerBase implements LanguageServerInterface {
         this._workspaceMap.forEach((workspace) => {
             this.updateSettingsForWorkspace(workspace).ignoreErrors();
         });
+    }
+
+    protected getCompletionOptions() {
+        return { format: this._completionDocFormat, snippet: this._completionSupportsSnippet };
     }
 
     protected initialize(
@@ -927,6 +932,7 @@ export abstract class LanguageServerBase implements LanguageServerInterface {
         this._completionDocFormat = this._getCompatibleMarkupKind(
             capabilities.textDocument?.completion?.completionItem?.documentationFormat
         );
+        this._completionSupportsSnippet = !!capabilities.textDocument?.completion?.completionItem?.snippetSupport;
         this._signatureDocFormat = this._getCompatibleMarkupKind(
             capabilities.textDocument?.signatureHelp?.signatureInformation?.documentationFormat
         );

--- a/packages/pyright-internal/src/tests/fourslash/completions.override2.fourslash.ts
+++ b/packages/pyright-internal/src/tests/fourslash/completions.override2.fourslash.ts
@@ -56,8 +56,7 @@
                     kind: Consts.CompletionItemKind.Method,
                     textEdit: {
                         range: helper.getPositionRange('marker3'),
-                        newText:
-                            '__call__(self, *args: Any, **kwds: Any) -> Any:\n    return super().__call__(*args, **kwds)',
+                        newText: '__call__(self, *args: Any, **kwds: Any) -> Any:\n    ${0:pass}',
                     },
                 },
             ],

--- a/packages/pyright-internal/src/tests/harness/fourslash/testState.ts
+++ b/packages/pyright-internal/src/tests/harness/fourslash/testState.ts
@@ -841,7 +841,7 @@ export class TestState {
                 filePath,
                 completionPosition,
                 this.workspace.rootPath,
-                docFormat,
+                { format: docFormat, snippet: true },
                 abbrMap ? new Map<string, AbbreviationInfo>(Object.entries(abbrMap)) : undefined,
                 CancellationToken.None
             );
@@ -877,7 +877,12 @@ export class TestState {
 
                         if (expected.documentation !== undefined) {
                             if (actual.documentation === undefined) {
-                                this.program.resolveCompletionItem(filePath, actual, docFormat, CancellationToken.None);
+                                this.program.resolveCompletionItem(
+                                    filePath,
+                                    actual,
+                                    { format: docFormat, snippet: true },
+                                    CancellationToken.None
+                                );
                             }
 
                             if (MarkupContent.is(actual.documentation)) {


### PR DESCRIPTION
Don't make `super()` calls in method override completions when a class has no parent class (only `object`).

Co-authored-by: Heejae Chang <heejaechang@outlook.com>