### PR TITLE
Fix getFileSystemEntriesFromDirEntries for directory symlinks

### DIFF
--- a/packages/pyright-internal/src/common/pathUtils.ts
+++ b/packages/pyright-internal/src/common/pathUtils.ts
@@ -597,7 +597,7 @@ export function getFileSystemEntriesFromDirEntries(
             if (stat?.isFile()) {
                 files.push(entry.name);
             } else if (stat?.isDirectory()) {
-                files.push(entry.name);
+                directories.push(entry.name);
             }
         }
     }


### PR DESCRIPTION
For https://github.com/microsoft/pylance-release/issues/1031.

Fixes a copy/paste error in https://github.com/microsoft/pyright/commit/3ad0555d44b8377fd7afe2e9ab7c1bc910ec7588.