### PR TITLE
Fixed two issues in the import resolution logic. First, it was return…

### DIFF
--- a/packages/pyright-internal/src/analyzer/importResult.ts
+++ b/packages/pyright-internal/src/analyzer/importResult.ts
@@ -33,6 +33,10 @@ export interface ImportResult {
     // True if import was resolved to a module or file.
     isImportFound: boolean;
 
+    // The specific submodule was not found but a part of
+    // its path was resolved.
+    isPartlyResolved: boolean;
+
     // True if the import refers to a namespace package (a
     // folder without an __init__.py file).
     isNamespacePackage: boolean;


### PR DESCRIPTION
…ing a namespace module if it found one in the workspace path or extraPaths even if a traditional (non-namespace) module satisfied the import from the PYTHONPATH. The interpreter searches all paths and always prefers a traditional module if it can find it. Second, it was resolving a namespace module if a traditional module only partially resolved the import path. The real interpreter always prefers a traditional module even if it partially resolves the path (in which case the full import fails).