### PR TITLE
Performance improvements, fix config file watching

### DIFF
--- a/packages/pyright-internal/src/analyzer/binder.ts
+++ b/packages/pyright-internal/src/analyzer/binder.ts
@@ -133,10 +133,6 @@ interface FinalInfo {
     finalTypeNode?: ExpressionNode;
 }
 
-export interface BinderResults {
-    moduleDocString?: string;
-}
-
 export class Binder extends ParseTreeWalker {
     private readonly _fileInfo: AnalyzerFileInfo;
 
@@ -210,7 +206,7 @@ export class Binder extends ParseTreeWalker {
         this._fileInfo = fileInfo;
     }
 
-    bindModule(node: ModuleNode): BinderResults {
+    bindModule(node: ModuleNode): void {
         // We'll assume that if there is no builtins scope provided, we must be
         // binding the builtins module itself.
         const isBuiltInModule = this._fileInfo.builtinsScope === undefined;
@@ -269,10 +265,6 @@ export class Binder extends ParseTreeWalker {
                 scope.symbolTable.get(name)?.setIsInDunderAll();
             }
         }
-
-        return {
-            moduleDocString: ParseTreeUtils.getDocString(node.statements),
-        };
     }
 
     visitModule(node: ModuleNode): boolean {

--- a/packages/pyright-internal/src/analyzer/docStringUtils.ts
+++ b/packages/pyright-internal/src/analyzer/docStringUtils.ts
@@ -9,7 +9,12 @@
  * (https://www.python.org/dev/peps/pep-0257/).
  */
 
-export function decodeDocString(rawString: string): string {
+// Cleans the a docstring as inspect.cleandoc does.
+export function cleanDocString(rawString: string): string {
+    return cleanAndSplitDocString(rawString).join('\n');
+}
+
+export function cleanAndSplitDocString(rawString: string): string[] {
     // Remove carriage returns and replace tabs.
     const unescaped = rawString.replace(/\r/g, '').replace(/\t/g, '        ');
 
@@ -37,7 +42,7 @@ export function decodeDocString(rawString: string): string {
     const trimmedLines: string[] = [];
     lines.forEach((line, index) => {
         if (index === 0) {
-            trimmedLines.push(line.trimRight());
+            trimmedLines.push(line.trim());
         } else {
             trimmedLines.push(line.substr(leftSpacesToRemove).trimRight());
         }
@@ -52,7 +57,7 @@ export function decodeDocString(rawString: string): string {
         trimmedLines.pop();
     }
 
-    return trimmedLines.join('\n');
+    return trimmedLines;
 }
 
 export function extractParameterDocumentation(functionDocString: string, paramName: string): string | undefined {
@@ -74,7 +79,7 @@ export function extractParameterDocumentation(functionDocString: string, paramNa
     //      Args:
     //          param1 (type): description
 
-    const docStringLines = functionDocString.split('\n');
+    const docStringLines = cleanAndSplitDocString(functionDocString);
     for (const line of docStringLines) {
         const trimmedLine = line.trim();
 

--- a/packages/pyright-internal/src/analyzer/program.ts
+++ b/packages/pyright-internal/src/analyzer/program.ts
@@ -61,7 +61,7 @@ import * as AnalyzerNodeInfo from './analyzerNodeInfo';
 import { CircularDependency } from './circularDependency';
 import { ImportResolver } from './importResolver';
 import { ImportResult, ImportType } from './importResult';
-import { findNodeByOffset } from './parseTreeUtils';
+import { findNodeByOffset, getDocString } from './parseTreeUtils';
 import { Scope } from './scope';
 import { getScopeForNode } from './scopeUtils';
 import { SourceFile } from './sourceFile';
@@ -768,13 +768,15 @@ export class Program {
             return undefined;
         }
 
-        const docString = sourceFileInfo.sourceFile.getModuleDocString();
         const parseResults = sourceFileInfo.sourceFile.getParseResults();
+        const moduleNode = parseResults!.parseTree;
 
         return {
             symbolTable,
             dunderAllNames: AnalyzerNodeInfo.getDunderAllNames(parseResults!.parseTree),
-            docString,
+            get docString() {
+                return getDocString(moduleNode.statements);
+            },
         };
     };
 

--- a/packages/pyright-internal/src/analyzer/service.ts
+++ b/packages/pyright-internal/src/analyzer/service.ts
@@ -754,6 +754,10 @@ export class AnalyzerService {
         return !!this._commandLineOptions?.watchForLibraryChanges;
     }
 
+    private get _watchForConfigChanges() {
+        return !!this._commandLineOptions?.watchForConfigChanges;
+    }
+
     private get _typeCheckingMode() {
         return this._commandLineOptions?.typeCheckingMode;
     }
@@ -1251,6 +1255,10 @@ export class AnalyzerService {
 
     private _updateConfigFileWatcher() {
         this._removeConfigFileWatcher();
+
+        if (!this._watchForConfigChanges) {
+            return;
+        }
 
         if (this._configFilePath) {
             this._configFileWatcher = this._fs.createFileSystemWatcher([this._configFilePath], (event) => {

--- a/packages/pyright-internal/src/analyzer/sourceFile.ts
+++ b/packages/pyright-internal/src/analyzer/sourceFile.ts
@@ -49,7 +49,7 @@ import { Token } from '../parser/tokenizerTypes';
 import { PyrightFileSystem } from '../pyrightFileSystem';
 import { AnalyzerFileInfo, ImportLookup } from './analyzerFileInfo';
 import * as AnalyzerNodeInfo from './analyzerNodeInfo';
-import { Binder, BinderResults } from './binder';
+import { Binder } from './binder';
 import { Checker } from './checker';
 import { CircularDependency } from './circularDependency';
 import * as CommentUtils from './commentUtils';
@@ -134,7 +134,6 @@ export class SourceFile {
 
     private _parseResults?: ParseResults;
     private _moduleSymbolTable?: SymbolTable;
-    private _binderResults?: BinderResults;
     private _cachedIndexResults?: IndexResults;
 
     // Reentrancy check for binding.
@@ -333,10 +332,6 @@ export class SourceFile {
         return this._moduleSymbolTable;
     }
 
-    getModuleDocString(): string | undefined {
-        return this._binderResults ? this._binderResults.moduleDocString : undefined;
-    }
-
     // Indicates whether the contents of the file have changed since
     // the last analysis was performed.
     didContentsChangeOnDisk(): boolean {
@@ -379,7 +374,6 @@ export class SourceFile {
         this._parseResults = undefined;
         this._moduleSymbolTable = undefined;
         this._isBindingNeeded = true;
-        this._binderResults = undefined;
     }
 
     markDirty(): void {
@@ -388,7 +382,6 @@ export class SourceFile {
         this._isBindingNeeded = true;
         this._indexingNeeded = true;
         this._moduleSymbolTable = undefined;
-        this._binderResults = undefined;
         this._cachedIndexResults = undefined;
     }
 
@@ -407,7 +400,6 @@ export class SourceFile {
                 this._isBindingNeeded = true;
                 this._indexingNeeded = true;
                 this._moduleSymbolTable = undefined;
-                this._binderResults = undefined;
                 this._cachedIndexResults = undefined;
             }
         }
@@ -934,7 +926,7 @@ export class SourceFile {
 
                     const binder = new Binder(fileInfo);
                     this._isBindingInProgress = true;
-                    this._binderResults = binder.bindModule(this._parseResults!.parseTree);
+                    binder.bindModule(this._parseResults!.parseTree);
 
                     // If we're in "test mode" (used for unit testing), run an additional
                     // "test walker" over the parse tree to validate its internal consistency.

--- a/packages/pyright-internal/src/analyzer/sourceMapper.ts
+++ b/packages/pyright-internal/src/analyzer/sourceMapper.ts
@@ -235,6 +235,8 @@ export class SourceMapper {
             return result;
         }
 
+        recursiveDeclCache.add(uniqueId);
+
         result = this._findMemberDeclarationsByName(
             sourceFile,
             className,

--- a/packages/pyright-internal/src/common/commandLineOptions.ts
+++ b/packages/pyright-internal/src/common/commandLineOptions.ts
@@ -50,6 +50,9 @@ export class CommandLineOptions {
     // Watch for changes in environment library/search paths.
     watchForLibraryChanges?: boolean;
 
+    // Watch for changes in config files.
+    watchForConfigChanges?: boolean;
+
     // Path of config file. This option cannot be combined with
     // file specs.
     configFilePath?: string;

--- a/packages/pyright-internal/src/languageServerBase.ts
+++ b/packages/pyright-internal/src/languageServerBase.ts
@@ -104,6 +104,7 @@ export interface ServerSettings {
     extraPaths?: string[];
     watchForSourceChanges?: boolean;
     watchForLibraryChanges?: boolean;
+    watchForConfigChanges?: boolean;
     diagnosticSeverityOverrides?: DiagnosticSeverityOverridesMap;
     logLevel?: LogLevel;
     autoImportCompletions?: boolean;

--- a/packages/pyright-internal/src/languageService/analyzerServiceExecutor.ts
+++ b/packages/pyright-internal/src/languageService/analyzerServiceExecutor.ts
@@ -52,9 +52,11 @@ function getEffectiveCommandLineOptions(
     if (!trackFiles) {
         commandLineOptions.watchForSourceChanges = false;
         commandLineOptions.watchForLibraryChanges = false;
+        commandLineOptions.watchForConfigChanges = false;
     } else {
         commandLineOptions.watchForSourceChanges = serverSettings.watchForSourceChanges;
         commandLineOptions.watchForLibraryChanges = serverSettings.watchForLibraryChanges;
+        commandLineOptions.watchForConfigChanges = serverSettings.watchForConfigChanges;
     }
 
     if (serverSettings.venvPath) {

--- a/packages/pyright-internal/src/pyright.ts
+++ b/packages/pyright-internal/src/pyright.ts
@@ -266,6 +266,7 @@ function processArgs() {
 
     const watch = args.watch !== undefined;
     options.watchForSourceChanges = watch;
+    options.watchForConfigChanges = watch;
 
     const service = new AnalyzerService('<default>', fileSystem, output);
 

--- a/packages/pyright-internal/src/server.ts
+++ b/packages/pyright-internal/src/server.ts
@@ -55,6 +55,7 @@ class PyrightServer extends LanguageServerBase {
         const serverSettings: ServerSettings = {
             watchForSourceChanges: true,
             watchForLibraryChanges: true,
+            watchForConfigChanges: true,
             openFilesOnly: true,
             useLibraryCodeForTypes: false,
             disableLanguageServices: false,

--- a/packages/pyright-internal/src/tests/docStringUtils.test.ts
+++ b/packages/pyright-internal/src/tests/docStringUtils.test.ts
@@ -8,49 +8,50 @@
 
 import * as assert from 'assert';
 
-import { decodeDocString } from '../analyzer/docStringUtils';
+import { cleanDocString } from '../analyzer/docStringUtils';
 
 test('EmptyDocString', () => {
     const input = '';
-    const result = decodeDocString(input);
-    assert.equal(result, '');
+    const result = cleanDocString(input);
+    assert.strictEqual(result, '');
 });
 
 test('OneLine', () => {
     const input = 'Simple text';
-    const result = decodeDocString(input);
-    assert.equal(result, input);
+    const result = cleanDocString(input);
+    assert.strictEqual(result, input);
 });
 
 test('OneLineLeftTrim', () => {
-    const input = '    Simple text';
-    const result = decodeDocString(input);
-    assert.equal(result, input);
+    const input = 'Simple text';
+    const inputWithSpaces = '    ' + input;
+    const result = cleanDocString(inputWithSpaces);
+    assert.strictEqual(result, input);
 });
 
 test('OneLineRightTrim', () => {
     const input = 'Simple text';
     const inputWithSpaces = input + '      ';
-    const result = decodeDocString(inputWithSpaces);
-    assert.equal(result, input);
+    const result = cleanDocString(inputWithSpaces);
+    assert.strictEqual(result, input);
 });
 
 test('OneLineTrimBoth', () => {
-    const input = '  Simple text';
-    const inputWithSpaces = input + '      ';
-    const result = decodeDocString(inputWithSpaces);
-    assert.equal(result, input);
+    const input = 'Simple text';
+    const inputWithSpaces = '  ' + input + '      ';
+    const result = cleanDocString(inputWithSpaces);
+    assert.strictEqual(result, input);
 });
 
 test('TwoLines', () => {
     const input = 'Simple text';
     const inputWithSpaces = input + '   \n    ';
-    const result = decodeDocString(inputWithSpaces);
-    assert.equal(result, input);
+    const result = cleanDocString(inputWithSpaces);
+    assert.strictEqual(result, input);
 });
 
 test('TwoLinesIndentation', () => {
     const input = 'Line 1  \n    Line2  \n      Line3\n    Line4\n    ';
-    const result = decodeDocString(input);
-    assert.equal(result, 'Line 1\nLine2\n  Line3\nLine4');
+    const result = cleanDocString(input);
+    assert.strictEqual(result, 'Line 1\nLine2\n  Line3\nLine4');
 });

--- a/packages/pyright-internal/src/tests/fourslash/hover.docstring.split.fourslash.ts
+++ b/packages/pyright-internal/src/tests/fourslash/hover.docstring.split.fourslash.ts
@@ -1,0 +1,24 @@
+/// <reference path="fourslash.ts" />
+
+// @filename: test.py
+//// def func():
+////     '''This docstring ''' '''is split.'''
+////     pass
+////
+//// def func2():
+////     f'''This docstring ''' '''is split.'''
+////     pass
+////
+//// def func3():
+////     '''This docstring ''' f'''is split.'''
+////     pass
+////
+//// [|/*marker1*/func|]()
+//// [|/*marker2*/func2|]()
+//// [|/*marker3*/func3|]()
+
+helper.verifyHover('markdown', {
+    marker1: '```python\n(function) func: () -> None\n```\n---\nThis docstring is split.',
+    marker2: '```python\n(function) func2: () -> None\n```',
+    marker3: '```python\n(function) func3: () -> None\n```',
+});


### PR DESCRIPTION
Rollup of:

- Performance improvements to module doc strings.
- Eliminate upfront docstring "decoding" (this is done by each provider during docstring conversion).
- Eliminate duplicated docstring code (old "decode" function was 3x faster than the one in the docstring converter, so delete the latter).
- Fix concatenated strings in docstrings.
- Don't start the config file watcher when not in watch mode (fixes jest hangs).
- Fix a source mapper infinite recursion bug.
- Improve performance for auto-imports (move cancellation check outside very tight loop, precalculate completion kind).