### PR TITLE
Optimize getUnescapedString and _skipToEndOfStringLiteral

### DIFF
--- a/packages/pyright-internal/src/parser/stringTokenUtils.ts
+++ b/packages/pyright-internal/src/parser/stringTokenUtils.ts
@@ -55,21 +55,46 @@ export interface UnescapedString {
     formatStringSegments: FormatStringSegment[];
 }
 
+interface IncompleteUnescapedString {
+    valueParts: string[];
+    unescapeErrors: UnescapeError[];
+    nonAsciiInBytes: boolean;
+    formatStringSegments: IncompleteFormatStringSegment[];
+}
+
+interface IncompleteFormatStringSegment {
+    offset: number;
+    length: number;
+    valueParts: string[];
+    isExpression: boolean;
+}
+
+function completeUnescapedString(incomplete: IncompleteUnescapedString): UnescapedString {
+    return {
+        ...incomplete,
+        value: incomplete.valueParts.join(''),
+        formatStringSegments: incomplete.formatStringSegments.map((segment) => ({
+            ...segment,
+            value: segment.valueParts.join(''),
+        })),
+    };
+}
+
 export function getUnescapedString(stringToken: StringToken): UnescapedString {
     const escapedString = stringToken.escapedValue;
     const isRaw = (stringToken.flags & StringTokenFlags.Raw) !== 0;
     const isBytes = (stringToken.flags & StringTokenFlags.Bytes) !== 0;
     const isFormat = (stringToken.flags & StringTokenFlags.Format) !== 0;
     let formatExpressionNestCount = 0;
-    let formatSegment: FormatStringSegment = {
+    let formatSegment: IncompleteFormatStringSegment = {
         offset: 0,
         length: 0,
-        value: '',
+        valueParts: [],
         isExpression: false,
     };
     let strOffset = 0;
-    const output: UnescapedString = {
-        value: '',
+    const output: IncompleteUnescapedString = {
+        valueParts: [],
         unescapeErrors: [],
         nonAsciiInBytes: false,
         formatStringSegments: [],
@@ -122,8 +147,8 @@ export function getUnescapedString(stringToken: StringToken): UnescapedString {
 
     const appendOutputChar = (charCode: number) => {
         const char = String.fromCharCode(charCode);
-        output.value += char;
-        formatSegment.value += char;
+        output.valueParts.push(char);
+        formatSegment.valueParts.push(char);
     };
 
     while (true) {
@@ -145,7 +170,7 @@ export function getUnescapedString(stringToken: StringToken): UnescapedString {
                     output.formatStringSegments.push(formatSegment);
                 }
             }
-            return output;
+            return completeUnescapedString(output);
         }
 
         if (curChar === Char.Backslash) {
@@ -305,8 +330,8 @@ export function getUnescapedString(stringToken: StringToken): UnescapedString {
                 }
             }
 
-            output.value += localValue;
-            formatSegment.value += localValue;
+            output.valueParts.push(localValue);
+            formatSegment.valueParts.push(localValue);
         } else if (curChar === Char.LineFeed || curChar === Char.CarriageReturn) {
             // Skip over the escaped new line (either one or two characters).
             if (curChar === Char.CarriageReturn && getEscapedCharacter(1) === Char.LineFeed) {
@@ -335,7 +360,7 @@ export function getUnescapedString(stringToken: StringToken): UnescapedString {
                     formatSegment = {
                         offset: strOffset,
                         length: 0,
-                        value: '',
+                        valueParts: [],
                         isExpression: true,
                     };
                 } else {
@@ -369,7 +394,7 @@ export function getUnescapedString(stringToken: StringToken): UnescapedString {
                     formatSegment = {
                         offset: strOffset,
                         length: 0,
-                        value: '',
+                        valueParts: [],
                         isExpression: false,
                     };
                 } else {
@@ -387,8 +412,8 @@ export function getUnescapedString(stringToken: StringToken): UnescapedString {
                 strOffset += 2;
                 appendOutputChar(curChar);
                 appendOutputChar(curChar);
-                output.value += String.fromCharCode(curChar);
-                output.value += String.fromCharCode(curChar);
+                output.valueParts.push(String.fromCharCode(curChar));
+                output.valueParts.push(String.fromCharCode(curChar));
             }
 
             while (true) {


### PR DESCRIPTION
Through profiling, I found that these functions accounted for more than 75% of the memory allocations when running on a test application. Both build strings via `+=`. Rewrite them to push into an array instead and `join('')` at the end, which is much faster overall. Presumably v8 knows to preallocate the output to the correct size when it sees it's joining an array of strings.

This halves the time spent in GC from 11% to around 5% of total CPU time.

(There are further tweaks that could be made to reuse these arrays and allocate less, but this fixes the great bulk of the problem.)