### PR TITLE
Fixing a typo in "extraPaths" of configuration.md document

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -154,7 +154,7 @@ The following settings can be specified for each execution environment.
 
 **root** [string, required]: Root path for the code that will execute within this execution environment.
 
-**extraPaths** [array of strings, optional]: Additional search paths (in addition to the root path) that will be used when searching for modules imported by files within this execution environment. If specified, this overrides the default extraPaths setting when resolving imports for files within this execution environment. Note that each file’s execution environment mapping is independent, so if file A is in one execution environment ane imports a second file B within a second execution environment, any imports from B will use the extraPaths in the second execution environment.
+**extraPaths** [array of strings, optional]: Additional search paths (in addition to the root path) that will be used when searching for modules imported by files within this execution environment. If specified, this overrides the default extraPaths setting when resolving imports for files within this execution environment. Note that each file’s execution environment mapping is independent, so if file A is in one execution environment and imports a second file B within a second execution environment, any imports from B will use the extraPaths in the second execution environment.
 
 **pythonVersion** [string, optional]: The version of Python used for this execution environment. If not specified, the global `pythonVersion` setting is used instead.
 


### PR DESCRIPTION
Changed 'ane' to and 