### PR TITLE
Remove duplicate yield keyword, source mapper improvements

### DIFF
--- a/packages/pyright-internal/src/analyzer/importResolver.ts
+++ b/packages/pyright-internal/src/analyzer/importResolver.ts
@@ -1664,12 +1664,7 @@ export class ImportResolver {
     }
 
     protected formatImportName(moduleDescriptor: ImportedModuleDescriptor) {
-        let name = '';
-        for (let i = 0; i < moduleDescriptor.leadingDots; i++) {
-            name += '.';
-        }
-
-        return name + moduleDescriptor.nameParts.map((part) => part).join('.');
+        return '.'.repeat(moduleDescriptor.leadingDots) + moduleDescriptor.nameParts.join('.');
     }
 
     private _resolveNativeModuleStub(

--- a/packages/pyright-internal/src/languageService/completionProvider.ts
+++ b/packages/pyright-internal/src/languageService/completionProvider.ts
@@ -41,6 +41,7 @@ import {
     getModuleDocString,
     getOverloadedFunctionDocStringsInherited,
     getPropertyDocStringInherited,
+    getVariableInStubFileDocStrings,
 } from '../analyzer/typeDocStringUtils';
 import { CallSignatureInfo, TypeEvaluator } from '../analyzer/typeEvaluator';
 import {
@@ -139,7 +140,6 @@ const _keywords: string[] = [
     'return',
     'try',
     'while',
-    'yield',
 ];
 
 enum SortCategory {
@@ -1849,20 +1849,15 @@ export class CompletionProvider {
                                 ).find((doc) => doc);
                             } else if (primaryDecl?.type === DeclarationType.Function) {
                                 // @property functions
-                                const enclosingClass = isFunctionDeclaration(primaryDecl)
-                                    ? ParseTreeUtils.getEnclosingClass(primaryDecl.node.name, false)
-                                    : undefined;
-                                const classResults = enclosingClass
-                                    ? this._evaluator.getTypeOfClass(enclosingClass)
-                                    : undefined;
-                                if (classResults) {
-                                    documentation = getPropertyDocStringInherited(
-                                        primaryDecl,
-                                        this._sourceMapper,
-                                        this._evaluator,
-                                        classResults?.classType
-                                    );
-                                }
+                                documentation = getPropertyDocStringInherited(
+                                    primaryDecl,
+                                    this._sourceMapper,
+                                    this._evaluator
+                                );
+                            } else if (primaryDecl?.type === DeclarationType.Variable) {
+                                documentation = getVariableInStubFileDocStrings(primaryDecl, this._sourceMapper).find(
+                                    (doc) => doc
+                                );
                             }
 
                             if (this._options.format === MarkupKind.Markdown) {

--- a/packages/pyright-internal/src/tests/fourslash/completions.wildcardimports.fourslash.ts
+++ b/packages/pyright-internal/src/tests/fourslash/completions.wildcardimports.fourslash.ts
@@ -1,0 +1,116 @@
+/// <reference path="fourslash.ts" />
+
+// @filename: lib1/definition.py
+// @library: true
+//// def func():
+////     '''func docs'''
+////     pass
+////
+//// class MyType:
+////     def func2():
+////         '''func2 docs'''
+////         pass
+
+// @filename: lib1/alias.py
+// @library: true
+//// def func3():
+////     '''func3 docs'''
+////     pass
+
+// @filename: lib1/withall.py
+// @library: true
+//// def func4():
+////     '''func4 docs'''
+////     pass
+////
+//// def func5():
+////     '''func5 docs'''
+////     pass
+////
+//// __all__ = ['func5']
+
+// @filename: lib1/redirect.py
+// @library: true
+//// from . import withall
+//// from .withall import *
+////
+//// __all__ += withall.__all__
+
+// @filename: lib1/wildcard.py
+// @library: true
+//// from .definition import *
+//// from .redirect import *
+//// from .alias import func3
+
+// @filename: lib1/__init__.py
+// @library: true
+//// from .wildcard import *
+
+// @filename: lib1/__init__.pyi
+// @library: true
+//// class ufunc:
+////     def __call__(self): ...
+////
+//// func: ufunc
+//// class MyType:
+////     def func2() -> None : ...
+//// func3: ufunc
+//// func4: ufunc
+//// func5: ufunc
+
+// @filename: test.py
+//// import lib1
+//// lib1.[|/*marker1*/func|]()
+//// lib1.MyType().[|/*marker2*/func2|]()
+//// lib1.[|/*marker3*/func3|]()
+//// lib1.[|/*marker4*/func4|]()
+//// lib1.[|/*marker5*/func5|]()
+
+// @ts-ignore
+await helper.verifyCompletion('includes', 'markdown', {
+    marker1: {
+        completions: [
+            {
+                label: 'func',
+                kind: Consts.CompletionItemKind.Variable,
+                documentation: '```python\nfunc: ufunc\n```\n---\nfunc docs',
+            },
+        ],
+    },
+    marker2: {
+        completions: [
+            {
+                label: 'func2',
+                kind: Consts.CompletionItemKind.Method,
+                documentation: '```python\nfunc2: () -> None\n```\n---\nfunc2 docs',
+            },
+        ],
+    },
+    marker3: {
+        completions: [
+            {
+                label: 'func3',
+                kind: Consts.CompletionItemKind.Variable,
+                documentation: '```python\nfunc3: ufunc\n```\n---\nfunc3 docs',
+            },
+        ],
+    },
+    marker4: {
+        completions: [
+            {
+                label: 'func4',
+                kind: Consts.CompletionItemKind.Variable,
+                documentation: '```python\nfunc4: ufunc\n```\n---\nfunc4 docs',
+            },
+        ],
+    },
+    marker5: {
+        completions: [
+            {
+                label: 'func5',
+                kind: Consts.CompletionItemKind.Variable,
+                documentation: '```python\nfunc5: ufunc\n```\n---\nfunc5 docs',
+            },
+        ],
+    },
+});

--- a/packages/pyright-internal/src/tests/fourslash/findDefinitions.wildcardimports.fourslash.ts
+++ b/packages/pyright-internal/src/tests/fourslash/findDefinitions.wildcardimports.fourslash.ts
@@ -1,0 +1,117 @@
+/// <reference path="fourslash.ts" />
+
+// @filename: lib1/definition.py
+// @library: true
+//// def [|func|]():
+////     '''func docs'''
+////     pass
+////
+//// class MyType:
+////     def [|func2|]():
+////         '''func2 docs'''
+////         pass
+
+// @filename: lib1/alias.py
+// @library: true
+//// def [|func3|]():
+////     '''func3 docs'''
+////     pass
+
+// @filename: lib1/withall.py
+// @library: true
+//// def [|func4|]():
+////     '''func4 docs'''
+////     pass
+////
+//// def [|func5|]():
+////     '''func5 docs'''
+////     pass
+////
+//// __all__ = ['func5']
+
+// @filename: lib1/redirect.py
+// @library: true
+//// from . import withall
+//// from .withall import *
+////
+//// __all__ += withall.__all__
+
+// @filename: lib1/wildcard.py
+// @library: true
+//// from .definition import *
+//// from .redirect import *
+//// from .alias import func3
+
+// @filename: lib1/__init__.py
+// @library: true
+//// from .wildcard import *
+
+// @filename: lib1/__init__.pyi
+// @library: true
+//// class ufunc:
+////     def __call__(self) -> None : ...
+////
+//// func: ufunc
+//// class MyType:
+////     def func2() -> None : ...
+//// func3: ufunc
+//// func4: ufunc
+//// func5: ufunc
+
+// @filename: test.py
+//// import lib1
+//// lib1.[|/*marker1*/func|]()
+//// lib1.MyType().[|/*marker2*/func2|]()
+//// lib1.[|/*marker3*/func3|]()
+//// lib1.[|/*marker4*/func4|]()
+//// lib1.[|/*marker5*/func5|]()
+
+{
+    const rangeMap = helper.getRangesByText();
+
+    helper.verifyFindDefinitions(
+        {
+            marker1: {
+                definitions: rangeMap
+                    .get('func')!
+                    .filter((r) => !r.marker)
+                    .map((r) => {
+                        return { path: r.fileName, range: helper.convertPositionRange(r) };
+                    }),
+            },
+            marker2: {
+                definitions: rangeMap
+                    .get('func2')!
+                    .filter((r) => !r.marker)
+                    .map((r) => {
+                        return { path: r.fileName, range: helper.convertPositionRange(r) };
+                    }),
+            },
+            marker3: {
+                definitions: rangeMap
+                    .get('func3')!
+                    .filter((r) => !r.marker)
+                    .map((r) => {
+                        return { path: r.fileName, range: helper.convertPositionRange(r) };
+                    }),
+            },
+            marker4: {
+                definitions: rangeMap
+                    .get('func4')!
+                    .filter((r) => !r.marker)
+                    .map((r) => {
+                        return { path: r.fileName, range: helper.convertPositionRange(r) };
+                    }),
+            },
+            marker5: {
+                definitions: rangeMap
+                    .get('func5')!
+                    .filter((r) => !r.marker)
+                    .map((r) => {
+                        return { path: r.fileName, range: helper.convertPositionRange(r) };
+                    }),
+            },
+        },
+        'preferSource'
+    );
+}

--- a/packages/pyright-internal/src/tests/fourslash/hover.wildcardimports.fourslash.ts
+++ b/packages/pyright-internal/src/tests/fourslash/hover.wildcardimports.fourslash.ts
@@ -1,0 +1,80 @@
+/// <reference path="fourslash.ts" />
+
+// @filename: lib1/definition.py
+// @library: true
+//// def func():
+////     '''func docs'''
+////     pass
+////
+//// class MyType:
+////     '''MyType docs'''
+////     pass
+////
+//// class MyType2:
+////     def func2():
+////         '''func2 docs'''
+////         pass
+
+// @filename: lib1/alias.py
+// @library: true
+//// def func3():
+////     '''func3 docs'''
+////     pass
+
+// @filename: lib1/withall.py
+// @library: true
+//// def func4():
+////     '''func4 docs'''
+////     pass
+////
+//// def func5():
+////     '''func5 docs'''
+////     pass
+////
+//// __all__ = ['func5']
+
+// @filename: lib1/redirect.py
+// @library: true
+//// from . import withall
+//// from .withall import *
+////
+//// __all__ += withall.__all__
+
+// @filename: lib1/wildcard.py
+// @library: true
+//// from .definition import *
+//// from .redirect import *
+//// from .alias import func3
+
+// @filename: lib1/__init__.py
+// @library: true
+//// from .wildcard import *
+
+// @filename: lib1/__init__.pyi
+// @library: true
+//// from typing import Any
+//// func: Any
+//// MyType: Any
+//// class MyType2:
+////     def func2() -> None : ...
+//// func3: Any
+//// func4: Any
+//// func5: Any
+
+// @filename: test.py
+//// import lib1
+//// lib1.[|/*marker1*/func|]()
+//// c = lib1.[|/*marker2*/MyType|]()
+//// lib1.MyType2().[|/*marker3*/func2|]()
+//// lib1.[|/*marker4*/func3|]()
+//// lib1.[|/*marker5*/func4|]()
+//// lib1.[|/*marker6*/func5|]()
+
+helper.verifyHover('markdown', {
+    marker1: '```python\n(variable) func: Any\n```\n---\nfunc docs',
+    marker2: '```python\n(variable) MyType: Any\n```\n---\nMyType docs',
+    marker3: '```python\n(method) func2: () -> None\n```\n---\nfunc2 docs',
+    marker4: '```python\n(variable) func3: Any\n```\n---\nfunc3 docs',
+    marker5: '```python\n(variable) func4: Any\n```\n---\nfunc4 docs',
+    marker6: '```python\n(variable) func5: Any\n```\n---\nfunc5 docs',
+});

--- a/packages/pyright-internal/src/tests/fourslash/signature.docstrings.wildcardimports.fourslash.ts
+++ b/packages/pyright-internal/src/tests/fourslash/signature.docstrings.wildcardimports.fourslash.ts
@@ -1,0 +1,122 @@
+/// <reference path="fourslash.ts" />
+
+// @filename: lib1/definition.py
+// @library: true
+//// def func():
+////     '''func docs'''
+////     pass
+////
+//// class MyType:
+////     def func2():
+////         '''func2 docs'''
+////         pass
+
+// @filename: lib1/alias.py
+// @library: true
+//// def func3():
+////     '''func3 docs'''
+////     pass
+
+// @filename: lib1/withall.py
+// @library: true
+//// def func4():
+////     '''func4 docs'''
+////     pass
+////
+//// def func5():
+////     '''func5 docs'''
+////     pass
+////
+//// __all__ = ['func5']
+
+// @filename: lib1/redirect.py
+// @library: true
+//// from . import withall
+//// from .withall import *
+////
+//// __all__ += withall.__all__
+
+// @filename: lib1/wildcard.py
+// @library: true
+//// from .definition import *
+//// from .redirect import *
+//// from .alias import func3
+
+// @filename: lib1/__init__.py
+// @library: true
+//// from .wildcard import *
+
+// @filename: lib1/__init__.pyi
+// @library: true
+//// class ufunc:
+////     def __call__(self) -> None : ...
+////
+//// func: ufunc
+//// class MyType:
+////     def func2() -> None : ...
+//// func3: ufunc
+//// func4: ufunc
+//// func5: ufunc
+
+// @filename: test.py
+//// import lib1
+//// lib1.func([|/*marker1*/|])
+//// lib1.MyType().func2([|/*marker2*/|])
+//// lib1.func3([|/*marker3*/|])
+//// lib1.func4([|/*marker4*/|])
+//// lib1.func5([|/*marker5*/|])
+
+{
+    helper.verifySignature('markdown', {
+        marker1: {
+            signatures: [
+                {
+                    label: '() -> None',
+                    parameters: [],
+                    documentation: 'func docs',
+                },
+            ],
+            activeParameters: [undefined],
+        },
+        marker2: {
+            signatures: [
+                {
+                    label: '() -> None',
+                    parameters: [],
+                    documentation: 'func2 docs',
+                },
+            ],
+            activeParameters: [undefined],
+        },
+        marker3: {
+            signatures: [
+                {
+                    label: '() -> None',
+                    parameters: [],
+                    documentation: 'func3 docs',
+                },
+            ],
+            activeParameters: [undefined],
+        },
+        marker4: {
+            signatures: [
+                {
+                    label: '() -> None',
+                    parameters: [],
+                    documentation: 'func4 docs',
+                },
+            ],
+            activeParameters: [undefined],
+        },
+        marker5: {
+            signatures: [
+                {
+                    label: '() -> None',
+                    parameters: [],
+                    documentation: 'func5 docs',
+                },
+            ],
+            activeParameters: [undefined],
+        },
+    });
+}


### PR DESCRIPTION
Rollup of:

- Remove duplicate yield keyword in completions
- Source mapper improvements (for more complicated stub layouts like numpy)
- Improve performance of import name creation in import resolver by 20%