### PR TITLE
Removed PEP 563 (deferred type annotation) behavior as default for Py…

### DIFF
--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -1334,7 +1334,11 @@ export function createTypeEvaluator(
     }
 
     function isAnnotationEvaluationPostponed(fileInfo: AnalyzerFileInfo) {
-        return fileInfo.futureImports.get('annotations') !== undefined || fileInfo.isStubFile;
+        return (
+            fileInfo.futureImports.get('annotations') !== undefined ||
+            fileInfo.executionEnvironment.pythonVersion >= PythonVersion.V3_11 ||
+            fileInfo.isStubFile
+        );
     }
 
     function getTypeOfAnnotation(

--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -1334,10 +1334,7 @@ export function createTypeEvaluator(
     }
 
     function isAnnotationEvaluationPostponed(fileInfo: AnalyzerFileInfo) {
-        return (
-            fileInfo.futureImports.get('annotations') !== undefined ||
-            fileInfo.isStubFile
-        );
+        return fileInfo.futureImports.get('annotations') !== undefined || fileInfo.isStubFile;
     }
 
     function getTypeOfAnnotation(

--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -1336,7 +1336,6 @@ export function createTypeEvaluator(
     function isAnnotationEvaluationPostponed(fileInfo: AnalyzerFileInfo) {
         return (
             fileInfo.futureImports.get('annotations') !== undefined ||
-            fileInfo.executionEnvironment.pythonVersion >= PythonVersion.V3_10 ||
             fileInfo.isStubFile
         );
     }

--- a/packages/pyright-internal/src/common/pythonVersion.ts
+++ b/packages/pyright-internal/src/common/pythonVersion.ts
@@ -23,6 +23,7 @@ export enum PythonVersion {
     V3_8 = 0x0308,
     V3_9 = 0x0309,
     V3_10 = 0x030a,
+    V3_11 = 0x030b,
 }
 
 export const latestStablePythonVersion = PythonVersion.V3_9;


### PR DESCRIPTION
…thon 3.10, reflecting a recent decision by the Python steering committee.