### PR TITLE
Improved docstrings, performance metrics, ignore tmp files

### DIFF
--- a/packages/pyright-internal/src/analyzer/docStringConversion.ts
+++ b/packages/pyright-internal/src/analyzer/docStringConversion.ts
@@ -51,11 +51,16 @@ const CrLfRegExp = /\r?\n/;
 const NonWhitespaceRegExp = /\S/;
 const TildaHeaderRegExp = /^\s*~~~+$/;
 const PlusHeaderRegExp = /^\s*\+\+\++$/;
+const LeadingDashListRegExp = /^(\s*)-\s/;
+const LeadingAsteriskListRegExp = /^(\s*)\*\s/;
+const LeadingNumberListRegExp = /^(\s*)\d+\.\s/;
 const LeadingAsteriskRegExp = /^(\s+\* )(.*)$/;
 const SpaceDotDotRegExp = /^\s*\.\. /;
 const DirectiveLikeRegExp = /^\s*\.\.\s+(\w+)::\s*(.*)$/;
 const DoctestRegExp = / *>>> /;
 const DirectivesExtraNewlineRegExp = /^\s*:(param|arg|type|return|rtype|raise|except|var|ivar|cvar|copyright|license)/;
+const epyDocFieldTokensRegExp = /^[.\s\t]+(@\w+)/; // cv2 has leading '.' http://epydoc.sourceforge.net/manual-epytext.html
+const epyDocCv2FixRegExp = /^(\.\s{3})|^(\.)/;
 
 const PotentialHeaders: RegExpReplacement[] = [
     { exp: /^\s*=+(\s+=+)+$/, replacement: '=' },
@@ -111,6 +116,12 @@ class DocStringConverter {
     }
 
     convert(): string {
+        const isEpyDoc = this._lines.some((v) => epyDocFieldTokensRegExp.exec(v));
+        if (isEpyDoc) {
+            // fixup cv2 leading '.'
+            this._lines = this._lines.map((v) => v.replace(epyDocCv2FixRegExp, ''));
+        }
+
         while (this._currentLineOrUndefined() !== undefined) {
             const before = this._state;
             const beforeLine = this._lineNum;
@@ -151,6 +162,10 @@ class DocStringConverter {
 
     private _currentIndent(): number {
         return _countLeadingSpaces(this._currentLine());
+    }
+
+    private _prevIndent(): number {
+        return _countLeadingSpaces(this._lineAt(this._lineNum - 1) ?? '');
     }
 
     private _lineAt(i: number): string | undefined {
@@ -211,10 +226,55 @@ class DocStringConverter {
             return;
         }
 
-        // TODO: Push into Google/Numpy style list parser.
+        if (this._beginList()) {
+            return;
+        }
 
-        this._appendTextLine(this._escapeHtml(this._currentLine()));
+        if (this._beginFieldList()) {
+            return;
+        }
+
+        const line = this.formatPlainTextIndent(this._currentLine());
+
+        this._appendTextLine(this._escapeHtml(line));
         this._eatLine();
+    }
+
+    private formatPlainTextIndent(line: string) {
+        const prev = this._lineAt(this._lineNum - 1);
+        const prevIndent = this._prevIndent();
+        const currIndent = this._currentIndent();
+
+        if (
+            currIndent > prevIndent &&
+            !_isUndefinedOrWhitespace(prev) &&
+            !this._builder.endsWith('\\\n') &&
+            !this._builder.endsWith('\n\n') &&
+            !_isHeader(prev)
+        ) {
+            this._builder = this._builder.slice(0, -1) + '\\\n';
+        }
+
+        if (
+            prevIndent > currIndent &&
+            !_isUndefinedOrWhitespace(prev) &&
+            !this._builder.endsWith('\\\n') &&
+            !this._builder.endsWith('\n\n')
+        ) {
+            this._builder = this._builder.slice(0, -1) + '\\\n';
+        }
+
+        if (prevIndent === 0 || this._builder.endsWith('\\\n') || this._builder.endsWith('\n\n')) {
+            line = this._convertIndent(line);
+        } else {
+            line = line.trimStart();
+        }
+        return line;
+    }
+
+    private _convertIndent(line: string) {
+        line = line.replace(/^([ \t]+)(.+)$/g, (_match, g1, g2) => '&nbsp;'.repeat(g1.length) + g2);
+        return line;
     }
 
     private _escapeHtml(line: string): string {
@@ -227,12 +287,6 @@ class DocStringConverter {
 
     private _appendTextLine(line: string): void {
         line = this._preprocessTextLine(line);
-
-        // Attempt to put directives lines into their own paragraphs.
-        // This should be removed once proper list-like parsing is written.
-        if (!this._insideInlineCode && DirectivesExtraNewlineRegExp.test(line)) {
-            this._appendLine();
-        }
 
         const parts = line.split('`');
 
@@ -464,6 +518,125 @@ class DocStringConverter {
         return true;
     }
 
+    // https://docutils.sourceforge.io/docs/ref/rst/restructuredtext.html#field-lists
+    // Python doesn't have a single standard for param documentation. There are four
+    // popular styles.
+    //
+    // 1. Epytext:
+    //      @param param1: description
+    // 2. reST:
+    //      :param param1: description
+    // 3. Google (variant 1):
+    //      Args:
+    //          param1: description
+    // 4. Google (variant 2):
+    //      Args:
+    //          param1 (type): description
+    private _beginFieldList(): boolean {
+        if (this._insideInlineCode) {
+            return false;
+        }
+
+        let line = this._currentLine();
+
+        // Handle epyDocs
+        if (line.startsWith('@')) {
+            this._appendLine();
+            this._appendTextLine(this._escapeHtml(line));
+            this._eatLine();
+            return true;
+        }
+
+        // catch-all for styles except reST
+        const hasOddNumColons =
+            !line?.endsWith(':') && !line?.endsWith('::') && (line.match(/:/g)?.length ?? 0) % 2 === 1; // odd number of colons
+
+        // reSt params. Attempt to put directives lines into their own paragraphs.
+        const restDirective = DirectivesExtraNewlineRegExp.test(line); //line.match(/^\s*:param/);
+
+        if (hasOddNumColons || restDirective) {
+            const prev = this._lineAt(this._lineNum - 1);
+            // Force a line break, if previous line doesn't already have a break or is blank
+            if (!this._builder.endsWith(`\\\n`) && !this._builder.endsWith(`\n\n`) && !_isHeader(prev)) {
+                this._builder = this._builder.slice(0, -1) + '\\\n';
+            }
+
+            // force indent for fields
+            line = this._convertIndent(line);
+            this._appendTextLine(this._escapeHtml(line));
+            this._eatLine();
+            return true;
+        }
+
+        return false;
+    }
+
+    private _beginList(): boolean {
+        if (this._insideInlineCode) {
+            return false;
+        }
+
+        let line = this._currentLine();
+        const dashMatch = LeadingDashListRegExp.exec(line);
+        if (dashMatch?.length === 2) {
+            // Prevent list item from being see as code, by halving leading spaces
+            if (dashMatch[1].length >= 4) {
+                line = ' '.repeat(dashMatch[1].length / 2) + line.trimLeft();
+            }
+
+            this._appendTextLine(line);
+            this._eatLine();
+
+            if (this._state !== this._parseList) {
+                this._pushAndSetState(this._parseList);
+            }
+            return true;
+        }
+
+        const asteriskMatch = LeadingAsteriskListRegExp.exec(line);
+        if (asteriskMatch?.length === 2) {
+            if (asteriskMatch[1].length === 0) {
+                line = line = ' ' + line;
+            } else if (asteriskMatch[1].length >= 4) {
+                // Prevent list item from being see as code, by halving leading spaces
+                line = ' '.repeat(asteriskMatch[1].length / 2) + line.trimLeft();
+            }
+
+            this._appendTextLine(line);
+            this._eatLine();
+            if (this._state !== this._parseList) {
+                this._pushAndSetState(this._parseList);
+            }
+            return true;
+        }
+
+        const leadingNumberList = LeadingNumberListRegExp.exec(line);
+        if (leadingNumberList?.length === 2) {
+            this._appendTextLine(line);
+            this._eatLine();
+            return true;
+        }
+
+        return false;
+    }
+
+    private _parseList(): void {
+        if (_isUndefinedOrWhitespace(this._currentLineOrUndefined()) || this._currentLineIsOutsideBlock()) {
+            this._popState();
+            return;
+        }
+
+        // Check for the start of a new list item
+        const isMultiLineItem = !this._beginList();
+
+        // Remove leading spaces so that multiline items get appear in a single block
+        if (isMultiLineItem) {
+            const line = this._currentLine().trimStart();
+            this._appendTextLine(this._escapeHtml(line));
+            this._eatLine();
+        }
+    }
+
     private _parseDirective(): void {
         // http://docutils.sourceforge.net/docs/ref/rst/restructuredtext.html#directives
 
@@ -575,4 +748,8 @@ function _countLeadingSpaces(s: string): number {
 
 function _isUndefinedOrWhitespace(s: string | undefined): boolean {
     return s === undefined || !NonWhitespaceRegExp.test(s);
+}
+
+function _isHeader(line: string | undefined): boolean {
+    return line !== undefined && (line.match(/^\s*[#`~=-]{3,}/)?.length ?? 0) > 0;
 }

--- a/packages/pyright-internal/src/analyzer/program.ts
+++ b/packages/pyright-internal/src/analyzer/program.ts
@@ -67,7 +67,8 @@ import { SourceFile } from './sourceFile';
 import { SourceMapper } from './sourceMapper';
 import { Symbol } from './symbol';
 import { isPrivateOrProtectedName } from './symbolNameUtils';
-import { createTypeEvaluator, TypeEvaluator } from './typeEvaluator';
+import { TypeEvaluator } from './typeEvaluator';
+import { createTypeEvaluatorWithTracker } from './typeEvaluatorWithTracker';
 import { PrintTypeFlags } from './typePrinter';
 import { Type } from './types';
 import { TypeStubWriter } from './typeStubWriter';
@@ -662,7 +663,7 @@ export class Program {
     }
 
     private _createNewEvaluator() {
-        this._evaluator = createTypeEvaluator(this._lookUpImport, {
+        this._evaluator = createTypeEvaluatorWithTracker(this._lookUpImport, {
             disableInferenceForPyTypedSources: this._configOptions.disableInferenceForPyTypedSources,
             printTypeFlags: Program._getPrintTypeFlags(this._configOptions),
         });

--- a/packages/pyright-internal/src/analyzer/sourceFile.ts
+++ b/packages/pyright-internal/src/analyzer/sourceFile.ts
@@ -513,7 +513,8 @@ export class SourceFile {
             let fileContents = this.getFileContents();
             if (fileContents === undefined) {
                 try {
-                    const elapsedTime = timingStats.readFileTime.timeOperation(() => {
+                    const startTime = timingStats.readFileTime.totalTime;
+                    timingStats.readFileTime.timeOperation(() => {
                         // Read the file's contents.
                         fileContents = content ?? this.fileSystem.readFileSync(this._filePath, 'utf8');
 
@@ -521,7 +522,7 @@ export class SourceFile {
                         this._lastFileContentLength = fileContents.length;
                         this._lastFileContentHash = StringUtils.hashString(fileContents);
                     });
-                    logState.add(`fs read ${elapsedTime}ms`);
+                    logState.add(`fs read ${timingStats.readFileTime.totalTime - startTime}ms`);
                 } catch (error) {
                     diagSink.addError(`Source file could not be read`, getEmptyRange());
                     fileContents = '';

--- a/packages/pyright-internal/src/analyzer/typeEvaluatorWithTracker.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluatorWithTracker.ts
@@ -1,0 +1,91 @@
+/*
+ * typeEvaluatorWithTracker.ts
+ *
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT license.
+ * Author: Eric Traut
+ *
+ * This wraps real type evaluator to track performance information such
+ * as which type inferring takes most of time, what files are read most of times
+ * and etc.
+ */
+
+import { LogTracker } from '../common/logTracker';
+import { timingStats } from '../common/timing';
+import { ImportLookup } from './analyzerFileInfo';
+import { createTypeEvaluator, EvaluatorOptions, TypeEvaluator } from './typeEvaluator';
+
+// We don't want to track calls from the type evaluator itself, but only entry points.
+export function createTypeEvaluatorWithTracker(
+    importLookup: ImportLookup,
+    evaluatorOptions: EvaluatorOptions,
+    logger?: LogTracker
+) {
+    function run<T>(title: string, callback: () => T): T {
+        return logger
+            ? logger.log(title, () => timingStats.typeEvaluationTime.timeOperation(callback), 50)
+            : timingStats.typeEvaluationTime.timeOperation(callback);
+    }
+
+    const typeEvaluator = createTypeEvaluator(importLookup, evaluatorOptions);
+
+    const withTracker: TypeEvaluator = {
+        runWithCancellationToken: typeEvaluator.runWithCancellationToken,
+        getType: (n) => run('getType', () => typeEvaluator.getType(n)),
+        getTypeOfClass: (n) => run('getTypeOfClass', () => typeEvaluator.getTypeOfClass(n)),
+        getTypeOfFunction: (n) => run('getTypeOfFunction', () => typeEvaluator.getTypeOfFunction(n)),
+        evaluateTypesForStatement: (n) =>
+            run('evaluateTypesForStatement', () => typeEvaluator.evaluateTypesForStatement(n)),
+        getDeclaredTypeForExpression: (n) =>
+            run('getDeclaredTypeForExpression', () => typeEvaluator.getDeclaredTypeForExpression(n)),
+        verifyRaiseExceptionType: (n) =>
+            run('verifyRaiseExceptionType', () => typeEvaluator.verifyRaiseExceptionType(n)),
+        verifyDeleteExpression: (n) => run('verifyDeleteExpression', () => typeEvaluator.verifyDeleteExpression(n)),
+        isAfterNodeReachable: (n) => run('isAfterNodeReachable', () => typeEvaluator.isAfterNodeReachable(n)),
+        isNodeReachable: (n) => run('isNodeReachable', () => typeEvaluator.isNodeReachable(n)),
+        suppressDiagnostics: (callback) =>
+            run('suppressDiagnostics', () => typeEvaluator.suppressDiagnostics(callback)),
+        getDeclarationsForNameNode: (n) =>
+            run('getDeclarationsForNameNode', () => typeEvaluator.getDeclarationsForNameNode(n)),
+        getTypeForDeclaration: (n) => run('getTypeForDeclaration', () => typeEvaluator.getTypeForDeclaration(n)),
+        resolveAliasDeclaration: (d, l) =>
+            run('resolveAliasDeclaration', () => typeEvaluator.resolveAliasDeclaration(d, l)),
+        getTypeFromIterable: (t, a, e) => run('getTypeFromIterable', () => typeEvaluator.getTypeFromIterable(t, a, e)),
+        getTypedDictMembersForClass: (c) =>
+            run('getTypedDictMembersForClass', () => typeEvaluator.getTypedDictMembersForClass(c)),
+        getGetterTypeFromProperty: (p, i) =>
+            run('getGetterTypeFromProperty', () => typeEvaluator.getGetterTypeFromProperty(p, i)),
+        markNamesAccessed: (n, a) => run('markNamesAccessed', () => typeEvaluator.markNamesAccessed(n, a)),
+        getScopeIdForNode: (n) => run('getScopeIdForNode', () => typeEvaluator.getScopeIdForNode(n)),
+        makeTopLevelTypeVarsConcrete: (t) =>
+            run('makeTopLevelTypeVarsConcrete', () => typeEvaluator.makeTopLevelTypeVarsConcrete(t)),
+        getEffectiveTypeOfSymbol: (s) =>
+            run('getEffectiveTypeOfSymbol', () => typeEvaluator.getEffectiveTypeOfSymbol(s)),
+        getFunctionDeclaredReturnType: (n) =>
+            run('getFunctionDeclaredReturnType', () => typeEvaluator.getFunctionDeclaredReturnType(n)),
+        getFunctionInferredReturnType: (t) =>
+            run('getFunctionInferredReturnType', () => typeEvaluator.getFunctionInferredReturnType(t)),
+        getBuiltInType: (n, b) => run('getBuiltInType', () => typeEvaluator.getBuiltInType(n, b)),
+        getTypeOfMember: (m) => run('getTypeOfMember', () => typeEvaluator.getTypeOfMember(m)),
+        bindFunctionToClassOrObject: (b, m) =>
+            run('bindFunctionToClassOrObject', () => typeEvaluator.bindFunctionToClassOrObject(b, m)),
+        getCallSignatureInfo: (n, i, a) =>
+            run('getCallSignatureInfo', () => typeEvaluator.getCallSignatureInfo(n, i, a)),
+        getTypeAnnotationForParameter: (n, p) =>
+            run('getTypeAnnotationForParameter', () => typeEvaluator.getTypeAnnotationForParameter(n, p)),
+        canAssignType: (d, s, a, m, f) => run('canAssignType', () => typeEvaluator.canAssignType(d, s, a, m, f)),
+        canOverrideMethod: (b, o, d) => run('canOverrideMethod', () => typeEvaluator.canOverrideMethod(b, o, d)),
+        addError: (m, n) => run('addError', () => typeEvaluator.addError(m, n)),
+        addWarning: (m, n) => run('addWarning', () => typeEvaluator.addWarning(m, n)),
+        addInformation: (m, n) => run('addInformation', () => typeEvaluator.addInformation(m, n)),
+        addUnusedCode: (n, t) => run('addUnusedCode', () => typeEvaluator.addUnusedCode(n, t)),
+        addDiagnostic: (d, r, m, n) => run('addDiagnostic', () => typeEvaluator.addDiagnostic(d, r, m, n)),
+        addDiagnosticForTextRange: (f, d, r, m, g) =>
+            run('addDiagnosticForTextRange', () => typeEvaluator.addDiagnosticForTextRange(f, d, r, m, g)),
+        printType: (t, e) => run('printType', () => typeEvaluator.printType(t, e)),
+        printFunctionParts: (t) => run('printFunctionParts', () => typeEvaluator.printFunctionParts(t)),
+        getTypeCacheSize: typeEvaluator.getTypeCacheSize,
+    };
+
+    return withTracker;
+}

--- a/packages/pyright-internal/src/common/core.ts
+++ b/packages/pyright-internal/src/common/core.ts
@@ -89,6 +89,10 @@ export function isNumber(x: unknown): x is number {
     return typeof x === 'number';
 }
 
+export function isBoolean(x: unknown): x is number {
+    return typeof x === 'boolean';
+}
+
 const hasOwnProperty = Object.prototype.hasOwnProperty;
 
 /**

--- a/packages/pyright-internal/src/common/timing.ts
+++ b/packages/pyright-internal/src/common/timing.ts
@@ -32,21 +32,20 @@ export class TimingStat {
     callCount = 0;
     isTiming = false;
 
-    timeOperation(callback: () => void) {
+    timeOperation<T>(callback: () => T): T {
         this.callCount++;
 
         // Handle reentrancy.
         if (this.isTiming) {
-            callback();
+            return callback();
         } else {
             this.isTiming = true;
             const duration = new Duration();
-            callback();
-            const elapsedTime = duration.getDurationInMilliseconds();
-            this.totalTime += elapsedTime;
+            const result = callback();
+            this.totalTime += duration.getDurationInMilliseconds();
             this.isTiming = false;
 
-            return elapsedTime;
+            return result;
         }
     }
 
@@ -79,6 +78,7 @@ export class TimingStats {
     cycleDetectionTime = new TimingStat();
     bindTime = new TimingStat();
     typeCheckerTime = new TimingStat();
+    typeEvaluationTime = new TimingStat();
 
     printSummary(console: ConsoleInterface) {
         console.info(`Completed in ${this.totalDuration.getDurationInSeconds()}sec`);

--- a/packages/pyright-internal/src/tests/docStringConversion.test.ts
+++ b/packages/pyright-internal/src/tests/docStringConversion.test.ts
@@ -16,7 +16,7 @@ const doubleTick = '``';
 const tripleTick = '```';
 
 test('PlaintextIndention', () => {
-    const all: Array<Array<string>> = [
+    const all: string[][] = [
         ['A\nB', 'A\nB'],
         ['A\n\nB', 'A\n\nB'],
         ['A\n    B', 'A\nB'],
@@ -27,8 +27,22 @@ test('PlaintextIndention', () => {
         ['  \n\nA \n    \nB  \n    ', 'A\n\nB'],
     ];
 
-    all.forEach((v) => _testConvertToMarkdown(v[0], v[1]));
     all.forEach((v) => _testConvertToPlainText(v[0], v[1]));
+});
+
+test('MarkdownIndention', () => {
+    const all: string[][] = [
+        ['A\nB', 'A\nB'],
+        ['A\n\nB', 'A\n\nB'],
+        ['A\n    B', 'A\nB'],
+        ['    A\n    B', 'A\nB'],
+        ['\nA\n    B', 'A\\\n&nbsp;&nbsp;&nbsp;&nbsp;B'],
+        ['\n    A\n    B', 'A\nB'],
+        ['\nA\nB\n', 'A\nB'],
+        ['  \n\nA \n    \nB  \n    ', 'A\n\nB'],
+    ];
+
+    all.forEach((v) => _testConvertToMarkdown(v[0], v[1]));
 });
 
 test('NormalText', () => {
@@ -96,10 +110,10 @@ test('AsterisksAtStartOfArgs', () => {
 
     const markdown = `Foo:
 
-Args:
-    foo (Foo): Foo!
-    \\*args: These are positional args.
-    \\*\\*kwargs: These are named args.
+Args:\\
+&nbsp;&nbsp;&nbsp;&nbsp;foo (Foo): Foo!\\
+&nbsp;&nbsp;&nbsp;&nbsp;\\*args: These are positional args.\\
+&nbsp;&nbsp;&nbsp;&nbsp;\\*\\*kwargs: These are named args.
 `;
 
     _testConvertToMarkdown(docstring, markdown);
@@ -114,8 +128,7 @@ test('CopyrightAndLicense', () => {
 
     const markdown = `This is a test.
 
-:copyright: Fake Name
-
+:copyright: Fake Name\\
 :license: ABCv123
 `;
 
@@ -137,19 +150,13 @@ test('CommonRestFieldLists', () => {
 
     const markdown = `This function does something.
 
-:param foo: This is a description of the foo parameter
-    which does something interesting.
-
-:type foo: Foo
-
-:param bar: This is a description of bar.
-
-:type bar: Bar
-
-:return: Something else.
-
-:rtype: Something
-
+:param foo: This is a description of the foo parameter\\
+&nbsp;&nbsp;&nbsp;&nbsp;which does something interesting.\\
+:type foo: Foo\\
+:param bar: This is a description of bar.\\
+:type bar: Bar\\
+:return: Something else.\\
+:rtype: Something\\
 :raises ValueError: If something goes wrong.
 `;
 
@@ -459,6 +466,238 @@ This is a list:
 test('SquareBrackets', () => {
     const docstring = 'Optional[List[str]]';
     const markdown = 'Optional\\[List\\[str\\]\\]';
+
+    _testConvertToMarkdown(docstring, markdown);
+});
+
+test('ListDashMultiline', () => {
+    const docstring = `Keyword Arguments:
+
+    - option_strings -- A list of command-line option strings which
+        should be associated with this action.
+
+    - dest -- The name of the attribute to hold the created object(s)
+`;
+
+    const markdown = `Keyword Arguments:
+
+- option\\_strings -- A list of command-line option strings which
+should be associated with this action.
+
+- dest -- The name of the attribute to hold the created object(s)`;
+
+    _testConvertToMarkdown(docstring, markdown);
+});
+
+test('HalfIndentOnLeadingDash', () => {
+    const docstring = `Dash List
+- foo
+    - foo
+- bar
+     - baz
+- qux
+    - aaa
+    `;
+
+    const markdown = `Dash List
+- foo
+  - foo
+- bar
+  - baz
+- qux
+  - aaa`;
+
+    _testConvertToMarkdown(docstring, markdown);
+});
+
+test('AsteriskMultilineList', () => {
+    const docstring = `
+This is a list:
+    * this is a long, multi-line paragraph. It
+      seems to go on and on.
+
+    * this is a long, multi-line paragraph. It
+      seems to go on and on.
+`;
+
+    const markdown = `This is a list:
+  * this is a long, multi-line paragraph. It
+seems to go on and on.
+
+  * this is a long, multi-line paragraph. It
+seems to go on and on.
+`;
+
+    _testConvertToMarkdown(docstring, markdown);
+});
+
+test('ListAsteriskAddLeadingSpace', () => {
+    const docstring = `Title
+* First line bullet, no leading space
+  with second line.
+* Second line bullet, no leading space
+  with second line.`;
+
+    const markdown = `Title
+ * First line bullet, no leading space
+with second line.
+ * Second line bullet, no leading space
+with second line.`;
+
+    _testConvertToMarkdown(docstring, markdown);
+});
+
+test('PandasReadCsvListIndent', () => {
+    const docstring = `Title
+keep_default_na : bool, default True
+    Whether or not to include the default NaN values when parsing the data.
+
+    * If \`keep_default_na\` is True, and \`na_values\` are specified, \`na_values\`
+        is appended to the default NaN values used for parsing.   
+
+na_filter : bool, default True`;
+
+    const markdown = `Title\\
+keep\\_default\\_na : bool, default True\\
+&nbsp;&nbsp;&nbsp;&nbsp;Whether or not to include the default NaN values when parsing the data.
+
+  * If \`keep_default_na\` is True, and \`na_values\` are specified, \`na_values\`
+is appended to the default NaN values used for parsing.
+
+na\\_filter : bool, default True`;
+
+    _testConvertToMarkdown(docstring, markdown);
+});
+
+test('FieldListEpyText', () => {
+    const docstring = `
+    1. Epytext:
+         @param param1: description`;
+
+    const markdown = `
+1. Epytext:\\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;@param param1: description`;
+
+    _testConvertToMarkdown(docstring, markdown);
+});
+
+test('FieldListRest', () => {
+    const docstring = `
+    2. reST:
+         :param param1: description`;
+
+    const markdown = `
+2. reST:\\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;:param param1: description`;
+
+    _testConvertToMarkdown(docstring, markdown);
+});
+
+test('FieldListGoogleV1', () => {
+    const docstring = `
+    3. Google (variant 1):
+         Args:
+             param1: description`;
+
+    const markdown = `
+3. Google (variant 1):\\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Args:\\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;param1: description`;
+
+    _testConvertToMarkdown(docstring, markdown);
+});
+
+test('FieldListGoogleV2', () => {
+    const docstring = `
+    4. Google (variant 2):
+         Args:
+             param1 (type): description`;
+
+    const markdown = `
+4. Google (variant 2):\\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Args:\\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;param1 (type): description`;
+
+    _testConvertToMarkdown(docstring, markdown);
+});
+
+test('FieldListDontAddLineBreaksToHeaders', () => {
+    const docstring = `
+    Parameters
+    ----------
+    ThisIsAFieldAfterAHeader : str`;
+
+    const markdown = `
+Parameters
+----------
+ThisIsAFieldAfterAHeader : str`;
+
+    _testConvertToMarkdown(docstring, markdown);
+});
+
+test('EpyDocCv2Imread', () => {
+    const docstring = `imread(filename[, flags]) -> retval
+.   @brief Loads an image from a file.
+.   @anchor imread
+.   
+.   The function imread loads an image from the specified file and returns it. If the image cannot be
+.   read (because of missing file, improper permissions, unsupported or invalid format), the function
+.
+.   Currently, the following file formats are supported:
+.   
+.   -   Windows bitmaps - \\*.bmp, \\*.dib (always supported)
+.   -   JPEG files - \\*.jpeg, \\*.jpg, \\*.jpe (see the *Note* section)`;
+
+    const markdown = `imread(filename\\[, flags\\]) -&gt; retval
+
+@brief Loads an image from a file.
+
+@anchor imread
+
+The function imread loads an image from the specified file and returns it. If the image cannot be
+read (because of missing file, improper permissions, unsupported or invalid format), the function
+
+Currently, the following file formats are supported:
+
+-   Windows bitmaps - \\*.bmp, \\*.dib (always supported)
+-   JPEG files - \\*.jpeg, \\*.jpg, \\*.jpe (see the \\*Note\\* section)`;
+
+    _testConvertToMarkdown(docstring, markdown);
+});
+
+test('EpyDocTest', () => {
+    const docstring = `Return the x intercept of the line M{y=m*x+b}.  The X{x intercept}
+of a line is the point at which it crosses the x axis (M{y=0}).
+
+This function can be used in conjuction with L{z_transform} to
+find an arbitrary function's zeros.
+
+@type  m: number
+@param m: The slope of the line.
+@type  b: number
+@param b: The y intercept of the line.  The X{y intercept} of a
+            line is the point at which it crosses the y axis (M{x=0}).
+@rtype:   number
+@return:  the x intercept of the line M{y=m*x+b}.`;
+
+    const markdown = `Return the x intercept of the line M{y=m\\*x+b}.  The X{x intercept}
+of a line is the point at which it crosses the x axis (M{y=0}).
+
+This function can be used in conjuction with L{z\\_transform} to
+find an arbitrary function's zeros.
+
+@type  m: number
+
+@param m: The slope of the line.
+
+@type  b: number
+
+@param b: The y intercept of the line.  The X{y intercept} of a\\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;line is the point at which it crosses the y axis (M{x=0}).
+
+@rtype:   number
+
+@return:  the x intercept of the line M{y=m\\*x+b}.`;
 
     _testConvertToMarkdown(docstring, markdown);
 });


### PR DESCRIPTION
Rollup of:

- Greatly improved docstring formatting for indented regions (like parameter sections), nested lists, and epydoc.
- Add type evaluator wrapper to get performance metrics on specific calls.
- Ignore `.tmp` files in file watching to prevent unwanted reanalysis.