### PR TITLE
Remove global search path cache

### DIFF
--- a/packages/pyright-internal/src/analyzer/pythonPathUtils.ts
+++ b/packages/pyright-internal/src/analyzer/pythonPathUtils.ts
@@ -29,8 +29,6 @@ interface PythonPathResult {
     prefix: string;
 }
 
-const cachedSearchPaths = new Map<string, PythonPathResult>();
-
 const extractSys = [
     'import os, os.path, sys',
     'normalize = lambda p: os.path.normcase(os.path.normpath(p))',
@@ -133,14 +131,6 @@ export function getPythonPathFromPythonInterpreter(
     interpreterPath: string | undefined,
     importFailureInfo: string[]
 ): PythonPathResult {
-    const searchKey = interpreterPath || '';
-
-    // If we've seen this request before, return the cached results.
-    const cachedPath = cachedSearchPaths.get(searchKey);
-    if (cachedPath) {
-        return cachedPath;
-    }
-
     let result: PythonPathResult | undefined;
 
     if (interpreterPath) {
@@ -166,7 +156,6 @@ export function getPythonPathFromPythonInterpreter(
         };
     }
 
-    cachedSearchPaths.set(searchKey, result);
     importFailureInfo.push(`Received ${result.paths.length} paths from interpreter`);
     result.paths.forEach((path) => {
         importFailureInfo.push(`  ${path}`);


### PR DESCRIPTION
Calls to this function only happen either on settings update (we do a bunch of work scanning files for other reasons that are no slower than calling Python), or in the import resolver (which has a cache for this call explicitly). Remove this cache so that editable installs modified while the LS is running are properly handled.

Last thing to finish https://github.com/microsoft/pylance-release/issues/78.