### PR TITLE
Add user index results to quick fixes, expose method from ImportResolver for use in subclasses

### DIFF
--- a/packages/pyright-internal/src/analyzer/importResolver.ts
+++ b/packages/pyright-internal/src/analyzer/importResolver.ts
@@ -104,7 +104,7 @@ export class ImportResolver {
         execEnv: ExecutionEnvironment,
         moduleDescriptor: ImportedModuleDescriptor
     ): ImportResult {
-        const importName = this._formatImportName(moduleDescriptor);
+        const importName = this.formatImportName(moduleDescriptor);
         const importFailureInfo: string[] = [];
 
         const notFoundResult: ImportResult = {
@@ -981,7 +981,7 @@ export class ImportResolver {
         moduleDescriptor: ImportedModuleDescriptor,
         allowPyi: boolean
     ): ImportResult | undefined {
-        const importName = this._formatImportName(moduleDescriptor);
+        const importName = this.formatImportName(moduleDescriptor);
         const importFailureInfo: string[] = [];
 
         // First check for a stdlib typeshed file.
@@ -1638,7 +1638,7 @@ export class ImportResolver {
         return [...implicitImportMap.values()];
     }
 
-    private _formatImportName(moduleDescriptor: ImportedModuleDescriptor) {
+    protected formatImportName(moduleDescriptor: ImportedModuleDescriptor) {
         let name = '';
         for (let i = 0; i < moduleDescriptor.leadingDots; i++) {
             name += '.';

--- a/packages/pyright-internal/src/analyzer/program.ts
+++ b/packages/pyright-internal/src/analyzer/program.ts
@@ -773,6 +773,7 @@ export class Program {
     private _buildModuleSymbolsMap(
         sourceFileToExclude: SourceFileInfo,
         userFileOnly: boolean,
+        includeIndexUserSymbols: boolean,
         token: CancellationToken
     ): ModuleSymbolMap {
         // If we have library map, always use the map for library symbols.
@@ -780,6 +781,7 @@ export class Program {
             this._sourceFileList.filter(
                 (s) => s !== sourceFileToExclude && (userFileOnly ? this._isUserCode(s) : true)
             ),
+            includeIndexUserSymbols,
             token
         );
     }
@@ -1014,7 +1016,12 @@ export class Program {
             }
 
             const writtenWord = fileContents.substr(textRange.start, textRange.length);
-            const map = this._buildModuleSymbolsMap(sourceFileInfo, !!libraryMap, token);
+            const map = this._buildModuleSymbolsMap(
+                sourceFileInfo,
+                !!libraryMap,
+                /* includeIndexUserSymbols */ true,
+                token
+            );
             const autoImporter = new AutoImporter(
                 this._configOptions.findExecEnvironment(filePath),
                 this._importResolver,
@@ -1415,7 +1422,13 @@ export class Program {
                         this._createSourceMapper(execEnv, /* mapCompiled */ true),
                         nameMap,
                         libraryMap,
-                        () => this._buildModuleSymbolsMap(sourceFileInfo, !!libraryMap, token),
+                        () =>
+                            this._buildModuleSymbolsMap(
+                                sourceFileInfo,
+                                !!libraryMap,
+                                /* includeIndexUserSymbols */ false,
+                                token
+                            ),
                         token
                     );
                 });
@@ -1474,7 +1487,13 @@ export class Program {
                 this._createSourceMapper(execEnv, /* mapCompiled */ true),
                 nameMap,
                 libraryMap,
-                () => this._buildModuleSymbolsMap(sourceFileInfo, !!libraryMap, token),
+                () =>
+                    this._buildModuleSymbolsMap(
+                        sourceFileInfo,
+                        !!libraryMap,
+                        /* includeIndexUserSymbols */ false,
+                        token
+                    ),
                 completionItem,
                 token
             );

--- a/packages/pyright-internal/src/backgroundAnalysisBase.ts
+++ b/packages/pyright-internal/src/backgroundAnalysisBase.ts
@@ -244,7 +244,7 @@ export class BackgroundAnalysisBase {
 
 export class BackgroundAnalysisRunnerBase extends BackgroundThreadBase {
     private _configOptions: ConfigOptions;
-    private _importResolver: ImportResolver;
+    protected _importResolver: ImportResolver;
     private _program: Program;
     protected _logTracker: LogTracker;
 

--- a/packages/pyright-internal/src/languageService/autoImporter.ts
+++ b/packages/pyright-internal/src/languageService/autoImporter.ts
@@ -46,7 +46,11 @@ export type ModuleSymbolMap = Map<string, ModuleSymbolTable>;
 
 // Build a map of all modules within this program and the module-
 // level scope that contains the symbol table for the module.
-export function buildModuleSymbolsMap(files: SourceFileInfo[], token: CancellationToken): ModuleSymbolMap {
+export function buildModuleSymbolsMap(
+    files: SourceFileInfo[],
+    includeIndexUserSymbols: boolean,
+    token: CancellationToken
+): ModuleSymbolMap {
     const moduleSymbolMap = new Map<string, ModuleSymbolTable>();
 
     files.forEach((file) => {
@@ -105,7 +109,12 @@ export function buildModuleSymbolsMap(files: SourceFileInfo[], token: Cancellati
             return;
         }
 
-        // For now, don't iterate through closed user files using indices.
+        // Iterate through closed user files using indices if asked.
+        const indexResults = file.sourceFile.getCachedIndexResults();
+        if (indexResults && includeIndexUserSymbols && !indexResults.privateOrProtected) {
+            moduleSymbolMap.set(filePath, createModuleSymbolTableFromIndexResult(indexResults, /* library */ false));
+            return;
+        }
     });
 
     return moduleSymbolMap;


### PR DESCRIPTION
Rollup of:

- Add user index results back to quick fixes only.
- Expose `formatImportName` as protected for use in ImportResolver subclasses