### PR TITLE
Ignore .git files, doc string inherit, logging, partial stubs

### DIFF
--- a/packages/pyright-internal/src/analyzer/service.ts
+++ b/packages/pyright-internal/src/analyzer/service.ts
@@ -1068,7 +1068,7 @@ export class AnalyzerService {
                     }
 
                     // Wholesale ignore events that appear to be from tmp file modification.
-                    if (path.endsWith('.tmp')) {
+                    if (path.endsWith('.tmp') || path.endsWith('.git')) {
                         return;
                     }
 

--- a/packages/pyright-internal/src/analyzer/sourceFile.ts
+++ b/packages/pyright-internal/src/analyzer/sourceFile.ts
@@ -46,6 +46,7 @@ import { Localizer } from '../localization/localize';
 import { ModuleNode } from '../parser/parseNodes';
 import { ModuleImport, ParseOptions, Parser, ParseResults } from '../parser/parser';
 import { Token } from '../parser/tokenizerTypes';
+import { PyrightFileSystem } from '../pyrightFileSystem';
 import { AnalyzerFileInfo, ImportLookup } from './analyzerFileInfo';
 import * as AnalyzerNodeInfo from './analyzerNodeInfo';
 import { Binder, BinderResults } from './binder';
@@ -502,7 +503,7 @@ export class SourceFile {
     // (or at least cancel) prior to calling again. It returns true if a parse
     // was required and false if the parse information was up to date already.
     parse(configOptions: ConfigOptions, importResolver: ImportResolver, content?: string): boolean {
-        return this._logTracker.log(`parsing: ${this._filePath}`, (logState) => {
+        return this._logTracker.log(`parsing: ${this._getPathForLogging(this._filePath)}`, (logState) => {
             // If the file is already parsed, we can skip.
             if (!this.isParseRequired()) {
                 logState.suppress();
@@ -630,7 +631,7 @@ export class SourceFile {
     }
 
     index(options: IndexOptions, token: CancellationToken): IndexResults | undefined {
-        return this._logTracker.log(`indexing: ${this._filePath}`, (ls) => {
+        return this._logTracker.log(`indexing: ${this._getPathForLogging(this._filePath)}`, (ls) => {
             // If we have no completed analysis job, there's nothing to do.
             if (!this._parseResults || !this.isIndexingRequired()) {
                 ls.suppress();
@@ -905,7 +906,7 @@ export class SourceFile {
         assert(!this._isBindingInProgress);
         assert(this._parseResults !== undefined);
 
-        return this._logTracker.log(`binding: ${this._filePath}`, () => {
+        return this._logTracker.log(`binding: ${this._getPathForLogging(this._filePath)}`, () => {
             try {
                 // Perform name binding.
                 timingStats.bindTime.timeOperation(() => {
@@ -972,7 +973,7 @@ export class SourceFile {
         assert(this.isCheckingRequired());
         assert(this._parseResults !== undefined);
 
-        return this._logTracker.log(`checking: ${this._filePath}`, () => {
+        return this._logTracker.log(`checking: ${this._getPathForLogging(this._filePath)}`, () => {
             try {
                 timingStats.typeCheckerTime.timeOperation(() => {
                     const checker = new Checker(this._parseResults!.parseTree, evaluator);
@@ -1148,5 +1149,13 @@ export class SourceFile {
             typeshedModulePath,
             collectionsModulePath,
         };
+    }
+
+    private _getPathForLogging(filepath: string) {
+        if (!(this.fileSystem instanceof PyrightFileSystem) || !this.fileSystem.isVirtual(filepath)) {
+            return filepath;
+        }
+
+        return '[virtual] ' + filepath;
     }
 }

--- a/packages/pyright-internal/src/analyzer/sourceMapper.ts
+++ b/packages/pyright-internal/src/analyzer/sourceMapper.ts
@@ -75,6 +75,12 @@ export class SourceMapper {
             .map((d) => d as ClassDeclaration);
     }
 
+    findClassDeclarationsByType(originatedPath: string, type: ClassType): ClassDeclaration[] {
+        const result: ClassOrFunctionOrVariableDeclaration[] = [];
+        this._addClassTypeDeclarations(originatedPath, type, result, new Set<string>());
+        return result.filter((r) => isClassDeclaration(r)).map((r) => r as ClassDeclaration);
+    }
+
     findFunctionDeclarations(stubDecl: FunctionDeclaration): FunctionDeclaration[] {
         return this._findFunctionOrTypeAliasDeclarations(stubDecl)
             .filter((d) => isFunctionDeclaration(d))

--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -696,10 +696,6 @@ export function createTypeEvaluator(
     let returnTypeInferenceTypeCache: TypeCache | undefined;
 
     function logInternalCall<T>(title: string, callback: () => T, value: PrintableType): T {
-        if (!evaluatorOptions.logCalls) {
-            return callback();
-        }
-
         return logger.log(
             title,
             (logState) => {
@@ -865,13 +861,10 @@ export function createTypeEvaluator(
         });
     }
 
-    function getTypeOfExpression(node: ExpressionNode, expectedType?: Type, flags = EvaluatorFlags.None) {
-        return logInternalCall(
-            'getTypeOfExpression',
-            () => getTypeOfExpressionInternal(node, expectedType, flags),
-            node
-        );
-    }
+    const getTypeOfExpression = evaluatorOptions.logCalls
+        ? (n: ExpressionNode, t?: Type, f = EvaluatorFlags.None) =>
+              logInternalCall('getTypeOfExpression', () => getTypeOfExpressionInternal(n, t, f), n)
+        : getTypeOfExpressionInternal;
 
     function getTypeOfExpressionInternal(
         node: ExpressionNode,
@@ -16643,13 +16636,14 @@ export function createTypeEvaluator(
         return getEffectiveTypeOfSymbolForUsage(symbol).type;
     }
 
-    function getEffectiveTypeOfSymbolForUsage(symbol: Symbol, usageNode?: NameNode, useLastDecl = false) {
-        return logInternalCall(
-            'getEffectiveTypeOfSymbolForUsage',
-            () => getEffectiveTypeOfSymbolForUsageInternal(symbol, usageNode, useLastDecl),
-            symbol
-        );
-    }
+    const getEffectiveTypeOfSymbolForUsage = evaluatorOptions.logCalls
+        ? (s: Symbol, u?: NameNode, l = false) =>
+              logInternalCall(
+                  'getEffectiveTypeOfSymbolForUsage',
+                  () => getEffectiveTypeOfSymbolForUsageInternal(s, u, l),
+                  s
+              )
+        : getEffectiveTypeOfSymbolForUsageInternal;
 
     function getEffectiveTypeOfSymbolForUsageInternal(
         symbol: Symbol,
@@ -16872,13 +16866,10 @@ export function createTypeEvaluator(
         return UnknownType.create();
     }
 
-    function getFunctionInferredReturnType(type: FunctionType, args?: ValidateArgTypeParams[]) {
-        return logInternalCall(
-            'getFunctionInferredReturnType',
-            () => getFunctionInferredReturnTypeInternal(type, args),
-            type
-        );
-    }
+    const getFunctionInferredReturnType = evaluatorOptions.logCalls
+        ? (t: FunctionType, a?: ValidateArgTypeParams[]) =>
+              logInternalCall('getFunctionInferredReturnType', () => getFunctionInferredReturnTypeInternal(t, a), t)
+        : getFunctionInferredReturnTypeInternal;
 
     function getFunctionInferredReturnTypeInternal(type: FunctionType, args?: ValidateArgTypeParams[]) {
         let returnType: Type | undefined;

--- a/packages/pyright-internal/src/analyzer/typeEvaluatorWithTracker.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluatorWithTracker.ts
@@ -10,6 +10,7 @@
  * and etc.
  */
 
+import { isDebugMode } from '../common/core';
 import { LogTracker } from '../common/logTracker';
 import { timingStats } from '../common/timing';
 import { ImportLookup } from './analyzerFileInfo';
@@ -23,6 +24,10 @@ export function createTypeEvaluatorWithTracker(
     logger: LogTracker,
     printer?: TracePrinter
 ) {
+    if (!evaluatorOptions.logCalls && isDebugMode()) {
+        return createTypeEvaluator(importLookup, evaluatorOptions, logger, undefined);
+    }
+
     function run<T>(title: string, callback: () => T, value?: PrintableType): T {
         return evaluatorOptions.logCalls
             ? logger.log(

--- a/packages/pyright-internal/src/backgroundThreadBase.ts
+++ b/packages/pyright-internal/src/backgroundThreadBase.ts
@@ -14,6 +14,7 @@ import { LogLevel } from './common/console';
 import * as debug from './common/debug';
 import { createFromRealFileSystem, FileSystem } from './common/fileSystem';
 import { FileSpec } from './common/pathUtils';
+import { PyrightFileSystem } from './pyrightFileSystem';
 
 export class BackgroundThreadBase {
     protected fs: FileSystem;
@@ -24,7 +25,7 @@ export class BackgroundThreadBase {
         // Stash the base directory into a global variable.
         (global as any).__rootDirectory = data.rootDirectory;
 
-        this.fs = createFromRealFileSystem(this.getConsole());
+        this.fs = new PyrightFileSystem(createFromRealFileSystem(this.getConsole()));
     }
 
     protected log(level: LogLevel, msg: string) {

--- a/packages/pyright-internal/src/common/pathConsts.ts
+++ b/packages/pyright-internal/src/common/pathConsts.ts
@@ -12,3 +12,4 @@ export const libAlternate = 'Lib';
 export const lib64 = 'lib64';
 export const sitePackages = 'site-packages';
 export const src = 'src';
+export const stubsSuffix = '-stubs';

--- a/packages/pyright-internal/src/languageServerBase.ts
+++ b/packages/pyright-internal/src/languageServerBase.ts
@@ -86,6 +86,7 @@ import { convertToFlatSymbols, WorkspaceSymbolCallback } from './languageService
 import { convertHoverResults } from './languageService/hoverProvider';
 import { ReferenceCallback } from './languageService/referencesProvider';
 import { Localizer } from './localization/localize';
+import { PyrightFileSystem } from './pyrightFileSystem';
 import { WorkspaceMap } from './workspaceMap';
 
 export interface ServerSettings {
@@ -213,7 +214,7 @@ export abstract class LanguageServerBase implements LanguageServerInterface {
 
         this.console.info(`Server root directory: ${_serverOptions.rootDirectory}`);
 
-        this.fs = createFromRealFileSystem(this.console, this);
+        this.fs = new PyrightFileSystem(createFromRealFileSystem(this.console, this));
 
         // Set the working directory to a known location within
         // the extension directory. Otherwise the execution of
@@ -238,6 +239,7 @@ export abstract class LanguageServerBase implements LanguageServerInterface {
     abstract createBackgroundAnalysis(): BackgroundAnalysisBase | undefined;
 
     protected abstract executeCommand(params: ExecuteCommandParams, token: CancellationToken): Promise<any>;
+
     protected isLongRunningCommand(command: string): boolean {
         // By default, all commands are considered "long-running" and should
         // display a cancelable progress dialog. Servers can override this

--- a/packages/pyright-internal/src/pyrightFileSystem.ts
+++ b/packages/pyright-internal/src/pyrightFileSystem.ts
@@ -1,0 +1,290 @@
+/*
+ * pyrightFileSystem.ts
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT license.
+ *
+ * a file system that knows how to deal with partial stub files.
+ */
+
+import * as fs from 'fs';
+
+import { getPyTypedInfo } from './analyzer/pyTypedUtils';
+import { ExecutionEnvironment } from './common/configOptions';
+import {
+    FileSystem,
+    FileWatcher,
+    FileWatcherEventHandler,
+    MkDirOptions,
+    Stats,
+    TmpfileOptions,
+} from './common/fileSystem';
+import { stubsSuffix } from './common/pathConsts';
+import { combinePaths, ensureTrailingDirectorySeparator, getDirectoryPath, getFileName } from './common/pathUtils';
+
+export class PyrightFileSystem implements FileSystem {
+    private readonly _pathMap = new Map<string, string>();
+    private readonly _folderMap = new Map<string, string[]>();
+
+    private readonly _rootSearched = new Set<string>();
+    private readonly _partialStubPackagePaths = new Set<string>();
+
+    constructor(private _realFS: FileSystem) {}
+
+    existsSync(path: string): boolean {
+        if (this._partialStubPackagePaths.has(path)) {
+            // Pretend partial stub package directory doesn't exist.
+            // To be 100% correct, we need to check whether a file is under partial stub package path,
+            // but for now, this is enough to make import resolver to skip this folder.
+            return false;
+        }
+
+        return this._realFS.existsSync(this._getPath(path));
+    }
+
+    mkdirSync(path: string, options?: MkDirOptions | number): void {
+        this._realFS.mkdirSync(path, options);
+    }
+
+    chdir(path: string): void {
+        this._realFS.chdir(path);
+    }
+
+    readdirEntriesSync(path: string): fs.Dirent[] {
+        const entries = this._realFS.readdirEntriesSync(path);
+
+        const partialStubs = this._folderMap.get(ensureTrailingDirectorySeparator(path));
+        if (!partialStubs) {
+            return entries;
+        }
+
+        return entries.concat(partialStubs.map((f) => new FakeFile(f)));
+    }
+
+    readdirSync(path: string): string[] {
+        const entries = this._realFS.readdirSync(path);
+
+        const partialStubs = this._folderMap.get(ensureTrailingDirectorySeparator(path));
+        if (!partialStubs) {
+            return entries;
+        }
+
+        return entries.concat(partialStubs);
+    }
+
+    readFileSync(path: string, encoding?: null): Buffer;
+    readFileSync(path: string, encoding: BufferEncoding): string;
+    readFileSync(path: string, encoding?: BufferEncoding | null): string | Buffer {
+        return this._realFS.readFileSync(this._getPath(path), encoding);
+    }
+
+    writeFileSync(path: string, data: string | Buffer, encoding: BufferEncoding | null): void {
+        this._realFS.writeFileSync(this._getPath(path), data, encoding);
+    }
+
+    statSync(path: string): Stats {
+        return this._realFS.statSync(this._getPath(path));
+    }
+
+    unlinkSync(path: string): void {
+        this._realFS.unlinkSync(this._getPath(path));
+    }
+
+    realpathSync(path: string): string {
+        return this._realFS.realpathSync(path);
+    }
+
+    getModulePath(): string {
+        return this._realFS.getModulePath();
+    }
+
+    createFileSystemWatcher(paths: string[], listener: FileWatcherEventHandler): FileWatcher {
+        return this._realFS.createFileSystemWatcher(paths, listener);
+    }
+
+    createReadStream(path: string): fs.ReadStream {
+        return this._realFS.createReadStream(this._getPath(path));
+    }
+
+    createWriteStream(path: string): fs.WriteStream {
+        return this._realFS.createWriteStream(this._getPath(path));
+    }
+
+    copyFileSync(src: string, dst: string): void {
+        this._realFS.copyFileSync(this._getPath(src), this._getPath(dst));
+    }
+
+    // Async I/O
+    readFile(path: string): Promise<Buffer> {
+        return this._realFS.readFile(this._getPath(path));
+    }
+
+    readFileText(path: string, encoding?: BufferEncoding): Promise<string> {
+        return this._realFS.readFileText(this._getPath(path), encoding);
+    }
+
+    // The directory returned by tmpdir must exist and be the same each time tmpdir is called.
+    tmpdir(): string {
+        return this._realFS.tmpdir();
+    }
+
+    tmpfile(options?: TmpfileOptions): string {
+        return this._realFS.tmpfile(options);
+    }
+
+    isPartialStubPackagesScanned(execEnv: ExecutionEnvironment): boolean {
+        return this.isPathScanned(execEnv.root);
+    }
+
+    isPathScanned(path: string): boolean {
+        return this._rootSearched.has(path);
+    }
+
+    processPartialStubPackages(paths: string[], roots: string[]) {
+        for (const path of paths) {
+            this._rootSearched.add(path);
+
+            if (!this._realFS.existsSync(path)) {
+                continue;
+            }
+
+            for (const entry of this._realFS.readdirEntriesSync(path)) {
+                if (!entry.isDirectory() || !entry.name.endsWith(stubsSuffix)) {
+                    continue;
+                }
+
+                const partialStubPackagePath = combinePaths(path, entry.name);
+                const pyTypedInfo = getPyTypedInfo(this._realFS, partialStubPackagePath);
+                if (!pyTypedInfo || !pyTypedInfo.isPartiallyTyped) {
+                    // Stub-Package is fully typed.
+                    continue;
+                }
+
+                // We found partially typed stub-packages.
+                this._partialStubPackagePaths.add(partialStubPackagePath);
+
+                // 1. Search the root to see whether we have matching package installed.
+                let partialStubs: string[] | undefined;
+                const packageName = entry.name.substr(0, entry.name.length - stubsSuffix.length);
+                for (const root of roots) {
+                    const packagePath = combinePaths(root, packageName);
+                    try {
+                        const stat = this._realFS.statSync(packagePath);
+                        if (!stat.isDirectory()) {
+                            continue;
+                        }
+
+                        // 2. Check py.typed of the package.
+                        const packagePyTyped = getPyTypedInfo(this._realFS, packagePath);
+                        if (packagePyTyped && !packagePyTyped.isPartiallyTyped) {
+                            // We have fully typed package.
+                            continue;
+                        }
+
+                        // 3. Merge partial stub packages to the library (py.typed not exist or partially typed).
+                        partialStubs = partialStubs ?? this._getRelativePathPartialStubs(partialStubPackagePath);
+                        for (const partialStub of partialStubs) {
+                            const pyiFile = combinePaths(packagePath, partialStub);
+                            if (this.existsSync(pyiFile)) {
+                                // Found existing pyi file, skip.
+                                continue;
+                            }
+
+                            this._pathMap.set(pyiFile, combinePaths(partialStubPackagePath, partialStub));
+
+                            const directory = ensureTrailingDirectorySeparator(getDirectoryPath(pyiFile));
+                            getOrAdd(this._folderMap, directory, () => []).push(getFileName(pyiFile));
+                        }
+                    } catch {
+                        // ignore
+                    }
+                }
+            }
+        }
+    }
+
+    isVirtual(filepath: string): boolean {
+        return this._pathMap.has(filepath);
+    }
+
+    clearPartialStubs(): void {
+        this._pathMap.clear();
+        this._folderMap.clear();
+
+        this._rootSearched.clear();
+        this._partialStubPackagePaths.clear();
+    }
+
+    private _getPath(path: string) {
+        return this._pathMap.get(path) ?? path;
+    }
+
+    private _getRelativePathPartialStubs(path: string) {
+        const paths: string[] = [];
+
+        const partialStubPathLength = ensureTrailingDirectorySeparator(path).length;
+        const searchAllStubs = (path: string) => {
+            for (const entry of this._realFS.readdirEntriesSync(path)) {
+                if (entry.isDirectory()) {
+                    searchAllStubs(combinePaths(path, entry.name));
+                }
+
+                if (entry.isFile() && entry.name.endsWith('.pyi')) {
+                    const stubFile = combinePaths(path, entry.name);
+                    const relative = stubFile.substring(partialStubPathLength);
+                    if (relative) {
+                        paths.push(relative);
+                    }
+                }
+            }
+        };
+
+        searchAllStubs(path);
+        return paths;
+    }
+}
+
+class FakeFile extends fs.Dirent {
+    constructor(public name: string) {
+        super();
+    }
+
+    isFile(): boolean {
+        return true;
+    }
+
+    isDirectory(): boolean {
+        return false;
+    }
+
+    isBlockDevice(): boolean {
+        return false;
+    }
+
+    isCharacterDevice(): boolean {
+        return false;
+    }
+
+    isSymbolicLink(): boolean {
+        return false;
+    }
+
+    isFIFO(): boolean {
+        return false;
+    }
+
+    isSocket(): boolean {
+        return false;
+    }
+}
+
+function getOrAdd<K, V>(map: Map<K, V>, key: K, newValueFactory: () => V): V {
+    const value = map.get(key);
+    if (value !== undefined) {
+        return value;
+    }
+
+    const newValue = newValueFactory();
+    map.set(key, newValue);
+
+    return newValue;
+}

--- a/packages/pyright-internal/src/tests/fourslash/completions.inherited.overload.docFromScrWithStub.fourslash.ts
+++ b/packages/pyright-internal/src/tests/fourslash/completions.inherited.overload.docFromScrWithStub.fourslash.ts
@@ -1,0 +1,52 @@
+/// <reference path="fourslash.ts" />
+
+// @filename: overloads_client.py
+//// from typing import overload
+//// import moduleA
+////
+//// class ChildA(moduleA.A):
+////     @overload
+////     def func(self, x: str) -> str:
+////         pass
+////
+////     @overload
+////     def func(self, x: int) -> int:
+////         pass
+////
+////
+//// ChildA.f[|/*marker1*/|]
+
+// @filename: typings/moduleA.pyi
+//// from typing import overload
+//// class A:
+////     @overload
+////     def func(self, x: str) -> str: ...
+////
+////     @overload
+////     def func(self, x: int) -> int: ...
+
+// @filename: typings/moduleA.py
+//// from typing import overload
+//// class A:
+////     @overload
+////     def func(self, x: str) -> str:
+////         pass
+////
+////     @overload
+////     def func(self, x: int) -> int:
+////         '''func docs'''
+////         pass
+
+// @ts-ignore
+await helper.verifyCompletion('included', 'markdown', {
+    marker1: {
+        completions: [
+            {
+                label: 'func',
+                kind: Consts.CompletionItemKind.Method,
+                documentation:
+                    '```python\nfunc(self: ChildA, x: str) -> str\nfunc(self: ChildA, x: int) -> int\n```\n---\nfunc docs',
+            },
+        ],
+    },
+});

--- a/packages/pyright-internal/src/tests/fourslash/completions.inherited.overload.docFromStub.fourslash.ts
+++ b/packages/pyright-internal/src/tests/fourslash/completions.inherited.overload.docFromStub.fourslash.ts
@@ -1,0 +1,53 @@
+/// <reference path="fourslash.ts" />
+
+// @filename: overloads_client.py
+//// from typing import overload
+//// import moduleA
+////
+//// class ChildA(moduleA.A):
+////     @overload
+////     def func(self, x: str) -> str:
+////         pass
+////
+////     @overload
+////     def func(self, x: int) -> int:
+////         pass
+////
+////
+//// ChildA.f[|/*marker1*/|]
+
+// @filename: typings/moduleA.pyi
+//// from typing import overload
+//// class A:
+////     @overload
+////     def func(self, x: str) -> str: ...
+////
+////     @overload
+////     def func(self, x: int) -> int:
+////         '''func docs'''
+////         ...
+
+// @filename: typings/moduleA.py
+//// from typing import overload
+//// class A:
+////     @overload
+////     def func(self, x: str) -> str:
+////         pass
+////
+////     @overload
+////     def func(self, x: int) -> int:
+////         pass
+
+// @ts-ignore
+await helper.verifyCompletion('included', 'markdown', {
+    marker1: {
+        completions: [
+            {
+                label: 'func',
+                kind: Consts.CompletionItemKind.Method,
+                documentation:
+                    '```python\nfunc(self: ChildA, x: str) -> str\nfunc(self: ChildA, x: int) -> int\n```\n---\nfunc docs',
+            },
+        ],
+    },
+});

--- a/packages/pyright-internal/src/tests/fourslash/completions.inherited.property.docFromSrc.fourslash.ts
+++ b/packages/pyright-internal/src/tests/fourslash/completions.inherited.property.docFromSrc.fourslash.ts
@@ -1,0 +1,104 @@
+/// <reference path="fourslash.ts" />
+
+// @filename: mspythonconfig.json
+//// {
+////   "useLibraryCodeForTypes": true
+//// }
+
+// @filename: test.py
+//// import testLib
+//// class ChildGetterDocs(testLib.ClassWithGetterDocs):
+////     def __init__(self, length):
+////         self._length = length
+////
+////     @property
+////     def length(self):
+////         return self._length
+////
+////     @length.setter
+////     def length(self, value):
+////         pass
+////
+//// class ChildSetterDocs(testLib.ClassWithSetterDocs):
+////     def __init__(self, length):
+////         self._length = length
+////
+////     @property
+////     def length(self):
+////         return self._length
+////
+////     @length.setter
+////     def length(self, value):
+////         pass
+////
+//// one = ChildGetterDocs(3)
+//// one.lengt[|/*marker1*/|]
+//// two = ChildSetterDocs(3)
+//// two.lengt[|/*marker2*/|]
+
+// @filename: testLib/__init__.py
+//// class ClassWithGetterDocs(object):
+////     def __init__(self, length):
+////         self._length = length
+////
+////     @property
+////     def length(self):
+////         """
+////         read property doc
+////         """
+////         return self._length
+////
+////     @length.setter
+////     def length(self, value):
+////         pass
+////
+//// class ClassWithSetterDocs(object):
+////     def __init__(self, length):
+////         self._length = length
+////
+////     @property
+////     def length(self):
+////         return self._length
+////
+////     @length.setter
+////     def length(self, value):
+////         """
+////         setter property doc
+////         """
+////         pass
+////
+
+// @filename: testLib/__init__.pyi
+//// class ClassWithGetterDocs(object):
+////     @property
+////     def length(self) -> int: ...
+////     @length.setter
+////     def length(self, value) -> None: ...
+////
+//// class ClassWithSetterDocs(object):
+////     @property
+////     def length(self) -> int: ...
+////     @length.setter
+////     def length(self, value) -> None: ...
+
+// @ts-ignore
+await helper.verifyCompletion('included', 'markdown', {
+    marker1: {
+        completions: [
+            {
+                label: 'length',
+                kind: Consts.CompletionItemKind.Property,
+                documentation: '```python\nlength: Unknown (property)\n```\n---\nread property doc',
+            },
+        ],
+    },
+    marker2: {
+        completions: [
+            {
+                label: 'length',
+                kind: Consts.CompletionItemKind.Property,
+                documentation: '```python\nlength: Unknown (property)\n```\n---\nsetter property doc',
+            },
+        ],
+    },
+});

--- a/packages/pyright-internal/src/tests/fourslash/completions.inherited.property.docFromStub.fourslash.ts
+++ b/packages/pyright-internal/src/tests/fourslash/completions.inherited.property.docFromStub.fourslash.ts
@@ -1,0 +1,108 @@
+/// <reference path="fourslash.ts" />
+
+// @filename: mspythonconfig.json
+//// {
+////   "useLibraryCodeForTypes": true
+//// }
+
+// @filename: test.py
+//// import testLib
+//// class ChildGetterDocs(testLib.ClassWithGetterDocs):
+////     def __init__(self, length):
+////         self._length = length
+////
+////     @property
+////     def length(self):
+////         return self._length
+////
+////     @length.setter
+////     def length(self, value):
+////         pass
+////
+//// class ChildSetterDocs(testLib.ClassWithSetterDocs):
+////     def __init__(self, length):
+////         self._length = length
+////
+////     @property
+////     def length(self):
+////         return self._length
+////
+////     @length.setter
+////     def length(self, value):
+////         pass
+////
+//// one = ChildGetterDocs(3)
+//// one.lengt[|/*marker1*/|]
+//// two = ChildSetterDocs(3)
+//// two.lengt[|/*marker2*/|]
+
+// @filename: testLib/__init__.py
+// @library: true
+//// class ClassWithGetterDocs(object):
+////     def __init__(self, length):
+////         self._length = length
+////
+////     @property
+////     def length(self):
+////         return self._length
+////
+////     @length.setter
+////     def length(self, value):
+////         pass
+////
+//// class ClassWithSetterDocs(object):
+////     def __init__(self, length):
+////         self._length = length
+////
+////     @property
+////     def length(self):
+////         return self._length
+////
+////     @length.setter
+////     def length(self, value):
+////         pass
+////
+
+// @filename: testLib/__init__.pyi
+// @library: true
+//// class ClassWithGetterDocs(object):
+////     @property
+////     def length(self) -> int:
+////         """
+////         read property doc
+////         """
+////         ...
+////     @length.setter
+////     def length(self, value) -> None: ...
+////
+//// class ClassWithSetterDocs(object):
+////     @property
+////     def length(self) -> int: ...
+////     @length.setter
+////     def length(self, value) -> None:
+////         """
+////         setter property doc
+////         """
+////         ...
+
+// @ts-ignore
+await helper.verifyCompletion('included', 'markdown', {
+    marker1: {
+        completions: [
+            {
+                label: 'length',
+                kind: Consts.CompletionItemKind.Property,
+                documentation: '```python\nlength: Unknown (property)\n```\n---\nread property doc',
+            },
+        ],
+    },
+    marker2: {
+        completions: [
+            {
+                label: 'length',
+                kind: Consts.CompletionItemKind.Property,
+                documentation: '```python\nlength: Unknown (property)\n```\n---\nsetter property doc',
+            },
+        ],
+    },
+});

--- a/packages/pyright-internal/src/tests/fourslash/hover.inherited.docFromSrc.fourslash.ts
+++ b/packages/pyright-internal/src/tests/fourslash/hover.inherited.docFromSrc.fourslash.ts
@@ -1,0 +1,63 @@
+/// <reference path="fourslash.ts" />
+
+// @filename: module1.py
+//// '''module1 docs'''
+////
+//// def func1():
+////     '''func1 docs'''
+////     return True
+////
+//// class A:
+////     '''A docs'''
+////     def method1(self) -> bool:
+////         '''A.method1 docs'''
+////         return True
+////
+//// class B:
+////     '''B docs'''
+////     def __init__(self):
+////         '''B init docs'''
+////         pass
+
+// @filename: testBasicInheritance.py
+//// import module1
+////
+//// class ChildA(module1.A):
+////     def method1(self) -> bool:
+////         return True
+////
+//// class ChildB(module1.B):
+////     def __init__(self):
+////         pass
+////
+//// childA =[|/*child_a_docs*/ChildA|]()
+//// childA.[|/*child_a_method1_docs*/method1|]()
+////
+//// childB =[|/*child_b_docs*/ChildB|]()
+//// childB.[|/*child_b_init_docs*/__init__|]()
+
+// @filename: testMultiLevelInheritance.py
+//// class Base:
+////     """Base docs"""
+////     def method(self):
+////         """Base.method docs"""
+////
+//// class Derived1(Base):
+////     def method(self):
+////         pass
+////
+//// class Derived2(Derived1):
+////     def method(self):
+////         pass
+////
+//// d2 = [|/*secondDerived_docs*/Derived2|]()
+//// d2.[|/*secondDerived_method_docs*/method|]()
+
+helper.verifyHover('markdown', {
+    child_a_method1_docs: '```python\n(method) method1: () -> bool\n```\nA.method1 docs',
+    child_a_docs: '```python\n(class) ChildA\n```\n',
+    child_b_docs: '```python\n(class) ChildB()\n```\nB init docs',
+    child_b_init_docs: '```python\n(method) __init__: () -> None\n```\nB init docs',
+    secondDerived_docs: '```python\n(class) Derived2\n```\n',
+    secondDerived_method_docs: '```python\n(method) method: () -> None\n```\nBase.method docs',
+});

--- a/packages/pyright-internal/src/tests/fourslash/hover.inherited.docFromSrcWithStub.fourslash.ts
+++ b/packages/pyright-internal/src/tests/fourslash/hover.inherited.docFromSrcWithStub.fourslash.ts
@@ -1,0 +1,54 @@
+/// <reference path="fourslash.ts" />
+
+// @filename: module1.py
+//// class A:
+////     '''A docs'''
+////     def method1(self):
+////         '''A.method1 docs'''
+////         return True
+////     class Inner:
+////         '''A.Inner docs'''
+////         def method1(self):
+////             '''A.Inner.method1 docs'''
+////             return True
+////
+//// class NoFields:
+////     '''NoFields docs'''
+
+// @filename: module1.pyi
+//// class A:
+////     def method1(self) -> bool:...
+////     class Inner:
+////         def method1(self) -> bool: ...
+////
+//// class NoFields:...
+
+// @filename: testInheritedDocsInSource.py
+//// import module1
+//// class ChildA(module1.A):
+////     def method1(self) -> bool:
+////         return True
+////     class ChildInner(module1.A.Inner):
+////         def method1(self) -> bool:
+////            return True
+////
+//// childA =[|/*child_a_docs*/ChildA|]()
+//// childA.[|/*child_a_method1_docs*/method1|]()
+////
+//// inner =ChildA.[|/*child_a_inner_docs*/ChildInner|]()
+//// inner.[|/*child_a_inner_method1_docs*/method1|]()
+
+// @filename: testInheritedClassNoFieldsDocsInSource.py
+//// import module1
+//// class ChildB(module1.NoFields):
+////     pass
+////
+//// childB =[|/*child_b_docs*/ChildB|]()
+
+helper.verifyHover('markdown', {
+    child_a_method1_docs: '```python\n(method) method1: () -> bool\n```\nA.method1 docs',
+    child_a_docs: '```python\n(class) ChildA\n```\n',
+    child_a_inner_docs: '```python\n(class) ChildInner\n```\n',
+    child_a_inner_method1_docs: '```python\n(method) method1: () -> bool\n```\nA.Inner.method1 docs',
+    child_b_docs: '```python\n(class) ChildB\n```\n',
+});

--- a/packages/pyright-internal/src/tests/fourslash/hover.inherited.docFromStub.fourslash.ts
+++ b/packages/pyright-internal/src/tests/fourslash/hover.inherited.docFromStub.fourslash.ts
@@ -1,0 +1,42 @@
+/// <reference path="fourslash.ts" />
+
+// @filename: module1.py
+//// class A:
+////     def method1(self) -> bool:
+////         return True
+////     class Inner:
+////         def method1(self):
+////             return True
+
+// @filename: module1.pyi
+//// class A:
+////     '''A docs'''
+////     def method1(self) -> bool:
+////         '''A.method1 docs'''
+////         ...
+////     class Inner:
+////         '''A.Inner docs'''
+////         def method1(self) -> bool:
+////             '''A.Inner.method1 docs'''
+////             ...
+
+// @filename: testInheritedDocsInStubs.py
+//// import module1
+//// class ChildA(module1.A):
+////     def method1(self) -> bool:
+////         return True
+////     class ChildInner(module1.A.Inner):
+////         def method1(self) -> bool:
+////            return True
+////
+//// childA =[|/*child_a_docs*/ChildA|]()
+//// childA.[|/*child_a_method1_docs*/method1|]()
+//// inner =ChildA.[|/*child_a_inner_docs*/ChildInner|]()
+//// inner.[|/*child_a_inner_method1_docs*/method1|]()
+
+helper.verifyHover('markdown', {
+    child_a_method1_docs: '```python\n(method) method1: () -> bool\n```\nA.method1 docs',
+    child_a_docs: '```python\n(class) ChildA\n```\n',
+    child_a_inner_docs: '```python\n(class) ChildInner\n```\n',
+    child_a_inner_method1_docs: '```python\n(method) method1: () -> bool\n```\nA.Inner.method1 docs',
+});

--- a/packages/pyright-internal/src/tests/fourslash/hover.inherited.overload.docFromSrcWithStub.fourslash.ts
+++ b/packages/pyright-internal/src/tests/fourslash/hover.inherited.overload.docFromSrcWithStub.fourslash.ts
@@ -1,0 +1,46 @@
+/// <reference path="fourslash.ts" />
+
+// @filename: overloads_client.py
+//// from typing import overload
+//// import moduleA
+////
+//// class ChildA(moduleA.A):
+////     @overload
+////     def func(self, x: str) -> str:
+////         pass
+////
+////     @overload
+////     def func(self, x: int) -> int:
+////         pass
+////
+////
+//// ChildA.[|/*child_a_func_doc*/func|]
+//// a = ChildA()
+//// a.[|/*child_a_instance_func_doc*/func|]
+
+// @filename: typings/moduleA.pyi
+//// from typing import overload
+//// class A:
+////     @overload
+////     def func(self, x: str) -> str: ...
+////
+////     @overload
+////     def func(self, x: int) -> int: ...
+
+// @filename: typings/moduleA.py
+//// from typing import overload
+//// class A:
+////     @overload
+////     def func(self, x: str) -> str:
+////         pass
+////
+////     @overload
+////     def func(self, x: int) -> int:
+////         '''func docs'''
+////         pass
+
+helper.verifyHover('markdown', {
+    child_a_func_doc:
+        '```python\n(method) func: Overload[(self: ChildA, x: str) -> str, (self: ChildA, x: int) -> int]\n```\nfunc docs',
+    child_a_instance_func_doc: '```python\n(method) func: Overload[(x: str) -> str, (x: int) -> int]\n```\nfunc docs',
+});

--- a/packages/pyright-internal/src/tests/fourslash/hover.inherited.overload.docFromStub.fourslash.ts
+++ b/packages/pyright-internal/src/tests/fourslash/hover.inherited.overload.docFromStub.fourslash.ts
@@ -1,0 +1,47 @@
+/// <reference path="fourslash.ts" />
+
+// @filename: overloads_client.py
+//// from typing import overload
+//// import moduleA
+////
+//// class ChildA(moduleA.A):
+////     @overload
+////     def func(self, x: str) -> str:
+////         pass
+////
+////     @overload
+////     def func(self, x: int) -> int:
+////         pass
+////
+////
+//// ChildA.[|/*child_a_func_doc*/func|]
+//// a = ChildA()
+//// a.[|/*child_a_instance_func_doc*/func|]
+
+// @filename: typings/moduleA.pyi
+//// from typing import overload
+//// class A:
+////     @overload
+////     def func(self, x: str) -> str: ...
+////
+////     @overload
+////     def func(self, x: int) -> int:
+////         '''func docs'''
+////         ...
+
+// @filename: typings/moduleA.py
+//// from typing import overload
+//// class A:
+////     @overload
+////     def func(self, x: str) -> str:
+////         pass
+////
+////     @overload
+////     def func(self, x: int) -> int:
+////         pass
+
+helper.verifyHover('markdown', {
+    child_a_func_doc:
+        '```python\n(method) func: Overload[(self: ChildA, x: str) -> str, (self: ChildA, x: int) -> int]\n```\nfunc docs',
+    child_a_instance_func_doc: '```python\n(method) func: Overload[(x: str) -> str, (x: int) -> int]\n```\nfunc docs',
+});

--- a/packages/pyright-internal/src/tests/fourslash/hover.inherited.property.docFromSrcWithStub.fourslash.ts
+++ b/packages/pyright-internal/src/tests/fourslash/hover.inherited.property.docFromSrcWithStub.fourslash.ts
@@ -1,0 +1,87 @@
+/// <reference path="fourslash.ts" />
+
+// @filename: mspythonconfig.json
+//// {
+////   "useLibraryCodeForTypes": true
+//// }
+
+// @filename: test.py
+//// import testLib
+//// class ChildGetterDocs(testLib.ClassWithGetterDocs):
+////     def __init__(self, length):
+////         self._length = length
+////
+////     @property
+////     def length(self):
+////         return self._length
+////
+////     @length.setter
+////     def length(self, value):
+////         pass
+////
+//// class ChildSetterDocs(testLib.ClassWithSetterDocs):
+////     def __init__(self, length):
+////         self._length = length
+////
+////     @property
+////     def length(self):
+////         return self._length
+////
+////     @length.setter
+////     def length(self, value):
+////         pass
+////
+//// one = ChildGetterDocs(3)
+//// one.[|/*getter_docs*/length|]
+//// two = ChildSetterDocs(3)
+//// two.[|/*setter_docs*/length|]
+
+// @filename: testLib/__init__.py
+//// class ClassWithGetterDocs(object):
+////     def __init__(self, length):
+////         self._length = length
+////
+////     @property
+////     def length(self):
+////         """
+////         read property doc
+////         """
+////         return self._length
+////
+////     @length.setter
+////     def length(self, value):
+////         pass
+////
+//// class ClassWithSetterDocs(object):
+////     def __init__(self, length):
+////         self._length = length
+////
+////     @property
+////     def length(self):
+////         return self._length
+////
+////     @length.setter
+////     def length(self, value):
+////         """
+////         setter property doc
+////         """
+////         pass
+////
+
+// @filename: testLib/__init__.pyi
+//// class ClassWithGetterDocs(object):
+////     @property
+////     def length(self) -> int: ...
+////     @length.setter
+////     def length(self, value) -> None: ...
+////
+//// class ClassWithSetterDocs(object):
+////     @property
+////     def length(self) -> int: ...
+////     @length.setter
+////     def length(self, value) -> None: ...
+
+helper.verifyHover('markdown', {
+    getter_docs: '```python\n(property) length: Literal[3]\n```\nread property doc',
+    setter_docs: '```python\n(property) length: Literal[3]\n```\nsetter property doc',
+});

--- a/packages/pyright-internal/src/tests/fourslash/hover.inherited.property.docFromStub.fourslash.ts
+++ b/packages/pyright-internal/src/tests/fourslash/hover.inherited.property.docFromStub.fourslash.ts
@@ -1,0 +1,91 @@
+/// <reference path="fourslash.ts" />
+
+// @filename: mspythonconfig.json
+//// {
+////   "useLibraryCodeForTypes": true
+//// }
+
+// @filename: test.py
+//// import testLib
+//// class ChildGetterDocs(testLib.ClassWithGetterDocs):
+////     def __init__(self, length):
+////         self._length = length
+////
+////     @property
+////     def length(self):
+////         return self._length
+////
+////     @length.setter
+////     def length(self, value):
+////         pass
+////
+//// class ChildSetterDocs(testLib.ClassWithSetterDocs):
+////     def __init__(self, length):
+////         self._length = length
+////
+////     @property
+////     def length(self):
+////         return self._length
+////
+////     @length.setter
+////     def length(self, value):
+////         pass
+////
+//// one = ChildGetterDocs(3)
+//// one.[|/*getter_docs*/length|]
+//// two = ChildSetterDocs(3)
+//// two.[|/*setter_docs*/length|]
+
+// @filename: testLib/__init__.py
+// @library: true
+//// class ClassWithGetterDocs(object):
+////     def __init__(self, length):
+////         self._length = length
+////
+////     @property
+////     def length(self):
+////         return self._length
+////
+////     @length.setter
+////     def length(self, value):
+////         pass
+////
+//// class ClassWithSetterDocs(object):
+////     def __init__(self, length):
+////         self._length = length
+////
+////     @property
+////     def length(self):
+////         return self._length
+////
+////     @length.setter
+////     def length(self, value):
+////         pass
+////
+
+// @filename: testLib/__init__.pyi
+// @library: true
+//// class ClassWithGetterDocs(object):
+////     @property
+////     def length(self) -> int:
+////         """
+////         read property doc
+////         """
+////         ...
+////     @length.setter
+////     def length(self, value) -> None: ...
+////
+//// class ClassWithSetterDocs(object):
+////     @property
+////     def length(self) -> int: ...
+////     @length.setter
+////     def length(self, value) -> None:
+////         """
+////         setter property doc
+////         """
+////         ...
+
+helper.verifyHover('markdown', {
+    getter_docs: '```python\n(property) length: Literal[3]\n```\nread property doc',
+    setter_docs: '```python\n(property) length: Literal[3]\n```\nsetter property doc',
+});

--- a/packages/pyright-internal/src/tests/importResolver.test.ts
+++ b/packages/pyright-internal/src/tests/importResolver.test.ts
@@ -1,0 +1,345 @@
+/*
+ * importResolver.test.ts
+ *
+ * importResolver tests.
+ */
+
+import assert from 'assert';
+
+import { ImportResolver } from '../analyzer/importResolver';
+import { ConfigOptions } from '../common/configOptions';
+import { lib, sitePackages, typeshedFallback } from '../common/pathConsts';
+import { combinePaths, getDirectoryPath, normalizeSlashes } from '../common/pathUtils';
+import { PyrightFileSystem } from '../pyrightFileSystem';
+import { TestFileSystem } from './harness/vfs/filesystem';
+
+const libraryRoot = combinePaths(normalizeSlashes('/'), lib, sitePackages);
+
+test('partial stub file exists', () => {
+    const files = [
+        {
+            path: combinePaths(libraryRoot, 'myLib-stubs', 'partialStub.pyi'),
+            content: 'def test(): ...',
+        },
+        {
+            path: combinePaths(libraryRoot, 'myLib-stubs', 'py.typed'),
+            content: 'partial\n',
+        },
+        {
+            path: combinePaths(libraryRoot, 'myLib', 'partialStub.py'),
+            content: 'def test(): pass',
+        },
+    ];
+
+    const importResult = getImportResult(files, ['myLib', 'partialStub']);
+    assert(importResult.isImportFound);
+    assert(importResult.isStubFile);
+    assert.strictEqual(
+        1,
+        importResult.resolvedPaths.filter((f) => f === combinePaths(libraryRoot, 'myLib', 'partialStub.pyi')).length
+    );
+});
+
+test('partial stub __init__ exists', () => {
+    const files = [
+        {
+            path: combinePaths(libraryRoot, 'myLib-stubs', '__init__.pyi'),
+            content: 'def test(): ...',
+        },
+        {
+            path: combinePaths(libraryRoot, 'myLib-stubs', 'py.typed'),
+            content: 'partial\n',
+        },
+        {
+            path: combinePaths(libraryRoot, 'myLib', '__init__.py'),
+            content: 'def test(): pass',
+        },
+    ];
+
+    const importResult = getImportResult(files, ['myLib']);
+    assert(importResult.isImportFound);
+    assert(importResult.isStubFile);
+    assert.strictEqual(
+        1,
+        importResult.resolvedPaths.filter((f) => f === combinePaths(libraryRoot, 'myLib', '__init__.pyi')).length
+    );
+});
+
+test('side by side files', () => {
+    const myFile = combinePaths('src', 'file.py');
+    const files = [
+        {
+            path: combinePaths(libraryRoot, 'myLib-stubs', 'partialStub.pyi'),
+            content: 'def test(): ...',
+        },
+        {
+            path: combinePaths(libraryRoot, 'myLib-stubs', 'py.typed'),
+            content: 'partial\n',
+        },
+        {
+            path: combinePaths(libraryRoot, 'myLib', 'partialStub.pyi'),
+            content: '# empty',
+        },
+        {
+            path: combinePaths(libraryRoot, 'myLib', 'partialStub.py'),
+            content: 'def test(): pass',
+        },
+        {
+            path: combinePaths(libraryRoot, 'myLib-stubs', 'partialStub2.pyi'),
+            content: 'def test(): ...',
+        },
+        {
+            path: combinePaths(libraryRoot, 'myLib', 'partialStub2.py'),
+            content: 'def test(): pass',
+        },
+        {
+            path: myFile,
+            content: '# not used',
+        },
+    ];
+
+    const fs = createFileSystem(files);
+    const configOptions = getConfigOption(fs);
+    const importResolver = new ImportResolver(fs, configOptions);
+
+    // Real side by side stub file win over virtual one.
+    const sideBySideResult = importResolver.resolveImport(myFile, configOptions.findExecEnvironment(myFile), {
+        leadingDots: 0,
+        nameParts: ['myLib', 'partialStub'],
+        importedSymbols: [],
+    });
+
+    assert(sideBySideResult.isImportFound);
+    assert(sideBySideResult.isStubFile);
+
+    const sideBySideStubFile = combinePaths(libraryRoot, 'myLib', 'partialStub.pyi');
+    assert.strictEqual(1, sideBySideResult.resolvedPaths.filter((f) => f === sideBySideStubFile).length);
+    assert.strictEqual('# empty', fs.readFileSync(sideBySideStubFile, 'utf8'));
+
+    // Side by side stub doesn't completely disable partial stub.
+    const partialStubResult = importResolver.resolveImport(myFile, configOptions.findExecEnvironment(myFile), {
+        leadingDots: 0,
+        nameParts: ['myLib', 'partialStub2'],
+        importedSymbols: [],
+    });
+
+    assert(partialStubResult.isImportFound);
+    assert(partialStubResult.isStubFile);
+
+    const partialStubFile = combinePaths(libraryRoot, 'myLib', 'partialStub2.pyi');
+    assert.strictEqual(1, partialStubResult.resolvedPaths.filter((f) => f === partialStubFile).length);
+});
+
+test('stub package', () => {
+    const files = [
+        {
+            path: combinePaths(libraryRoot, 'myLib-stubs', 'stub.pyi'),
+            content: '# empty',
+        },
+        {
+            path: combinePaths(libraryRoot, 'myLib', 'partialStub.py'),
+            content: 'def test(): pass',
+        },
+    ];
+
+    // If fully typed stub package exists, that wins over the real package.
+    const importResult = getImportResult(files, ['myLib', 'partialStub']);
+    assert(!importResult.isImportFound);
+});
+
+test('stub in typing folder over partial stub package', () => {
+    const typingFolder = combinePaths(normalizeSlashes('/'), 'typing');
+    const files = [
+        {
+            path: combinePaths(libraryRoot, 'myLib-stubs', '__init__.pyi'),
+            content: 'def test(): ...',
+        },
+        {
+            path: combinePaths(libraryRoot, 'myLib-stubs', 'py.typed'),
+            content: 'partial\n',
+        },
+        {
+            path: combinePaths(typingFolder, 'myLib.pyi'),
+            content: '# empty',
+        },
+        {
+            path: combinePaths(libraryRoot, 'myLib', '__init__.py'),
+            content: 'def test(): pass',
+        },
+    ];
+
+    // If the package exists in typing folder, that gets picked up first.
+    const importResult = getImportResult(files, ['myLib'], (c) => (c.stubPath = typingFolder));
+    assert(importResult.isImportFound);
+    assert(importResult.isStubFile);
+    assert.strictEqual(
+        0,
+        importResult.resolvedPaths.filter((f) => f === combinePaths(libraryRoot, 'myLib', '__init__.pyi')).length
+    );
+});
+
+test('partial stub package in typing folder', () => {
+    const typingFolder = combinePaths(normalizeSlashes('/'), 'typing');
+    const files = [
+        {
+            path: combinePaths(typingFolder, 'myLib-stubs', '__init__.pyi'),
+            content: 'def test(): ...',
+        },
+        {
+            path: combinePaths(typingFolder, 'myLib-stubs', 'py.typed'),
+            content: 'partial\n',
+        },
+        {
+            path: combinePaths(libraryRoot, 'myLib', '__init__.py'),
+            content: 'def test(): pass',
+        },
+    ];
+
+    const importResult = getImportResult(files, ['myLib'], (c) => (c.stubPath = typingFolder));
+    assert(importResult.isImportFound);
+    assert(importResult.isStubFile);
+    assert.strictEqual(
+        1,
+        importResult.resolvedPaths.filter((f) => f === combinePaths(libraryRoot, 'myLib', '__init__.pyi')).length
+    );
+});
+
+test('typeshed folder', () => {
+    const typeshedFolder = combinePaths(normalizeSlashes('/'), 'ts');
+    const files = [
+        {
+            path: combinePaths(libraryRoot, 'myLib-stubs', '__init__.pyi'),
+            content: 'def test(): ...',
+        },
+        {
+            path: combinePaths(libraryRoot, 'myLib-stubs', 'py.typed'),
+            content: 'partial\n',
+        },
+        {
+            path: combinePaths(typeshedFolder, 'stubs', 'myLibPackage', 'myLib.pyi'),
+            content: '# empty',
+        },
+        {
+            path: combinePaths(libraryRoot, 'myLib', '__init__.py'),
+            content: 'def test(): pass',
+        },
+    ];
+
+    // Stub packages win over typeshed.
+    const importResult = getImportResult(files, ['myLib'], (c) => (c.typeshedPath = typeshedFolder));
+    assert(importResult.isImportFound);
+    assert(importResult.isStubFile);
+    assert.strictEqual(
+        1,
+        importResult.resolvedPaths.filter((f) => f === combinePaths(libraryRoot, 'myLib', '__init__.pyi')).length
+    );
+});
+
+test('typeshed fallback folder', () => {
+    const files = [
+        {
+            path: combinePaths(libraryRoot, 'myLib-stubs', '__init__.pyi'),
+            content: 'def test(): ...',
+        },
+        {
+            path: combinePaths(libraryRoot, 'myLib-stubs', 'py.typed'),
+            content: 'partial\n',
+        },
+        {
+            path: combinePaths(typeshedFallback, 'stubs', 'myLibPackage', 'myLib.pyi'),
+            content: '# empty',
+        },
+        {
+            path: combinePaths(libraryRoot, 'myLib', '__init__.py'),
+            content: 'def test(): pass',
+        },
+    ];
+
+    // Stub packages win over typeshed.
+    const importResult = getImportResult(files, ['myLib']);
+    assert(importResult.isImportFound);
+    assert(importResult.isStubFile);
+    assert.strictEqual(
+        1,
+        importResult.resolvedPaths.filter((f) => f === combinePaths(libraryRoot, 'myLib', '__init__.pyi')).length
+    );
+});
+
+test('py.typed file', () => {
+    const files = [
+        {
+            path: combinePaths(libraryRoot, 'myLib-stubs', '__init__.pyi'),
+            content: 'def test(): ...',
+        },
+        {
+            path: combinePaths(libraryRoot, 'myLib-stubs', 'py.typed'),
+            content: 'partial\n',
+        },
+        {
+            path: combinePaths(libraryRoot, 'myLib', '__init__.py'),
+            content: 'def test(): pass',
+        },
+        {
+            path: combinePaths(libraryRoot, 'myLib', 'py.typed'),
+            content: '# typed',
+        },
+    ];
+
+    // If py.typed file exists, then partial stub is disabled for this library.
+    const importResult = getImportResult(files, ['myLib']);
+    assert(importResult.isImportFound);
+    assert(!importResult.isStubFile);
+});
+
+function getImportResult(
+    files: { path: string; content: string }[],
+    nameParts: string[],
+    setup?: (c: ConfigOptions) => void
+) {
+    setup =
+        setup ??
+        ((c) => {
+            /* empty */
+        });
+
+    const file = combinePaths('src', 'file.py');
+    files.push({
+        path: file,
+        content: '# not used',
+    });
+
+    const fs = createFileSystem(files);
+    const configOptions = getConfigOption(fs);
+    setup(configOptions);
+
+    const importResolver = new ImportResolver(fs, configOptions);
+    const importResult = importResolver.resolveImport(file, configOptions.findExecEnvironment(file), {
+        leadingDots: 0,
+        nameParts: nameParts,
+        importedSymbols: [],
+    });
+
+    return importResult;
+}
+
+function getConfigOption(fs: PyrightFileSystem) {
+    const configOptions = new ConfigOptions(normalizeSlashes('/'));
+    configOptions.venvPath = fs.getModulePath();
+    configOptions.defaultVenv = fs.getModulePath();
+
+    return configOptions;
+}
+
+function createFileSystem(files: { path: string; content: string }[]): PyrightFileSystem {
+    const fs = new TestFileSystem(/* ignoreCase */ false, { cwd: normalizeSlashes('/') });
+
+    for (const file of files) {
+        const path = normalizeSlashes(file.path);
+        const dir = getDirectoryPath(path);
+        fs.mkdirpSync(dir);
+
+        fs.writeFileSync(path, file.content);
+    }
+
+    return new PyrightFileSystem(fs);
+}

--- a/packages/pyright-internal/src/tests/pyrightFileSystem.test.ts
+++ b/packages/pyright-internal/src/tests/pyrightFileSystem.test.ts
@@ -1,0 +1,156 @@
+/*
+ * pyrightFileSystem.test.ts
+ *
+ * pyrightFileSystem tests.
+ */
+
+import assert from 'assert';
+
+import { lib, sitePackages } from '../common/pathConsts';
+import { combinePaths, getDirectoryPath, normalizeSlashes } from '../common/pathUtils';
+import { PyrightFileSystem } from '../pyrightFileSystem';
+import { TestFileSystem } from './harness/vfs/filesystem';
+
+const libraryRoot = combinePaths(normalizeSlashes('/'), lib, sitePackages);
+
+test('virtual file exists', () => {
+    const files = [
+        {
+            path: combinePaths(libraryRoot, 'myLib-stubs', 'partialStub.pyi'),
+            content: 'def test(): ...',
+        },
+        {
+            path: combinePaths(libraryRoot, 'myLib-stubs', 'py.typed'),
+            content: 'partial\n',
+        },
+        {
+            path: combinePaths(libraryRoot, 'myLib', 'partialStub.py'),
+            content: 'def test(): pass',
+        },
+    ];
+
+    const fs = createFileSystem(files);
+    fs.processPartialStubPackages([libraryRoot], [libraryRoot]);
+
+    const stubFile = combinePaths(libraryRoot, 'myLib', 'partialStub.pyi');
+    assert(fs.existsSync(stubFile));
+    assert(fs.isVirtual(stubFile));
+
+    const myLib = combinePaths(libraryRoot, 'myLib');
+    const entries = fs.readdirEntriesSync(myLib);
+    assert.strictEqual(2, entries.length);
+
+    const fakeFile = entries.filter((e) => e.name.endsWith('.pyi'))[0];
+    assert(fakeFile.isFile());
+
+    assert(!fs.existsSync(combinePaths(libraryRoot, 'myLib-stubs')));
+});
+
+test('virtual file not exist', () => {
+    const files = [
+        {
+            path: combinePaths(libraryRoot, 'myLib-stubs', 'partialStub.pyi'),
+            content: 'def test(): ...',
+        },
+        {
+            path: combinePaths(libraryRoot, 'myLib', 'otherType.py'),
+            content: 'def test(): pass',
+        },
+    ];
+
+    const fs = createFileSystem(files);
+    fs.processPartialStubPackages([libraryRoot], [libraryRoot]);
+
+    assert(!fs.existsSync(combinePaths(libraryRoot, 'myLib', 'partialStub.pyi')));
+
+    const myLib = combinePaths(libraryRoot, 'myLib');
+    const entries = fs.readdirEntriesSync(myLib);
+    assert.strictEqual(1, entries.length);
+
+    assert.strictEqual(0, entries.filter((e) => e.name.endsWith('.pyi')).length);
+
+    assert(fs.existsSync(combinePaths(libraryRoot, 'myLib-stubs')));
+});
+
+test('existing stub file', () => {
+    const files = [
+        {
+            path: combinePaths(libraryRoot, 'myLib-stubs', 'partialStub.pyi'),
+            content: 'def test(): ...',
+        },
+        {
+            path: combinePaths(libraryRoot, 'myLib-stubs', 'py.typed'),
+            content: 'partial\n',
+        },
+        {
+            path: combinePaths(libraryRoot, 'myLib', 'partialStub.py'),
+            content: 'def test(): pass',
+        },
+        {
+            path: combinePaths(libraryRoot, 'myLib', 'partialStub.pyi'),
+            content: 'def test(): pass',
+        },
+    ];
+
+    const fs = createFileSystem(files);
+    fs.processPartialStubPackages([libraryRoot], [libraryRoot]);
+
+    const stubFile = combinePaths(libraryRoot, 'myLib', 'partialStub.pyi');
+    assert(fs.existsSync(stubFile));
+
+    const myLib = combinePaths(libraryRoot, 'myLib');
+    const entries = fs.readdirEntriesSync(myLib);
+    assert.strictEqual(2, entries.length);
+
+    assert.strictEqual('def test(): pass', fs.readFileSync(stubFile, 'utf8'));
+
+    assert(!fs.existsSync(combinePaths(libraryRoot, 'myLib-stubs')));
+});
+
+test('multiple package installed', () => {
+    const extraRoot = combinePaths(normalizeSlashes('/'), lib, 'extra');
+    const files = [
+        {
+            path: combinePaths(libraryRoot, 'myLib-stubs', 'partialStub.pyi'),
+            content: 'def test(): ...',
+        },
+        {
+            path: combinePaths(libraryRoot, 'myLib-stubs', 'py.typed'),
+            content: 'partial\n',
+        },
+        {
+            path: combinePaths(libraryRoot, 'myLib', 'partialStub.py'),
+            content: 'def test(): pass',
+        },
+        {
+            path: combinePaths(extraRoot, 'myLib', 'partialStub.py'),
+            content: 'def test(): pass',
+        },
+    ];
+
+    const fs = createFileSystem(files);
+    fs.processPartialStubPackages([libraryRoot, extraRoot], [libraryRoot, extraRoot]);
+
+    assert(fs.isPathScanned(libraryRoot));
+    assert(fs.isPathScanned(extraRoot));
+
+    assert(fs.existsSync(combinePaths(libraryRoot, 'myLib', 'partialStub.pyi')));
+    assert(fs.existsSync(combinePaths(extraRoot, 'myLib', 'partialStub.pyi')));
+
+    assert.strictEqual(2, fs.readdirEntriesSync(combinePaths(libraryRoot, 'myLib')).length);
+    assert.strictEqual(2, fs.readdirEntriesSync(combinePaths(extraRoot, 'myLib')).length);
+});
+
+function createFileSystem(files: { path: string; content: string }[]): PyrightFileSystem {
+    const fs = new TestFileSystem(/* ignoreCase */ false, { cwd: normalizeSlashes('/') });
+
+    for (const file of files) {
+        const path = normalizeSlashes(file.path);
+        const dir = getDirectoryPath(path);
+        fs.mkdirpSync(dir);
+
+        fs.writeFileSync(path, file.content);
+    }
+
+    return new PyrightFileSystem(fs);
+}

--- a/packages/pyright-internal/src/tests/testState.test.ts
+++ b/packages/pyright-internal/src/tests/testState.test.ts
@@ -44,7 +44,7 @@ test('Multiple files', () => {
 
     const state = parseAndGetTestState(code).state;
 
-    assert.equal(state.fs.cwd(), normalizeSlashes('/'));
+    assert.equal(state.cwd(), normalizeSlashes('/'));
     assert(state.fs.existsSync(normalizeSlashes(combinePaths(factory.srcFolder, 'file1.py'))));
 });
 
@@ -114,7 +114,7 @@ test('Configuration', () => {
 
     const state = parseAndGetTestState(code).state;
 
-    assert.equal(state.fs.cwd(), normalizeSlashes('/'));
+    assert.equal(state.cwd(), normalizeSlashes('/'));
     assert(state.fs.existsSync(normalizeSlashes(combinePaths(factory.srcFolder, 'file1.py'))));
 
     assert.equal(state.configOptions.diagnosticRuleSet.reportMissingImports, 'error');
@@ -159,7 +159,7 @@ test('ProjectRoot', () => {
 
     const state = parseAndGetTestState(code).state;
 
-    assert.equal(state.fs.cwd(), normalizeSlashes('/'));
+    assert.equal(state.cwd(), normalizeSlashes('/'));
     assert(state.fs.existsSync(normalizeSlashes('/root/file1.py')));
 
     assert.equal(state.configOptions.projectRoot, normalizeSlashes('/root'));


### PR DESCRIPTION
Rollup of:

- Ignore files with `.git` extension in file watching; these are created by some git tools/VS Code extensions and cause re-analysis.
- Inherit method docs from parent classes.
- Improve logging, perf tracing, disable in debug mode.
- Support partial stubs, as defined in PEP 561.