### PR TITLE
Update command line directions with new output format

### DIFF
--- a/docs/command-line.md
+++ b/docs/command-line.md
@@ -50,7 +50,7 @@ If the “--outputjson” option is specified on the command line, diagnostics a
 {
     version: string,
     time: string,
-    diagnostics: Diagnostic[],
+    generalDiagnostics: Diagnostic[],
     summary: {
         filesAnalyzed: number,
         errorCount: number,


### PR DESCRIPTION
Since https://github.com/microsoft/pyright/commit/ba901d1449fceb0642934bfd1993e79ed0fb136d#diff-c3f0fa903325059f6e7dda1116458aafa72061ac3d1a51ddfd077a5dc0801030R394, the `--outputjson` result schema has changed.