### PR TITLE
Use `null` instead of `-1` for `SignatureHelp.activeParameter`

### DIFF
--- a/packages/pyright-internal/src/languageServerBase.ts
+++ b/packages/pyright-internal/src/languageServerBase.ts
@@ -694,11 +694,7 @@ export abstract class LanguageServerBase implements LanguageServerInterface {
             }
 
             if (this.client.hasActiveParameterCapability || activeSignature === null) {
-                // A value of -1 is out of bounds but is legal within the LSP (should be treated
-                // as undefined). It produces a better result in VS Code by preventing it from
-                // highlighting the first parameter when no parameter works, since the LSP client
-                // converts null into zero.
-                activeParameter = -1;
+                activeParameter = null;
             }
 
             return { signatures, activeSignature, activeParameter };


### PR DESCRIPTION
LSP 3.16 (current) specification says that `SignatureHelp.activeParameter` should be `uinteger`. (https://microsoft.github.io/language-server-protocol/specifications/specification-3-16/#textDocument_signatureHelp) But `pyright-langserver` returns `-1` in certain situation. It makes Rust lsp-types break. (https://docs.rs/lsp-types/0.89.0/lsp_types/struct.SignatureHelp.html#structfield.active_parameter)