### PR TITLE
Moved checks for string literal errors (unsupported escape characters…

### DIFF
--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -2821,7 +2821,9 @@ export function createTypeEvaluator(
         }
 
         const diagnostic = fileInfo.diagnosticSink.addDiagnosticWithTextRange(diagLevel, message, range);
-        diagnostic.setRule(rule);
+        if (rule) {
+            diagnostic.setRule(rule);
+        }
 
         return diagnostic;
     }


### PR DESCRIPTION
…, etc.) from binder to checker for performance reasons.