### PR TITLE
Added file system caching to virtual file system interface and made use of it within import resolver

### DIFF
--- a/packages/pyright-internal/src/analyzer/pyTypedUtils.ts
+++ b/packages/pyright-internal/src/analyzer/pyTypedUtils.ts
@@ -8,7 +8,7 @@
  */
 
 import { FileSystem } from '../common/fileSystem';
-import { combinePaths, isDirectory, isFile } from '../common/pathUtils';
+import { combinePaths } from '../common/pathUtils';
 
 export interface PyTypedInfo {
     pyTypedPath: string;
@@ -18,14 +18,14 @@ export interface PyTypedInfo {
 const _pyTypedFileName = 'py.typed';
 
 export function getPyTypedInfo(fileSystem: FileSystem, dirPath: string): PyTypedInfo | undefined {
-    if (!fileSystem.existsSync(dirPath) || !isDirectory(fileSystem, dirPath)) {
+    if (!fileSystem.dirExistsSync(dirPath, /* canCache */ true)) {
         return undefined;
     }
 
     let isPartiallyTyped = false;
     const pyTypedPath = combinePaths(dirPath, _pyTypedFileName);
 
-    if (!fileSystem.existsSync(dirPath) || !isFile(fileSystem, pyTypedPath)) {
+    if (!fileSystem.fileExistsSync(pyTypedPath, /* canCache */ true)) {
         return undefined;
     }
 

--- a/packages/pyright-internal/src/tests/harness/vfs/filesystem.ts
+++ b/packages/pyright-internal/src/tests/harness/vfs/filesystem.ts
@@ -335,6 +335,10 @@ export class TestFileSystem implements FileSystem {
         return path;
     }
 
+    invalidateCache() {
+        // Nothing to do
+    }
+
     private _scan(path: string, stats: Stats, axis: Axis, traversal: Traversal, noFollow: boolean, results: string[]) {
         if (axis === 'ancestors-or-self' || axis === 'self' || axis === 'descendants-or-self') {
             if (!traversal.accept || traversal.accept(path, stats)) {
@@ -477,9 +481,33 @@ export class TestFileSystem implements FileSystem {
     /**
      * Determines whether a path exists.
      */
-    existsSync(path: string) {
+    existsSync(path: string, canCache = false) {
         const result = this._walk(this._resolve(path), /*noFollow*/ true, () => 'stop');
         return result !== undefined && result.node !== undefined;
+    }
+
+    /**
+     * Determines whether a file exists.
+     */
+    fileExistsSync(path: string, canCache = false): boolean {
+        try {
+            const stats = this.statSync(path);
+            return stats.isFile();
+        } catch {
+            return false;
+        }
+    }
+
+    /**
+     * Determines whether a directory exists.
+     */
+    dirExistsSync(path: string, canCache = false): boolean {
+        try {
+            const stats = this.statSync(path);
+            return stats.isDirectory();
+        } catch {
+            return false;
+        }
     }
 
     /**
@@ -554,7 +582,7 @@ export class TestFileSystem implements FileSystem {
      *
      * NOTE: do not rename this method as it is intended to align with the same named export of the "fs" module.
      */
-    readdirSync(path: string) {
+    readdirSync(path: string, canCache = false) {
         const { node } = this._walk(this._resolve(path));
         if (!node) {
             throw createIOError('ENOENT');
@@ -572,7 +600,7 @@ export class TestFileSystem implements FileSystem {
      *
      * NOTE: do not rename this method as it is intended to align with the same named export of the "fs" module.
      */
-    readdirEntriesSync(path: string): Dirent[] {
+    readdirEntriesSync(path: string, canCache = false): Dirent[] {
         const { node } = this._walk(this._resolve(path));
         if (!node) {
             throw createIOError('ENOENT');


### PR DESCRIPTION
This change significantly improves import resolution performance for large projects, especially those that use namespace modules internally. Namespace modules require full searches of all import resolution paths.

My team's code base consists of ~250K lines of code in over 700 files. The "Resolve Imports" time for analysis consumed about 2 sec several months ago, but it has ballooned to over 6 sec as we added bug fixes for namespace import resolutions.

This change gains back all of the perf loss and then some, resulting in a 30% overall perf improvement for analysis times.

Prior to change:
----------------
    Searching for source files
    Found 712 source files
    0 errors, 0 warnings, 0 infos 
    Completed in 20.721sec

    Analysis stats
    Total files analyzed: 1426

    Timing stats
    Find Source Files:    0.17sec
    Read Source Files:    0.56sec
    Tokenize:             0.48sec
    Parse:                0.94sec
    Resolve Imports:      6.25sec
    Bind:                 1sec
    Check:                10.04sec
    Detect Cycles:        0.65sec


After change:
-------------
    Searching for source files
    Found 712 source files
    0 errors, 0 warnings, 0 infos 
    Completed in 15.645sec

    Analysis stats
    Total files analyzed: 1426

    Timing stats
    Find Source Files:    0.17sec
    Read Source Files:    0.64sec
    Tokenize:             0.47sec
    Parse:                0.95sec
    Resolve Imports:      1.28sec
    Bind:                 0.93sec
    Check:                9.85sec
    Detect Cycles:        0.65sec
