### PR TITLE
Changed binder logic for "from .a import b" statements in `__init__.p…

### DIFF
--- a/packages/pyright-internal/src/analyzer/binder.ts
+++ b/packages/pyright-internal/src/analyzer/binder.ts
@@ -1457,7 +1457,7 @@ export class Binder extends ParseTreeWalker {
         // declaration list because it should "win" when resolving the alias.
         const fileName = stripFileExtension(getFileName(this._fileInfo.filePath));
         const isModuleInitFile =
-            fileName === '__init__' && node.module.leadingDots === 1 && node.module.nameParts.length > 0;
+            fileName === '__init__' && node.module.leadingDots === 1 && node.module.nameParts.length === 1;
 
         let isTypingImport = false;
         if (node.module.nameParts.length === 1) {

--- a/packages/pyright-internal/src/tests/fourslash/hover.import.django.view.fourslash.ts
+++ b/packages/pyright-internal/src/tests/fourslash/hover.import.django.view.fourslash.ts
@@ -1,0 +1,27 @@
+/// <reference path="fourslash.ts" />
+
+// @filename: test.py
+//// from django.view import generic
+//// generic.[|/*marker*/TemplateView|]
+
+// @filename: django/__init__.py
+//// '''documentation for library'''
+
+// @filename: django/view/__init__.py
+//// from .generic.base import View
+//// __all__ = ['View']
+
+// @filename: django/view/generic/__init__.py
+//// from .base import (View, TemplateView)
+//// __all__ = ['View', 'TemplateView']
+
+// @filename: django/view/generic/base.py
+//// class View():
+////     pass
+////
+//// class TemplateView():
+////     pass
+
+helper.verifyHover('markdown', {
+    marker: '```python\n(class) TemplateView\n```',
+});


### PR DESCRIPTION
…y` files so implicit import of submodule "a" is performed only if it's not a multi-part module path.