### PR TITLE
Make fewer calls to python at config time, print actual import roots

### DIFF
--- a/packages/pyright-internal/src/analyzer/backgroundAnalysisProgram.ts
+++ b/packages/pyright-internal/src/analyzer/backgroundAnalysisProgram.ts
@@ -62,13 +62,13 @@ export class BackgroundAnalysisProgram {
         this._configOptions = configOptions;
         this._backgroundAnalysis?.setConfigOptions(configOptions);
         this._program.setConfigOptions(configOptions);
-
-        configOptions.getExecutionEnvironments().forEach((e) => this._ensurePartialStubPackages(e));
     }
 
     setImportResolver(importResolver: ImportResolver) {
         this._importResolver = importResolver;
         this._program.setImportResolver(importResolver);
+
+        this._configOptions.getExecutionEnvironments().forEach((e) => this._ensurePartialStubPackages(e));
 
         // Do nothing for background analysis.
         // Background analysis updates importer when configOptions is changed rather than

--- a/packages/pyright-internal/src/analyzer/backgroundAnalysisProgram.ts
+++ b/packages/pyright-internal/src/analyzer/backgroundAnalysisProgram.ts
@@ -212,13 +212,6 @@ export class BackgroundAnalysisProgram {
         this._program.markAllFilesDirty(true);
     }
 
-    invalidateCache() {
-        // Invalidate import resolver because it could have cached
-        // imports that are no longer valid because a source file has
-        // been deleted or added.
-        this._importResolver.invalidateCache();
-    }
-
     restart() {
         this._backgroundAnalysis?.restart();
     }

--- a/packages/pyright-internal/src/analyzer/importResolver.ts
+++ b/packages/pyright-internal/src/analyzer/importResolver.ts
@@ -439,7 +439,7 @@ export class ImportResolver {
         return this._getStdlibTypeshedPath(execEnv, unused);
     }
 
-    getImportRoots(execEnv: ExecutionEnvironment) {
+    getImportRoots(execEnv: ExecutionEnvironment, forLogging = false) {
         const importFailureInfo: string[] = [];
         const roots = [];
 
@@ -455,8 +455,18 @@ export class ImportResolver {
             roots.push(this._configOptions.stubPath);
         }
 
-        const thirdPartyPaths = this._getThirdPartyTypeshedPackagePaths(execEnv, importFailureInfo);
-        roots.push(...thirdPartyPaths);
+        if (forLogging) {
+            // There's one path for each third party package, which blows up logging.
+            // Just get the root directly and show it with `...` to indicate that this
+            // is where the third party folder is in the roots.
+            const thirdPartyRoot = this._getThirdPartyTypeshedPath(execEnv, importFailureInfo);
+            if (thirdPartyRoot) {
+                roots.push(combinePaths(thirdPartyRoot, '...'));
+            }
+        } else {
+            const thirdPartyPaths = this._getThirdPartyTypeshedPackagePaths(execEnv, importFailureInfo);
+            roots.push(...thirdPartyPaths);
+        }
 
         const typeshedPathEx = this.getTypeshedPathEx(execEnv, importFailureInfo);
         if (typeshedPathEx) {

--- a/packages/pyright-internal/src/analyzer/service.ts
+++ b/packages/pyright-internal/src/analyzer/service.ts
@@ -59,7 +59,7 @@ import { AnalysisCompleteCallback } from './analysis';
 import { BackgroundAnalysisProgram, BackgroundAnalysisProgramFactory } from './backgroundAnalysisProgram';
 import { ImportedModuleDescriptor, ImportResolver, ImportResolverFactory } from './importResolver';
 import { MaxAnalysisTime } from './program';
-import { findPythonSearchPaths, getPythonPathFromPythonInterpreter } from './pythonPathUtils';
+import { findPythonSearchPaths } from './pythonPathUtils';
 import { TypeEvaluator } from './typeEvaluator';
 
 export const configFileNames = ['pyrightconfig.json', 'mspythonconfig.json'];
@@ -645,36 +645,6 @@ export class AnalyzerService {
                     }
                 }
             }
-        } else {
-            const importFailureInfo: string[] = [];
-            const pythonPaths = getPythonPathFromPythonInterpreter(
-                this._fs,
-                configOptions.pythonPath,
-                importFailureInfo
-            ).paths;
-            if (pythonPaths.length === 0) {
-                const logLevel = configOptions.verboseOutput ? LogLevel.Error : LogLevel.Log;
-                if (commandLineOptions.fromVsCodeExtension || configOptions.verboseOutput) {
-                    log(this._console, logLevel, `No search paths found for configured python interpreter.`);
-                }
-            } else {
-                if (commandLineOptions.fromVsCodeExtension || configOptions.verboseOutput) {
-                    const logLevel = configOptions.verboseOutput ? LogLevel.Info : LogLevel.Log;
-                    log(this._console, logLevel, `Search paths found for configured python interpreter:`);
-                    pythonPaths.forEach((path) => {
-                        log(this._console, logLevel, `  ${path}`);
-                    });
-                }
-            }
-
-            if (configOptions.verboseOutput) {
-                if (importFailureInfo.length > 0) {
-                    this._console.info(`When attempting to get search paths from python interpreter:`);
-                    importFailureInfo.forEach((diag) => {
-                        this._console.info(`  ${diag}`);
-                    });
-                }
-            }
         }
 
         // Is there a reference to a venv? If so, there needs to be a valid venvPath.
@@ -1069,8 +1039,6 @@ export class AnalyzerService {
     private _updateSourceFileWatchers() {
         this._removeSourceFileWatchers();
 
-        this._backgroundAnalysisProgram.invalidateCache();
-
         if (!this._watchForSourceChanges) {
             return;
         }
@@ -1148,8 +1116,6 @@ export class AnalyzerService {
 
     private _updateLibraryFileWatcher() {
         this._removeLibraryFileWatcher();
-
-        this._backgroundAnalysisProgram.invalidateCache();
 
         if (!this._watchForLibraryChanges) {
             return;
@@ -1291,6 +1257,17 @@ export class AnalyzerService {
         // cached based on the previous config options.
         const importResolver = this._importResolverFactory(this._fs, this._backgroundAnalysisProgram.configOptions);
         this._backgroundAnalysisProgram.setImportResolver(importResolver);
+
+        if (this._commandLineOptions?.fromVsCodeExtension || this._configOptions.verboseOutput) {
+            const logLevel = this._configOptions.verboseOutput ? LogLevel.Info : LogLevel.Log;
+            for (const execEnv of this._configOptions.getExecutionEnvironments()) {
+                log(this._console, logLevel, `Search paths for ${execEnv.root}`);
+                const roots = importResolver.getImportRoots(execEnv);
+                roots.forEach((path) => {
+                    log(this._console, logLevel, `  ${path}`);
+                });
+            }
+        }
 
         this._updateLibraryFileWatcher();
         this._updateConfigFileWatcher();

--- a/packages/pyright-internal/src/analyzer/service.ts
+++ b/packages/pyright-internal/src/analyzer/service.ts
@@ -1262,7 +1262,7 @@ export class AnalyzerService {
             const logLevel = this._configOptions.verboseOutput ? LogLevel.Info : LogLevel.Log;
             for (const execEnv of this._configOptions.getExecutionEnvironments()) {
                 log(this._console, logLevel, `Search paths for ${execEnv.root}`);
-                const roots = importResolver.getImportRoots(execEnv);
+                const roots = importResolver.getImportRoots(execEnv, /* forLogging */ true);
                 roots.forEach((path) => {
                     log(this._console, logLevel, `  ${path}`);
                 });


### PR DESCRIPTION
Through profiling, I found that we were calling python 4 times at startup. This was due to a couple of issues:

- We wanted to log the search paths (for helping debug users), but called out to python to get them directly (distinctly from the import resolver). Instead, don't do this, and print the actual set of import roots later (per execution environment), which is what we actually want to know.
- The file watcher setup functions were invalidating the import cache. I have no idea why; the setup functions are called directly after a new import resolver is constructed. The import resolver's caches are certainly empty.
- The ensure partial stub function was run on setConfig, but then all callers of setConfig immediately created a new import resolver, leading to an extra python call as the ensure function fetches search paths. (It's also dubious that the partial stubs are even ready in the old code, if the import resolver was created _after_ the ensure call; @heejaechang I'm curious if you think this is alright in the new code.)

Now, we only call twice, once to get the default interpreter's version, once to get the import roots. Those are in entirely different parts of the code, so is less simple to fix (but would be nice later).