### PR TITLE
Improve source mapper to handle more cases

### DIFF
--- a/packages/pyright-internal/src/analyzer/declaration.ts
+++ b/packages/pyright-internal/src/analyzer/declaration.ts
@@ -180,3 +180,23 @@ export type Declaration =
     | ParameterDeclaration
     | VariableDeclaration
     | AliasDeclaration;
+
+export function isFunctionDeclaration(decl: Declaration): decl is FunctionDeclaration {
+    return decl.type === DeclarationType.Function;
+}
+
+export function isClassDeclaration(decl: Declaration): decl is ClassDeclaration {
+    return decl.type === DeclarationType.Class;
+}
+
+export function isParameterDeclaration(decl: Declaration): decl is ParameterDeclaration {
+    return decl.type === DeclarationType.Parameter;
+}
+
+export function isVariableDeclaration(decl: Declaration): decl is VariableDeclaration {
+    return decl.type === DeclarationType.Variable;
+}
+
+export function isAliasDeclaration(decl: Declaration): decl is AliasDeclaration {
+    return decl.type === DeclarationType.Alias;
+}

--- a/packages/pyright-internal/src/analyzer/importResolver.ts
+++ b/packages/pyright-internal/src/analyzer/importResolver.ts
@@ -218,15 +218,19 @@ export class ImportResolver {
         // When ImportResolver resolves an import to a stub file, a second resolve is done
         // ignoring stub files, which gives us an approximation of where the implementation
         // for that stub is located.
-        this._cachedImportResults.forEach((map, env) => {
+        this._cachedImportResults.forEach((map) => {
             map.forEach((result) => {
                 if (result.isStubFile && result.isImportFound && result.nonStubImportResult) {
-                    if (result.resolvedPaths.some((f) => f === stubFilePath)) {
+                    if (result.resolvedPaths[result.resolvedPaths.length - 1] === stubFilePath) {
                         if (result.nonStubImportResult.isImportFound) {
-                            const nonEmptyPaths = result.nonStubImportResult.resolvedPaths.filter((p) =>
-                                p.endsWith('.py')
-                            );
-                            sourceFilePaths.push(...nonEmptyPaths);
+                            const nonEmptyPath =
+                                result.nonStubImportResult.resolvedPaths[
+                                    result.nonStubImportResult.resolvedPaths.length - 1
+                                ];
+
+                            if (nonEmptyPath.endsWith('.py')) {
+                                sourceFilePaths.push(nonEmptyPath);
+                            }
                         }
                     }
                 }

--- a/packages/pyright-internal/src/analyzer/program.ts
+++ b/packages/pyright-internal/src/analyzer/program.ts
@@ -1863,6 +1863,7 @@ export class Program {
                 this._addShadowedFile(stubFileInfo, implFilePath);
                 return this.getBoundSourceFile(implFilePath);
             },
+            (f) => this.getBoundSourceFile(f),
             mapCompiled ?? false
         );
         return sourceMapper;

--- a/packages/pyright-internal/src/analyzer/sourceMapper.ts
+++ b/packages/pyright-internal/src/analyzer/sourceMapper.ts
@@ -9,15 +9,32 @@
 import * as AnalyzerNodeInfo from '../analyzer/analyzerNodeInfo';
 import * as ParseTreeUtils from '../analyzer/parseTreeUtils';
 import { ExecutionEnvironment } from '../common/configOptions';
+import { isDefined } from '../common/core';
 import { getAnyExtensionFromPath } from '../common/pathUtils';
-import { ClassNode, ModuleNode, ParseNode } from '../parser/parseNodes';
-import { ClassDeclaration, Declaration, DeclarationType, FunctionDeclaration } from './declaration';
+import { ClassNode, ModuleNode, ParseNode, ParseNodeType } from '../parser/parseNodes';
+import {
+    ClassDeclaration,
+    Declaration,
+    FunctionDeclaration,
+    isAliasDeclaration,
+    isClassDeclaration,
+    isFunctionDeclaration,
+    isParameterDeclaration,
+    isVariableDeclaration,
+    ParameterDeclaration,
+    VariableDeclaration,
+} from './declaration';
 import { ImportResolver } from './importResolver';
 import { SourceFile } from './sourceFile';
 import { TypeEvaluator } from './typeEvaluator';
+import { isClass, isFunction, isOverloadedFunction } from './types';
+import { lookUpClassMember } from './typeUtils';
+
+type ClassOrFunctionOrVariableDeclaration = ClassDeclaration | FunctionDeclaration | VariableDeclaration;
 
 // Creates and binds a shadowed file within the program.
 export type ShadowFileBinder = (stubFilePath: string, implFilePath: string) => SourceFile | undefined;
+export type BoundSourceGetter = (filePath: string) => SourceFile | undefined;
 
 export class SourceMapper {
     constructor(
@@ -25,37 +42,56 @@ export class SourceMapper {
         private _execEnv: ExecutionEnvironment,
         private _evaluator: TypeEvaluator,
         private _fileBinder: ShadowFileBinder,
+        private _boundSourceGetter: BoundSourceGetter,
         private _mapCompiled: boolean
     ) {}
 
-    public findModules(stubFilePath: string): ModuleNode[] {
-        const sourceFiles = this._getBoundSourceFiles(stubFilePath);
-        return sourceFiles.map((sf) => sf.getParseResults()?.parseTree).filter(_isDefined);
+    findModules(stubFilePath: string): ModuleNode[] {
+        const sourceFiles = this._getBoundSourceFilesFromStubFile(stubFilePath);
+        return sourceFiles.map((sf) => sf.getParseResults()?.parseTree).filter(isDefined);
     }
 
-    public findDeclarations(stubDecl: Declaration): Declaration[] {
-        if (stubDecl.type === DeclarationType.Class) {
-            return this.findClassDeclarations(stubDecl);
-        } else if (stubDecl.type === DeclarationType.Function) {
-            return this.findFunctionDeclarations(stubDecl);
+    findDeclarations(stubDecl: Declaration): Declaration[] {
+        if (isClassDeclaration(stubDecl)) {
+            return this._findClassOrTypeAliasDeclarations(stubDecl);
+        } else if (isFunctionDeclaration(stubDecl)) {
+            return this._findFunctionOrTypeAliasDeclarations(stubDecl);
+        } else if (isVariableDeclaration(stubDecl)) {
+            return this._findVariableDeclarations(stubDecl);
+        } else if (isParameterDeclaration(stubDecl)) {
+            return this._findParameterDeclarations(stubDecl);
         }
 
         return [];
     }
 
-    public findClassDeclarations(stubDecl: ClassDeclaration): ClassDeclaration[] {
-        const className = this._getFullClassName(stubDecl.node);
-
-        const sourceFiles = this._getBoundSourceFiles(stubDecl.path);
-        return sourceFiles.flatMap((sourceFile) => this._findClassDeclarations(sourceFile, className));
+    findClassDeclarations(stubDecl: ClassDeclaration): ClassDeclaration[] {
+        return this._findClassOrTypeAliasDeclarations(stubDecl)
+            .filter((d) => isClassDeclaration(d))
+            .map((d) => d as ClassDeclaration);
     }
 
-    public findFunctionDeclarations(
+    findFunctionDeclarations(stubDecl: FunctionDeclaration): FunctionDeclaration[] {
+        return this._findFunctionOrTypeAliasDeclarations(stubDecl)
+            .filter((d) => isFunctionDeclaration(d))
+            .map((d) => d as FunctionDeclaration);
+    }
+
+    private _findClassOrTypeAliasDeclarations(stubDecl: ClassDeclaration, recursiveDeclCache = new Set<string>()) {
+        const className = this._getFullClassName(stubDecl.node);
+        const sourceFiles = this._getBoundSourceFilesFromStubFile(stubDecl.path);
+
+        return sourceFiles.flatMap((sourceFile) =>
+            this._findClassDeclarationsByName(sourceFile, className, recursiveDeclCache)
+        );
+    }
+
+    private _findFunctionOrTypeAliasDeclarations(
         stubDecl: FunctionDeclaration,
         recursiveDeclCache = new Set<string>()
-    ): FunctionDeclaration[] {
+    ): ClassOrFunctionOrVariableDeclaration[] {
         const functionName = stubDecl.node.name.value;
-        const sourceFiles = this._getBoundSourceFiles(stubDecl.path);
+        const sourceFiles = this._getBoundSourceFilesFromStubFile(stubDecl.path);
 
         if (stubDecl.isMethod) {
             const classNode = ParseTreeUtils.getEnclosingClass(stubDecl.node);
@@ -64,31 +100,95 @@ export class SourceMapper {
             }
 
             const className = this._getFullClassName(classNode);
-
             return sourceFiles.flatMap((sourceFile) =>
-                this._findMethodDeclarations(sourceFile, className, functionName)
+                this._findMethodDeclarationsByName(sourceFile, className, functionName, recursiveDeclCache)
             );
         } else {
             return sourceFiles.flatMap((sourceFile) =>
-                this._findFunctionDeclarations(sourceFile, functionName, recursiveDeclCache)
+                this._findFunctionDeclarationsByName(sourceFile, functionName, recursiveDeclCache)
             );
         }
     }
 
-    private _findMethodDeclarations(
+    private _findVariableDeclarations(
+        stubDecl: VariableDeclaration,
+        recursiveDeclCache = new Set<string>()
+    ): VariableDeclaration[] {
+        if (stubDecl.node.nodeType !== ParseNodeType.Name) {
+            return [];
+        }
+
+        const variableName = stubDecl.node.value;
+        const sourceFiles = this._getBoundSourceFilesFromStubFile(stubDecl.path);
+        const classNode = ParseTreeUtils.getEnclosingClass(stubDecl.node);
+
+        if (classNode) {
+            const className = this._getFullClassName(classNode);
+
+            return sourceFiles.flatMap((sourceFile) =>
+                this._findFieldDeclarationsByName(sourceFile, className, variableName, recursiveDeclCache)
+            );
+        } else {
+            return sourceFiles.flatMap((sourceFile) =>
+                this._findVariableDeclarationsByName(sourceFile, variableName, recursiveDeclCache)
+            );
+        }
+    }
+
+    private _findParameterDeclarations(stubDecl: ParameterDeclaration): ParameterDeclaration[] {
+        const result: ParameterDeclaration[] = [];
+
+        if (!stubDecl.node.name) {
+            return result;
+        }
+
+        const functionNode = ParseTreeUtils.getEnclosingFunction(stubDecl.node);
+        if (!functionNode) {
+            return result;
+        }
+
+        const functionStubDecls = this._evaluator.getDeclarationsForNameNode(functionNode.name);
+        if (!functionStubDecls) {
+            return result;
+        }
+
+        const recursiveDeclCache = new Set<string>();
+        for (const functionStubDecl of functionStubDecls) {
+            for (const functionDecl of this._findFunctionOrTypeAliasDeclarations(
+                functionStubDecl as FunctionDeclaration,
+                recursiveDeclCache
+            )) {
+                result.push(
+                    ...this._lookUpSymbolDeclarations(functionDecl.node, stubDecl.node.name.value)
+                        .filter((d) => isParameterDeclaration(d))
+                        .map((d) => d as ParameterDeclaration)
+                );
+            }
+        }
+
+        return result;
+    }
+
+    private _findMemberDeclarationsByName<T extends Declaration>(
         sourceFile: SourceFile,
         className: string,
-        functionName: string
-    ): FunctionDeclaration[] {
-        const result: FunctionDeclaration[] = [];
+        memberName: string,
+        declAdder: (d: Declaration, c: Set<string>, r: T[]) => void,
+        recursiveDeclCache: Set<string>
+    ): T[] {
+        const result: T[] = [];
+        const classDecls = this._findClassDeclarationsByName(sourceFile, className, recursiveDeclCache);
 
-        const classDecls = this._findClassDeclarations(sourceFile, className);
+        for (const classDecl of classDecls.filter((d) => isClassDeclaration(d)).map((d) => d as ClassDeclaration)) {
+            const classResults = this._evaluator.getTypeOfClass(classDecl.node);
+            if (!classResults) {
+                continue;
+            }
 
-        for (const classDecl of classDecls) {
-            const methodDecls = this._lookUpSymbolDeclarations(classDecl.node, functionName);
-            for (const methodDecl of methodDecls) {
-                if (methodDecl.type === DeclarationType.Function && methodDecl.isMethod) {
-                    result.push(methodDecl);
+            const member = lookUpClassMember(classResults.classType, memberName);
+            if (member) {
+                for (const decl of member.symbol.getDeclarations()) {
+                    declAdder(decl, recursiveDeclCache, result);
                 }
             }
         }
@@ -96,12 +196,81 @@ export class SourceMapper {
         return result;
     }
 
-    private _findFunctionDeclarations(
+    private _findFieldDeclarationsByName(
+        sourceFile: SourceFile,
+        className: string,
+        variableName: string,
+        recursiveDeclCache: Set<string>
+    ): VariableDeclaration[] {
+        return this._findMemberDeclarationsByName(
+            sourceFile,
+            className,
+            variableName,
+            (decl, cache, result) => {
+                if (isVariableDeclaration(decl)) {
+                    if (isStubFile(decl.path)) {
+                        result.push(...this._findVariableDeclarations(decl, cache));
+                    } else {
+                        result.push(decl);
+                    }
+                }
+            },
+            recursiveDeclCache
+        );
+    }
+
+    private _findMethodDeclarationsByName(
+        sourceFile: SourceFile,
+        className: string,
+        functionName: string,
+        recursiveDeclCache: Set<string>
+    ): ClassOrFunctionOrVariableDeclaration[] {
+        return this._findMemberDeclarationsByName(
+            sourceFile,
+            className,
+            functionName,
+            (decl, cache, result) => {
+                if (isFunctionDeclaration(decl)) {
+                    if (isStubFile(decl.path)) {
+                        result.push(...this._findFunctionOrTypeAliasDeclarations(decl, cache));
+                    } else {
+                        result.push(decl);
+                    }
+                }
+            },
+            recursiveDeclCache
+        );
+    }
+
+    private _findVariableDeclarationsByName(
+        sourceFile: SourceFile,
+        variableName: string,
+        recursiveDeclCache: Set<string>
+    ): VariableDeclaration[] {
+        const result: VariableDeclaration[] = [];
+
+        const uniqueId = sourceFile.getFilePath() + variableName;
+        if (recursiveDeclCache.has(uniqueId)) {
+            return result;
+        }
+
+        recursiveDeclCache.add(uniqueId);
+
+        const decls = this._lookUpSymbolDeclarations(sourceFile.getParseResults()?.parseTree, variableName);
+        for (const decl of decls) {
+            this._addVariableDeclarations(decl, result, recursiveDeclCache);
+        }
+
+        recursiveDeclCache.delete(uniqueId);
+        return result;
+    }
+
+    private _findFunctionDeclarationsByName(
         sourceFile: SourceFile,
         functionName: string,
         recursiveDeclCache: Set<string>
-    ): FunctionDeclaration[] {
-        const result: FunctionDeclaration[] = [];
+    ): ClassOrFunctionOrVariableDeclaration[] {
+        const result: ClassOrFunctionOrVariableDeclaration[] = [];
 
         const uniqueId = sourceFile.getFilePath() + functionName;
         if (recursiveDeclCache.has(uniqueId)) {
@@ -110,76 +279,146 @@ export class SourceMapper {
 
         recursiveDeclCache.add(uniqueId);
 
-        const functionDecls = this._lookUpSymbolDeclarations(sourceFile.getParseResults()?.parseTree, functionName);
-
-        for (const functionDecl of functionDecls) {
-            if (functionDecl.type === DeclarationType.Function) {
-                result.push(functionDecl);
-            } else if (functionDecl.type === DeclarationType.Alias) {
-                const resolvedDecl = this._evaluator.resolveAliasDeclaration(
-                    functionDecl,
-                    /* resolveLocalNames */ true
-                );
-                if (resolvedDecl) {
-                    if (resolvedDecl.type === DeclarationType.Function) {
-                        if (isStubFile(resolvedDecl.path)) {
-                            result.push(...this.findFunctionDeclarations(resolvedDecl, recursiveDeclCache));
-                        } else {
-                            result.push(resolvedDecl);
-                        }
-                    }
-                }
-            }
+        const decls = this._lookUpSymbolDeclarations(sourceFile.getParseResults()?.parseTree, functionName);
+        for (const decl of decls) {
+            this._addClassOrFunctionDeclarations(decl, result, recursiveDeclCache);
         }
 
         recursiveDeclCache.delete(uniqueId);
         return result;
     }
 
-    private _findClassDeclarations(sourceFile: SourceFile, fullClassName: string): ClassDeclaration[] {
-        let result: ClassDeclaration[] = [];
+    private _findClassDeclarationsByName(
+        sourceFile: SourceFile,
+        fullClassName: string,
+        recursiveDeclCache: Set<string>
+    ): ClassOrFunctionOrVariableDeclaration[] {
+        let classDecls: ClassOrFunctionOrVariableDeclaration[] = [];
 
         // fullClassName is period delimited, for example: 'OuterClass.InnerClass'
         const parentNode = sourceFile.getParseResults()?.parseTree;
         if (parentNode) {
             let classNameParts = fullClassName.split('.');
             if (classNameParts.length > 0) {
-                result = this._findClassDeclarationsUnderNode(sourceFile, classNameParts[0], parentNode);
+                classDecls = this._findClassDeclarations(sourceFile, classNameParts[0], parentNode, recursiveDeclCache);
                 classNameParts = classNameParts.slice(1);
             }
 
             for (const classNamePart of classNameParts) {
-                result = this._findClassDeclarationsUnderClass(sourceFile, classNamePart, result);
+                classDecls = classDecls.flatMap((parentDecl) =>
+                    this._findClassDeclarations(sourceFile, classNamePart, parentDecl.node, recursiveDeclCache)
+                );
             }
         }
 
+        return classDecls;
+    }
+
+    private _findClassDeclarations(
+        sourceFile: SourceFile,
+        className: string,
+        parentNode: ParseNode,
+        recursiveDeclCache: Set<string>
+    ): ClassOrFunctionOrVariableDeclaration[] {
+        const result: ClassOrFunctionOrVariableDeclaration[] = [];
+
+        const uniqueId = sourceFile.getFilePath() + `@[${parentNode.start}]${className}`;
+        if (recursiveDeclCache.has(uniqueId)) {
+            return result;
+        }
+
+        recursiveDeclCache.add(uniqueId);
+
+        const decls = this._lookUpSymbolDeclarations(parentNode, className);
+        for (const decl of decls) {
+            this._addClassOrFunctionDeclarations(decl, result, recursiveDeclCache);
+        }
+
+        recursiveDeclCache.delete(uniqueId);
         return result;
     }
 
-    private _findClassDeclarationsUnderClass(
-        sourceFile: SourceFile,
-        className: string,
-        parentClassDecls: ClassDeclaration[]
-    ): ClassDeclaration[] {
-        return parentClassDecls.flatMap((parentDecl) =>
-            this._findClassDeclarationsUnderNode(sourceFile, className, parentDecl.node)
-        );
-    }
-
-    private _findClassDeclarationsUnderNode(
-        sourceFile: SourceFile,
-        className: string,
-        parentNode: ParseNode
-    ): ClassDeclaration[] {
-        const result: ClassDeclaration[] = [];
-
-        for (const decl of this._lookUpSymbolDeclarations(parentNode, className)) {
-            if (decl.type === DeclarationType.Class) {
+    private _addVariableDeclarations(
+        decl: Declaration,
+        result: ClassOrFunctionOrVariableDeclaration[],
+        recursiveDeclCache: Set<string>
+    ) {
+        if (isVariableDeclaration(decl)) {
+            if (isStubFile(decl.path)) {
+                result.push(...this._findVariableDeclarations(decl, recursiveDeclCache));
+            } else {
                 result.push(decl);
             }
+        } else if (isAliasDeclaration(decl)) {
+            const resolvedDecl = this._evaluator.resolveAliasDeclaration(decl, /* resolveLocalNames */ true);
+            if (resolvedDecl) {
+                this._addVariableDeclarations(resolvedDecl, result, recursiveDeclCache);
+            }
         }
+    }
 
-        return result;
+    private _addClassOrFunctionDeclarations(
+        decl: Declaration,
+        result: ClassOrFunctionOrVariableDeclaration[],
+        recursiveDeclCache: Set<string>
+    ) {
+        if (isClassDeclaration(decl)) {
+            if (isStubFile(decl.path)) {
+                result.push(...this._findClassOrTypeAliasDeclarations(decl, recursiveDeclCache));
+            } else {
+                result.push(decl);
+            }
+        } else if (isFunctionDeclaration(decl)) {
+            if (isStubFile(decl.path)) {
+                result.push(...this._findFunctionOrTypeAliasDeclarations(decl, recursiveDeclCache));
+            } else {
+                result.push(decl);
+            }
+        } else if (isAliasDeclaration(decl)) {
+            const resolvedDecl = this._evaluator.resolveAliasDeclaration(decl, /* resolveLocalNames */ true);
+            if (resolvedDecl) {
+                this._addClassOrFunctionDeclarations(resolvedDecl, result, recursiveDeclCache);
+            }
+        } else if (isVariableDeclaration(decl)) {
+            // Always add decl. This handles a case where function is dynamically generated such as pandas.read_csv or type alias.
+            this._addVariableDeclarations(decl, result, recursiveDeclCache);
+
+            // And try to add the real decl if we can. Sometimes, we can't since import resolver can't follow up the type alias or assignment.
+            // Import resolver can't resolve an import that only exists in the lib but not in the stub in certain circumstance.
+            const nodeToBind = decl.typeAliasName ?? decl.node;
+            const type = this._evaluator.getType(nodeToBind);
+            if (!type) {
+                return;
+            }
+
+            if (isFunction(type) && type.details.declaration) {
+                this._addClassOrFunctionDeclarations(type.details.declaration, result, recursiveDeclCache);
+            } else if (isOverloadedFunction(type)) {
+                for (const overloadDecl of type.overloads.map((o) => o.details.declaration).filter(isDefined)) {
+                    this._addClassOrFunctionDeclarations(overloadDecl, result, recursiveDeclCache);
+                }
+            } else if (type && isClass(type)) {
+                const importResult = this._importResolver.resolveImport(decl.path, this._execEnv, {
+                    leadingDots: 0,
+                    nameParts: type.details.moduleName.split('.'),
+                    importedSymbols: [],
+                });
+
+                if (importResult.isImportFound && importResult.resolvedPaths.length > 0) {
+                    const sourceFile = this._boundSourceGetter(
+                        importResult.resolvedPaths[importResult.resolvedPaths.length - 1]
+                    );
+                    if (sourceFile) {
+                        const fullClassName = type.details.fullName.substring(
+                            type.details.moduleName.length + 1 /* +1 for trailing dot */
+                        );
+                        result.push(
+                            ...this._findClassDeclarationsByName(sourceFile, fullClassName, recursiveDeclCache)
+                        );
+                    }
+                }
+            }
+        }
     }
 
     private _lookUpSymbolDeclarations(node: ParseNode | undefined, symbolName: string): Declaration[] {
@@ -206,16 +445,12 @@ export class SourceMapper {
         return fullName.reverse().join('.');
     }
 
-    private _getBoundSourceFiles(stubFilePath: string): SourceFile[] {
+    private _getBoundSourceFilesFromStubFile(stubFilePath: string): SourceFile[] {
         const paths = this._importResolver.getSourceFilesFromStub(stubFilePath, this._execEnv, this._mapCompiled);
-        return paths.map((fp) => this._fileBinder(stubFilePath, fp)).filter(_isDefined);
+        return paths.map((fp) => this._fileBinder(stubFilePath, fp)).filter(isDefined);
     }
 }
 
 export function isStubFile(filePath: string): boolean {
     return getAnyExtensionFromPath(filePath, ['.pyi'], /* ignoreCase */ false) === '.pyi';
-}
-
-function _isDefined<T>(element: T | undefined): element is T {
-    return element !== undefined;
 }

--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -16153,6 +16153,13 @@ export function createTypeEvaluator(
                         if (paramDecl) {
                             declarations.push(paramDecl);
                         }
+                    } else if (isOverloadedFunction(baseType)) {
+                        baseType.overloads.forEach((f) => {
+                            const paramDecl = getDeclarationFromFunctionNamedParameter(f, paramName);
+                            if (paramDecl) {
+                                declarations.push(paramDecl);
+                            }
+                        });
                     } else if (isClass(baseType)) {
                         const initMethodType = getTypeFromObjectMember(
                             argNode.parent.leftExpression,

--- a/packages/pyright-internal/src/common/core.ts
+++ b/packages/pyright-internal/src/common/core.ts
@@ -146,3 +146,7 @@ interface Thenable<T> {
 export function isThenable<T>(v: any): v is Thenable<T> {
     return typeof v?.then === 'function';
 }
+
+export function isDefined<T>(element: T | undefined): element is T {
+    return element !== undefined;
+}

--- a/packages/pyright-internal/src/tests/fourslash/findDefinitions.classes.fourslash.ts
+++ b/packages/pyright-internal/src/tests/fourslash/findDefinitions.classes.fourslash.ts
@@ -1,0 +1,101 @@
+/// <reference path="fourslash.ts" />
+
+// @filename: testLib1/__init__.pyi
+// @library: true
+//// class C: ...
+////
+//// class C2: ...
+////
+//// class C3: ...
+////
+//// class C4: ...
+////
+//// def C5(a, b): ...
+
+// @filename: testLib1/__init__.py
+// @library: true
+//// from .M import C2
+//// from . import D
+////
+//// class [|C|]:
+////     pass
+////
+//// [|C3|] = D.C3
+//// [|C4|] = D.N.C4
+////
+//// class [|C5|]:
+////     def __init__(self, a, b):
+////         pass
+
+// @filename: testLib1/M.py
+// @library: true
+//// class [|C2|]:
+////     pass
+
+// @filename: testLib1/D.py
+// @library: true
+//// class [|C3|]:
+////     pass
+////
+//// class N:
+////     class [|C4|]:
+////         pass
+
+// @filename: test.py
+//// import testLib1
+////
+//// a = testLib1.[|/*marker1*/C|]()
+//// a = testLib1.[|/*marker2*/C2|]()
+//// a = testLib1.[|/*marker3*/C3|]()
+//// a = testLib1.[|/*marker4*/C4|]()
+//// a = testLib1.[|/*marker5*/C5|](1, 2)
+
+{
+    const rangeMap = helper.getRangesByText();
+
+    helper.verifyFindDefinitions(
+        {
+            marker1: {
+                definitions: rangeMap
+                    .get('C')!
+                    .filter((r) => !r.marker)
+                    .map((r) => {
+                        return { path: r.fileName, range: helper.convertPositionRange(r) };
+                    }),
+            },
+            marker2: {
+                definitions: rangeMap
+                    .get('C2')!
+                    .filter((r) => !r.marker)
+                    .map((r) => {
+                        return { path: r.fileName, range: helper.convertPositionRange(r) };
+                    }),
+            },
+            marker3: {
+                definitions: rangeMap
+                    .get('C3')!
+                    .filter((r) => !r.marker)
+                    .map((r) => {
+                        return { path: r.fileName, range: helper.convertPositionRange(r) };
+                    }),
+            },
+            marker4: {
+                definitions: rangeMap
+                    .get('C4')!
+                    .filter((r) => !r.marker)
+                    .map((r) => {
+                        return { path: r.fileName, range: helper.convertPositionRange(r) };
+                    }),
+            },
+            marker5: {
+                definitions: rangeMap
+                    .get('C5')!
+                    .filter((r) => !r.marker)
+                    .map((r) => {
+                        return { path: r.fileName, range: helper.convertPositionRange(r) };
+                    }),
+            },
+        },
+        'preferSource'
+    );
+}

--- a/packages/pyright-internal/src/tests/fourslash/findDefinitions.fields.fourslash.ts
+++ b/packages/pyright-internal/src/tests/fourslash/findDefinitions.fields.fourslash.ts
@@ -1,0 +1,131 @@
+/// <reference path="fourslash.ts" />
+
+// @filename: testLib1/__init__.pyi
+// @library: true
+//// from typing import ClassVar
+////
+//// class C:
+////     V = ...
+////
+//// class C2:
+////     V2 = ...
+////
+//// class C3:
+////     V3 = ...
+////
+//// class C4:
+////     V4: ClassVar[int] = ...
+////
+//// class C5:
+////     V5: ClassVar[int] = ...
+////
+//// class C6:
+////     V6 = ...
+
+// @filename: testLib1/__init__.py
+// @library: true
+//// from .M import C2
+//// from . import D
+////
+//// class C:
+////     def __init__(self):
+////         self.[|V|] = 1
+////
+//// C3 = D.C3
+//// C4 = D.N.C4
+////
+//// class B:
+////     [|V5|] = 1
+////
+////     def __init__(self):
+////         self.[|V6|] = 1
+////
+//// class C5(B):
+////     pass
+////
+//// class C6(B):
+////     pass
+
+// @filename: testLib1/M.py
+// @library: true
+//// class C2:
+////     def __init__(self):
+////         self.[|V2|] = 1
+
+// @filename: testLib1/D.py
+// @library: true
+//// class C3:
+////     def [|__init__|](self):
+////         self.[|V3|] = 1
+////
+//// class N:
+////     class C4:
+////         [|V4|] = 1
+
+// @filename: test.py
+//// import testLib1
+////
+//// a = testLib1.C().[|/*marker1*/V|]()
+//// a = testLib1.C2().[|/*marker2*/V2|]()
+//// a = testLib1.C3().[|/*marker3*/V3|]()
+//// a = testLib1.C4().[|/*marker4*/V4|]()
+//// a = testLib1.C5().[|/*marker5*/V5|]()
+//// a = testLib1.C6().[|/*marker6*/V6|]()
+
+{
+    const rangeMap = helper.getRangesByText();
+
+    helper.verifyFindDefinitions(
+        {
+            marker1: {
+                definitions: rangeMap
+                    .get('V')!
+                    .filter((r) => !r.marker)
+                    .map((r) => {
+                        return { path: r.fileName, range: helper.convertPositionRange(r) };
+                    }),
+            },
+            marker2: {
+                definitions: rangeMap
+                    .get('V2')!
+                    .filter((r) => !r.marker)
+                    .map((r) => {
+                        return { path: r.fileName, range: helper.convertPositionRange(r) };
+                    }),
+            },
+            marker3: {
+                definitions: rangeMap
+                    .get('V3')!
+                    .filter((r) => !r.marker)
+                    .map((r) => {
+                        return { path: r.fileName, range: helper.convertPositionRange(r) };
+                    }),
+            },
+            marker4: {
+                definitions: rangeMap
+                    .get('V4')!
+                    .filter((r) => !r.marker)
+                    .map((r) => {
+                        return { path: r.fileName, range: helper.convertPositionRange(r) };
+                    }),
+            },
+            marker5: {
+                definitions: rangeMap
+                    .get('V5')!
+                    .filter((r) => !r.marker)
+                    .map((r) => {
+                        return { path: r.fileName, range: helper.convertPositionRange(r) };
+                    }),
+            },
+            marker6: {
+                definitions: rangeMap
+                    .get('V6')!
+                    .filter((r) => !r.marker)
+                    .map((r) => {
+                        return { path: r.fileName, range: helper.convertPositionRange(r) };
+                    }),
+            },
+        },
+        'preferSource'
+    );
+}

--- a/packages/pyright-internal/src/tests/fourslash/findDefinitions.functions.fourslash.ts
+++ b/packages/pyright-internal/src/tests/fourslash/findDefinitions.functions.fourslash.ts
@@ -1,0 +1,87 @@
+/// <reference path="fourslash.ts" />
+
+// @filename: testLib1/__init__.pyi
+// @library: true
+//// def C(): ...
+////
+//// def C2(): ...
+////
+//// def C3(): ...
+////
+//// def C4(): ...
+
+// @filename: testLib1/__init__.py
+// @library: true
+//// from .M import C2
+//// from . import D
+////
+//// def [|C|]():
+////     pass
+////
+//// [|C3|] = D.C3
+//// [|C4|] = D.Generate()
+
+// @filename: testLib1/M.py
+// @library: true
+//// def [|C2|]():
+////     pass
+
+// @filename: testLib1/D.py
+// @library: true
+//// def [|C3|]():
+////     pass
+////
+//// def Generate():
+////     def [|C4|]():
+////         pass
+////     return C4;
+
+// @filename: test.py
+//// import testLib1
+////
+//// a = testLib1.[|/*marker1*/C|]()
+//// a = testLib1.[|/*marker2*/C2|]()
+//// a = testLib1.[|/*marker3*/C3|]()
+//// a = testLib1.[|/*marker4*/C4|]()
+
+{
+    const rangeMap = helper.getRangesByText();
+
+    helper.verifyFindDefinitions(
+        {
+            marker1: {
+                definitions: rangeMap
+                    .get('C')!
+                    .filter((r) => !r.marker)
+                    .map((r) => {
+                        return { path: r.fileName, range: helper.convertPositionRange(r) };
+                    }),
+            },
+            marker2: {
+                definitions: rangeMap
+                    .get('C2')!
+                    .filter((r) => !r.marker)
+                    .map((r) => {
+                        return { path: r.fileName, range: helper.convertPositionRange(r) };
+                    }),
+            },
+            marker3: {
+                definitions: rangeMap
+                    .get('C3')!
+                    .filter((r) => !r.marker)
+                    .map((r) => {
+                        return { path: r.fileName, range: helper.convertPositionRange(r) };
+                    }),
+            },
+            marker4: {
+                definitions: rangeMap
+                    .get('C4')!
+                    .filter((r) => !r.marker)
+                    .map((r) => {
+                        return { path: r.fileName, range: helper.convertPositionRange(r) };
+                    }),
+            },
+        },
+        'preferSource'
+    );
+}

--- a/packages/pyright-internal/src/tests/fourslash/findDefinitions.methods.fourslash.ts
+++ b/packages/pyright-internal/src/tests/fourslash/findDefinitions.methods.fourslash.ts
@@ -1,0 +1,162 @@
+/// <reference path="fourslash.ts" />
+
+// @filename: testLib1/__init__.pyi
+// @library: true
+//// from typing import overload
+////
+//// class C:
+////     def method(self): ...
+////
+//// class C2:
+////     def method2(self): ...
+////
+//// class C3:
+////     def method3(self): ...
+////
+//// class C4:
+////     def method4(self): ...
+////
+//// class C5:
+////     def method5(self): ...
+////
+//// class C6:
+////     def method6(self): ...
+////
+//// class C7:
+////     @overload
+////     def method7(self): ...
+////     @overload
+////     def method7(self, a): ...
+
+// @filename: testLib1/__init__.py
+// @library: true
+//// from .M import C2
+//// from . import D
+////
+//// class C:
+////     def [|method|](self):
+////         pass
+////
+//// C3 = D.C3
+//// C4 = D.N.C4
+////
+//// class B:
+////     def [|method5|](self):
+////         pass
+////
+////     def method6(self):
+////         pass
+////
+//// class C5(B):
+////     pass
+////
+//// class C6(B):
+////     def [|method6|](self):
+////         pass
+////
+//// class C7:
+////     def [|method7|](self, a):
+////         pass
+
+// @filename: testLib1/M.py
+// @library: true
+//// class C2:
+////     def [|method2|](self):
+////         pass
+
+// @filename: testLib1/D.py
+// @library: true
+//// class C3:
+////     def [|method3|](self):
+////         pass
+////
+//// class N:
+////     class C4:
+////         def [|method4|](self):
+////             pass
+
+// @filename: test.py
+//// import testLib1
+////
+//// testLib1.C().[|/*marker1*/method|]()
+//// testLib1.C2().[|/*marker2*/method2|]()
+//// testLib1.C3().[|/*marker3*/method3|]()
+//// testLib1.C4().[|/*marker4*/method4|]()
+//// testLib1.C5().[|/*marker5*/method5|]()
+//// testLib1.C6().[|/*marker6*/method6|]()
+//// testLib1.C7().[|/*marker7*/method7|]()
+//// testLib1.C7().[|/*marker7_1*/method7|](1)
+
+{
+    const rangeMap = helper.getRangesByText();
+
+    helper.verifyFindDefinitions(
+        {
+            marker1: {
+                definitions: rangeMap
+                    .get('method')!
+                    .filter((r) => !r.marker)
+                    .map((r) => {
+                        return { path: r.fileName, range: helper.convertPositionRange(r) };
+                    }),
+            },
+            marker2: {
+                definitions: rangeMap
+                    .get('method2')!
+                    .filter((r) => !r.marker)
+                    .map((r) => {
+                        return { path: r.fileName, range: helper.convertPositionRange(r) };
+                    }),
+            },
+            marker3: {
+                definitions: rangeMap
+                    .get('method3')!
+                    .filter((r) => !r.marker)
+                    .map((r) => {
+                        return { path: r.fileName, range: helper.convertPositionRange(r) };
+                    }),
+            },
+            marker4: {
+                definitions: rangeMap
+                    .get('method4')!
+                    .filter((r) => !r.marker)
+                    .map((r) => {
+                        return { path: r.fileName, range: helper.convertPositionRange(r) };
+                    }),
+            },
+            marker5: {
+                definitions: rangeMap
+                    .get('method5')!
+                    .filter((r) => !r.marker)
+                    .map((r) => {
+                        return { path: r.fileName, range: helper.convertPositionRange(r) };
+                    }),
+            },
+            marker6: {
+                definitions: rangeMap
+                    .get('method6')!
+                    .filter((r) => !r.marker)
+                    .map((r) => {
+                        return { path: r.fileName, range: helper.convertPositionRange(r) };
+                    }),
+            },
+            marker7: {
+                definitions: rangeMap
+                    .get('method7')!
+                    .filter((r) => !r.marker)
+                    .map((r) => {
+                        return { path: r.fileName, range: helper.convertPositionRange(r) };
+                    }),
+            },
+            marker7_1: {
+                definitions: rangeMap
+                    .get('method7')!
+                    .filter((r) => !r.marker)
+                    .map((r) => {
+                        return { path: r.fileName, range: helper.convertPositionRange(r) };
+                    }),
+            },
+        },
+        'preferSource'
+    );
+}

--- a/packages/pyright-internal/src/tests/fourslash/findDefinitions.modules.fourslash.ts
+++ b/packages/pyright-internal/src/tests/fourslash/findDefinitions.modules.fourslash.ts
@@ -1,0 +1,50 @@
+/// <reference path="fourslash.ts" />
+
+// @filename: testLib1/__init__.pyi
+// @library: true
+//// from . import M as M
+//// from . import D as D
+
+// @filename: testLib1/D.pyi
+// @library: true
+//// # empty
+
+// @filename: testLib1/__init__.py
+// @library: true
+//// [|/*def1*/|]# empty
+
+// @filename: testLib1/M.py
+// @library: true
+//// [|/*def2*/|]# empty
+
+// @filename: testLib1/D.py
+// @library: true
+//// [|/*def3*/|]# empty
+
+// @filename: test.py
+//// import [|/*marker1*/testLib1|]
+//// import testLib1.[|/*marker2*/M|]
+//// import testLib1.[|/*marker3*/D|]
+
+{
+    helper.verifyFindDefinitions(
+        {
+            marker1: {
+                definitions: [
+                    { path: helper.getMarkerByName('def1').fileName, range: helper.getPositionRange('def1') },
+                ],
+            },
+            marker2: {
+                definitions: [
+                    { path: helper.getMarkerByName('def2').fileName, range: helper.getPositionRange('def2') },
+                ],
+            },
+            marker3: {
+                definitions: [
+                    { path: helper.getMarkerByName('def3').fileName, range: helper.getPositionRange('def3') },
+                ],
+            },
+        },
+        'preferSource'
+    );
+}

--- a/packages/pyright-internal/src/tests/fourslash/findDefinitions.overloads.fourslash.ts
+++ b/packages/pyright-internal/src/tests/fourslash/findDefinitions.overloads.fourslash.ts
@@ -1,0 +1,223 @@
+/// <reference path="fourslash.ts" />
+
+// @filename: testLib1/__init__.pyi
+// @library: true
+//// from typing import overload
+////
+//// class C:
+////     @overload
+////     def method(self): ...
+////     @overload
+////     def method(self, a): ...
+////
+//// class C2:
+////     @overload
+////     def method2(self): ...
+////     @overload
+////     def method2(self, a): ...
+////
+//// class C3(C2):
+////     @overload
+////     def method2(self): ...
+////     @overload
+////     def method2(self, a): ...
+////
+//// class C4:
+////     @overload
+////     def method4(self): ...
+////     @overload
+////     def method4(self, a): ...
+////
+//// class C5:
+////     @overload
+////     def method5(self): ...
+////     @overload
+////     def method5(self, a): ...
+////
+//// class C6:
+////     @overload
+////     def method6(self): ...
+////     @overload
+////     def method6(self, a): ...
+////
+//// @overload
+//// def method7(): ...
+//// @overload
+//// def method7(a): ...
+
+// @filename: testLib1/__init__.py
+// @library: true
+//// from .M import C2, C3 as MC3, method7 as m7
+//// from . import D
+////
+//// class C:
+////     @overload
+////     def [|method|](self):
+////         pass
+////
+////     @overload
+////     def [|method|](self, a):
+////         pass
+////
+//// C3 = MC3
+//// C4 = D.N.C4
+////
+//// class B:
+////     @overload
+////     def [|method5|](self):
+////         pass
+////
+////     def [|method5|](self, a):
+////         pass
+////
+////     @overload
+////     def method6(self):
+////         pass
+////
+////     @overload
+////     def method6(self, a):
+////         pass
+////
+//// class C5(B):
+////     pass
+////
+//// class C6(B):
+////     @overload
+////     def [|method6|](self):
+////         pass
+////
+////     @overload
+////     def [|method6|](self, a):
+////         pass
+////
+//// [|method7|] = m7
+
+// @filename: testLib1/M.pyi
+// @library: true
+//// from . import D
+//// C2 = D.C2
+//// C3 = D.C3
+//// method7 = D.method7
+
+// @filename: testLib1/M.py
+// @library: true
+//// from . import D
+//// C2 = D.C2
+//// C3 = D.C3
+//// method7 = D.method7
+
+// @filename: testLib1/D.pyi
+// @library: true
+//// class C2:
+////     @overload
+////     def method2(self): ...
+////     @overload
+////     def method2(self, a): ...
+////
+//// class C3(C2): ...
+////
+//// class N:
+////     class C4:
+////         @overload
+////         def method4(self): ...
+////         @overload
+////         def method4(self, a): ...
+////
+//// @overload
+//// def method7(): ...
+//// @overload
+//// def method7(a): ...
+
+// @filename: testLib1/D.py
+// @library: true
+//// class C2:
+////     def [|method2|](self, a):
+////         pass
+////
+//// class C3(C2):
+////     pass
+////
+//// class N:
+////     class C4:
+////         def [|method4|](self, a):
+////             pass
+////
+//// def [|method7|](a):
+////     pass
+
+// @filename: test.py
+//// import testLib1
+////
+//// testLib1.C().[|/*marker1*/method|]()
+//// testLib1.C2().[|/*marker2*/method2|]()
+//// testLib1.C3().[|/*marker3*/method2|]()
+//// testLib1.C4().[|/*marker4*/method4|](1)
+//// testLib1.C5().[|/*marker5*/method5|]()
+//// testLib1.C6().[|/*marker6*/method6|](1)
+//// testLib1.[|/*marker7*/method7|](1)
+
+{
+    const rangeMap = helper.getRangesByText();
+
+    helper.verifyFindDefinitions(
+        {
+            marker1: {
+                definitions: rangeMap
+                    .get('method')!
+                    .filter((r) => !r.marker)
+                    .map((r) => {
+                        return { path: r.fileName, range: helper.convertPositionRange(r) };
+                    }),
+            },
+            marker2: {
+                definitions: rangeMap
+                    .get('method2')!
+                    .filter((r) => !r.marker)
+                    .map((r) => {
+                        return { path: r.fileName, range: helper.convertPositionRange(r) };
+                    }),
+            },
+            marker3: {
+                definitions: rangeMap
+                    .get('method2')!
+                    .filter((r) => !r.marker)
+                    .map((r) => {
+                        return { path: r.fileName, range: helper.convertPositionRange(r) };
+                    }),
+            },
+            marker4: {
+                definitions: rangeMap
+                    .get('method4')!
+                    .filter((r) => !r.marker)
+                    .map((r) => {
+                        return { path: r.fileName, range: helper.convertPositionRange(r) };
+                    }),
+            },
+            marker5: {
+                definitions: rangeMap
+                    .get('method5')!
+                    .filter((r) => !r.marker)
+                    .map((r) => {
+                        return { path: r.fileName, range: helper.convertPositionRange(r) };
+                    }),
+            },
+            marker6: {
+                definitions: rangeMap
+                    .get('method6')!
+                    .filter((r) => !r.marker)
+                    .map((r) => {
+                        return { path: r.fileName, range: helper.convertPositionRange(r) };
+                    }),
+            },
+            marker7: {
+                definitions: rangeMap
+                    .get('method7')!
+                    .filter((r) => !r.marker)
+                    .map((r) => {
+                        return { path: r.fileName, range: helper.convertPositionRange(r) };
+                    }),
+            },
+        },
+        'preferSource'
+    );
+}

--- a/packages/pyright-internal/src/tests/fourslash/findDefinitions.parameters.fourslash.ts
+++ b/packages/pyright-internal/src/tests/fourslash/findDefinitions.parameters.fourslash.ts
@@ -1,0 +1,162 @@
+/// <reference path="fourslash.ts" />
+
+// @filename: testLib1/__init__.pyi
+// @library: true
+//// from typing import overload
+////
+//// class C:
+////     def method(self, a): ...
+////
+//// class C2:
+////     def method2(self, a2): ...
+////
+//// class C3:
+////     def method3(self, a3): ...
+////
+//// class C4:
+////     def method4(self, a4): ...
+////
+//// class C5:
+////     def method5(self, a5): ...
+////
+//// class C6:
+////     def method6(self, a6): ...
+////
+//// class C7:
+////     @overload
+////     def method7(self, a7): ...
+////     @overload
+////     def method7(self, a7, b7): ...
+
+// @filename: testLib1/__init__.py
+// @library: true
+//// from .M import C2
+//// from . import D
+////
+//// class C:
+////     def method(self, [|a|]):
+////         pass
+////
+//// C3 = D.C3
+//// C4 = D.N.C4
+////
+//// class B:
+////     def method5(self, [|a5|]):
+////         pass
+////
+////     def method6(self, a6):
+////         pass
+////
+//// class C5(B):
+////     pass
+////
+//// class C6(B):
+////     def method6(self, [|a6|]):
+////         pass
+////
+//// class C7:
+////     def method7(self, [|a7|], [|b7|]):
+////         pass
+
+// @filename: testLib1/M.py
+// @library: true
+//// class C2:
+////     def method2(self, [|a2|]):
+////         pass
+
+// @filename: testLib1/D.py
+// @library: true
+//// class C3:
+////     def method3(self, [|a3|]):
+////         pass
+////
+//// class N:
+////     class C4:
+////         def method4(self, [|a4|]):
+////             pass
+
+// @filename: test.py
+//// import testLib1
+////
+//// testLib1.C().method([|/*marker1*/a|] = 1)
+//// testLib1.C2().method2([|/*marker2*/a2|] = 1)
+//// testLib1.C3().method3([|/*marker3*/a3|] = 1)
+//// testLib1.C4().method4([|/*marker4*/a4|] = 1)
+//// testLib1.C5().method5([|/*marker5*/a5|] = 1)
+//// testLib1.C6().method6([|/*marker6*/a6|] = 1)
+//// testLib1.C7().method7([|/*marker7*/a7|] = 1)
+//// testLib1.C7().method7(a7 = 1, [|/*marker7_1*/b7|] = 1)
+
+{
+    const rangeMap = helper.getRangesByText();
+
+    helper.verifyFindDefinitions(
+        {
+            marker1: {
+                definitions: rangeMap
+                    .get('a')!
+                    .filter((r) => !r.marker)
+                    .map((r) => {
+                        return { path: r.fileName, range: helper.convertPositionRange(r) };
+                    }),
+            },
+            marker2: {
+                definitions: rangeMap
+                    .get('a2')!
+                    .filter((r) => !r.marker)
+                    .map((r) => {
+                        return { path: r.fileName, range: helper.convertPositionRange(r) };
+                    }),
+            },
+            marker3: {
+                definitions: rangeMap
+                    .get('a3')!
+                    .filter((r) => !r.marker)
+                    .map((r) => {
+                        return { path: r.fileName, range: helper.convertPositionRange(r) };
+                    }),
+            },
+            marker4: {
+                definitions: rangeMap
+                    .get('a4')!
+                    .filter((r) => !r.marker)
+                    .map((r) => {
+                        return { path: r.fileName, range: helper.convertPositionRange(r) };
+                    }),
+            },
+            marker5: {
+                definitions: rangeMap
+                    .get('a5')!
+                    .filter((r) => !r.marker)
+                    .map((r) => {
+                        return { path: r.fileName, range: helper.convertPositionRange(r) };
+                    }),
+            },
+            marker6: {
+                definitions: rangeMap
+                    .get('a6')!
+                    .filter((r) => !r.marker)
+                    .map((r) => {
+                        return { path: r.fileName, range: helper.convertPositionRange(r) };
+                    }),
+            },
+            marker7: {
+                definitions: rangeMap
+                    .get('a7')!
+                    .filter((r) => !r.marker)
+                    .map((r) => {
+                        return { path: r.fileName, range: helper.convertPositionRange(r) };
+                    }),
+            },
+            marker7_1: {
+                definitions: rangeMap
+                    .get('b7')!
+                    .filter((r) => !r.marker)
+                    .map((r) => {
+                        return { path: r.fileName, range: helper.convertPositionRange(r) };
+                    }),
+            },
+        },
+        'preferSource'
+    );
+}

--- a/packages/pyright-internal/src/tests/fourslash/findDefinitions.stubOnly.fourslash.ts
+++ b/packages/pyright-internal/src/tests/fourslash/findDefinitions.stubOnly.fourslash.ts
@@ -1,23 +1,61 @@
 /// <reference path="fourslash.ts" />
 
 // @filename: typings/testLib1/__init__.pyi
+//// from typing import overload
+////
 //// class [|Test1|]:
 ////     def M(self, a: str):
+////         pass
+////     @overload
+////     def [|OL|](self, [|a|]):
+////         pass
+////     @overload
+////     def [|OL|](self, [|a|], [|b|]):
 ////         pass
 
 // @filename: test.py
 //// import testLib1
 ////
 //// a = testLib1.[|/*marker*/Test1|]()
+//// testLib1.Test1().[|/*marker2*/OL|]("hello")
+//// testLib1.Test1().OL([|/*marker3*/a|] = "hello")
+//// testLib1.Test1().OL(a = "hello", [|/*marker4*/b|] = 1)
 
 {
-    const ranges = helper.getRanges().filter((r) => !r.marker);
+    const rangeMap = helper.getRangesByText();
 
     helper.verifyFindDefinitions({
         marker: {
-            definitions: ranges.map((r) => {
-                return { path: r.fileName, range: helper.convertPositionRange(r) };
-            }),
+            definitions: rangeMap
+                .get('Test1')!
+                .filter((r) => !r.marker)
+                .map((r) => {
+                    return { path: r.fileName, range: helper.convertPositionRange(r) };
+                }),
+        },
+        marker2: {
+            definitions: rangeMap
+                .get('OL')!
+                .filter((r) => !r.marker)
+                .map((r) => {
+                    return { path: r.fileName, range: helper.convertPositionRange(r) };
+                }),
+        },
+        marker3: {
+            definitions: rangeMap
+                .get('a')!
+                .filter((r) => !r.marker)
+                .map((r) => {
+                    return { path: r.fileName, range: helper.convertPositionRange(r) };
+                }),
+        },
+        marker4: {
+            definitions: rangeMap
+                .get('b')!
+                .filter((r) => !r.marker)
+                .map((r) => {
+                    return { path: r.fileName, range: helper.convertPositionRange(r) };
+                }),
         },
     });
 }

--- a/packages/pyright-internal/src/tests/fourslash/findDefinitions.variables.fourslash.ts
+++ b/packages/pyright-internal/src/tests/fourslash/findDefinitions.variables.fourslash.ts
@@ -1,0 +1,88 @@
+/// <reference path="fourslash.ts" />
+
+// @filename: testLib1/__init__.pyi
+// @library: true
+//// C = ...
+////
+//// C2 = ...
+////
+//// C3 = ...
+////
+//// C4 = ...
+
+// @filename: testLib1/__init__.py
+// @library: true
+//// from .M import C2
+//// from . import D
+////
+//// [|C|] = 1
+////
+//// [|C3|] = D.C3
+//// [|C4|] = D.Generate()
+
+// @filename: testLib1/M.py
+// @library: true
+//// [|C2|] = 1
+
+// @filename: testLib1/D.pyi
+// @library: true
+//// C3 = ...
+////
+//// def Generate(): ...
+
+// @filename: testLib1/D.py
+// @library: true
+//// C3 = 1
+////
+//// def Generate():
+////     return 1;
+
+// @filename: test.py
+//// import testLib1
+////
+//// a = testLib1.[|/*marker1*/C|]
+//// a = testLib1.[|/*marker2*/C2|]
+//// a = testLib1.[|/*marker3*/C3|]
+//// a = testLib1.[|/*marker4*/C4|]
+
+{
+    const rangeMap = helper.getRangesByText();
+
+    helper.verifyFindDefinitions(
+        {
+            marker1: {
+                definitions: rangeMap
+                    .get('C')!
+                    .filter((r) => !r.marker)
+                    .map((r) => {
+                        return { path: r.fileName, range: helper.convertPositionRange(r) };
+                    }),
+            },
+            marker2: {
+                definitions: rangeMap
+                    .get('C2')!
+                    .filter((r) => !r.marker)
+                    .map((r) => {
+                        return { path: r.fileName, range: helper.convertPositionRange(r) };
+                    }),
+            },
+            marker3: {
+                definitions: rangeMap
+                    .get('C3')!
+                    .filter((r) => !r.marker)
+                    .map((r) => {
+                        return { path: r.fileName, range: helper.convertPositionRange(r) };
+                    }),
+            },
+            marker4: {
+                definitions: rangeMap
+                    .get('C4')!
+                    .filter((r) => !r.marker)
+                    .map((r) => {
+                        return { path: r.fileName, range: helper.convertPositionRange(r) };
+                    }),
+            },
+        },
+        'preferSource'
+    );
+}


### PR DESCRIPTION
Handles:

- Import aliases of classes
- Type aliases
- Class methods
- Variables
- Class fields
- Parameters
- Mismatched types between stubs and real code (e.g. when something is declared as a function in typeshed, but is a class in the real code)
