### PR TITLE
Revert file watcher change

### DIFF
--- a/packages/pyright-internal/src/common/fileSystem.ts
+++ b/packages/pyright-internal/src/common/fileSystem.ts
@@ -219,17 +219,23 @@ class RealFileSystem implements FileSystem {
     }
 }
 
-export class ChokidarFileWatcherProvider implements FileWatcherProvider {
+class ChokidarFileWatcherProvider implements FileWatcherProvider {
     constructor(private _console: ConsoleInterface) {}
 
     createFileWatcher(paths: string[], listener: FileWatcherEventHandler): FileWatcher {
         return this._createFileSystemWatcher(paths).on('all', listener);
     }
 
+    createReadStream(path: string): fs.ReadStream {
+        return fs.createReadStream(path);
+    }
+    createWriteStream(path: string): fs.WriteStream {
+        return fs.createWriteStream(path);
+    }
+
     private _createFileSystemWatcher(paths: string[]): chokidar.FSWatcher {
         // The following options are copied from VS Code source base. It also
         // uses chokidar for its file watching.
-        // https://github.com/microsoft/vscode/blob/master/src/vs/platform/files/node/watcher/unix/chokidarWatcherService.ts
         const watcherOptions: chokidar.WatchOptions = {
             ignoreInitial: true,
             ignorePermissionErrors: true,

--- a/packages/pyright-internal/src/languageServerBase.ts
+++ b/packages/pyright-internal/src/languageServerBase.ts
@@ -11,6 +11,7 @@
 
 import './common/extensions';
 
+import * as fs from 'fs';
 import {
     CancellationToken,
     CancellationTokenSource,
@@ -68,7 +69,6 @@ import { Diagnostic as AnalyzerDiagnostic, DiagnosticCategory } from './common/d
 import { DiagnosticRule } from './common/diagnosticRules';
 import { LanguageServiceExtension } from './common/extensibility';
 import {
-    ChokidarFileWatcherProvider,
     createFromRealFileSystem,
     FileSystem,
     FileWatcher,
@@ -380,19 +380,21 @@ export abstract class LanguageServerBase implements LanguageServerInterface {
             }
         });
 
-        // For any non-workspace paths, create a file watcher.
-        let nonWorkspaceWatchers: FileWatcher | undefined;
+        // For any non-workspace paths, use the node file watcher.
+        let nodeWatchers: FileWatcher[];
 
         try {
-            nonWorkspaceWatchers = new ChokidarFileWatcherProvider(this.console).createFileWatcher(
-                nonWorkspacePaths,
-                listener
-            );
+            nodeWatchers = nonWorkspacePaths.map((path) => {
+                return fs.watch(path, { recursive: true }, (event, filename) =>
+                    listener(event as FileWatcherEventType, filename)
+                );
+            });
         } catch (e) {
             // Versions of node >= 14 are reportedly throwing exceptions
             // when calling fs.watch with recursive: true. Just swallow
             // the exception and proceed.
             this.console.error(`Exception received when installing recursive file system watcher`);
+            nodeWatchers = [];
         }
 
         const fileWatcher: InternalFileWatcher = {
@@ -400,8 +402,10 @@ export abstract class LanguageServerBase implements LanguageServerInterface {
                 // Stop listening for workspace paths.
                 lsBase._fileWatchers = lsBase._fileWatchers.filter((watcher) => watcher !== fileWatcher);
 
-                // Close the non-workspace watchers.
-                nonWorkspaceWatchers?.close();
+                // Close the node watchers.
+                nodeWatchers.forEach((watcher) => {
+                    watcher.close();
+                });
             },
             workspacePaths,
             eventHandler: listener,


### PR DESCRIPTION
Plain revert, as this was causing too many problems. Non-workspace folders may not be watched properly, which was the old behavior, but at least that wasn't crashing people.