### PR TITLE
Add lowercased items from __all__ in auto-imports, fix completion in stubs, log tracker passing

### DIFF
--- a/packages/pyright-internal/src/analyzer/program.ts
+++ b/packages/pyright-internal/src/analyzer/program.ts
@@ -984,6 +984,7 @@ export class Program {
         nameMap: AbbreviationMap | undefined,
         libraryMap: Map<string, IndexResults> | undefined,
         lazyEdit: boolean,
+        allowVariableInAll: boolean,
         token: CancellationToken
     ): AutoImportResult[] {
         const sourceFileInfo = this._getSourceFileInfoFromPath(filePath);
@@ -1023,6 +1024,7 @@ export class Program {
                 map,
                 {
                     lazyEdit,
+                    allowVariableInAll,
                     libraryMap,
                     patternMatcher: (p, t) => computeCompletionSimilarity(p, t) > similarityLimit,
                 }

--- a/packages/pyright-internal/src/analyzer/service.ts
+++ b/packages/pyright-internal/src/analyzer/service.ts
@@ -235,6 +235,7 @@ export class AnalyzerService {
         similarityLimit: number,
         nameMap: AbbreviationMap | undefined,
         lazyEdit: boolean,
+        allowVariableInAll: boolean,
         token: CancellationToken
     ) {
         return this._program.getAutoImports(
@@ -244,6 +245,7 @@ export class AnalyzerService {
             nameMap,
             this._backgroundAnalysisProgram.getIndexing(filePath),
             lazyEdit,
+            allowVariableInAll,
             token
         );
     }

--- a/packages/pyright-internal/src/backgroundAnalysisBase.ts
+++ b/packages/pyright-internal/src/backgroundAnalysisBase.ts
@@ -246,6 +246,7 @@ export class BackgroundAnalysisRunnerBase extends BackgroundThreadBase {
     private _configOptions: ConfigOptions;
     private _importResolver: ImportResolver;
     private _program: Program;
+    protected _logTracker: LogTracker;
 
     get program(): Program {
         return this._program;
@@ -260,13 +261,16 @@ export class BackgroundAnalysisRunnerBase extends BackgroundThreadBase {
 
         this._configOptions = new ConfigOptions(data.rootDirectory);
         this._importResolver = this.createImportResolver(this.fs, this._configOptions);
+
         const console = this.getConsole();
+        this._logTracker = new LogTracker(console, `BG(${threadId})`);
+
         this._program = new Program(
             this._importResolver,
             this._configOptions,
             console,
             this._extension,
-            new LogTracker(console, `BG(${threadId})`)
+            this._logTracker
         );
     }
 

--- a/packages/pyright-internal/src/languageService/hoverProvider.ts
+++ b/packages/pyright-internal/src/languageService/hoverProvider.ts
@@ -424,7 +424,13 @@ export class HoverProvider {
     private static _addDocumentationResultsPart(format: MarkupKind, parts: HoverTextPart[], docString?: string) {
         if (docString) {
             if (format === MarkupKind.Markdown) {
-                this._addResultsPart(parts, convertDocStringToMarkdown(docString));
+                const markDown = convertDocStringToMarkdown(docString);
+
+                if (parts.length > 0 && markDown.length > 0) {
+                    parts.push({ text: '---\n' });
+                }
+
+                this._addResultsPart(parts, markDown);
             } else if (format === MarkupKind.PlainText) {
                 this._addResultsPart(parts, convertDocStringToPlainText(docString));
             } else {

--- a/packages/pyright-internal/src/tests/fourslash/completions.autoimport.shadow.fourslash.ts
+++ b/packages/pyright-internal/src/tests/fourslash/completions.autoimport.shadow.fourslash.ts
@@ -24,7 +24,7 @@
     // This will cause shadow file to be injected.
     helper.openFile(helper.getMarkerByName('hover').fileName);
     helper.verifyHover('markdown', {
-        hover: '```python\n(method) method: () -> Unknown\n```\ndoc string',
+        hover: '```python\n(method) method: () -> Unknown\n```\n---\ndoc string',
     });
 
     const importRange = helper.getPositionRange('import');

--- a/packages/pyright-internal/src/tests/fourslash/completions.private.fourslash.ts
+++ b/packages/pyright-internal/src/tests/fourslash/completions.private.fourslash.ts
@@ -1,0 +1,64 @@
+/// <reference path="fourslash.ts" />
+
+// @filename: test1.py
+//// def __hello():
+////     pass
+////
+//// __hello[|/*marker1*/|]
+
+// @filename: test2.pyi
+//// from typing import Union
+////
+//// Union[|/*marker2*/|]
+////
+//// def __hello1():
+////     pass
+////
+//// __hello1[|/*marker3*/|]
+
+{
+    helper.openFiles(helper.getMarkers().map((m) => m.fileName));
+
+    // @ts-ignore
+    await helper.verifyCompletion('included', 'markdown', {
+        marker1: {
+            completions: [
+                // Private symbol in same file suggested.
+                {
+                    label: '__hello',
+                    kind: Consts.CompletionItemKind.Function,
+                },
+            ],
+        },
+        marker2: {
+            completions: [
+                // No Auto-import on Union exists.
+                {
+                    label: 'Union',
+                    kind: Consts.CompletionItemKind.Class,
+                },
+            ],
+        },
+        marker3: {
+            completions: [
+                {
+                    label: '__hello1',
+                    kind: Consts.CompletionItemKind.Function,
+                },
+            ],
+        },
+    });
+
+    // @ts-ignore
+    await helper.verifyCompletion('excluded', 'markdown', {
+        marker3: {
+            completions: [
+                // Private symbol from other file not suggested.
+                {
+                    label: '__hello',
+                    kind: Consts.CompletionItemKind.Function,
+                },
+            ],
+        },
+    });
+}

--- a/packages/pyright-internal/src/tests/fourslash/hover.classNoInit.fourslash.ts
+++ b/packages/pyright-internal/src/tests/fourslash/hover.classNoInit.fourslash.ts
@@ -10,5 +10,5 @@
 //// [|/*marker1*/Something|]()
 
 helper.verifyHover('markdown', {
-    marker1: '```python\n(class) Something(text: str)\n```\nThis is a test.',
+    marker1: '```python\n(class) Something(text: str)\n```\n---\nThis is a test.',
 });

--- a/packages/pyright-internal/src/tests/fourslash/hover.docFromSrc.fourslash.ts
+++ b/packages/pyright-internal/src/tests/fourslash/hover.docFromSrc.fourslash.ts
@@ -71,13 +71,13 @@
 //// print(inner.[|/*inner_method1_docs*/method1|]())
 
 helper.verifyHover('markdown', {
-    a_docs: '```python\n(class) A\n```\nA docs',
-    b_docs: '```python\n(class) B()\n```\nB init docs',
-    a_inner_docs: '```python\n(class) Inner\n```\nA.Inner docs',
-    func1_docs: '```python\n(function) func1: () -> bool\n```\nfunc1 docs',
-    func2_docs: '```python\n(function) func2: () -> bool\n```\nfunc2 docs',
-    inner_method1_docs: '```python\n(method) method1: () -> bool\n```\nA.Inner.method1 docs',
-    method1_docs: '```python\n(method) method1: () -> bool\n```\nA.method1 docs',
-    module1_docs: '```python\n(module) module1\n```\nmodule1 docs',
-    module2_docs: '```python\n(module) module2\n```\nmodule2 docs',
+    a_docs: '```python\n(class) A\n```\n---\nA docs',
+    b_docs: '```python\n(class) B()\n```\n---\nB init docs',
+    a_inner_docs: '```python\n(class) Inner\n```\n---\nA.Inner docs',
+    func1_docs: '```python\n(function) func1: () -> bool\n```\n---\nfunc1 docs',
+    func2_docs: '```python\n(function) func2: () -> bool\n```\n---\nfunc2 docs',
+    inner_method1_docs: '```python\n(method) method1: () -> bool\n```\n---\nA.Inner.method1 docs',
+    method1_docs: '```python\n(method) method1: () -> bool\n```\n---\nA.method1 docs',
+    module1_docs: '```python\n(module) module1\n```\n---\nmodule1 docs',
+    module2_docs: '```python\n(module) module2\n```\n---\nmodule2 docs',
 });

--- a/packages/pyright-internal/src/tests/fourslash/hover.docFromSrc.pkg-vs-module1.fourslash.ts
+++ b/packages/pyright-internal/src/tests/fourslash/hover.docFromSrc.pkg-vs-module1.fourslash.ts
@@ -22,5 +22,5 @@
 //// print([|/*func1_docs*/func1|]())
 
 helper.verifyHover('markdown', {
-    func1_docs: '```python\n(function) func1: () -> bool\n```\nfunc1 docs',
+    func1_docs: '```python\n(function) func1: () -> bool\n```\n---\nfunc1 docs',
 });

--- a/packages/pyright-internal/src/tests/fourslash/hover.docFromSrc.pkg-vs-module2.fourslash.ts
+++ b/packages/pyright-internal/src/tests/fourslash/hover.docFromSrc.pkg-vs-module2.fourslash.ts
@@ -22,5 +22,5 @@
 //// print([|/*func1_docs*/func1|]())
 
 helper.verifyHover('markdown', {
-    func1_docs: '```python\n(function) func1: () -> bool\n```\nfunc1 docs',
+    func1_docs: '```python\n(function) func1: () -> bool\n```\n---\nfunc1 docs',
 });

--- a/packages/pyright-internal/src/tests/fourslash/hover.docFromSrc.relativeImport1.fourslash.ts
+++ b/packages/pyright-internal/src/tests/fourslash/hover.docFromSrc.relativeImport1.fourslash.ts
@@ -18,6 +18,6 @@
 //// print([|/*module1_docs*/module1|].[|/*func1_docs*/func1|]())
 
 helper.verifyHover('markdown', {
-    func1_docs: '```python\n(function) func1: () -> bool\n```\nfunc1 docs',
-    module1_docs: '```python\n(module) module1\n```\nmodule1 docs',
+    func1_docs: '```python\n(function) func1: () -> bool\n```\n---\nfunc1 docs',
+    module1_docs: '```python\n(module) module1\n```\n---\nmodule1 docs',
 });

--- a/packages/pyright-internal/src/tests/fourslash/hover.docFromSrc.relativeImport2.fourslash.ts
+++ b/packages/pyright-internal/src/tests/fourslash/hover.docFromSrc.relativeImport2.fourslash.ts
@@ -18,5 +18,5 @@
 //// print([|/*func1_docs*/func1|]())
 
 helper.verifyHover('markdown', {
-    func1_docs: '```python\n(function) func1: () -> bool\n```\nfunc1 docs',
+    func1_docs: '```python\n(function) func1: () -> bool\n```\n---\nfunc1 docs',
 });

--- a/packages/pyright-internal/src/tests/fourslash/hover.docFromSrc.relativeImport3.fourslash.ts
+++ b/packages/pyright-internal/src/tests/fourslash/hover.docFromSrc.relativeImport3.fourslash.ts
@@ -42,5 +42,5 @@
 //// p.[|/*marker*/clean_fields|]()
 
 helper.verifyHover('markdown', {
-    marker: '```python\n(method) clean_fields: () -> None\n```\nclean\\_fields docs',
+    marker: '```python\n(method) clean_fields: () -> None\n```\n---\nclean\\_fields docs',
 });

--- a/packages/pyright-internal/src/tests/fourslash/hover.docFromSrc.stubs-package.fourslash.ts
+++ b/packages/pyright-internal/src/tests/fourslash/hover.docFromSrc.stubs-package.fourslash.ts
@@ -24,6 +24,6 @@
 //// print(package1.[|/*marker*/func1|]())
 
 helper.verifyHover('markdown', {
-    marker: '```python\n(function) func1: () -> bool\n```\nfunc1 docs',
-    marker2: '```python\n(function) func2: () -> bool\n```\nfunc2 docs',
+    marker: '```python\n(function) func1: () -> bool\n```\n---\nfunc1 docs',
+    marker2: '```python\n(function) func2: () -> bool\n```\n---\nfunc2 docs',
 });

--- a/packages/pyright-internal/src/tests/fourslash/hover.docFromSrc.typeshed.fourslash.ts
+++ b/packages/pyright-internal/src/tests/fourslash/hover.docFromSrc.typeshed.fourslash.ts
@@ -16,5 +16,6 @@
 //// print(requests.[|/*marker*/head|](''))
 
 helper.verifyHover('markdown', {
-    marker: '```python\n(function) head: (url: Unknown, **kwargs: Unknown) -> None\n```\nSends a &lt;HEAD&gt; request.',
+    marker:
+        '```python\n(function) head: (url: Unknown, **kwargs: Unknown) -> None\n```\n---\nSends a &lt;HEAD&gt; request.',
 });

--- a/packages/pyright-internal/src/tests/fourslash/hover.fourslash.ts
+++ b/packages/pyright-internal/src/tests/fourslash/hover.fourslash.ts
@@ -15,6 +15,6 @@
 //// validator.[|/*marker2*/is_valid|]('hello')
 
 helper.verifyHover('markdown', {
-    marker1: '```python\n(class) Validator\n```\nThe validator class',
-    marker2: '```python\n(method) is_valid: (text: str) -> bool\n```\nChecks if the input string is valid.',
+    marker1: '```python\n(class) Validator\n```\n---\nThe validator class',
+    marker2: '```python\n(method) is_valid: (text: str) -> bool\n```\n---\nChecks if the input string is valid.',
 });

--- a/packages/pyright-internal/src/tests/fourslash/hover.import.fourslash.ts
+++ b/packages/pyright-internal/src/tests/fourslash/hover.import.fourslash.ts
@@ -7,5 +7,5 @@
 //// '''documentation for library'''
 
 helper.verifyHover('markdown', {
-    marker: '```python\n(module) library\n```\ndocumentation for library',
+    marker: '```python\n(module) library\n```\n---\ndocumentation for library',
 });

--- a/packages/pyright-internal/src/tests/fourslash/hover.inherited.docFromSrc.fourslash.ts
+++ b/packages/pyright-internal/src/tests/fourslash/hover.inherited.docFromSrc.fourslash.ts
@@ -54,10 +54,10 @@
 //// d2.[|/*secondDerived_method_docs*/method|]()
 
 helper.verifyHover('markdown', {
-    child_a_method1_docs: '```python\n(method) method1: () -> bool\n```\nA.method1 docs',
+    child_a_method1_docs: '```python\n(method) method1: () -> bool\n```\n---\nA.method1 docs',
     child_a_docs: '```python\n(class) ChildA\n```\n',
-    child_b_docs: '```python\n(class) ChildB()\n```\nB init docs',
-    child_b_init_docs: '```python\n(method) __init__: () -> None\n```\nB init docs',
+    child_b_docs: '```python\n(class) ChildB()\n```\n---\nB init docs',
+    child_b_init_docs: '```python\n(method) __init__: () -> None\n```\n---\nB init docs',
     secondDerived_docs: '```python\n(class) Derived2\n```\n',
-    secondDerived_method_docs: '```python\n(method) method: () -> None\n```\nBase.method docs',
+    secondDerived_method_docs: '```python\n(method) method: () -> None\n```\n---\nBase.method docs',
 });

--- a/packages/pyright-internal/src/tests/fourslash/hover.inherited.docFromSrcWithStub.fourslash.ts
+++ b/packages/pyright-internal/src/tests/fourslash/hover.inherited.docFromSrcWithStub.fourslash.ts
@@ -46,9 +46,9 @@
 //// childB =[|/*child_b_docs*/ChildB|]()
 
 helper.verifyHover('markdown', {
-    child_a_method1_docs: '```python\n(method) method1: () -> bool\n```\nA.method1 docs',
+    child_a_method1_docs: '```python\n(method) method1: () -> bool\n```\n---\nA.method1 docs',
     child_a_docs: '```python\n(class) ChildA\n```\n',
     child_a_inner_docs: '```python\n(class) ChildInner\n```\n',
-    child_a_inner_method1_docs: '```python\n(method) method1: () -> bool\n```\nA.Inner.method1 docs',
+    child_a_inner_method1_docs: '```python\n(method) method1: () -> bool\n```\n---\nA.Inner.method1 docs',
     child_b_docs: '```python\n(class) ChildB\n```\n',
 });

--- a/packages/pyright-internal/src/tests/fourslash/hover.inherited.docFromStub.fourslash.ts
+++ b/packages/pyright-internal/src/tests/fourslash/hover.inherited.docFromStub.fourslash.ts
@@ -35,8 +35,8 @@
 //// inner.[|/*child_a_inner_method1_docs*/method1|]()
 
 helper.verifyHover('markdown', {
-    child_a_method1_docs: '```python\n(method) method1: () -> bool\n```\nA.method1 docs',
+    child_a_method1_docs: '```python\n(method) method1: () -> bool\n```\n---\nA.method1 docs',
     child_a_docs: '```python\n(class) ChildA\n```\n',
     child_a_inner_docs: '```python\n(class) ChildInner\n```\n',
-    child_a_inner_method1_docs: '```python\n(method) method1: () -> bool\n```\nA.Inner.method1 docs',
+    child_a_inner_method1_docs: '```python\n(method) method1: () -> bool\n```\n---\nA.Inner.method1 docs',
 });

--- a/packages/pyright-internal/src/tests/fourslash/hover.inherited.overload.docFromSrcWithStub.fourslash.ts
+++ b/packages/pyright-internal/src/tests/fourslash/hover.inherited.overload.docFromSrcWithStub.fourslash.ts
@@ -41,6 +41,6 @@
 
 helper.verifyHover('markdown', {
     child_a_func_doc:
-        '```python\n(method)\nfunc(self: ChildA, x: str) -> str\nfunc(self: ChildA, x: int) -> int\n```\nfunc docs',
-    child_a_instance_func_doc: '```python\n(method)\nfunc(x: str) -> str\nfunc(x: int) -> int\n```\nfunc docs',
+        '```python\n(method)\nfunc(self: ChildA, x: str) -> str\nfunc(self: ChildA, x: int) -> int\n```\n---\nfunc docs',
+    child_a_instance_func_doc: '```python\n(method)\nfunc(x: str) -> str\nfunc(x: int) -> int\n```\n---\nfunc docs',
 });

--- a/packages/pyright-internal/src/tests/fourslash/hover.inherited.overload.docFromStub.fourslash.ts
+++ b/packages/pyright-internal/src/tests/fourslash/hover.inherited.overload.docFromStub.fourslash.ts
@@ -42,6 +42,6 @@
 
 helper.verifyHover('markdown', {
     child_a_func_doc:
-        '```python\n(method)\nfunc(self: ChildA, x: str) -> str\nfunc(self: ChildA, x: int) -> int\n```\nfunc docs',
-    child_a_instance_func_doc: '```python\n(method)\nfunc(x: str) -> str\nfunc(x: int) -> int\n```\nfunc docs',
+        '```python\n(method)\nfunc(self: ChildA, x: str) -> str\nfunc(self: ChildA, x: int) -> int\n```\n---\nfunc docs',
+    child_a_instance_func_doc: '```python\n(method)\nfunc(x: str) -> str\nfunc(x: int) -> int\n```\n---\nfunc docs',
 });

--- a/packages/pyright-internal/src/tests/fourslash/hover.inherited.property.docFromSrcWithStub.fourslash.ts
+++ b/packages/pyright-internal/src/tests/fourslash/hover.inherited.property.docFromSrcWithStub.fourslash.ts
@@ -82,6 +82,6 @@
 ////     def length(self, value) -> None: ...
 
 helper.verifyHover('markdown', {
-    getter_docs: '```python\n(property) length: int\n```\nread property doc',
-    setter_docs: '```python\n(property) length: int\n```\nsetter property doc',
+    getter_docs: '```python\n(property) length: int\n```\n---\nread property doc',
+    setter_docs: '```python\n(property) length: int\n```\n---\nsetter property doc',
 });

--- a/packages/pyright-internal/src/tests/fourslash/hover.inherited.property.docFromStub.fourslash.ts
+++ b/packages/pyright-internal/src/tests/fourslash/hover.inherited.property.docFromStub.fourslash.ts
@@ -86,6 +86,6 @@
 ////         ...
 
 helper.verifyHover('markdown', {
-    getter_docs: '```python\n(property) length: int\n```\nread property doc',
-    setter_docs: '```python\n(property) length: int\n```\nsetter property doc',
+    getter_docs: '```python\n(property) length: int\n```\n---\nread property doc',
+    setter_docs: '```python\n(property) length: int\n```\n---\nsetter property doc',
 });

--- a/packages/pyright-internal/src/tests/fourslash/hover.init.fourslash.ts
+++ b/packages/pyright-internal/src/tests/fourslash/hover.init.fourslash.ts
@@ -31,9 +31,9 @@
 //// c = test.[|/*marker5*/C1|]()
 
 helper.verifyHover('markdown', {
-    marker1: '```python\n(class) C1(name: Unknown = "hello")\n```\n\\_\\_init\\_\\_ docs',
+    marker1: '```python\n(class) C1(name: Unknown = "hello")\n```\n---\n\\_\\_init\\_\\_ docs',
     marker2: '```python\n(type alias) unionType: Type[C1] | Type[C2]\n```\n',
     marker3: '```python\n(class) G(value: int)\n```\n',
     marker4: '```python\n(class) G\n```\n',
-    marker5: '```python\n(class) C1(name: Unknown = "hello")\n```\n\\_\\_init\\_\\_ docs',
+    marker5: '```python\n(class) C1(name: Unknown = "hello")\n```\n---\n\\_\\_init\\_\\_ docs',
 });

--- a/packages/pyright-internal/src/tests/fourslash/hover.libCodeAndStub.fourslash.ts
+++ b/packages/pyright-internal/src/tests/fourslash/hover.libCodeAndStub.fourslash.ts
@@ -44,9 +44,9 @@
 //// obj.[|/*marker5*/read_write_prop|] = r
 
 helper.verifyHover('markdown', {
-    marker1: '```python\n(class) Validator\n```\nThe validator class',
-    marker2: '```python\n(method) is_valid: (text: str) -> bool\n```\nChecks if the input string is valid.',
-    marker3: '```python\n(property) read_only_prop: bool\n```\nThe read-only property.',
-    marker4: '```python\n(property) read_write_prop: bool\n```\nThe read-write property.',
-    marker5: '```python\n(property) read_write_prop: bool\n```\nThe read-write property.',
+    marker1: '```python\n(class) Validator\n```\n---\nThe validator class',
+    marker2: '```python\n(method) is_valid: (text: str) -> bool\n```\n---\nChecks if the input string is valid.',
+    marker3: '```python\n(property) read_only_prop: bool\n```\n---\nThe read-only property.',
+    marker4: '```python\n(property) read_write_prop: bool\n```\n---\nThe read-write property.',
+    marker5: '```python\n(property) read_write_prop: bool\n```\n---\nThe read-write property.',
 });

--- a/packages/pyright-internal/src/tests/fourslash/hover.libCodeNoStub.fourslash.ts
+++ b/packages/pyright-internal/src/tests/fourslash/hover.libCodeNoStub.fourslash.ts
@@ -33,9 +33,9 @@
 //// obj.[|/*marker5*/read_write_prop|] = r
 
 helper.verifyHover('markdown', {
-    marker1: '```python\n(class) Validator\n```\nThe validator class',
-    marker2: '```python\n(method) is_valid: (text: str) -> bool\n```\nChecks if the input string is valid.',
-    marker3: '```python\n(property) read_only_prop: bool\n```\nThe read-only property.',
-    marker4: '```python\n(property) read_write_prop: bool\n```\nThe read-write property.',
-    marker5: '```python\n(property) read_write_prop: bool\n```\nThe read-write property.',
+    marker1: '```python\n(class) Validator\n```\n---\nThe validator class',
+    marker2: '```python\n(method) is_valid: (text: str) -> bool\n```\n---\nChecks if the input string is valid.',
+    marker3: '```python\n(property) read_only_prop: bool\n```\n---\nThe read-only property.',
+    marker4: '```python\n(property) read_write_prop: bool\n```\n---\nThe read-write property.',
+    marker5: '```python\n(property) read_write_prop: bool\n```\n---\nThe read-write property.',
 });

--- a/packages/pyright-internal/src/tests/fourslash/hover.libStub.fourslash.ts
+++ b/packages/pyright-internal/src/tests/fourslash/hover.libStub.fourslash.ts
@@ -33,9 +33,9 @@
 //// obj.[|/*marker5*/read_write_prop|] = r
 
 helper.verifyHover('markdown', {
-    marker1: '```python\n(class) Validator\n```\nThe validator class',
-    marker2: '```python\n(method) is_valid: (text: str) -> bool\n```\nChecks if the input string is valid.',
-    marker3: '```python\n(property) read_only_prop: bool\n```\nThe read-only property.',
-    marker4: '```python\n(property) read_write_prop: bool\n```\nThe read-write property.',
-    marker5: '```python\n(property) read_write_prop: bool\n```\nThe read-write property.',
+    marker1: '```python\n(class) Validator\n```\n---\nThe validator class',
+    marker2: '```python\n(method) is_valid: (text: str) -> bool\n```\n---\nChecks if the input string is valid.',
+    marker3: '```python\n(property) read_only_prop: bool\n```\n---\nThe read-only property.',
+    marker4: '```python\n(property) read_write_prop: bool\n```\n---\nThe read-write property.',
+    marker5: '```python\n(property) read_write_prop: bool\n```\n---\nThe read-write property.',
 });


### PR DESCRIPTION
Rollup of:

- Include all items from `__all__` for auto-imports (even lowercased). This filter was already a heuristic but to some was inconsistent.
- Fix completions for members in stubs; the completion provider only offered symbols that were exported from the stub (versus things actually accessible internally).
- Pass the log tracker to the background analysis.
- Add a horizontal line to the hover tooltip, matching the completion tooltip.