### PR TITLE
Change client watch glob to get folder change events

### DIFF
--- a/packages/pyright-internal/src/analyzer/backgroundAnalysisProgram.ts
+++ b/packages/pyright-internal/src/analyzer/backgroundAnalysisProgram.ts
@@ -195,8 +195,10 @@ export class BackgroundAnalysisProgram {
         return this._program.writeTypeStub(targetImportPath, targetIsSingleFile, stubPath, token);
     }
 
-    invalidateAndForceReanalysis() {
-        this.refreshIndexing();
+    invalidateAndForceReanalysis(rebuildLibraryIndexing: boolean) {
+        if (rebuildLibraryIndexing) {
+            this.refreshIndexing();
+        }
 
         this._backgroundAnalysis?.invalidateAndForceReanalysis();
 

--- a/packages/pyright-internal/src/analyzer/service.ts
+++ b/packages/pyright-internal/src/analyzer/service.ts
@@ -31,7 +31,7 @@ import { ConsoleInterface, log, LogLevel, StandardConsole } from '../common/cons
 import { Diagnostic } from '../common/diagnostic';
 import { FileEditAction, TextEditAction } from '../common/editAction';
 import { LanguageServiceExtension } from '../common/extensibility';
-import { FileSystem, FileWatcher, ignoredWatchEventFunction } from '../common/fileSystem';
+import { FileSystem, FileWatcher, ignoredWatchEventFunction, Stats } from '../common/fileSystem';
 import {
     combinePaths,
     FileSpec,
@@ -706,9 +706,9 @@ export class AnalyzerService {
     // This is called after a new type stub has been created. It allows
     // us to invalidate caches and force reanalysis of files that potentially
     // are affected by the appearance of a new type stub.
-    invalidateAndForceReanalysis() {
+    invalidateAndForceReanalysis(rebuildLibraryIndexing = true) {
         // Mark all files with one or more errors dirty.
-        this._backgroundAnalysisProgram.invalidateAndForceReanalysis();
+        this._backgroundAnalysisProgram.invalidateAndForceReanalysis(rebuildLibraryIndexing);
     }
 
     // Forces the service to stop all analysis, discard all its caches,
@@ -1057,8 +1057,19 @@ export class AnalyzerService {
                         this._console.info(`SourceFile: Received fs event '${event}' for path '${path}'`);
                     }
 
+                    let stats: Stats | undefined;
+                    try {
+                        stats = this._fs.statSync(path);
+                    } catch {
+                        stats = undefined;
+                    }
+
+                    if (stats && stats.isFile() && !path.endsWith('py') && !path.endsWith('pyi')) {
+                        return;
+                    }
+
                     // Delete comes in as a change event, so try to distinguish here.
-                    if (event === 'change' && this._fs.existsSync(path)) {
+                    if (event === 'change' && stats) {
                         this._backgroundAnalysisProgram.markFilesDirty([path], false);
                         this._scheduleReanalysis(false);
                     } else {
@@ -1079,7 +1090,7 @@ export class AnalyzerService {
                         if (!isTemporaryFile) {
                             // Added/deleted/renamed files impact imports,
                             // clear the import resolver cache and reanalyze everything.
-                            this.invalidateAndForceReanalysis();
+                            this.invalidateAndForceReanalysis(false);
                             this._scheduleReanalysis(true);
                         }
                     }

--- a/packages/pyright-internal/src/languageServerBase.ts
+++ b/packages/pyright-internal/src/languageServerBase.ts
@@ -374,7 +374,7 @@ export abstract class LanguageServerBase implements LanguageServerInterface {
         });
 
         // For any non-workspace paths, use the node file watcher.
-        let nodeWatchers: fs.FSWatcher[];
+        let nodeWatchers: FileWatcher[];
 
         try {
             nodeWatchers = nonWorkspacePaths.map((path) => {
@@ -838,7 +838,7 @@ export abstract class LanguageServerBase implements LanguageServerInterface {
                             };
                         }),
                         {
-                            globPattern: '**/*.{py,pyi}',
+                            globPattern: '**',
                             kind: WatchKind.Create | WatchKind.Change | WatchKind.Delete,
                         },
                     ],


### PR DESCRIPTION
For context, see microsoft/vscode#109754 and golang/go#42348. To get folder deletion events, we either need to watch the workspace and filter events ourselves (this code), or register a file watcher for every folder in the workspace and manage them.