### PR TITLE
Log to stderr in CLI outputjson mode

### DIFF
--- a/packages/pyright-internal/src/common/console.ts
+++ b/packages/pyright-internal/src/common/console.ts
@@ -68,6 +68,24 @@ export class StandardConsole implements ConsoleInterface {
     }
 }
 
+export class StderrConsole implements ConsoleInterface {
+    log(message: string) {
+        console.error(message);
+    }
+
+    info(message: string) {
+        console.error(message);
+    }
+
+    warn(message: string) {
+        console.error(message);
+    }
+
+    error(message: string) {
+        console.error(message);
+    }
+}
+
 export class ConsoleWithLogLevel implements ConsoleInterface {
     private _levelMap: Map<string, number> = new Map([
         [LogLevel.Error, 0],

--- a/packages/pyright-internal/src/pyright.ts
+++ b/packages/pyright-internal/src/pyright.ts
@@ -21,7 +21,7 @@ import * as process from 'process';
 import { PackageTypeVerifier } from './analyzer/packageTypeVerifier';
 import { AnalyzerService } from './analyzer/service';
 import { CommandLineOptions as PyrightCommandLineOptions } from './common/commandLineOptions';
-import { NullConsole } from './common/console';
+import { StderrConsole } from './common/console';
 import { Diagnostic, DiagnosticCategory } from './common/diagnostic';
 import { FileDiagnostics } from './common/diagnosticSink';
 import { combinePaths, normalizePath } from './common/pathUtils';
@@ -248,7 +248,7 @@ function processArgs() {
     }
     options.checkOnlyOpenFiles = false;
 
-    const output = args.outputjson ? new NullConsole() : undefined;
+    const output = args.outputjson ? new StderrConsole() : undefined;
     const fileSystem = new PyrightFileSystem(createFromRealFileSystem(output));
 
     // The package type verification uses a different path.


### PR DESCRIPTION
Forcing all logging to stderr lets me inherit stderr in `pyright-action` (so they are logged), but still capture the JSON summary over stdout to process.