### PR TITLE
Fix sys.path script for pypy

### DIFF
--- a/packages/pyright-internal/src/analyzer/pythonPathUtils.ts
+++ b/packages/pyright-internal/src/analyzer/pythonPathUtils.ts
@@ -33,7 +33,7 @@ const extractSys = [
     'import os, os.path, sys',
     'normalize = lambda p: os.path.normcase(os.path.normpath(p))',
     'cwd = normalize(os.getcwd())',
-    'sys.path[:] = (p for p in sys.path if p != "" and normalize(p) != cwd)',
+    'sys.path[:] = [p for p in sys.path if p != "" and normalize(p) != cwd]',
     'import json',
     'json.dump(dict(path=sys.path, prefix=sys.prefix), sys.stdout)',
 ].join('; ');


### PR DESCRIPTION
Assigning a generator to a slice like this isn't well-defined; use a list instead.

(Updating to match the core extension's isolated runner.)