### PR TITLE
Fixed bug in type inference of dictionary, list and set expressions w…

### DIFF
--- a/packages/pyright-internal/src/analyzer/checker.ts
+++ b/packages/pyright-internal/src/analyzer/checker.ts
@@ -2359,7 +2359,7 @@ export class Checker extends ParseTreeWalker {
                       }),
                 node
             );
-        } else if (isTypeSame(filteredType, arg0Type)) {
+        } else if (isTypeSame(filteredType, arg0Type, /* ignorePseudoGeneric */ true)) {
             this._evaluator.addDiagnostic(
                 this._fileInfo.diagnosticRuleSet.reportUnnecessaryIsInstance,
                 DiagnosticRule.reportUnnecessaryIsInstance,

--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -7061,7 +7061,7 @@ export function createTypeEvaluator(
                             const castToType = getTypeForArgumentExpectingType(argList[0]);
                             const castFromType = getTypeForArgument(argList[1]);
                             if (isClass(castToType) && isObject(castFromType)) {
-                                if (isTypeSame(castToType, castFromType.classType)) {
+                                if (isTypeSame(castToType, castFromType.classType, /* ignorePseudoGeneric */ true)) {
                                     addDiagnostic(
                                         getFileInfo(errorNode).diagnosticRuleSet.reportUnnecessaryCast,
                                         DiagnosticRule.reportUnnecessaryCast,
@@ -8008,7 +8008,7 @@ export function createTypeEvaluator(
                 const typeParams = type.strippedFirstParamType!.classType.details.typeParameters;
                 type.strippedFirstParamType.classType.typeArguments.forEach((typeArg, index) => {
                     const typeParam = typeParams[index];
-                    if (!isTypeSame(typeParam, typeArg)) {
+                    if (!isTypeSame(typeParam, typeArg, /* ignorePseudoGeneric */ true)) {
                         typeVarMap.setTypeVarType(typeParams[index], typeArg);
                     }
                 });
@@ -10264,7 +10264,7 @@ export function createTypeEvaluator(
             if (getFileInfo(node).diagnosticRuleSet.strictDictionaryInference || !!expectedType) {
                 valueType = combineTypes(valueTypes);
             } else {
-                valueType = areTypesSame(valueTypes)
+                valueType = areTypesSame(valueTypes, /* ignorePseudoGeneric */ true)
                     ? valueTypes[0]
                     : expectedType
                     ? AnyType.create()
@@ -10550,7 +10550,9 @@ export function createTypeEvaluator(
                 inferredEntryType = combineTypes(entryTypes, maxSubtypesForInferredType);
             } else {
                 // Is the list or set homogeneous? If so, use stricter rules. Otherwise relax the rules.
-                inferredEntryType = areTypesSame(entryTypes) ? entryTypes[0] : inferredEntryType;
+                inferredEntryType = areTypesSame(entryTypes, /* ignorePseudoGeneric */ true)
+                    ? entryTypes[0]
+                    : inferredEntryType;
             }
         } else {
             isEmptyContainer = true;
@@ -18934,7 +18936,7 @@ export function createTypeEvaluator(
         // Some protocol definitions include recursive references to themselves.
         // We need to protect against infinite recursion, so we'll check for that here.
         if (ClassType.isSameGenericClass(srcType, destType)) {
-            if (isTypeSame(srcType, destType)) {
+            if (isTypeSame(srcType, destType, /* ignorePseudoGeneric */ true)) {
                 return true;
             }
 
@@ -19426,7 +19428,14 @@ export function createTypeEvaluator(
                     typesAreConsistent = false;
                 }
 
-                if (!isTypeSame(destEntry.valueType, srcEntry.valueType, recursionCount + 1)) {
+                if (
+                    !isTypeSame(
+                        destEntry.valueType,
+                        srcEntry.valueType,
+                        /* ignorePseudoGeneric */ true,
+                        recursionCount + 1
+                    )
+                ) {
                     diag.addMessage(Localizer.DiagnosticAddendum.memberTypeMismatch().format({ name }));
                     typesAreConsistent = false;
                 }
@@ -20303,7 +20312,7 @@ export function createTypeEvaluator(
             if (destTypeVar.details.constraints.length > 0) {
                 if (
                     findSubtype(srcType, (srcSubtype, constraints) => {
-                        if (isTypeSame(destTypeVar, srcSubtype)) {
+                        if (isTypeSame(destTypeVar, srcSubtype, /* ignorePseudoGeneric */ true)) {
                             return false;
                         }
 

--- a/packages/pyright-internal/src/analyzer/typeUtils.ts
+++ b/packages/pyright-internal/src/analyzer/typeUtils.ts
@@ -217,13 +217,13 @@ export function doForEachSubtype(
 }
 
 // Determines if all of the types in the array are the same.
-export function areTypesSame(types: Type[]): boolean {
+export function areTypesSame(types: Type[], ignorePseudoGeneric: boolean): boolean {
     if (types.length < 2) {
         return true;
     }
 
     for (let i = 1; i < types.length; i++) {
-        if (!isTypeSame(types[0], types[i])) {
+        if (!isTypeSame(types[0], types[i], ignorePseudoGeneric)) {
             return false;
         }
     }


### PR DESCRIPTION
…hen they contain classes or class instances that are apparently the same type but internally appear different because they are "pseudo-generic". Pseudo-generic classes are those that have no type annotations in the `__init__` method and are treated internally as generics to improve type inference.