### PR TITLE
Make calls to realpath safe, like stat

### DIFF
--- a/packages/pyright-internal/src/analyzer/importResolver.ts
+++ b/packages/pyright-internal/src/analyzer/importResolver.ts
@@ -31,6 +31,7 @@ import {
     resolvePaths,
     stripFileExtension,
     stripTrailingDirectorySeparator,
+    tryRealpath,
     tryStat,
 } from '../common/pathUtils';
 import { equateStringsCaseInsensitive } from '../common/stringUtils';
@@ -505,8 +506,8 @@ export class ImportResolver {
         }
 
         if (entry?.isSymbolicLink()) {
-            const realPath = this.fileSystem.realpathSync(path);
-            if (this.fileSystem.existsSync(realPath) && isFile(this.fileSystem, realPath)) {
+            const realPath = tryRealpath(this.fileSystem, path);
+            if (realPath && this.fileSystem.existsSync(realPath) && isFile(this.fileSystem, realPath)) {
                 return true;
             }
         }
@@ -531,8 +532,8 @@ export class ImportResolver {
         }
 
         if (entry?.isSymbolicLink()) {
-            const realPath = this.fileSystem.realpathSync(path);
-            if (this.fileSystem.existsSync(realPath) && isDirectory(this.fileSystem, realPath)) {
+            const realPath = tryRealpath(this.fileSystem, path);
+            if (realPath && this.fileSystem.existsSync(realPath) && isDirectory(this.fileSystem, realPath)) {
                 return true;
             }
         }

--- a/packages/pyright-internal/src/analyzer/service.ts
+++ b/packages/pyright-internal/src/analyzer/service.ts
@@ -44,6 +44,7 @@ import {
     isDirectory,
     normalizePath,
     stripFileExtension,
+    tryRealpath,
     tryStat,
 } from '../common/pathUtils';
 import { DocumentRange, Position, Range } from '../common/textRange';
@@ -1009,7 +1010,12 @@ export class AnalyzerService {
 
         const seenDirs = new Set<string>();
         const visitDirectory = (absolutePath: string, includeRegExp: RegExp) => {
-            const realDirPath = this._fs.realpathSync(absolutePath);
+            const realDirPath = tryRealpath(this._fs, absolutePath);
+            if (!realDirPath) {
+                this._console.warn(`Skipping broken link "${absolutePath}"`);
+                return;
+            }
+
             if (seenDirs.has(realDirPath)) {
                 this._console.warn(`Skipping recursive symlink "${absolutePath}" -> "${realDirPath}"`);
                 return;

--- a/packages/pyright-internal/src/common/pathUtils.ts
+++ b/packages/pyright-internal/src/common/pathUtils.ts
@@ -555,6 +555,14 @@ export function tryStat(fs: FileSystem, path: string): Stats | undefined {
     }
 }
 
+export function tryRealpath(fs: FileSystem, path: string): string | undefined {
+    try {
+        return fs.realpathSync(path);
+    } catch (e) {
+        return undefined;
+    }
+}
+
 export function getFileSystemEntries(fs: FileSystem, path: string): FileSystemEntries {
     try {
         return getFileSystemEntriesFromDirEntries(fs.readdirEntriesSync(path || '.'), fs, path);


### PR DESCRIPTION
For https://github.com/microsoft/pylance-release/issues/1102.

`realpath` can fail similarly to `stat` (because it's largely a stat wrapper). Wrap it like we do `stat` to ensure we don't fail to `realpath` a broken link.