### PR TITLE
Changed the logic that searches for a config file

### DIFF
--- a/packages/pyright-internal/src/analyzer/service.ts
+++ b/packages/pyright-internal/src/analyzer/service.ts
@@ -454,7 +454,17 @@ export class AnalyzerService {
                 }
             }
         } else if (projectRoot) {
-            configFilePath = this._findConfigFileHereOrUp(projectRoot);
+            // In a project-based IDE like VS Code, we should assume that the
+            // project root directory contains the config file. If pyright is
+            // being executed from the command line, the working directory
+            // may be deep within a project, and we need to walk up the directory
+            // hierarchy to find the project root.
+            if (commandLineOptions.fromVsCodeExtension) {
+                configFilePath = this._findConfigFile(projectRoot);
+            } else {
+                configFilePath = this._findConfigFileHereOrUp(projectRoot);
+            }
+
             if (configFilePath) {
                 projectRoot = getDirectoryPath(configFilePath);
             } else {


### PR DESCRIPTION
It currently searches from the current working directory all the way up the folder hierarchy. This makes sense only for a command-line tool, not for a language server. The latter already knows the project root, and we should look only in that directory for a config file.