### PR TITLE
Make auto-import edits lazy, handle partial path mapping, split overloads in hover, disable user index results for auto imports temporarily

### DIFF
--- a/packages/pyright-internal/src/analyzer/backgroundAnalysisProgram.ts
+++ b/packages/pyright-internal/src/analyzer/backgroundAnalysisProgram.ts
@@ -85,6 +85,11 @@ export class BackgroundAnalysisProgram {
         this._program.setAllowedThirdPartyImports(importNames);
     }
 
+    ensurePartialStubPackages(path: string) {
+        this._backgroundAnalysis?.ensurePartialStubPackages(path);
+        return this._importResolver.ensurePartialStubPackages(this._configOptions.findExecEnvironment(path));
+    }
+
     setFileOpened(filePath: string, version: number | null, contents: string) {
         this._backgroundAnalysis?.setFileOpened(filePath, version, [{ text: contents }]);
         this._program.setFileOpened(filePath, version, [{ text: contents }]);

--- a/packages/pyright-internal/src/analyzer/service.ts
+++ b/packages/pyright-internal/src/analyzer/service.ts
@@ -191,6 +191,10 @@ export class AnalyzerService {
         this._applyConfigOptions(reanalyze);
     }
 
+    ensurePartialStubPackages(path: string) {
+        return this._backgroundAnalysisProgram.ensurePartialStubPackages(path);
+    }
+
     setFileOpened(path: string, version: number | null, contents: string) {
         this._backgroundAnalysisProgram.setFileOpened(path, version, contents);
         this._scheduleReanalysis(false);
@@ -230,6 +234,7 @@ export class AnalyzerService {
         range: Range,
         similarityLimit: number,
         nameMap: AbbreviationMap | undefined,
+        lazyEdit: boolean,
         token: CancellationToken
     ) {
         return this._program.getAutoImports(
@@ -238,6 +243,7 @@ export class AnalyzerService {
             similarityLimit,
             nameMap,
             this._backgroundAnalysisProgram.getIndexing(filePath),
+            lazyEdit,
             token
         );
     }
@@ -322,9 +328,17 @@ export class AnalyzerService {
         filePath: string,
         completionItem: CompletionItem,
         options: CompletionOptions,
+        nameMap: AbbreviationMap | undefined,
         token: CancellationToken
     ) {
-        this._program.resolveCompletionItem(filePath, completionItem, options, token);
+        this._program.resolveCompletionItem(
+            filePath,
+            completionItem,
+            options,
+            nameMap,
+            this._backgroundAnalysisProgram.getIndexing(filePath),
+            token
+        );
     }
 
     performQuickAction(

--- a/packages/pyright-internal/src/analyzer/sourceFile.ts
+++ b/packages/pyright-internal/src/analyzer/sourceFile.ts
@@ -857,6 +857,9 @@ export class SourceFile {
         evaluator: TypeEvaluator,
         options: CompletionOptions,
         sourceMapper: SourceMapper,
+        nameMap: AbbreviationMap | undefined,
+        libraryMap: Map<string, IndexResults> | undefined,
+        moduleSymbolsCallback: () => ModuleSymbolMap,
         completionItem: CompletionItem,
         token: CancellationToken
     ) {
@@ -878,7 +881,11 @@ export class SourceFile {
             evaluator,
             options,
             sourceMapper,
-            undefined,
+            {
+                nameMap,
+                libraryMap,
+                getModuleSymbolsMap: moduleSymbolsCallback,
+            },
             token
         );
 
@@ -1152,7 +1159,7 @@ export class SourceFile {
     }
 
     private _getPathForLogging(filepath: string) {
-        if (!(this.fileSystem instanceof PyrightFileSystem) || !this.fileSystem.isVirtual(filepath)) {
+        if (!(this.fileSystem instanceof PyrightFileSystem) || !this.fileSystem.isMappedFilePath(filepath)) {
             return filepath;
         }
 

--- a/packages/pyright-internal/src/backgroundAnalysisBase.ts
+++ b/packages/pyright-internal/src/backgroundAnalysisBase.ts
@@ -94,6 +94,10 @@ export class BackgroundAnalysisBase {
         this.enqueueRequest({ requestType: 'setAllowedThirdPartyImports', data: importNames });
     }
 
+    ensurePartialStubPackages(filePath: string) {
+        this.enqueueRequest({ requestType: 'ensurePartialStubPackages', data: { filePath } });
+    }
+
     setFileOpened(filePath: string, version: number | null, contents: TextDocumentContentChangeEvent[]) {
         this.enqueueRequest({ requestType: 'setFileOpened', data: { filePath, version, contents } });
     }
@@ -361,6 +365,12 @@ export class BackgroundAnalysisRunnerBase extends BackgroundThreadBase {
                 break;
             }
 
+            case 'ensurePartialStubPackages': {
+                const { filePath } = msg.data;
+                this._importResolver.ensurePartialStubPackages(this._configOptions.findExecEnvironment(filePath));
+                break;
+            }
+
             case 'setFileOpened': {
                 const { filePath, version, contents } = msg.data;
                 this.program.setFileOpened(filePath, version, contents);
@@ -518,6 +528,7 @@ export interface AnalysisRequest {
         | 'setConfigOptions'
         | 'setTrackedFiles'
         | 'setAllowedThirdPartyImports'
+        | 'ensurePartialStubPackages'
         | 'setFileOpened'
         | 'setFileClosed'
         | 'markAllFilesDirty'

--- a/packages/pyright-internal/src/commands/createTypeStub.ts
+++ b/packages/pyright-internal/src/commands/createTypeStub.ts
@@ -31,7 +31,7 @@ export class CreateTypeStubCommand implements ServerCommand {
             const workspace: WorkspaceServiceInstance = {
                 workspaceName: `Create Type Stub ${importName}`,
                 rootPath: workspaceRoot,
-                rootUri: convertPathToUri(workspaceRoot),
+                rootUri: convertPathToUri(this._ls.fs, workspaceRoot),
                 serviceInstance: service,
                 disableLanguageServices: true,
                 disableOrganizeImports: true,

--- a/packages/pyright-internal/src/commands/quickActionCommand.ts
+++ b/packages/pyright-internal/src/commands/quickActionCommand.ts
@@ -21,7 +21,7 @@ export class QuickActionCommand implements ServerCommand {
         if (params.arguments && params.arguments.length >= 1) {
             const docUri = params.arguments[0];
             const otherArgs = params.arguments.slice(1);
-            const filePath = convertUriToPath(docUri);
+            const filePath = convertUriToPath(this._ls.fs, docUri);
             const workspace = await this._ls.getWorkspaceForFile(filePath);
 
             if (params.command === Commands.orderImports && workspace.disableOrganizeImports) {

--- a/packages/pyright-internal/src/common/pathUtils.ts
+++ b/packages/pyright-internal/src/common/pathUtils.ts
@@ -13,6 +13,7 @@ import * as path from 'path';
 import Char from 'typescript-char';
 import { URI } from 'vscode-uri';
 
+import { PyrightFileSystem } from '../pyrightFileSystem';
 import { some } from './collectionUtils';
 import { compareValues, Comparison, GetCanonicalFileName, identity } from './core';
 import * as debug from './debug';
@@ -859,7 +860,7 @@ function fileSystemEntryExists(fs: FileSystem, path: string, entryKind: FileSyst
     }
 }
 
-export function convertUriToPath(uriString: string): string {
+export function convertUriToPath(fs: FileSystem, uriString: string): string {
     const uri = URI.parse(uriString);
     let convertedPath = normalizePath(uri.path);
     // If this is a DOS-style path with a drive letter, remove
@@ -867,10 +868,19 @@ export function convertUriToPath(uriString: string): string {
     if (convertedPath.match(/^\\[a-zA-Z]:\\/)) {
         convertedPath = convertedPath.substr(1);
     }
+
+    if (fs instanceof PyrightFileSystem) {
+        return fs.getMappedFilePath(convertedPath);
+    }
+
     return convertedPath;
 }
 
-export function convertPathToUri(path: string): string {
+export function convertPathToUri(fs: FileSystem, path: string): string {
+    if (fs instanceof PyrightFileSystem) {
+        path = fs.getOriginalFilePath(path);
+    }
+
     return URI.file(path).toString();
 }
 

--- a/packages/pyright-internal/src/common/textEditUtils.ts
+++ b/packages/pyright-internal/src/common/textEditUtils.ts
@@ -8,8 +8,7 @@
 
 import { TextEdit, WorkspaceEdit } from 'vscode-languageserver';
 
-import { FileEditAction, TextEditAction } from '../common/editAction';
-import { convertPathToUri } from '../common/pathUtils';
+import { TextEditAction } from '../common/editAction';
 
 export function convertTextEdits(uri: string, editActions: TextEditAction[] | undefined): WorkspaceEdit {
     if (!editActions) {
@@ -29,18 +28,4 @@ export function convertTextEdits(uri: string, editActions: TextEditAction[] | un
             [uri]: edits,
         },
     };
-}
-
-export function convertWorkspaceEdits(edits: FileEditAction[]) {
-    const workspaceEdits: WorkspaceEdit = {
-        changes: {},
-    };
-
-    edits.forEach((edit) => {
-        const uri = convertPathToUri(edit.filePath);
-        workspaceEdits.changes![uri] = workspaceEdits.changes![uri] || [];
-        workspaceEdits.changes![uri].push({ range: edit.range, newText: edit.replacementText });
-    });
-
-    return workspaceEdits;
 }

--- a/packages/pyright-internal/src/common/workspaceEditUtils.ts
+++ b/packages/pyright-internal/src/common/workspaceEditUtils.ts
@@ -1,0 +1,27 @@
+/*
+ * workspaceEditUtils.ts
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT license.
+ *
+ * Convert Pyright's FileEditActions to LanguageServer's WorkspaceEdits.
+ */
+
+import { WorkspaceEdit } from 'vscode-languageserver';
+
+import { FileEditAction } from '../common/editAction';
+import { convertPathToUri } from '../common/pathUtils';
+import { FileSystem } from './fileSystem';
+
+export function convertWorkspaceEdits(fs: FileSystem, edits: FileEditAction[]) {
+    const workspaceEdits: WorkspaceEdit = {
+        changes: {},
+    };
+
+    edits.forEach((edit) => {
+        const uri = convertPathToUri(fs, edit.filePath);
+        workspaceEdits.changes![uri] = workspaceEdits.changes![uri] || [];
+        workspaceEdits.changes![uri].push({ range: edit.range, newText: edit.replacementText });
+    });
+
+    return workspaceEdits;
+}

--- a/packages/pyright-internal/src/languageService/hoverProvider.ts
+++ b/packages/pyright-internal/src/languageService/hoverProvider.ts
@@ -42,6 +42,7 @@ import { Position, Range } from '../common/textRange';
 import { TextRange } from '../common/textRange';
 import { NameNode, ParseNode, ParseNodeType } from '../parser/parseNodes';
 import { ParseResults } from '../parser/parser';
+import { getOverloadedFunctionTooltip } from './tooltipUtils';
 
 export interface HoverTextPart {
     python?: boolean;
@@ -231,7 +232,13 @@ export class HoverProvider {
                     label = declaredType && isProperty(declaredType) ? 'property' : 'method';
                 }
 
-                this._addResultsPart(parts, `(${label}) ` + node.value + this._getTypeText(node, evaluator), true);
+                const type = evaluator.getType(node);
+                if (type && isOverloadedFunction(type)) {
+                    this._addResultsPart(parts, `(${label})\n${getOverloadedFunctionTooltip(type, evaluator)}`, true);
+                } else {
+                    this._addResultsPart(parts, `(${label}) ` + node.value + this._getTypeText(node, evaluator), true);
+                }
+
                 this._addDocumentationPart(format, sourceMapper, parts, node, evaluator, resolvedDecl);
                 break;
             }

--- a/packages/pyright-internal/src/languageService/tooltipUtils.ts
+++ b/packages/pyright-internal/src/languageService/tooltipUtils.ts
@@ -1,0 +1,39 @@
+/*
+ * tooltipUtils.ts
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT license.
+ * Author: Eric Traut
+ *
+ * Tooltip helper methods that can be shared between multiple language server features such as
+ * hover and completion tooltip.
+ */
+
+import { TypeEvaluator } from '../analyzer/typeEvaluator';
+import { OverloadedFunctionType } from '../analyzer/types';
+
+// 70 is vscode's default hover width size.
+export function getOverloadedFunctionTooltip(
+    type: OverloadedFunctionType,
+    evaluator: TypeEvaluator,
+    columnThreshold = 70
+) {
+    let content = '';
+    const overloads = type.overloads.map((o) => o.details.name + evaluator.printType(o, /* expandTypeAlias */ false));
+
+    for (let i = 0; i < overloads.length; i++) {
+        if (i !== 0 && overloads[i].length > columnThreshold && overloads[i - 1].length <= columnThreshold) {
+            content += '\n';
+        }
+
+        content += overloads[i];
+
+        if (i < overloads.length - 1) {
+            content += '\n';
+            if (overloads[i].length > columnThreshold) {
+                content += '\n';
+            }
+        }
+    }
+
+    return content;
+}

--- a/packages/pyright-internal/src/server.ts
+++ b/packages/pyright-internal/src/server.ts
@@ -208,7 +208,7 @@ class PyrightServer extends LanguageServerBase {
     ): Promise<(Command | CodeAction)[] | undefined | null> {
         this.recordUserInteractionTime();
 
-        const filePath = convertUriToPath(params.textDocument.uri);
+        const filePath = convertUriToPath(this.fs, params.textDocument.uri);
         const workspace = await this.getWorkspaceForFile(filePath);
         return CodeActionProvider.getCodeActionsForPosition(workspace, filePath, params.range, token);
     }
@@ -221,7 +221,7 @@ class PyrightServer extends LanguageServerBase {
         return {
             isEnabled: (data: AnalysisResults) => true,
             begin: () => {
-                if (this._hasWindowProgressCapability) {
+                if (this.client.hasWindowProgressCapability) {
                     workDoneProgress = this._connection.window.createWorkDoneProgress();
                     workDoneProgress
                         .then((progress) => {

--- a/packages/pyright-internal/src/tests/fourslash/findDefinitions.stubPackages.fourslash.ts
+++ b/packages/pyright-internal/src/tests/fourslash/findDefinitions.stubPackages.fourslash.ts
@@ -1,0 +1,71 @@
+/// <reference path="fourslash.ts" />
+
+// @filename: mspythonconfig.json
+//// {
+////   "useLibraryCodeForTypes": true
+//// }
+
+// @filename: testLib1-stubs/py.typed
+// @library: true
+//// partial
+////
+
+// @filename: testLib1-stubs/__init__.pyi
+// @library: true
+//// from .core import C as C
+//// from .base import C2 as C2
+
+// @filename: testLib1/__init__.py
+// @library: true
+//// from .core import C
+//// from .base import C2 as C2
+
+// @filename: testLib1-stubs/core/__init__.pyi
+// @library: true
+//// class [|C|]: ...
+
+// @filename: testLib1/core/__init__.py
+// @library: true
+//// class C:
+////     pass
+
+// @filename: testLib1/base/__init__.py
+// @library: true
+//// from ..main import C2 as C2
+
+// @filename: testLib1/main.py
+// @library: true
+//// class [|C2|]:
+////     pass
+
+// @filename: test.py
+//// import testLib1
+////
+//// a = testLib1.[|/*marker1*/C|]()
+//// a = testLib1.[|/*marker2*/C2|]()
+
+{
+    const rangeMap = helper.getRangesByText();
+
+    helper.verifyFindDefinitions(
+        {
+            marker1: {
+                definitions: rangeMap
+                    .get('C')!
+                    .filter((r) => !r.marker)
+                    .map((r) => {
+                        return { path: helper.getMappedFilePath(r.fileName), range: helper.convertPositionRange(r) };
+                    }),
+            },
+            marker2: {
+                definitions: rangeMap
+                    .get('C2')!
+                    .filter((r) => !r.marker)
+                    .map((r) => {
+                        return { path: r.fileName, range: helper.convertPositionRange(r) };
+                    }),
+            },
+        },
+        'preferStubs'
+    );
+}

--- a/packages/pyright-internal/src/tests/fourslash/fourslash.ts
+++ b/packages/pyright-internal/src/tests/fourslash/fourslash.ts
@@ -143,6 +143,7 @@ declare namespace _ {
     type DefinitionFilter = 'all' | 'preferSource' | 'preferStubs';
 
     interface Fourslash {
+        getMappedFilePath(path: string): string;
         getDocumentHighlightKind(m?: Marker): DocumentHighlightKind | undefined;
 
         getMarkerName(m: Marker): string;

--- a/packages/pyright-internal/src/tests/fourslash/hover.inherited.overload.docFromSrcWithStub.fourslash.ts
+++ b/packages/pyright-internal/src/tests/fourslash/hover.inherited.overload.docFromSrcWithStub.fourslash.ts
@@ -41,6 +41,6 @@
 
 helper.verifyHover('markdown', {
     child_a_func_doc:
-        '```python\n(method) func: Overload[(self: ChildA, x: str) -> str, (self: ChildA, x: int) -> int]\n```\nfunc docs',
-    child_a_instance_func_doc: '```python\n(method) func: Overload[(x: str) -> str, (x: int) -> int]\n```\nfunc docs',
+        '```python\n(method)\nfunc(self: ChildA, x: str) -> str\nfunc(self: ChildA, x: int) -> int\n```\nfunc docs',
+    child_a_instance_func_doc: '```python\n(method)\nfunc(x: str) -> str\nfunc(x: int) -> int\n```\nfunc docs',
 });

--- a/packages/pyright-internal/src/tests/fourslash/hover.inherited.overload.docFromStub.fourslash.ts
+++ b/packages/pyright-internal/src/tests/fourslash/hover.inherited.overload.docFromStub.fourslash.ts
@@ -42,6 +42,6 @@
 
 helper.verifyHover('markdown', {
     child_a_func_doc:
-        '```python\n(method) func: Overload[(self: ChildA, x: str) -> str, (self: ChildA, x: int) -> int]\n```\nfunc docs',
-    child_a_instance_func_doc: '```python\n(method) func: Overload[(x: str) -> str, (x: int) -> int]\n```\nfunc docs',
+        '```python\n(method)\nfunc(self: ChildA, x: str) -> str\nfunc(self: ChildA, x: int) -> int\n```\nfunc docs',
+    child_a_instance_func_doc: '```python\n(method)\nfunc(x: str) -> str\nfunc(x: int) -> int\n```\nfunc docs',
 });

--- a/packages/pyright-internal/src/tests/pyrightFileSystem.test.ts
+++ b/packages/pyright-internal/src/tests/pyrightFileSystem.test.ts
@@ -34,7 +34,7 @@ test('virtual file exists', () => {
 
     const stubFile = combinePaths(libraryRoot, 'myLib', 'partialStub.pyi');
     assert(fs.existsSync(stubFile));
-    assert(fs.isVirtual(stubFile));
+    assert(fs.isMappedFilePath(stubFile));
 
     const myLib = combinePaths(libraryRoot, 'myLib');
     const entries = fs.readdirEntriesSync(myLib);


### PR DESCRIPTION
Rollup of:

- Make auto-import "additional text edits" lazy, if the client supports it. Building these edits took a significant amount of time when many auto-import candidates are present.
- Handle path mapping to files in partial stub folders; navigation would previously jump to nonexistent files in the merged filesystem, but now jump to the real file in its true location.
- Split overloads in hover, matching the tooltip that already exists in completions.
- Add an extra newline in overload tooltips, if the line would be too long.
- Disable use of user code indexer results for auto-imports while we test changed (only active in Pylance).