### PR TITLE
fix: printUsage

### DIFF
--- a/packages/pyright-internal/src/pyright.ts
+++ b/packages/pyright-internal/src/pyright.ts
@@ -489,7 +489,7 @@ function printUsage() {
             '  -t,--typeshed-path DIRECTORY     Use typeshed type stubs at this location\n' +
             '  -v,--venv-path DIRECTORY         Directory that contains virtual environments\n' +
             '  --verbose                        Emit verbose diagnostics\n' +
-            '  --verifytypes PACKAGE            Verify type completeness of a py.typed package' +
+            '  --verifytypes PACKAGE            Verify type completeness of a py.typed package\n' +
             '  --version                        Print Pyright version\n' +
             '  -w,--watch                       Continue to run and watch for changes\n'
     );


### PR DESCRIPTION
The `--version` should be printed in new line, before:

```
  Options:
  --createstub IMPORT              Create type stub file(s) for import
  --dependencies                   Emit import dependency information
  -h,--help                        Show this help message
  --lib                            Use library code to infer types when stubs are missing
  --outputjson                     Output results in JSON format
  -p,--project FILE OR DIRECTORY   Use the configuration file at this location
  --stats                          Print detailed performance stats
  -t,--typeshed-path DIRECTORY     Use typeshed type stubs at this location
  -v,--venv-path DIRECTORY         Directory that contains virtual environments
  --verbose                        Emit verbose diagnostics
  --verifytypes PACKAGE            Verify type completeness of a py.typed package  --version                        Print Pyright version
  -w,--watch                       Continue to run and watch for changes
```

After:

```
  Options:
  --createstub IMPORT              Create type stub file(s) for import
  --dependencies                   Emit import dependency information
  -h,--help                        Show this help message
  --lib                            Use library code to infer types when stubs are missing
  --outputjson                     Output results in JSON format
  -p,--project FILE OR DIRECTORY   Use the configuration file at this location
  --stats                          Print detailed performance stats
  -t,--typeshed-path DIRECTORY     Use typeshed type stubs at this location
  -v,--venv-path DIRECTORY         Directory that contains virtual environments
  --verbose                        Emit verbose diagnostics
  --verifytypes PACKAGE            Verify type completeness of a py.typed package  
  --version                        Print Pyright version
  -w,--watch                       Continue to run and watch for changes
```