### PR TITLE
Cache filename to module name, fix crash on function with stub as differing type, fix HTML escaping in code blocks

### DIFF
--- a/packages/pyright-internal/src/analyzer/docStringConversion.ts
+++ b/packages/pyright-internal/src/analyzer/docStringConversion.ts
@@ -236,7 +236,7 @@ class DocStringConverter {
 
         const line = this.formatPlainTextIndent(this._currentLine());
 
-        this._appendTextLine(this._escapeHtml(line));
+        this._appendTextLine(line);
         this._eatLine();
     }
 
@@ -302,6 +302,8 @@ class DocStringConverter {
                 this._append(part);
                 continue;
             }
+
+            part = this._escapeHtml(part);
 
             if (i === 0) {
                 // Only one part, and not inside code, so check header cases.
@@ -542,7 +544,7 @@ class DocStringConverter {
         // Handle epyDocs
         if (line.startsWith('@')) {
             this._appendLine();
-            this._appendTextLine(this._escapeHtml(line));
+            this._appendTextLine(line);
             this._eatLine();
             return true;
         }
@@ -563,7 +565,7 @@ class DocStringConverter {
 
             // force indent for fields
             line = this._convertIndent(line);
-            this._appendTextLine(this._escapeHtml(line));
+            this._appendTextLine(line);
             this._eatLine();
             return true;
         }
@@ -632,7 +634,7 @@ class DocStringConverter {
         // Remove leading spaces so that multiline items get appear in a single block
         if (isMultiLineItem) {
             const line = this._currentLine().trimStart();
-            this._appendTextLine(this._escapeHtml(line));
+            this._appendTextLine(line);
             this._eatLine();
         }
     }

--- a/packages/pyright-internal/src/common/collectionUtils.ts
+++ b/packages/pyright-internal/src/common/collectionUtils.ts
@@ -301,3 +301,15 @@ export function getNestedProperty(object: any, property: string) {
     }, object);
     return value;
 }
+
+export function getOrAdd<K, V>(map: Map<K, V>, key: K, newValueFactory: () => V): V {
+    const value = map.get(key);
+    if (value !== undefined) {
+        return value;
+    }
+
+    const newValue = newValueFactory();
+    map.set(key, newValue);
+
+    return newValue;
+}

--- a/packages/pyright-internal/src/languageService/hoverProvider.ts
+++ b/packages/pyright-internal/src/languageService/hoverProvider.ts
@@ -11,7 +11,7 @@
 
 import { CancellationToken, Hover, MarkupKind } from 'vscode-languageserver';
 
-import { Declaration, DeclarationBase, DeclarationType, FunctionDeclaration } from '../analyzer/declaration';
+import { Declaration, DeclarationType, FunctionDeclaration } from '../analyzer/declaration';
 import { convertDocStringToMarkdown, convertDocStringToPlainText } from '../analyzer/docStringConversion';
 import * as ParseTreeUtils from '../analyzer/parseTreeUtils';
 import { SourceMapper } from '../analyzer/sourceMapper';
@@ -334,7 +334,7 @@ export class HoverProvider {
         parts: HoverTextPart[],
         node: NameNode,
         evaluator: TypeEvaluator,
-        resolvedDecl: DeclarationBase | undefined
+        resolvedDecl: Declaration | undefined
     ) {
         const type = evaluator.getType(node);
         if (type) {
@@ -347,7 +347,7 @@ export class HoverProvider {
         sourceMapper: SourceMapper,
         parts: HoverTextPart[],
         type: Type,
-        resolvedDecl: DeclarationBase | undefined,
+        resolvedDecl: Declaration | undefined,
         evaluator: TypeEvaluator
     ): boolean {
         const docStrings: (string | undefined)[] = [];

--- a/packages/pyright-internal/src/tests/docStringConversion.test.ts
+++ b/packages/pyright-internal/src/tests/docStringConversion.test.ts
@@ -702,6 +702,22 @@ find an arbitrary function's zeros.
     _testConvertToMarkdown(docstring, markdown);
 });
 
+test('DontEscapeHtmlTagsInsideCodeBlocks', () => {
+    const docstring = 'hello  `<code>`';
+
+    const markdown = 'hello  `<code>`';
+
+    _testConvertToMarkdown(docstring, markdown);
+});
+
+test('EscapeHtmlTagsOutsideCodeBlocks', () => {
+    const docstring = 'hello  <noncode>';
+
+    const markdown = 'hello  &lt;noncode&gt;';
+
+    _testConvertToMarkdown(docstring, markdown);
+});
+
 function _testConvertToMarkdown(docstring: string, expectedMarkdown: string) {
     const actualMarkdown = convertDocStringToMarkdown(docstring);
 

--- a/packages/pyright-internal/src/tests/fourslash/completions.inherited.function.docFromStub.fourslash.ts
+++ b/packages/pyright-internal/src/tests/fourslash/completions.inherited.function.docFromStub.fourslash.ts
@@ -1,0 +1,28 @@
+/// <reference path="fourslash.ts" />
+
+// @filename: testFunctionWithVariableStub.py
+//// import module1
+////
+//// module1.[|/*marker1*/displayhook|]
+
+// @filename: module1.py
+//// def displayhook() -> None:
+////     '''displayhook docs'''
+////     ...
+
+// @filename: module1.pyi
+//// from typing import Callable
+//// displayhook: Callable[[],Any]
+
+// @ts-ignore
+await helper.verifyCompletion('included', 'markdown', {
+    marker1: {
+        completions: [
+            {
+                label: 'displayhook',
+                kind: Consts.CompletionItemKind.Variable,
+                documentation: '```python\ndisplayhook: () -> Unknown\n```\n',
+            },
+        ],
+    },
+});


### PR DESCRIPTION
Rollup of:

- Cache filename to module name mapping.
- Fix crash in docstring mapping when the source is a function but the stub is not.
- Fix HTML escaping happening inside code blocks in docstrings.