### PR TITLE
Improve override completion, partial stub fixes, perf data cleanup, update extension interface

### DIFF
--- a/packages/pyright-internal/src/analyzer/backgroundAnalysisProgram.ts
+++ b/packages/pyright-internal/src/analyzer/backgroundAnalysisProgram.ts
@@ -11,7 +11,7 @@ import { CancellationToken } from 'vscode-languageserver';
 import { TextDocumentContentChangeEvent } from 'vscode-languageserver-textdocument';
 
 import { BackgroundAnalysisBase } from '../backgroundAnalysisBase';
-import { ConfigOptions } from '../common/configOptions';
+import { ConfigOptions, ExecutionEnvironment } from '../common/configOptions';
 import { ConsoleInterface } from '../common/console';
 import { Diagnostic } from '../common/diagnostic';
 import { FileDiagnostics } from '../common/diagnosticSink';
@@ -62,6 +62,8 @@ export class BackgroundAnalysisProgram {
         this._configOptions = configOptions;
         this._backgroundAnalysis?.setConfigOptions(configOptions);
         this._program.setConfigOptions(configOptions);
+
+        configOptions.getExecutionEnvironments().forEach((e) => this._ensurePartialStubPackages(e));
     }
 
     setImportResolver(importResolver: ImportResolver) {
@@ -83,11 +85,6 @@ export class BackgroundAnalysisProgram {
     setAllowedThirdPartyImports(importNames: string[]) {
         this._backgroundAnalysis?.setAllowedThirdPartyImports(importNames);
         this._program.setAllowedThirdPartyImports(importNames);
-    }
-
-    ensurePartialStubPackages(path: string) {
-        this._backgroundAnalysis?.ensurePartialStubPackages(path);
-        return this._importResolver.ensurePartialStubPackages(this._configOptions.findExecEnvironment(path));
     }
 
     setFileOpened(filePath: string, version: number | null, contents: string) {
@@ -224,6 +221,11 @@ export class BackgroundAnalysisProgram {
 
     restart() {
         this._backgroundAnalysis?.restart();
+    }
+
+    private _ensurePartialStubPackages(execEnv: ExecutionEnvironment) {
+        this._backgroundAnalysis?.ensurePartialStubPackages(execEnv.root);
+        return this._importResolver.ensurePartialStubPackages(execEnv);
     }
 
     private _getIndices(): Indices {

--- a/packages/pyright-internal/src/analyzer/program.ts
+++ b/packages/pyright-internal/src/analyzer/program.ts
@@ -1443,15 +1443,13 @@ export class Program {
             return completionResult;
         }
 
-        const pr = sourceFileInfo.sourceFile.getParseResults();
-        const content = sourceFileInfo.sourceFile.getFileContents();
-        if (pr?.parseTree && content !== undefined) {
-            const offset = convertPositionToOffset(position, pr.tokenizerOutput.lines);
+        const parseResults = sourceFileInfo.sourceFile.getParseResults();
+        if (parseResults?.parseTree && parseResults?.text) {
+            const offset = convertPositionToOffset(position, parseResults.tokenizerOutput.lines);
             if (offset !== undefined) {
                 await this._extension.completionListExtension.updateCompletionResults(
                     completionResult,
-                    pr.parseTree,
-                    content,
+                    parseResults,
                     offset,
                     token
                 );

--- a/packages/pyright-internal/src/analyzer/service.ts
+++ b/packages/pyright-internal/src/analyzer/service.ts
@@ -192,10 +192,6 @@ export class AnalyzerService {
         this._applyConfigOptions(reanalyze);
     }
 
-    ensurePartialStubPackages(path: string) {
-        return this._backgroundAnalysisProgram.ensurePartialStubPackages(path);
-    }
-
     setFileOpened(path: string, version: number | null, contents: string) {
         this._backgroundAnalysisProgram.setFileOpened(path, version, contents);
         this._scheduleReanalysis(false);

--- a/packages/pyright-internal/src/backgroundAnalysisBase.ts
+++ b/packages/pyright-internal/src/backgroundAnalysisBase.ts
@@ -94,8 +94,8 @@ export class BackgroundAnalysisBase {
         this.enqueueRequest({ requestType: 'setAllowedThirdPartyImports', data: importNames });
     }
 
-    ensurePartialStubPackages(filePath: string) {
-        this.enqueueRequest({ requestType: 'ensurePartialStubPackages', data: { filePath } });
+    ensurePartialStubPackages(executionRoot: string) {
+        this.enqueueRequest({ requestType: 'ensurePartialStubPackages', data: { executionRoot } });
     }
 
     setFileOpened(filePath: string, version: number | null, contents: TextDocumentContentChangeEvent[]) {
@@ -370,8 +370,11 @@ export class BackgroundAnalysisRunnerBase extends BackgroundThreadBase {
             }
 
             case 'ensurePartialStubPackages': {
-                const { filePath } = msg.data;
-                this._importResolver.ensurePartialStubPackages(this._configOptions.findExecEnvironment(filePath));
+                const { executionRoot } = msg.data;
+                const execEnv = this._configOptions.getExecutionEnvironments().find((e) => e.root === executionRoot);
+                if (execEnv) {
+                    this._importResolver.ensurePartialStubPackages(execEnv);
+                }
                 break;
             }
 
@@ -541,7 +544,8 @@ export interface AnalysisRequest {
         | 'restart'
         | 'getDiagnosticsForRange'
         | 'writeTypeStub'
-        | 'getSemanticTokens';
+        | 'getSemanticTokens'
+        | 'setExperimentOptions';
 
     data: any;
     port?: MessagePort;

--- a/packages/pyright-internal/src/common/configOptions.ts
+++ b/packages/pyright-internal/src/common/configOptions.ts
@@ -650,28 +650,6 @@ export class ConfigOptions {
         return getBasicDiagnosticRuleSet();
     }
 
-    // Finds the best execution environment for a given file path. The
-    // specified file path should be absolute.
-    // If no matching execution environment can be found, a default
-    // execution environment is used.
-    findExecEnvironment(filePath: string): ExecutionEnvironment {
-        let execEnv = this.executionEnvironments.find((env) => {
-            const envRoot = ensureTrailingDirectorySeparator(normalizePath(combinePaths(this.projectRoot, env.root)));
-            return filePath.startsWith(envRoot);
-        });
-
-        if (!execEnv) {
-            execEnv = new ExecutionEnvironment(
-                this.projectRoot,
-                this.defaultPythonVersion,
-                this.defaultPythonPlatform,
-                this.defaultExtraPaths
-            );
-        }
-
-        return execEnv;
-    }
-
     getDefaultExecEnvironment(): ExecutionEnvironment {
         return new ExecutionEnvironment(
             this.projectRoot,
@@ -679,6 +657,29 @@ export class ConfigOptions {
             this.defaultPythonPlatform,
             this.defaultExtraPaths
         );
+    }
+
+    // Finds the best execution environment for a given file path. The
+    // specified file path should be absolute.
+    // If no matching execution environment can be found, a default
+    // execution environment is used.
+    findExecEnvironment(filePath: string): ExecutionEnvironment {
+        return (
+            this.executionEnvironments.find((env) => {
+                const envRoot = ensureTrailingDirectorySeparator(
+                    normalizePath(combinePaths(this.projectRoot, env.root))
+                );
+                return filePath.startsWith(envRoot);
+            }) ?? this.getDefaultExecEnvironment()
+        );
+    }
+
+    getExecutionEnvironments(): ExecutionEnvironment[] {
+        if (this.executionEnvironments.length > 0) {
+            return this.executionEnvironments;
+        }
+
+        return [this.getDefaultExecEnvironment()];
     }
 
     // Initialize the structure from a JSON object.

--- a/packages/pyright-internal/src/common/extensibility.ts
+++ b/packages/pyright-internal/src/common/extensibility.ts
@@ -9,7 +9,7 @@
 import { CancellationToken } from 'vscode-languageserver';
 
 import { CompletionResults } from '../languageService/completionProvider';
-import { ModuleNode } from '../parser/parseNodes';
+import { ParseResults } from '../parser/parser';
 
 export interface LanguageServiceExtension {
     readonly completionListExtension: CompletionListExtension;
@@ -19,8 +19,7 @@ export interface CompletionListExtension {
     // Extension updates completion list provided by the application.
     updateCompletionResults(
         completionResults: CompletionResults,
-        ast: ModuleNode,
-        content: string,
+        parseResults: ParseResults,
         position: number,
         token: CancellationToken
     ): Promise<void>;

--- a/packages/pyright-internal/src/languageServerBase.ts
+++ b/packages/pyright-internal/src/languageServerBase.ts
@@ -825,15 +825,8 @@ export abstract class LanguageServerBase implements LanguageServerInterface {
         });
 
         this._connection.onDidOpenTextDocument(async (params) => {
-            let filePath = convertUriToPath(this.fs, params.textDocument.uri);
+            const filePath = convertUriToPath(this.fs, params.textDocument.uri);
             const workspace = await this.getWorkspaceForFile(filePath);
-
-            // Make sure partial stub packages are processed for the given exe environment.
-            // This can happen if a user opens file inside of a partial stub package directly out of band.
-            if (workspace.serviceInstance.ensurePartialStubPackages(filePath)) {
-                // If mapping happened, re-check mapped file path.
-                filePath = convertUriToPath(this.fs, params.textDocument.uri);
-            }
 
             workspace.serviceInstance.setFileOpened(filePath, params.textDocument.version, params.textDocument.text);
         });

--- a/packages/pyright-internal/src/languageService/autoImporter.ts
+++ b/packages/pyright-internal/src/languageService/autoImporter.ts
@@ -174,12 +174,8 @@ export class AutoImporter {
         importAliasTimeInMS: 0,
 
         symbolCount: 0,
-        userIndexCount: 0,
         indexCount: 0,
         importAliasCount: 0,
-
-        editTimeInMS: 0,
-        moduleResolveTimeInMS: 0,
     };
 
     constructor(
@@ -661,13 +657,7 @@ export class AutoImporter {
     // convert to a module name that can be used in an
     // 'import from' statement.
     private _getModuleNameAndTypeFromFilePath(filePath: string): ModuleNameAndType {
-        const startTime = this._stopWatch.getDurationInMilliseconds();
-        try {
-            return this._importResolver.getModuleNameForImport(filePath, this._execEnvironment);
-        } finally {
-            const endTime = this._stopWatch.getDurationInMilliseconds();
-            this._perfInfo.moduleResolveTimeInMS += endTime - startTime;
-        }
+        return this._importResolver.getModuleNameForImport(filePath, this._execEnvironment);
     }
 
     private _getImportGroupFromModuleNameAndType(moduleNameAndType: ModuleNameAndType): ImportGroup {
@@ -682,30 +672,6 @@ export class AutoImporter {
     }
 
     private _getTextEditsForAutoImportByFilePath(
-        moduleName: string,
-        importName: string | undefined,
-        abbrFromUsers: string | undefined,
-        insertionText: string,
-        importGroup: ImportGroup,
-        filePath: string
-    ) {
-        const startTime = this._stopWatch.getDurationInMilliseconds();
-        try {
-            return this._getTextEditsForAutoImportByFilePathInternal(
-                moduleName,
-                importName,
-                abbrFromUsers,
-                insertionText,
-                importGroup,
-                filePath
-            );
-        } finally {
-            const endTime = this._stopWatch.getDurationInMilliseconds();
-            this._perfInfo.editTimeInMS += endTime - startTime;
-        }
-    }
-
-    private _getTextEditsForAutoImportByFilePathInternal(
         moduleName: string,
         importName: string | undefined,
         abbrFromUsers: string | undefined,
@@ -835,8 +801,6 @@ export class AutoImporter {
             this._perfInfo.symbolCount++;
         } else if (library) {
             this._perfInfo.indexCount++;
-        } else {
-            this._perfInfo.userIndexCount++;
         }
     }
 

--- a/packages/pyright-internal/src/tests/fourslash/completions.override.property.stub.fourslash.ts
+++ b/packages/pyright-internal/src/tests/fourslash/completions.override.property.stub.fourslash.ts
@@ -1,0 +1,31 @@
+/// <reference path="fourslash.ts" />
+
+// @filename: test.pyi
+//// class B:
+////     @property
+////     def prop(self):
+////         return 1
+////
+////     @prop.setter
+////     def prop(self, value):
+////         pass
+////
+//// class C(B):
+////     @property
+////     def [|pr/*marker*/|]
+
+// @ts-ignore
+await helper.verifyCompletion('included', 'markdown', {
+    marker: {
+        completions: [
+            {
+                label: 'prop',
+                kind: Consts.CompletionItemKind.Property,
+                textEdit: {
+                    range: helper.getPositionRange('marker'),
+                    newText: 'prop(self): ...',
+                },
+            },
+        ],
+    },
+});

--- a/packages/pyright-internal/src/tests/fourslash/completions.override.stub.fourslash.ts
+++ b/packages/pyright-internal/src/tests/fourslash/completions.override.stub.fourslash.ts
@@ -1,0 +1,47 @@
+/// <reference path="fourslash.ts" />
+
+// @filename: test.pyi
+//// class B:
+////     def method1(self, a: str, *args, **kwargs):
+////         pass
+////
+////     def method2(self, b, /, *args):
+////         pass
+////
+////     def method3(self, b, *, c: str):
+////         pass
+////
+//// class C(B):
+////     def [|method/*marker*/|]
+
+// @ts-ignore
+await helper.verifyCompletion('included', 'markdown', {
+    marker: {
+        completions: [
+            {
+                label: 'method1',
+                kind: Consts.CompletionItemKind.Method,
+                textEdit: {
+                    range: helper.getPositionRange('marker'),
+                    newText: 'method1(self, a: str, *args, **kwargs): ...',
+                },
+            },
+            {
+                label: 'method2',
+                kind: Consts.CompletionItemKind.Method,
+                textEdit: {
+                    range: helper.getPositionRange('marker'),
+                    newText: 'method2(self, b, /, *args): ...',
+                },
+            },
+            {
+                label: 'method3',
+                kind: Consts.CompletionItemKind.Method,
+                textEdit: {
+                    range: helper.getPositionRange('marker'),
+                    newText: 'method3(self, b, *, c: str): ...',
+                },
+            },
+        ],
+    },
+});


### PR DESCRIPTION
Rollup of:

- Don't fill out function bodies in override completions in stub files. Stubs shouldn't have statements other than `...`.
- Fix partial stub mapping for open files; some features weren't working properly.
- Ensure partial stubs are scanned early enough (at config setup time).
- Clean up perf data that we're no longer using.
- Expose some import resolver methods as protected.
- Update the completion "extension" API.