### PR TITLE
Fix n^2 duplicate completion check

### DIFF
--- a/packages/pyright-internal/src/analyzer/program.ts
+++ b/packages/pyright-internal/src/analyzer/program.ts
@@ -46,7 +46,6 @@ import {
     AutoImporter,
     AutoImportResult,
     buildModuleSymbolsMap,
-    getAutoImportCandidatesForAbbr,
     ModuleSymbolMap,
 } from '../languageService/autoImporter';
 import { CallHierarchyProvider } from '../languageService/callHierarchyProvider';
@@ -1019,7 +1018,7 @@ export class Program {
                 this._importResolver,
                 parseTree,
                 range.start,
-                [],
+                new Set(),
                 map,
                 libraryMap,
                 (p, t) => computeCompletionSimilarity(p, t) > similarityLimit
@@ -1033,7 +1032,7 @@ export class Program {
                 const info = nameMap?.get(writtenWord);
                 if (info) {
                     // No scope filter is needed since we only do exact match.
-                    results.push(...getAutoImportCandidatesForAbbr(autoImporter, writtenWord, info, token));
+                    results.push(...autoImporter.getAutoImportCandidatesForAbbr(writtenWord, info, token));
                 }
 
                 results.push(

--- a/packages/pyright-internal/src/languageService/completionProvider.ts
+++ b/packages/pyright-internal/src/languageService/completionProvider.ts
@@ -93,13 +93,7 @@ import {
 } from '../parser/parseNodes';
 import { ParseResults } from '../parser/parser';
 import { Token } from '../parser/tokenizerTypes';
-import {
-    AbbreviationInfo,
-    AutoImporter,
-    AutoImportResult,
-    getAutoImportCandidatesForAbbr,
-    ModuleSymbolMap,
-} from './autoImporter';
+import { AbbreviationInfo, AutoImporter, AutoImportResult, ModuleSymbolMap } from './autoImporter';
 import { IndexResults } from './documentSymbolProvider';
 
 const _keywords: string[] = [
@@ -1352,7 +1346,7 @@ export class CompletionProvider {
         }
 
         const moduleSymbolMap = this._autoImportMaps.getModuleSymbolsMap();
-        const excludes = completionList.items.filter((i) => !i.data?.autoImport).map((i) => i.label);
+        const excludes = new Set(completionList.items.filter((i) => !i.data?.autoImport).map((i) => i.label));
         const autoImporter = new AutoImporter(
             this._configOptions.findExecEnvironment(this._filePath),
             this._importResolver,
@@ -1365,8 +1359,8 @@ export class CompletionProvider {
 
         const results: AutoImportResult[] = [];
         const info = this._autoImportMaps.nameMap?.get(priorWord);
-        if (info && priorWord.length > 1 && !excludes.some((e) => e === priorWord)) {
-            results.push(...getAutoImportCandidatesForAbbr(autoImporter, priorWord, info, this._cancellationToken));
+        if (info && priorWord.length > 1 && !excludes.has(priorWord)) {
+            results.push(...autoImporter.getAutoImportCandidatesForAbbr(priorWord, info, this._cancellationToken));
         }
 
         results.push(


### PR DESCRIPTION
Building the completion list was an n^2 operation; use a set to deduplicate results which greatly reduces completion time with a large number of items.