### PR TITLE
Fix more symlink cases, add tryStat helper to clean up many try/catch stat calls

### DIFF
--- a/packages/pyright-internal/src/analyzer/importResolver.ts
+++ b/packages/pyright-internal/src/analyzer/importResolver.ts
@@ -31,6 +31,7 @@ import {
     resolvePaths,
     stripFileExtension,
     stripTrailingDirectorySeparator,
+    tryStat,
 } from '../common/pathUtils';
 import { equateStringsCaseInsensitive } from '../common/stringUtils';
 import * as StringUtils from '../common/stringUtils';
@@ -494,12 +495,7 @@ export class ImportResolver {
             if (!this.fileSystem.existsSync(path)) {
                 return false;
             }
-            try {
-                const stats = this.fileSystem.statSync(path);
-                return stats.isFile();
-            } catch {
-                return false;
-            }
+            return tryStat(this.fileSystem, path)?.isFile() ?? false;
         }
 
         const entries = this.readdirEntriesCached(splitPath[0]);
@@ -525,12 +521,7 @@ export class ImportResolver {
             if (!this.fileSystem.existsSync(path)) {
                 return false;
             }
-            try {
-                const stats = this.fileSystem.statSync(path);
-                return stats.isDirectory();
-            } catch {
-                return false;
-            }
+            return tryStat(this.fileSystem, path)?.isDirectory() ?? false;
         }
 
         const entries = this.readdirEntriesCached(splitPath[0]);

--- a/packages/pyright-internal/src/analyzer/importResolver.ts
+++ b/packages/pyright-internal/src/analyzer/importResolver.ts
@@ -1424,7 +1424,7 @@ export class ImportResolver {
         // Add any symbolic links that point to files.
         entriesInDir.forEach((f) => {
             const linkPath = combinePaths(dirPath, f.name);
-            if (f.isSymbolicLink() && this.fileSystem.statSync(linkPath).isFile()) {
+            if (f.isSymbolicLink() && tryStat(this.fileSystem, linkPath)?.isFile()) {
                 filesInDir.push(f.name);
             }
         });

--- a/packages/pyright-internal/src/analyzer/pythonPathUtils.ts
+++ b/packages/pyright-internal/src/analyzer/pythonPathUtils.ts
@@ -21,6 +21,7 @@ import {
     getFileSystemEntries,
     isDirectory,
     normalizePath,
+    tryStat,
 } from '../common/pathUtils';
 
 interface PythonPathResult {
@@ -272,10 +273,10 @@ function getPathsFromPthFiles(fs: FileSystem, parentDir: string): string[] {
 
     pthFiles.forEach((pthFile) => {
         const filePath = combinePaths(parentDir, pthFile.name);
-        const fileStats = fs.statSync(filePath);
+        const fileStats = tryStat(fs, filePath);
 
         // Skip all files that are much larger than expected.
-        if (fileStats.isFile() && fileStats.size > 0 && fileStats.size < 64 * 1024) {
+        if (fileStats?.isFile() && fileStats.size > 0 && fileStats.size < 64 * 1024) {
             const data = fs.readFileSync(filePath, 'utf8');
             const lines = data.split(/\r?\n/);
             lines.forEach((line) => {

--- a/packages/pyright-internal/src/analyzer/service.ts
+++ b/packages/pyright-internal/src/analyzer/service.ts
@@ -32,7 +32,7 @@ import { ConsoleInterface, log, LogLevel, StandardConsole } from '../common/cons
 import { Diagnostic } from '../common/diagnostic';
 import { FileEditAction, TextEditAction } from '../common/editAction';
 import { LanguageServiceExtension } from '../common/extensibility';
-import { FileSystem, FileWatcher, ignoredWatchEventFunction, Stats } from '../common/fileSystem';
+import { FileSystem, FileWatcher, ignoredWatchEventFunction } from '../common/fileSystem';
 import {
     combinePaths,
     FileSpec,

--- a/packages/pyright-internal/src/analyzer/service.ts
+++ b/packages/pyright-internal/src/analyzer/service.ts
@@ -44,6 +44,7 @@ import {
     isDirectory,
     normalizePath,
     stripFileExtension,
+    tryStat,
 } from '../common/pathUtils';
 import { DocumentRange, Position, Range } from '../common/textRange';
 import { timingStats } from '../common/timing';
@@ -1071,12 +1072,7 @@ export class AnalyzerService {
                         return;
                     }
 
-                    let stats: Stats | undefined;
-                    try {
-                        stats = this._fs.statSync(path);
-                    } catch {
-                        stats = undefined;
-                    }
+                    const stats = tryStat(this._fs, path);
 
                     if (stats && stats.isFile() && !path.endsWith('.py') && !path.endsWith('.pyi')) {
                         return;


### PR DESCRIPTION
There were still a few places in the code that didn't handle symlinks (via other readdirEntries variants), clean those up.

Since the "try/catch stat and do something" is done so often, add a helper for it and replace all of the easy cases with it.