### PR TITLE
FS watch fixes, perf tracker, go-to-def/decl

### DIFF
--- a/packages/pyright-internal/src/analyzer/parseTreeUtils.ts
+++ b/packages/pyright-internal/src/analyzer/parseTreeUtils.ts
@@ -7,7 +7,7 @@
  * Utility routines for traversing a parse tree.
  */
 
-import { fail } from '../common/debug';
+import { assertNever, fail } from '../common/debug';
 import { convertPositionToOffset } from '../common/positionUtils';
 import { Position } from '../common/textRange';
 import { TextRange } from '../common/textRange';
@@ -1197,4 +1197,199 @@ export function getCallNodeAndActiveParameterIndex(
 
         return tokens.getItemAt(index);
     }
+}
+
+export function printParseNodeType(type: ParseNodeType) {
+    switch (type) {
+        case ParseNodeType.Error:
+            return 'Error';
+
+        case ParseNodeType.Argument:
+            return 'Argument';
+
+        case ParseNodeType.Assert:
+            return 'Assert';
+
+        case ParseNodeType.Assignment:
+            return 'Assignment';
+
+        case ParseNodeType.AssignmentExpression:
+            return 'AssignmentExpression';
+
+        case ParseNodeType.AugmentedAssignment:
+            return 'AugmentedAssignment';
+
+        case ParseNodeType.Await:
+            return 'Await';
+
+        case ParseNodeType.BinaryOperation:
+            return 'BinaryOperation';
+
+        case ParseNodeType.Break:
+            return 'Break';
+
+        case ParseNodeType.Call:
+            return 'Call';
+
+        case ParseNodeType.Class:
+            return 'Class';
+
+        case ParseNodeType.Constant:
+            return 'Constant';
+
+        case ParseNodeType.Continue:
+            return 'Continue';
+
+        case ParseNodeType.Decorator:
+            return 'Decorator';
+
+        case ParseNodeType.Del:
+            return 'Del';
+
+        case ParseNodeType.Dictionary:
+            return 'Dictionary';
+
+        case ParseNodeType.DictionaryExpandEntry:
+            return 'DictionaryExpandEntry';
+
+        case ParseNodeType.DictionaryKeyEntry:
+            return 'DictionaryKeyEntry';
+
+        case ParseNodeType.Ellipsis:
+            return 'Ellipsis';
+
+        case ParseNodeType.If:
+            return 'If';
+
+        case ParseNodeType.Import:
+            return 'Import';
+
+        case ParseNodeType.ImportAs:
+            return 'ImportAs';
+
+        case ParseNodeType.ImportFrom:
+            return 'ImportFrom';
+
+        case ParseNodeType.ImportFromAs:
+            return 'ImportFromAs';
+
+        case ParseNodeType.Index:
+            return 'Index';
+
+        case ParseNodeType.Except:
+            return 'Except';
+
+        case ParseNodeType.For:
+            return 'For';
+
+        case ParseNodeType.FormatString:
+            return 'FormatString';
+
+        case ParseNodeType.Function:
+            return 'Function';
+
+        case ParseNodeType.Global:
+            return 'Global';
+
+        case ParseNodeType.Lambda:
+            return 'Lambda';
+
+        case ParseNodeType.List:
+            return 'List';
+
+        case ParseNodeType.ListComprehension:
+            return 'ListComprehension';
+
+        case ParseNodeType.ListComprehensionFor:
+            return 'ListComprehensionFor';
+
+        case ParseNodeType.ListComprehensionIf:
+            return 'ListComprehensionIf';
+
+        case ParseNodeType.MemberAccess:
+            return 'MemberAccess';
+
+        case ParseNodeType.Module:
+            return 'Module';
+
+        case ParseNodeType.ModuleName:
+            return 'ModuleName';
+
+        case ParseNodeType.Name:
+            return 'Name';
+
+        case ParseNodeType.Nonlocal:
+            return 'Nonlocal';
+
+        case ParseNodeType.Number:
+            return 'Number';
+
+        case ParseNodeType.Parameter:
+            return 'Parameter';
+
+        case ParseNodeType.Pass:
+            return 'Pass';
+
+        case ParseNodeType.Raise:
+            return 'Raise';
+
+        case ParseNodeType.Return:
+            return 'Return';
+
+        case ParseNodeType.Set:
+            return 'Set';
+
+        case ParseNodeType.Slice:
+            return 'Slice';
+
+        case ParseNodeType.StatementList:
+            return 'StatementList';
+
+        case ParseNodeType.StringList:
+            return 'StringList';
+
+        case ParseNodeType.String:
+            return 'String';
+
+        case ParseNodeType.Suite:
+            return 'Suite';
+
+        case ParseNodeType.Ternary:
+            return 'Ternary';
+
+        case ParseNodeType.Tuple:
+            return 'Tuple';
+
+        case ParseNodeType.Try:
+            return 'Try';
+
+        case ParseNodeType.TypeAnnotation:
+            return 'TypeAnnotation';
+
+        case ParseNodeType.UnaryOperation:
+            return 'UnaryOperation';
+
+        case ParseNodeType.Unpack:
+            return 'Unpack';
+
+        case ParseNodeType.While:
+            return 'While';
+
+        case ParseNodeType.With:
+            return 'With';
+
+        case ParseNodeType.WithItem:
+            return 'WithItem';
+
+        case ParseNodeType.Yield:
+            return 'Yield';
+
+        case ParseNodeType.YieldFrom:
+            return 'YieldFrom';
+
+        case ParseNodeType.FunctionAnnotation:
+            return 'FunctionAnnotation';
+    }
+
+    assertNever(type);
 }

--- a/packages/pyright-internal/src/analyzer/sourceFile.ts
+++ b/packages/pyright-internal/src/analyzer/sourceFile.ts
@@ -35,7 +35,7 @@ import { timingStats } from '../common/timing';
 import { ModuleSymbolMap } from '../languageService/autoImporter';
 import { AbbreviationMap, CompletionOptions, CompletionResults } from '../languageService/completionProvider';
 import { CompletionItemData, CompletionProvider } from '../languageService/completionProvider';
-import { DefinitionProvider } from '../languageService/definitionProvider';
+import { DefinitionFilter, DefinitionProvider } from '../languageService/definitionProvider';
 import { DocumentHighlightProvider } from '../languageService/documentHighlightProvider';
 import { DocumentSymbolProvider, IndexOptions, IndexResults } from '../languageService/documentSymbolProvider';
 import { HoverProvider, HoverResults } from '../languageService/hoverProvider';
@@ -650,6 +650,7 @@ export class SourceFile {
     getDefinitionsForPosition(
         sourceMapper: SourceMapper,
         position: Position,
+        filter: DefinitionFilter,
         evaluator: TypeEvaluator,
         token: CancellationToken
     ): DocumentRange[] | undefined {
@@ -662,6 +663,7 @@ export class SourceFile {
             sourceMapper,
             this._parseResults,
             position,
+            filter,
             evaluator,
             token
         );

--- a/packages/pyright-internal/src/analyzer/tracePrinter.ts
+++ b/packages/pyright-internal/src/analyzer/tracePrinter.ts
@@ -1,0 +1,250 @@
+/*
+ * tracePrinter.ts
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT license.
+ *
+ * Converts various types into a string representation.
+ */
+
+import { isNumber, isString } from '../common/core';
+import { assertNever } from '../common/debug';
+import { ensureTrailingDirectorySeparator, stripFileExtension } from '../common/pathUtils';
+import { isExpressionNode, ParseNode, ParseNodeType } from '../parser/parseNodes';
+import * as AnalyzerNodeInfo from './analyzerNodeInfo';
+import { Declaration, DeclarationType } from './declaration';
+import * as ParseTreeUtils from './parseTreeUtils';
+import { Symbol } from './symbol';
+import { Type, TypeCategory } from './types';
+
+export type PrintableType = ParseNode | Declaration | Symbol | Type | undefined;
+
+export interface TracePrinter {
+    print(o: PrintableType): string;
+    printFileOrModuleName(filePath: string): string;
+}
+
+export function createTracePrinter(roots: string[]): TracePrinter {
+    function wrap(value: string | undefined, ch = "'") {
+        return value ? `${ch}${value}${ch}` : '';
+    }
+
+    // Sort roots in desc order so that we compare longer path first
+    // when getting relative path.
+    // ex) d:/root/.env/lib/site-packages, d:/root/.env
+    roots = roots
+        .map((r) => ensureTrailingDirectorySeparator(r))
+        .sort((a, b) => a.localeCompare(b))
+        .reverse();
+
+    const separatorRegExp = /[\\/]/g;
+    function printFileOrModuleName(filePath: string | undefined) {
+        if (filePath) {
+            for (const root of roots) {
+                if (filePath.startsWith(root)) {
+                    const subFile = filePath.substring(root.length);
+                    return stripFileExtension(subFile).replace(separatorRegExp, '.');
+                }
+            }
+
+            return filePath;
+        }
+        return '';
+    }
+
+    function printType(type: Type | undefined): string {
+        if (type) {
+            switch (type.category) {
+                case TypeCategory.Any:
+                    return `Any ${wrap(type.typeAliasInfo?.fullName)}`;
+
+                case TypeCategory.Class:
+                    return `Class '${type.details.name}' (${type.details.moduleName})`;
+
+                case TypeCategory.Function:
+                    return `Function '${type.details.name}' (${type.details.moduleName})`;
+
+                case TypeCategory.Module:
+                    return `Module '${type.moduleName}' (${type.moduleName})`;
+
+                case TypeCategory.Never:
+                    return `Never ${wrap(type.typeAliasInfo?.fullName)}`;
+
+                case TypeCategory.None:
+                    return `None ${wrap(type.typeAliasInfo?.fullName)}`;
+
+                case TypeCategory.Object:
+                    return `Object [${printType(type.classType)}]`;
+
+                case TypeCategory.OverloadedFunction:
+                    return `OverloadedFunction [${type.overloads.map((o) => wrap(printType(o), '"')).join(',')}]`;
+
+                case TypeCategory.TypeVar:
+                    return `TypeVar '${type.details.name}' ${wrap(type.typeAliasInfo?.fullName)}`;
+
+                case TypeCategory.Unbound:
+                    return `Unbound ${wrap(type.typeAliasInfo?.fullName)}`;
+
+                case TypeCategory.Union:
+                    return `Union [${type.subtypes.map((o) => wrap(printType(o), '"')).join(',')}]`;
+
+                case TypeCategory.Unknown:
+                    return `Unknown ${wrap(type.typeAliasInfo?.fullName)}`;
+
+                default:
+                    assertNever(type);
+            }
+        }
+        return '';
+    }
+
+    function printSymbol(symbol: Symbol | undefined) {
+        if (symbol) {
+            if (symbol.hasDeclarations()) {
+                return `symbol ${printDeclaration(symbol.getDeclarations()[0])}`;
+            }
+
+            return `<symbol>`;
+        }
+
+        return '';
+    }
+
+    function printDeclaration(decl: Declaration | undefined) {
+        if (decl) {
+            switch (decl.type) {
+                case DeclarationType.Alias:
+                    return `Alias, ${printNode(decl.node)} (${printFileOrModuleName(decl.path)})`;
+
+                case DeclarationType.Class:
+                    return `Class, ${printNode(decl.node)} (${printFileOrModuleName(decl.path)})`;
+
+                case DeclarationType.Function:
+                    return `Function, ${printNode(decl.node)} (${printFileOrModuleName(decl.path)})`;
+
+                case DeclarationType.Intrinsic:
+                    return `Intrinsic, ${printNode(decl.node)} ${decl.intrinsicType} (${printFileOrModuleName(
+                        decl.path
+                    )})`;
+
+                case DeclarationType.Parameter:
+                    return `Parameter, ${printNode(decl.node)} (${printFileOrModuleName(decl.path)})`;
+
+                case DeclarationType.SpecialBuiltInClass:
+                    return `SpecialBuiltInClass, ${printNode(decl.node)} (${printFileOrModuleName(decl.path)})`;
+
+                case DeclarationType.Variable:
+                    return `Variable, ${printNode(decl.node)} (${printFileOrModuleName(decl.path)})`;
+
+                default:
+                    assertNever(decl);
+            }
+        }
+
+        return '';
+    }
+
+    function getFileInfo(node: ParseNode) {
+        while (node.nodeType !== ParseNodeType.Module && node.parent) {
+            node = node.parent;
+        }
+
+        return node.nodeType === ParseNodeType.Module ? AnalyzerNodeInfo.getFileInfo(node) : undefined;
+    }
+
+    function getText(value: string, max = 30) {
+        if (value.length < max) {
+            return value;
+        }
+
+        return value.substring(0, max) + ' <shortened> ';
+    }
+
+    function printNode(node: ParseNode | undefined, printPath = false): string {
+        if (!node) {
+            return '';
+        }
+
+        const path = printPath ? `(${printFileOrModuleName(getFileInfo(node)?.filePath)})` : '';
+        if (isExpressionNode(node)) {
+            return wrap(getText(ParseTreeUtils.printExpression(node)), '"') + ` ${path}`;
+        }
+
+        switch (node.nodeType) {
+            case ParseNodeType.ImportAs:
+                return `importAs '${printNode(node.module)}' ${wrap(node.alias ? printNode(node.alias) : '')} ${path}`;
+
+            case ParseNodeType.ImportFrom:
+                return `importFrom [${node.imports.map((i) => wrap(printNode(i), '"')).join(',')}]`;
+
+            case ParseNodeType.ImportFromAs:
+                return `ImportFromAs '${printNode(node.name)}' ${wrap(
+                    node.alias ? printNode(node.alias) : ''
+                )} ${path}`;
+
+            case ParseNodeType.Module:
+                return `module ${path}`;
+
+            case ParseNodeType.Class:
+                return `class '${printNode(node.name)}' ${path}`;
+
+            case ParseNodeType.Function:
+                return `function '${printNode(node.name)}' ${path}`;
+
+            case ParseNodeType.ModuleName:
+                return `moduleName '${node.nameParts.map((n) => printNode(n)).join('.')}' ${path}`;
+
+            case ParseNodeType.Argument:
+                return `argument '${node.name ? printNode(node.name) : 'N/A'}' ${path}`;
+
+            case ParseNodeType.Parameter:
+                return `parameter '${node.name ? printNode(node.name) : 'N/A'}' ${path}`;
+
+            default:
+                return `${ParseTreeUtils.printParseNodeType(node.nodeType)} ${path}`;
+        }
+    }
+
+    function isNode(o: any): o is ParseNode {
+        const n = o as ParseNode;
+        return n && isNumber(n.nodeType);
+    }
+
+    function isDeclaration(o: any): o is Declaration {
+        const d = o as Declaration;
+        return d && isNumber(d.type) && isString(d.path) && isString(d.moduleName);
+    }
+
+    function isType(o: any): o is Type {
+        const t = o as Type;
+        return t && isNumber(t.category) && isNumber(t.flags);
+    }
+
+    function print(o: PrintableType) {
+        if (!o) {
+            return '';
+        }
+
+        if (isNode(o)) {
+            return printNode(o, /*printPath*/ true);
+        }
+
+        if (isDeclaration(o)) {
+            return printDeclaration(o as Declaration);
+        }
+
+        if (o instanceof Symbol) {
+            return printSymbol(o);
+        }
+
+        if (isType(o)) {
+            return printType(o as Type);
+        }
+
+        assertNever(o);
+    }
+
+    return {
+        print: print,
+        printFileOrModuleName: printFileOrModuleName,
+    };
+}

--- a/packages/pyright-internal/src/analyzer/typeEvaluatorWithTracker.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluatorWithTracker.ts
@@ -13,77 +13,101 @@
 import { LogTracker } from '../common/logTracker';
 import { timingStats } from '../common/timing';
 import { ImportLookup } from './analyzerFileInfo';
+import { PrintableType, TracePrinter } from './tracePrinter';
 import { createTypeEvaluator, EvaluatorOptions, TypeEvaluator } from './typeEvaluator';
 
 // We don't want to track calls from the type evaluator itself, but only entry points.
 export function createTypeEvaluatorWithTracker(
     importLookup: ImportLookup,
     evaluatorOptions: EvaluatorOptions,
-    logger?: LogTracker
+    logger: LogTracker,
+    printer?: TracePrinter
 ) {
-    function run<T>(title: string, callback: () => T): T {
-        return logger
-            ? logger.log(title, () => timingStats.typeEvaluationTime.timeOperation(callback), 50)
+    function run<T>(title: string, callback: () => T, value?: PrintableType): T {
+        return evaluatorOptions.logCalls
+            ? logger.log(
+                  title,
+                  (s) => {
+                      s.add(printer?.print(value));
+                      return timingStats.typeEvaluationTime.timeOperation(callback);
+                  },
+                  evaluatorOptions.minimumLoggingThreshold,
+                  true
+              )
             : timingStats.typeEvaluationTime.timeOperation(callback);
     }
 
-    const typeEvaluator = createTypeEvaluator(importLookup, evaluatorOptions);
+    const lookup: ImportLookup = evaluatorOptions.logCalls
+        ? (filePath) =>
+              logger.log(
+                  'import lookup',
+                  (s) => {
+                      s.add(printer?.printFileOrModuleName(filePath));
+                      return importLookup(filePath);
+                  },
+                  evaluatorOptions.minimumLoggingThreshold,
+                  true
+              )
+        : importLookup;
+
+    const typeEvaluator = createTypeEvaluator(lookup, evaluatorOptions, logger, printer);
 
     const withTracker: TypeEvaluator = {
         runWithCancellationToken: typeEvaluator.runWithCancellationToken,
-        getType: (n) => run('getType', () => typeEvaluator.getType(n)),
-        getTypeOfClass: (n) => run('getTypeOfClass', () => typeEvaluator.getTypeOfClass(n)),
-        getTypeOfFunction: (n) => run('getTypeOfFunction', () => typeEvaluator.getTypeOfFunction(n)),
+        getType: (n) => run('getType', () => typeEvaluator.getType(n), n),
+        getTypeOfClass: (n) => run('getTypeOfClass', () => typeEvaluator.getTypeOfClass(n), n),
+        getTypeOfFunction: (n) => run('getTypeOfFunction', () => typeEvaluator.getTypeOfFunction(n), n),
         evaluateTypesForStatement: (n) =>
-            run('evaluateTypesForStatement', () => typeEvaluator.evaluateTypesForStatement(n)),
+            run('evaluateTypesForStatement', () => typeEvaluator.evaluateTypesForStatement(n), n),
         getDeclaredTypeForExpression: (n) =>
-            run('getDeclaredTypeForExpression', () => typeEvaluator.getDeclaredTypeForExpression(n)),
+            run('getDeclaredTypeForExpression', () => typeEvaluator.getDeclaredTypeForExpression(n), n),
         verifyRaiseExceptionType: (n) =>
-            run('verifyRaiseExceptionType', () => typeEvaluator.verifyRaiseExceptionType(n)),
-        verifyDeleteExpression: (n) => run('verifyDeleteExpression', () => typeEvaluator.verifyDeleteExpression(n)),
-        isAfterNodeReachable: (n) => run('isAfterNodeReachable', () => typeEvaluator.isAfterNodeReachable(n)),
-        isNodeReachable: (n) => run('isNodeReachable', () => typeEvaluator.isNodeReachable(n)),
+            run('verifyRaiseExceptionType', () => typeEvaluator.verifyRaiseExceptionType(n), n),
+        verifyDeleteExpression: (n) => run('verifyDeleteExpression', () => typeEvaluator.verifyDeleteExpression(n), n),
+        isAfterNodeReachable: (n) => run('isAfterNodeReachable', () => typeEvaluator.isAfterNodeReachable(n), n),
+        isNodeReachable: (n) => run('isNodeReachable', () => typeEvaluator.isNodeReachable(n), n),
         suppressDiagnostics: (callback) =>
             run('suppressDiagnostics', () => typeEvaluator.suppressDiagnostics(callback)),
         getDeclarationsForNameNode: (n) =>
-            run('getDeclarationsForNameNode', () => typeEvaluator.getDeclarationsForNameNode(n)),
-        getTypeForDeclaration: (n) => run('getTypeForDeclaration', () => typeEvaluator.getTypeForDeclaration(n)),
+            run('getDeclarationsForNameNode', () => typeEvaluator.getDeclarationsForNameNode(n), n),
+        getTypeForDeclaration: (n) => run('getTypeForDeclaration', () => typeEvaluator.getTypeForDeclaration(n), n),
         resolveAliasDeclaration: (d, l) =>
-            run('resolveAliasDeclaration', () => typeEvaluator.resolveAliasDeclaration(d, l)),
-        getTypeFromIterable: (t, a, e) => run('getTypeFromIterable', () => typeEvaluator.getTypeFromIterable(t, a, e)),
+            run('resolveAliasDeclaration', () => typeEvaluator.resolveAliasDeclaration(d, l), d),
+        getTypeFromIterable: (t, a, e) =>
+            run('getTypeFromIterable', () => typeEvaluator.getTypeFromIterable(t, a, e), t),
         getTypedDictMembersForClass: (c) =>
-            run('getTypedDictMembersForClass', () => typeEvaluator.getTypedDictMembersForClass(c)),
+            run('getTypedDictMembersForClass', () => typeEvaluator.getTypedDictMembersForClass(c), c),
         getGetterTypeFromProperty: (p, i) =>
-            run('getGetterTypeFromProperty', () => typeEvaluator.getGetterTypeFromProperty(p, i)),
-        markNamesAccessed: (n, a) => run('markNamesAccessed', () => typeEvaluator.markNamesAccessed(n, a)),
-        getScopeIdForNode: (n) => run('getScopeIdForNode', () => typeEvaluator.getScopeIdForNode(n)),
+            run('getGetterTypeFromProperty', () => typeEvaluator.getGetterTypeFromProperty(p, i), p),
+        markNamesAccessed: (n, a) => run('markNamesAccessed', () => typeEvaluator.markNamesAccessed(n, a), n),
+        getScopeIdForNode: (n) => run('getScopeIdForNode', () => typeEvaluator.getScopeIdForNode(n), n),
         makeTopLevelTypeVarsConcrete: (t) =>
-            run('makeTopLevelTypeVarsConcrete', () => typeEvaluator.makeTopLevelTypeVarsConcrete(t)),
+            run('makeTopLevelTypeVarsConcrete', () => typeEvaluator.makeTopLevelTypeVarsConcrete(t), t),
         getEffectiveTypeOfSymbol: (s) =>
-            run('getEffectiveTypeOfSymbol', () => typeEvaluator.getEffectiveTypeOfSymbol(s)),
+            run('getEffectiveTypeOfSymbol', () => typeEvaluator.getEffectiveTypeOfSymbol(s), s),
         getFunctionDeclaredReturnType: (n) =>
-            run('getFunctionDeclaredReturnType', () => typeEvaluator.getFunctionDeclaredReturnType(n)),
+            run('getFunctionDeclaredReturnType', () => typeEvaluator.getFunctionDeclaredReturnType(n), n),
         getFunctionInferredReturnType: (t) =>
-            run('getFunctionInferredReturnType', () => typeEvaluator.getFunctionInferredReturnType(t)),
-        getBuiltInType: (n, b) => run('getBuiltInType', () => typeEvaluator.getBuiltInType(n, b)),
-        getTypeOfMember: (m) => run('getTypeOfMember', () => typeEvaluator.getTypeOfMember(m)),
+            run('getFunctionInferredReturnType', () => typeEvaluator.getFunctionInferredReturnType(t), t),
+        getBuiltInType: (n, b) => run('getBuiltInType', () => typeEvaluator.getBuiltInType(n, b), n),
+        getTypeOfMember: (m) => run('getTypeOfMember', () => typeEvaluator.getTypeOfMember(m), m.symbol),
         bindFunctionToClassOrObject: (b, m) =>
-            run('bindFunctionToClassOrObject', () => typeEvaluator.bindFunctionToClassOrObject(b, m)),
+            run('bindFunctionToClassOrObject', () => typeEvaluator.bindFunctionToClassOrObject(b, m), m),
         getCallSignatureInfo: (n, i, a) =>
-            run('getCallSignatureInfo', () => typeEvaluator.getCallSignatureInfo(n, i, a)),
+            run('getCallSignatureInfo', () => typeEvaluator.getCallSignatureInfo(n, i, a), n),
         getTypeAnnotationForParameter: (n, p) =>
-            run('getTypeAnnotationForParameter', () => typeEvaluator.getTypeAnnotationForParameter(n, p)),
-        canAssignType: (d, s, a, m, f) => run('canAssignType', () => typeEvaluator.canAssignType(d, s, a, m, f)),
-        canOverrideMethod: (b, o, d) => run('canOverrideMethod', () => typeEvaluator.canOverrideMethod(b, o, d)),
-        addError: (m, n) => run('addError', () => typeEvaluator.addError(m, n)),
-        addWarning: (m, n) => run('addWarning', () => typeEvaluator.addWarning(m, n)),
-        addInformation: (m, n) => run('addInformation', () => typeEvaluator.addInformation(m, n)),
-        addUnusedCode: (n, t) => run('addUnusedCode', () => typeEvaluator.addUnusedCode(n, t)),
-        addDiagnostic: (d, r, m, n) => run('addDiagnostic', () => typeEvaluator.addDiagnostic(d, r, m, n)),
+            run('getTypeAnnotationForParameter', () => typeEvaluator.getTypeAnnotationForParameter(n, p), n),
+        canAssignType: (d, s, a, m, f) => run('canAssignType', () => typeEvaluator.canAssignType(d, s, a, m, f), d),
+        canOverrideMethod: (b, o, d) => run('canOverrideMethod', () => typeEvaluator.canOverrideMethod(b, o, d), o),
+        addError: (m, n) => run('addError', () => typeEvaluator.addError(m, n), n),
+        addWarning: (m, n) => run('addWarning', () => typeEvaluator.addWarning(m, n), n),
+        addInformation: (m, n) => run('addInformation', () => typeEvaluator.addInformation(m, n), n),
+        addUnusedCode: (n, t) => run('addUnusedCode', () => typeEvaluator.addUnusedCode(n, t), n),
+        addDiagnostic: (d, r, m, n) => run('addDiagnostic', () => typeEvaluator.addDiagnostic(d, r, m, n), n),
         addDiagnosticForTextRange: (f, d, r, m, g) =>
             run('addDiagnosticForTextRange', () => typeEvaluator.addDiagnosticForTextRange(f, d, r, m, g)),
-        printType: (t, e) => run('printType', () => typeEvaluator.printType(t, e)),
-        printFunctionParts: (t) => run('printFunctionParts', () => typeEvaluator.printFunctionParts(t)),
+        printType: (t, e) => run('printType', () => typeEvaluator.printType(t, e), t),
+        printFunctionParts: (t) => run('printFunctionParts', () => typeEvaluator.printFunctionParts(t), t),
         getTypeCacheSize: typeEvaluator.getTypeCacheSize,
     };
 

--- a/packages/pyright-internal/src/backgroundThreadBase.ts
+++ b/packages/pyright-internal/src/backgroundThreadBase.ts
@@ -74,6 +74,8 @@ export function createConfigOptionsFrom(jsonObject: any): ConfigOptions {
     configOptions.executionEnvironments = jsonObject.executionEnvironments;
     configOptions.autoImportCompletions = jsonObject.autoImportCompletions;
     configOptions.indexing = jsonObject.indexing;
+    configOptions.logTypeEvaluationTime = jsonObject.logTypeEvaluationTime;
+    configOptions.typeEvaluationTimeThreshold = jsonObject.typeEvaluationTimeThreshold;
     configOptions.include = jsonObject.include.map((f: any) => getFileSpec(f));
     configOptions.exclude = jsonObject.exclude.map((f: any) => getFileSpec(f));
     configOptions.ignore = jsonObject.ignore.map((f: any) => getFileSpec(f));

--- a/packages/pyright-internal/src/common/commandLineOptions.ts
+++ b/packages/pyright-internal/src/common/commandLineOptions.ts
@@ -106,4 +106,10 @@ export class CommandLineOptions {
 
     // Use indexing.
     indexing?: boolean;
+
+    // Use type evaluator call tracking
+    logTypeEvaluationTime = false;
+
+    // Minimum threshold for type eval logging
+    typeEvaluationTimeThreshold = 50;
 }

--- a/packages/pyright-internal/src/common/configOptions.ts
+++ b/packages/pyright-internal/src/common/configOptions.ts
@@ -574,6 +574,12 @@ export class ConfigOptions {
     // Use indexing.
     indexing = false;
 
+    // Use type evaluator call tracking
+    logTypeEvaluationTime = false;
+
+    // Minimum threshold for type eval logging
+    typeEvaluationTimeThreshold = 50;
+
     // Avoid using type inference for files within packages that claim
     // to contain type annotations?
     disableInferenceForPyTypedSources = true;
@@ -1291,6 +1297,24 @@ export class ConfigOptions {
                 console.error(`Config "indexing" field must be true or false.`);
             } else {
                 this.indexing = configObj.indexing;
+            }
+        }
+
+        // Read the "logTypeEvaluationTime" setting.
+        if (configObj.logTypeEvaluationTime !== undefined) {
+            if (typeof configObj.logTypeEvaluationTime !== 'boolean') {
+                console.error(`Config "logTypeEvaluationTime" field must be true or false.`);
+            } else {
+                this.logTypeEvaluationTime = configObj.logTypeEvaluationTime;
+            }
+        }
+
+        // Read the "typeEvaluationTimeThreshold" setting.
+        if (configObj.typeEvaluationTimeThreshold !== undefined) {
+            if (typeof configObj.typeEvaluationTimeThreshold !== 'number') {
+                console.error(`Config "typeEvaluationTimeThreshold" field must be a number.`);
+            } else {
+                this.typeEvaluationTimeThreshold = configObj.typeEvaluationTimeThreshold;
             }
         }
     }

--- a/packages/pyright-internal/src/common/fileSystem.ts
+++ b/packages/pyright-internal/src/common/fileSystem.ts
@@ -219,23 +219,17 @@ class RealFileSystem implements FileSystem {
     }
 }
 
-class ChokidarFileWatcherProvider implements FileWatcherProvider {
+export class ChokidarFileWatcherProvider implements FileWatcherProvider {
     constructor(private _console: ConsoleInterface) {}
 
     createFileWatcher(paths: string[], listener: FileWatcherEventHandler): FileWatcher {
         return this._createFileSystemWatcher(paths).on('all', listener);
     }
 
-    createReadStream(path: string): fs.ReadStream {
-        return fs.createReadStream(path);
-    }
-    createWriteStream(path: string): fs.WriteStream {
-        return fs.createWriteStream(path);
-    }
-
     private _createFileSystemWatcher(paths: string[]): chokidar.FSWatcher {
         // The following options are copied from VS Code source base. It also
         // uses chokidar for its file watching.
+        // https://github.com/microsoft/vscode/blob/master/src/vs/platform/files/node/watcher/unix/chokidarWatcherService.ts
         const watcherOptions: chokidar.WatchOptions = {
             ignoreInitial: true,
             ignorePermissionErrors: true,

--- a/packages/pyright-internal/src/languageService/analyzerServiceExecutor.ts
+++ b/packages/pyright-internal/src/languageService/analyzerServiceExecutor.ts
@@ -46,6 +46,8 @@ function getEffectiveCommandLineOptions(
     commandLineOptions.typeCheckingMode = serverSettings.typeCheckingMode;
     commandLineOptions.autoImportCompletions = serverSettings.autoImportCompletions;
     commandLineOptions.indexing = serverSettings.indexing;
+    commandLineOptions.logTypeEvaluationTime = serverSettings.logTypeEvaluationTime ?? false;
+    commandLineOptions.typeEvaluationTimeThreshold = serverSettings.typeEvaluationTimeThreshold ?? 50;
 
     if (!trackFiles) {
         commandLineOptions.watchForSourceChanges = false;

--- a/packages/pyright-internal/src/server.ts
+++ b/packages/pyright-internal/src/server.ts
@@ -145,6 +145,17 @@ class PyrightServer extends LanguageServerBase {
                 if (pythonAnalysisSection.autoImportCompletions !== undefined) {
                     serverSettings.autoImportCompletions = pythonAnalysisSection.autoImportCompletions;
                 }
+
+                if (
+                    serverSettings.logLevel === LogLevel.Log &&
+                    pythonAnalysisSection.logTypeEvaluationTime !== undefined
+                ) {
+                    serverSettings.logTypeEvaluationTime = pythonAnalysisSection.logTypeEvaluationTime;
+                }
+
+                if (pythonAnalysisSection.typeEvaluationTimeThreshold !== undefined) {
+                    serverSettings.typeEvaluationTimeThreshold = pythonAnalysisSection.typeEvaluationTimeThreshold;
+                }
             } else {
                 serverSettings.autoSearchPaths = true;
             }

--- a/packages/pyright-internal/src/tests/fourslash/findDefinitions.definitionFilter.preferSource.fourslash.ts
+++ b/packages/pyright-internal/src/tests/fourslash/findDefinitions.definitionFilter.preferSource.fourslash.ts
@@ -1,0 +1,29 @@
+/// <reference path="fourslash.ts" />
+
+// @filename: testLib1/__init__.py
+// @library: true
+//// def [|func1|](a):
+////     pass
+
+// @filename: typings/testLib1/__init__.pyi
+//// def [|/*ignore*/func1|](a: str): ...
+
+// @filename: test.py
+//// from testLib1 import func1
+////
+//// [|/*marker*/func1|]('')
+
+{
+    const ranges = helper.getRanges().filter((r) => !r.marker);
+
+    helper.verifyFindDefinitions(
+        {
+            marker: {
+                definitions: ranges.map((r) => {
+                    return { path: r.fileName, range: helper.convertPositionRange(r) };
+                }),
+            },
+        },
+        'preferSource'
+    );
+}

--- a/packages/pyright-internal/src/tests/fourslash/findDefinitions.definitionFilter.preferSource.onlyStubs.ts
+++ b/packages/pyright-internal/src/tests/fourslash/findDefinitions.definitionFilter.preferSource.onlyStubs.ts
@@ -1,0 +1,24 @@
+/// <reference path="fourslash.ts" />
+
+// @filename: typings/testLib1/__init__.pyi
+//// def [|func1|](a: str): ...
+
+// @filename: test.py
+//// from testLib1 import func1
+////
+//// [|/*marker*/func1|]('')
+
+{
+    const ranges = helper.getRanges().filter((r) => !r.marker);
+
+    helper.verifyFindDefinitions(
+        {
+            marker: {
+                definitions: ranges.map((r) => {
+                    return { path: r.fileName, range: helper.convertPositionRange(r) };
+                }),
+            },
+        },
+        'preferSource'
+    );
+}

--- a/packages/pyright-internal/src/tests/fourslash/findDefinitions.definitionFilter.preferStub.fourslash.ts
+++ b/packages/pyright-internal/src/tests/fourslash/findDefinitions.definitionFilter.preferStub.fourslash.ts
@@ -1,0 +1,29 @@
+/// <reference path="fourslash.ts" />
+
+// @filename: testLib1/__init__.py
+// @library: true
+//// def [|/*ignore*/func1|](a):
+////     pass
+
+// @filename: typings/testLib1/__init__.pyi
+//// def [|func1|](a: str): ...
+
+// @filename: test.py
+//// from testLib1 import func1
+////
+//// [|/*marker*/func1|]('')
+
+{
+    const ranges = helper.getRanges().filter((r) => !r.marker);
+
+    helper.verifyFindDefinitions(
+        {
+            marker: {
+                definitions: ranges.map((r) => {
+                    return { path: r.fileName, range: helper.convertPositionRange(r) };
+                }),
+            },
+        },
+        'preferStubs'
+    );
+}

--- a/packages/pyright-internal/src/tests/fourslash/findDefinitions.definitionFilter.preferStub.onlySource.fourslash.ts
+++ b/packages/pyright-internal/src/tests/fourslash/findDefinitions.definitionFilter.preferStub.onlySource.fourslash.ts
@@ -1,0 +1,25 @@
+/// <reference path="fourslash.ts" />
+
+// @filename: testLib1/__init__.py
+//// def [|func1|](a):
+////     pass
+
+// @filename: test.py
+//// from testLib1 import func1
+////
+//// [|/*marker*/func1|]('')
+
+{
+    const ranges = helper.getRanges().filter((r) => !r.marker);
+
+    helper.verifyFindDefinitions(
+        {
+            marker: {
+                definitions: ranges.map((r) => {
+                    return { path: r.fileName, range: helper.convertPositionRange(r) };
+                }),
+            },
+        },
+        'preferStubs'
+    );
+}

--- a/packages/pyright-internal/src/tests/fourslash/fourslash.ts
+++ b/packages/pyright-internal/src/tests/fourslash/fourslash.ts
@@ -140,6 +140,8 @@ declare namespace _ {
 
     type MarkupKind = 'markdown' | 'plaintext';
 
+    type DefinitionFilter = 'all' | 'preferSource' | 'preferStubs';
+
     interface Fourslash {
         getDocumentHighlightKind(m?: Marker): DocumentHighlightKind | undefined;
 
@@ -228,11 +230,14 @@ declare namespace _ {
                 references: DocumentHighlight[];
             };
         }): void;
-        verifyFindDefinitions(map: {
-            [marker: string]: {
-                definitions: DocumentRange[];
-            };
-        }): void;
+        verifyFindDefinitions(
+            map: {
+                [marker: string]: {
+                    definitions: DocumentRange[];
+                };
+            },
+            filter?: DefinitionFilter
+        ): void;
         verifyRename(map: {
             [marker: string]: {
                 newName: string;

--- a/packages/pyright-internal/src/tests/harness/fourslash/testState.ts
+++ b/packages/pyright-internal/src/tests/harness/fourslash/testState.ts
@@ -49,6 +49,7 @@ import { DocumentRange, Position, Range as PositionRange, rangesAreEqual, TextRa
 import { TextRangeCollection } from '../../../common/textRangeCollection';
 import { LanguageServerInterface, WorkspaceServiceInstance } from '../../../languageServerBase';
 import { AbbreviationInfo } from '../../../languageService/autoImporter';
+import { DefinitionFilter } from '../../../languageService/definitionProvider';
 import { convertHoverResults } from '../../../languageService/hoverProvider';
 import { ParseResults } from '../../../parser/parser';
 import { Tokenizer } from '../../../parser/tokenizer';
@@ -1105,11 +1106,14 @@ export class TestState {
         }
     }
 
-    verifyFindDefinitions(map: {
-        [marker: string]: {
-            definitions: DocumentRange[];
-        };
-    }) {
+    verifyFindDefinitions(
+        map: {
+            [marker: string]: {
+                definitions: DocumentRange[];
+            };
+        },
+        filter: DefinitionFilter = DefinitionFilter.All
+    ) {
         this._analyze();
 
         for (const marker of this.getMarkers()) {
@@ -1123,7 +1127,7 @@ export class TestState {
             const expected = map[name].definitions;
 
             const position = this.convertOffsetToPosition(fileName, marker.position);
-            const actual = this.program.getDefinitionsForPosition(fileName, position, CancellationToken.None);
+            const actual = this.program.getDefinitionsForPosition(fileName, position, filter, CancellationToken.None);
 
             assert.equal(actual?.length ?? 0, expected.length);
 


### PR DESCRIPTION
Rollup of:

- Print FS events before ignoring them in verboseOutput mode.
- Use chokidar for non-workspace file watching; fixes library installs outside of the workspace.
- Add performance tracker for type evaluator
- Add go-to-declaration support. Go-to-definition now prefers source, while go-to-declaration prefers stubs.