### PR TITLE
Sync python.analysis.logLevel setting with the code

### DIFF
--- a/docs/settings.md
+++ b/docs/settings.md
@@ -20,7 +20,7 @@ The Pyright VS Code extension honors the following settings.
 
 **python.analysis.extraPaths** [array of paths]: Paths to add to the default execution environment extra paths if there are no execution environments defined in the config file.
 
-**python.analysis.logLevel** ["error", "warn", "info", or "log"]: Level of logging for Output panel. The default value for this option is "info".
+**python.analysis.logLevel** ["Error", "Warning", "Information", or "Trace"]: Level of logging for Output panel. The default value for this option is "Information".
 
 **python.analysis.stubPath** [path]: Path to directory containing custom type stub files.
 

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -20,7 +20,7 @@ The Pyright VS Code extension honors the following settings.
 
 **python.analysis.extraPaths** [array of paths]: Paths to add to the default execution environment extra paths if there are no execution environments defined in the config file.
 
-**python.analysis.logLevel** ["Error", "Warning", "Information", or "Trace"]: Level of logging for Output panel. The default value for this option is "Information".
+**python.analysis.logLevel** ["error", "warn", "info", or "log"]: Level of logging for Output panel. The default value for this option is "info".
 
 **python.analysis.stubPath** [path]: Path to directory containing custom type stub files.
 

--- a/packages/vscode-pyright/package.json
+++ b/packages/vscode-pyright/package.json
@@ -635,13 +635,13 @@
                 },
                 "python.analysis.logLevel": {
                     "type": "string",
-                    "default": "info",
+                    "default": "Information",
                     "description": "Specifies the level of logging for the Output panel",
                     "enum": [
-                        "error",
-                        "warn",
-                        "info",
-                        "log"
+                        "Error",
+                        "Warning",
+                        "Information",
+                        "Trace"
                     ]
                 },
                 "python.analysis.typeCheckingMode": {

--- a/packages/vscode-pyright/package.json
+++ b/packages/vscode-pyright/package.json
@@ -638,10 +638,10 @@
                     "default": "info",
                     "description": "Specifies the level of logging for the Output panel",
                     "enum": [
-                        "Error",
-                        "Warning",
-                        "Information",
-                        "Trace"
+                        "error",
+                        "warn",
+                        "info",
+                        "log"
                     ]
                 },
                 "python.analysis.typeCheckingMode": {


### PR DESCRIPTION
According to the code the value of "python.analysis.logLevel" are
"error", "warn", "info" and "log", and not what was said in the
documentation and the schema.