### PR TITLE
Performance improvements, remove dep

### DIFF
--- a/packages/pyright-internal/src/analyzer/binder.ts
+++ b/packages/pyright-internal/src/analyzer/binder.ts
@@ -200,7 +200,7 @@ export class Binder extends ParseTreeWalker {
     // on whether they are listed in the __all__ list.
     private _potentialPrivateSymbols = new Map<string, Symbol>();
 
-    constructor(fileInfo: AnalyzerFileInfo) {
+    constructor(fileInfo: AnalyzerFileInfo, private _moduleSymbolOnly = false) {
         super();
 
         this._fileInfo = fileInfo;
@@ -373,11 +373,11 @@ export class Binder extends ParseTreeWalker {
         this._createNewScope(ScopeType.Class, parentScope, () => {
             AnalyzerNodeInfo.setScope(node, this._currentScope);
 
-            // Analyze the suite.
-            this.walk(node.suite);
+            if (!this._moduleSymbolOnly) {
+                // Analyze the suite.
+                this.walk(node.suite);
+            }
         });
-
-        this._bindNameToScope(this._currentScope, node.name.value);
 
         this._createAssignmentTargetFlowNodes(node.name, /* walkTargets */ false, /* unbound */ false);
 
@@ -3344,6 +3344,10 @@ export class Binder extends ParseTreeWalker {
     }
 
     private _deferBinding(callback: () => void) {
+        if (this._moduleSymbolOnly) {
+            return;
+        }
+
         this._deferredBindingTasks.push({
             scope: this._currentScope,
             codeFlowExpressionMap: this._currentExecutionScopeReferenceMap!,

--- a/packages/pyright-internal/src/analyzer/sourceFile.ts
+++ b/packages/pyright-internal/src/analyzer/sourceFile.ts
@@ -539,6 +539,7 @@ export class SourceFile {
                 parseOptions.isStubFile = true;
             }
             parseOptions.pythonVersion = execEnvironment.pythonVersion;
+            parseOptions.skipFunctionAndClassBody = configOptions.indexGenerationMode ?? false;
 
             try {
                 // Parse the token stream, building the abstract syntax tree.
@@ -924,7 +925,7 @@ export class SourceFile {
                     );
                     AnalyzerNodeInfo.setFileInfo(this._parseResults!.parseTree, fileInfo);
 
-                    const binder = new Binder(fileInfo);
+                    const binder = new Binder(fileInfo, configOptions.indexGenerationMode);
                     this._isBindingInProgress = true;
                     binder.bindModule(this._parseResults!.parseTree);
 

--- a/packages/pyright-internal/src/backgroundThreadBase.ts
+++ b/packages/pyright-internal/src/backgroundThreadBase.ts
@@ -67,6 +67,7 @@ export function createConfigOptionsFrom(jsonObject: any): ConfigOptions {
     configOptions.checkOnlyOpenFiles = jsonObject.checkOnlyOpenFiles;
     configOptions.useLibraryCodeForTypes = jsonObject.useLibraryCodeForTypes;
     configOptions.internalTestMode = jsonObject.internalTestMode;
+    configOptions.indexGenerationMode = jsonObject.indexGenerationMode;
     configOptions.venvPath = jsonObject.venvPath;
     configOptions.venv = jsonObject.venv;
     configOptions.defaultPythonVersion = jsonObject.defaultPythonVersion;

--- a/packages/pyright-internal/src/common/configOptions.ts
+++ b/packages/pyright-internal/src/common/configOptions.ts
@@ -652,6 +652,9 @@ export class ConfigOptions {
     // Run additional analysis as part of test cases?
     internalTestMode?: boolean;
 
+    // Run program in index generation mode.
+    indexGenerationMode?: boolean;
+
     static getDiagnosticRuleSet(typeCheckingMode?: string): DiagnosticRuleSet {
         if (typeCheckingMode === 'strict') {
             return getStrictDiagnosticRuleSet();

--- a/packages/pyright-internal/src/common/pathUtils.ts
+++ b/packages/pyright-internal/src/common/pathUtils.ts
@@ -198,9 +198,14 @@ export function directoryExists(fs: FileSystem, path: string): boolean {
     return fileSystemEntryExists(fs, path, FileSystemEntryKind.Directory);
 }
 
+const invalidSeparator = path.sep === '/' ? '\\' : '/';
 export function normalizeSlashes(pathString: string): string {
-    const separatorRegExp = /[\\/]/g;
-    return pathString.replace(separatorRegExp, path.sep);
+    if (pathString.includes(invalidSeparator)) {
+        const separatorRegExp = /[\\/]/g;
+        return pathString.replace(separatorRegExp, path.sep);
+    }
+
+    return pathString;
 }
 
 /**

--- a/packages/pyright/package-lock.json
+++ b/packages/pyright/package-lock.json
@@ -36,12 +36,6 @@
                 "fastq": "^1.6.0"
             }
         },
-        "@types/anymatch": {
-            "version": "1.3.1",
-            "resolved": "https://registry.npmjs.org/@types/anymatch/-/anymatch-1.3.1.tgz",
-            "integrity": "sha512-/+CRPXpBDpo2RK9C68N3b2cOvO0Cf5B9aPijHsoDQTHivnGSObdOF2BRQOYjojWTDy6nQvMjmqRXIxH55VjxxA==",
-            "dev": true
-        },
         "@types/eslint": {
             "version": "7.2.10",
             "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-7.2.10.tgz",
@@ -68,16 +62,6 @@
             "integrity": "sha512-c5ciR06jK8u9BstrmJyO97m+klJrrhCf9u3rLu3DEAJBirxRqSCvDQoYKmxuYwQI5SZChAWu+tq9oVlGRuzPAg==",
             "dev": true
         },
-        "@types/glob": {
-            "version": "7.1.3",
-            "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.3.tgz",
-            "integrity": "sha512-SEYeGAIQIQX8NN6LDKprLjbrd5dARM5EXsd8GI/A5l0apYI1fGMWgPHSe4ZKL4eozlAyI+doUE9XbYS4xCkQ1w==",
-            "dev": true,
-            "requires": {
-                "@types/minimatch": "*",
-                "@types/node": "*"
-            }
-        },
         "@types/json-schema": {
             "version": "7.0.7",
             "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.7.tgz",
@@ -90,71 +74,11 @@
             "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4=",
             "dev": true
         },
-        "@types/minimatch": {
-            "version": "3.0.4",
-            "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.4.tgz",
-            "integrity": "sha512-1z8k4wzFnNjVK/tlxvrWuK5WMt6mydWWP7+zvH5eFep4oj+UkrfiJTRtjCeBXNpwaA/FYqqtb4/QS4ianFpIRA==",
-            "dev": true
-        },
         "@types/node": {
             "version": "12.20.10",
             "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.10.tgz",
             "integrity": "sha512-TxCmnSSppKBBOzYzPR2BR25YlX5Oay8z2XGwFBInuA/Co0V9xJhLlW4kjbxKtgeNo3NOMbQP1A5Rc03y+XecPw==",
             "dev": true
-        },
-        "@types/source-list-map": {
-            "version": "0.1.2",
-            "resolved": "https://registry.npmjs.org/@types/source-list-map/-/source-list-map-0.1.2.tgz",
-            "integrity": "sha512-K5K+yml8LTo9bWJI/rECfIPrGgxdpeNbj+d53lwN4QjW1MCwlkhUms+gtdzigTeUyBr09+u8BwOIY3MXvHdcsA==",
-            "dev": true
-        },
-        "@types/tapable": {
-            "version": "1.0.7",
-            "resolved": "https://registry.npmjs.org/@types/tapable/-/tapable-1.0.7.tgz",
-            "integrity": "sha512-0VBprVqfgFD7Ehb2vd8Lh9TG3jP98gvr8rgehQqzztZNI7o8zS8Ad4jyZneKELphpuE212D8J70LnSNQSyO6bQ==",
-            "dev": true
-        },
-        "@types/uglify-js": {
-            "version": "3.13.0",
-            "resolved": "https://registry.npmjs.org/@types/uglify-js/-/uglify-js-3.13.0.tgz",
-            "integrity": "sha512-EGkrJD5Uy+Pg0NUR8uA4bJ5WMfljyad0G+784vLCNUkD+QwOJXUbBYExXfVGf7YtyzdQp3L/XMYcliB987kL5Q==",
-            "dev": true,
-            "requires": {
-                "source-map": "^0.6.1"
-            }
-        },
-        "@types/webpack": {
-            "version": "4.41.27",
-            "resolved": "https://registry.npmjs.org/@types/webpack/-/webpack-4.41.27.tgz",
-            "integrity": "sha512-wK/oi5gcHi72VMTbOaQ70VcDxSQ1uX8S2tukBK9ARuGXrYM/+u4ou73roc7trXDNmCxCoerE8zruQqX/wuHszA==",
-            "dev": true,
-            "requires": {
-                "@types/anymatch": "*",
-                "@types/node": "*",
-                "@types/tapable": "^1",
-                "@types/uglify-js": "*",
-                "@types/webpack-sources": "*",
-                "source-map": "^0.6.0"
-            }
-        },
-        "@types/webpack-sources": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/@types/webpack-sources/-/webpack-sources-2.1.0.tgz",
-            "integrity": "sha512-LXn/oYIpBeucgP1EIJbKQ2/4ZmpvRl+dlrFdX7+94SKRUV3Evy3FsfMZY318vGhkWUS5MPhtOM3w1/hCOAOXcg==",
-            "dev": true,
-            "requires": {
-                "@types/node": "*",
-                "@types/source-list-map": "*",
-                "source-map": "^0.7.3"
-            },
-            "dependencies": {
-                "source-map": {
-                    "version": "0.7.3",
-                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
-                    "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
-                    "dev": true
-                }
-            }
         },
         "@webassemblyjs/ast": {
             "version": "1.11.0",
@@ -374,21 +298,6 @@
                 "color-convert": "^2.0.1"
             }
         },
-        "array-union": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
-            "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
-            "dev": true,
-            "requires": {
-                "array-uniq": "^1.0.1"
-            }
-        },
-        "array-uniq": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
-            "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
-            "dev": true
-        },
         "balanced-match": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -454,16 +363,6 @@
             "resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.3.tgz",
             "integrity": "sha512-p3KULyQg4S7NIHixdwbGX+nFHkoBiA4YQmyWtjb8XngSKV124nJmRysgAeujbUVb15vh+RvFUfCPqU7rXk+hZg==",
             "dev": true
-        },
-        "clean-webpack-plugin": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/clean-webpack-plugin/-/clean-webpack-plugin-3.0.0.tgz",
-            "integrity": "sha512-MciirUH5r+cYLGCOL5JX/ZLzOZbVr1ot3Fw+KcvbhUb6PM+yycqd9ZhIlcigQ5gl+XhppNmw3bEFuaaMNyLj3A==",
-            "dev": true,
-            "requires": {
-                "@types/webpack": "^4.4.31",
-                "del": "^4.1.1"
-            }
         },
         "clone-deep": {
             "version": "4.0.1",
@@ -555,21 +454,6 @@
                 "path-key": "^3.1.0",
                 "shebang-command": "^2.0.0",
                 "which": "^2.0.1"
-            }
-        },
-        "del": {
-            "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/del/-/del-4.1.1.tgz",
-            "integrity": "sha512-QwGuEUouP2kVwQenAsOof5Fv8K9t3D8Ca8NxcXKrIpEHjTXK5J2nXLdP+ALI1cgv8wj7KuwBhTwBkOZSJKM5XQ==",
-            "dev": true,
-            "requires": {
-                "@types/glob": "^7.1.1",
-                "globby": "^6.1.0",
-                "is-path-cwd": "^2.0.0",
-                "is-path-in-cwd": "^2.0.0",
-                "p-map": "^2.0.0",
-                "pify": "^4.0.1",
-                "rimraf": "^2.6.3"
             }
         },
         "dir-glob": {
@@ -787,27 +671,6 @@
             "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
             "dev": true
         },
-        "globby": {
-            "version": "6.1.0",
-            "resolved": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
-            "integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
-            "dev": true,
-            "requires": {
-                "array-union": "^1.0.1",
-                "glob": "^7.0.3",
-                "object-assign": "^4.0.1",
-                "pify": "^2.0.0",
-                "pinkie-promise": "^2.0.0"
-            },
-            "dependencies": {
-                "pify": {
-                    "version": "2.3.0",
-                    "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-                    "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-                    "dev": true
-                }
-            }
-        },
         "graceful-fs": {
             "version": "4.2.6",
             "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz",
@@ -902,30 +765,6 @@
             "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
             "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
             "dev": true
-        },
-        "is-path-cwd": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-2.2.0.tgz",
-            "integrity": "sha512-w942bTcih8fdJPJmQHFzkS76NEP8Kzzvmw92cXsazb8intwLqPibPPdXf4ANdKV3rYMuuQYGIWtvz9JilB3NFQ==",
-            "dev": true
-        },
-        "is-path-in-cwd": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-2.1.0.tgz",
-            "integrity": "sha512-rNocXHgipO+rvnP6dk3zI20RpOtrAM/kzbB258Uw5BWr3TpXi861yzjo16Dn4hUox07iw5AyeMLHWsujkjzvRQ==",
-            "dev": true,
-            "requires": {
-                "is-path-inside": "^2.1.0"
-            }
-        },
-        "is-path-inside": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-2.1.0.tgz",
-            "integrity": "sha512-wiyhTzfDWsvwAW53OBWF5zuvaOGlZ6PwYxAbPVDhpm+gM09xKQGjBq/8uYN12aDvMxnAnq3dxTyoSoRNmg5YFg==",
-            "dev": true,
-            "requires": {
-                "path-is-inside": "^1.0.2"
-            }
         },
         "is-plain-object": {
             "version": "2.0.4",
@@ -1101,12 +940,6 @@
                 "path-key": "^3.0.0"
             }
         },
-        "object-assign": {
-            "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-            "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-            "dev": true
-        },
         "once": {
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -1154,12 +987,6 @@
                 }
             }
         },
-        "p-map": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/p-map/-/p-map-2.1.0.tgz",
-            "integrity": "sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==",
-            "dev": true
-        },
         "p-try": {
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
@@ -1176,12 +1003,6 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
             "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-            "dev": true
-        },
-        "path-is-inside": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
-            "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
             "dev": true
         },
         "path-key": {
@@ -1207,27 +1028,6 @@
             "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.3.tgz",
             "integrity": "sha512-KpELjfwcCDUb9PeigTs2mBJzXUPzAuP2oPcA989He8Rte0+YUAjw1JVedDhuTKPkHjSYzMN3npC9luThGYEKdg==",
             "dev": true
-        },
-        "pify": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
-            "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
-            "dev": true
-        },
-        "pinkie": {
-            "version": "2.0.4",
-            "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-            "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
-            "dev": true
-        },
-        "pinkie-promise": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-            "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
-            "dev": true,
-            "requires": {
-                "pinkie": "^2.0.0"
-            }
         },
         "pkg-dir": {
             "version": "4.2.0",
@@ -1298,15 +1098,6 @@
             "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
             "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
             "dev": true
-        },
-        "rimraf": {
-            "version": "2.7.1",
-            "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-            "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
-            "dev": true,
-            "requires": {
-                "glob": "^7.1.3"
-            }
         },
         "run-parallel": {
             "version": "1.2.0",

--- a/packages/pyright/package.json
+++ b/packages/pyright/package.json
@@ -24,7 +24,6 @@
     },
     "devDependencies": {
         "@types/node": "^12.20.10",
-        "clean-webpack-plugin": "^3.0.0",
         "copy-webpack-plugin": "^8.1.1",
         "shx": "^0.3.3",
         "ts-loader": "^9.1.0",

--- a/packages/pyright/webpack.config.js
+++ b/packages/pyright/webpack.config.js
@@ -9,7 +9,6 @@
 const path = require('path');
 const CopyPlugin = require('copy-webpack-plugin');
 const { TsconfigPathsPlugin } = require('tsconfig-paths-webpack-plugin');
-const { CleanWebpackPlugin } = require('clean-webpack-plugin');
 const { monorepoResourceNameMapper } = require('../../build/lib/webpack');
 
 const outPath = path.resolve(__dirname, 'dist');
@@ -29,6 +28,7 @@ module.exports = (_, { mode }) => {
             path: outPath,
             devtoolModuleFilenameTemplate:
                 mode === 'development' ? '../[resource-path]' : monorepoResourceNameMapper('pyright'),
+            clean: true,
         },
         devtool: mode === 'development' ? 'source-map' : 'nosources-source-map',
         stats: {
@@ -59,10 +59,7 @@ module.exports = (_, { mode }) => {
                 },
             ],
         },
-        plugins: [
-            new CleanWebpackPlugin(),
-            new CopyPlugin({ patterns: [{ from: typeshedFallback, to: 'typeshed-fallback' }] }),
-        ],
+        plugins: [new CopyPlugin({ patterns: [{ from: typeshedFallback, to: 'typeshed-fallback' }] })],
         optimization: {
             splitChunks: {
                 cacheGroups: {

--- a/packages/vscode-pyright/package-lock.json
+++ b/packages/vscode-pyright/package-lock.json
@@ -41,12 +41,6 @@
                 "fastq": "^1.6.0"
             }
         },
-        "@types/anymatch": {
-            "version": "1.3.1",
-            "resolved": "https://registry.npmjs.org/@types/anymatch/-/anymatch-1.3.1.tgz",
-            "integrity": "sha512-/+CRPXpBDpo2RK9C68N3b2cOvO0Cf5B9aPijHsoDQTHivnGSObdOF2BRQOYjojWTDy6nQvMjmqRXIxH55VjxxA==",
-            "dev": true
-        },
         "@types/eslint": {
             "version": "7.2.10",
             "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-7.2.10.tgz",
@@ -73,16 +67,6 @@
             "integrity": "sha512-c5ciR06jK8u9BstrmJyO97m+klJrrhCf9u3rLu3DEAJBirxRqSCvDQoYKmxuYwQI5SZChAWu+tq9oVlGRuzPAg==",
             "dev": true
         },
-        "@types/glob": {
-            "version": "7.1.3",
-            "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.3.tgz",
-            "integrity": "sha512-SEYeGAIQIQX8NN6LDKprLjbrd5dARM5EXsd8GI/A5l0apYI1fGMWgPHSe4ZKL4eozlAyI+doUE9XbYS4xCkQ1w==",
-            "dev": true,
-            "requires": {
-                "@types/minimatch": "*",
-                "@types/node": "*"
-            }
-        },
         "@types/json-schema": {
             "version": "7.0.7",
             "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.7.tgz",
@@ -95,77 +79,17 @@
             "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4=",
             "dev": true
         },
-        "@types/minimatch": {
-            "version": "3.0.4",
-            "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.4.tgz",
-            "integrity": "sha512-1z8k4wzFnNjVK/tlxvrWuK5WMt6mydWWP7+zvH5eFep4oj+UkrfiJTRtjCeBXNpwaA/FYqqtb4/QS4ianFpIRA==",
-            "dev": true
-        },
         "@types/node": {
             "version": "12.20.10",
             "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.10.tgz",
             "integrity": "sha512-TxCmnSSppKBBOzYzPR2BR25YlX5Oay8z2XGwFBInuA/Co0V9xJhLlW4kjbxKtgeNo3NOMbQP1A5Rc03y+XecPw==",
             "dev": true
         },
-        "@types/source-list-map": {
-            "version": "0.1.2",
-            "resolved": "https://registry.npmjs.org/@types/source-list-map/-/source-list-map-0.1.2.tgz",
-            "integrity": "sha512-K5K+yml8LTo9bWJI/rECfIPrGgxdpeNbj+d53lwN4QjW1MCwlkhUms+gtdzigTeUyBr09+u8BwOIY3MXvHdcsA==",
-            "dev": true
-        },
-        "@types/tapable": {
-            "version": "1.0.7",
-            "resolved": "https://registry.npmjs.org/@types/tapable/-/tapable-1.0.7.tgz",
-            "integrity": "sha512-0VBprVqfgFD7Ehb2vd8Lh9TG3jP98gvr8rgehQqzztZNI7o8zS8Ad4jyZneKELphpuE212D8J70LnSNQSyO6bQ==",
-            "dev": true
-        },
-        "@types/uglify-js": {
-            "version": "3.13.0",
-            "resolved": "https://registry.npmjs.org/@types/uglify-js/-/uglify-js-3.13.0.tgz",
-            "integrity": "sha512-EGkrJD5Uy+Pg0NUR8uA4bJ5WMfljyad0G+784vLCNUkD+QwOJXUbBYExXfVGf7YtyzdQp3L/XMYcliB987kL5Q==",
-            "dev": true,
-            "requires": {
-                "source-map": "^0.6.1"
-            }
-        },
         "@types/vscode": {
             "version": "1.52.0",
             "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.52.0.tgz",
             "integrity": "sha512-Kt3bvWzAvvF/WH9YEcrCICDp0Z7aHhJGhLJ1BxeyNP6yRjonWqWnAIh35/pXAjswAnWOABrYlF7SwXR9+1nnLA==",
             "dev": true
-        },
-        "@types/webpack": {
-            "version": "4.41.27",
-            "resolved": "https://registry.npmjs.org/@types/webpack/-/webpack-4.41.27.tgz",
-            "integrity": "sha512-wK/oi5gcHi72VMTbOaQ70VcDxSQ1uX8S2tukBK9ARuGXrYM/+u4ou73roc7trXDNmCxCoerE8zruQqX/wuHszA==",
-            "dev": true,
-            "requires": {
-                "@types/anymatch": "*",
-                "@types/node": "*",
-                "@types/tapable": "^1",
-                "@types/uglify-js": "*",
-                "@types/webpack-sources": "*",
-                "source-map": "^0.6.0"
-            }
-        },
-        "@types/webpack-sources": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/@types/webpack-sources/-/webpack-sources-2.1.0.tgz",
-            "integrity": "sha512-LXn/oYIpBeucgP1EIJbKQ2/4ZmpvRl+dlrFdX7+94SKRUV3Evy3FsfMZY318vGhkWUS5MPhtOM3w1/hCOAOXcg==",
-            "dev": true,
-            "requires": {
-                "@types/node": "*",
-                "@types/source-list-map": "*",
-                "source-map": "^0.7.3"
-            },
-            "dependencies": {
-                "source-map": {
-                    "version": "0.7.3",
-                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
-                    "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
-                    "dev": true
-                }
-            }
         },
         "@webassemblyjs/ast": {
             "version": "1.11.0",
@@ -394,21 +318,6 @@
                 "sprintf-js": "~1.0.2"
             }
         },
-        "array-union": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
-            "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
-            "dev": true,
-            "requires": {
-                "array-uniq": "^1.0.1"
-            }
-        },
-        "array-uniq": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
-            "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
-            "dev": true
-        },
         "at-least-node": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
@@ -530,16 +439,6 @@
             "integrity": "sha512-p3KULyQg4S7NIHixdwbGX+nFHkoBiA4YQmyWtjb8XngSKV124nJmRysgAeujbUVb15vh+RvFUfCPqU7rXk+hZg==",
             "dev": true
         },
-        "clean-webpack-plugin": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/clean-webpack-plugin/-/clean-webpack-plugin-3.0.0.tgz",
-            "integrity": "sha512-MciirUH5r+cYLGCOL5JX/ZLzOZbVr1ot3Fw+KcvbhUb6PM+yycqd9ZhIlcigQ5gl+XhppNmw3bEFuaaMNyLj3A==",
-            "dev": true,
-            "requires": {
-                "@types/webpack": "^4.4.31",
-                "del": "^4.1.1"
-            }
-        },
         "clone-deep": {
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/clone-deep/-/clone-deep-4.0.1.tgz",
@@ -649,21 +548,6 @@
             "resolved": "https://registry.npmjs.org/css-what/-/css-what-5.0.0.tgz",
             "integrity": "sha512-qxyKHQvgKwzwDWC/rGbT821eJalfupxYW2qbSJSAtdSTimsr/MlaGONoNLllaUPZWf8QnbcKM/kPVYUQuEKAFA==",
             "dev": true
-        },
-        "del": {
-            "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/del/-/del-4.1.1.tgz",
-            "integrity": "sha512-QwGuEUouP2kVwQenAsOof5Fv8K9t3D8Ca8NxcXKrIpEHjTXK5J2nXLdP+ALI1cgv8wj7KuwBhTwBkOZSJKM5XQ==",
-            "dev": true,
-            "requires": {
-                "@types/glob": "^7.1.1",
-                "globby": "^6.1.0",
-                "is-path-cwd": "^2.0.0",
-                "is-path-in-cwd": "^2.0.0",
-                "p-map": "^2.0.0",
-                "pify": "^4.0.1",
-                "rimraf": "^2.6.3"
-            }
         },
         "denodeify": {
             "version": "1.2.1",
@@ -962,27 +846,6 @@
             "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
             "dev": true
         },
-        "globby": {
-            "version": "6.1.0",
-            "resolved": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
-            "integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
-            "dev": true,
-            "requires": {
-                "array-union": "^1.0.1",
-                "glob": "^7.0.3",
-                "object-assign": "^4.0.1",
-                "pify": "^2.0.0",
-                "pinkie-promise": "^2.0.0"
-            },
-            "dependencies": {
-                "pify": {
-                    "version": "2.3.0",
-                    "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-                    "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-                    "dev": true
-                }
-            }
-        },
         "graceful-fs": {
             "version": "4.2.6",
             "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz",
@@ -1089,30 +952,6 @@
             "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
             "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
             "dev": true
-        },
-        "is-path-cwd": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-2.2.0.tgz",
-            "integrity": "sha512-w942bTcih8fdJPJmQHFzkS76NEP8Kzzvmw92cXsazb8intwLqPibPPdXf4ANdKV3rYMuuQYGIWtvz9JilB3NFQ==",
-            "dev": true
-        },
-        "is-path-in-cwd": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-2.1.0.tgz",
-            "integrity": "sha512-rNocXHgipO+rvnP6dk3zI20RpOtrAM/kzbB258Uw5BWr3TpXi861yzjo16Dn4hUox07iw5AyeMLHWsujkjzvRQ==",
-            "dev": true,
-            "requires": {
-                "is-path-inside": "^2.1.0"
-            }
-        },
-        "is-path-inside": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-2.1.0.tgz",
-            "integrity": "sha512-wiyhTzfDWsvwAW53OBWF5zuvaOGlZ6PwYxAbPVDhpm+gM09xKQGjBq/8uYN12aDvMxnAnq3dxTyoSoRNmg5YFg==",
-            "dev": true,
-            "requires": {
-                "path-is-inside": "^1.0.2"
-            }
         },
         "is-plain-object": {
             "version": "2.0.4",
@@ -1365,12 +1204,6 @@
                 "boolbase": "^1.0.0"
             }
         },
-        "object-assign": {
-            "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-            "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-            "dev": true
-        },
         "once": {
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -1446,12 +1279,6 @@
                 }
             }
         },
-        "p-map": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/p-map/-/p-map-2.1.0.tgz",
-            "integrity": "sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==",
-            "dev": true
-        },
         "p-try": {
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
@@ -1502,12 +1329,6 @@
             "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
             "dev": true
         },
-        "path-is-inside": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
-            "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
-            "dev": true
-        },
         "path-key": {
             "version": "3.1.1",
             "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
@@ -1537,27 +1358,6 @@
             "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.3.tgz",
             "integrity": "sha512-KpELjfwcCDUb9PeigTs2mBJzXUPzAuP2oPcA989He8Rte0+YUAjw1JVedDhuTKPkHjSYzMN3npC9luThGYEKdg==",
             "dev": true
-        },
-        "pify": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
-            "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
-            "dev": true
-        },
-        "pinkie": {
-            "version": "2.0.4",
-            "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-            "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
-            "dev": true
-        },
-        "pinkie-promise": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-            "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
-            "dev": true,
-            "requires": {
-                "pinkie": "^2.0.0"
-            }
         },
         "pkg-dir": {
             "version": "4.2.0",
@@ -1637,15 +1437,6 @@
             "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
             "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
             "dev": true
-        },
-        "rimraf": {
-            "version": "2.7.1",
-            "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-            "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
-            "dev": true,
-            "requires": {
-                "glob": "^7.1.3"
-            }
         },
         "run-parallel": {
             "version": "1.2.0",

--- a/packages/vscode-pyright/package.json
+++ b/packages/vscode-pyright/package.json
@@ -760,7 +760,6 @@
         "@types/node": "^12.20.10",
         "@types/vscode": "~1.52.0",
         "chalk": "^4.1.1",
-        "clean-webpack-plugin": "^3.0.0",
         "copy-webpack-plugin": "^8.1.1",
         "detect-indent": "^6.0.0",
         "fs-extra": "^9.1.0",

--- a/packages/vscode-pyright/webpack.config.js
+++ b/packages/vscode-pyright/webpack.config.js
@@ -9,7 +9,6 @@
 const path = require('path');
 const CopyPlugin = require('copy-webpack-plugin');
 const { TsconfigPathsPlugin } = require('tsconfig-paths-webpack-plugin');
-const { CleanWebpackPlugin } = require('clean-webpack-plugin');
 const { monorepoResourceNameMapper } = require('../../build/lib/webpack');
 
 const outPath = path.resolve(__dirname, 'dist');
@@ -30,6 +29,7 @@ module.exports = (_, { mode }) => {
             libraryTarget: 'commonjs2',
             devtoolModuleFilenameTemplate:
                 mode === 'development' ? '../[resource-path]' : monorepoResourceNameMapper('vscode-pyright'),
+            clean: true,
         },
         devtool: mode === 'development' ? 'source-map' : 'nosources-source-map',
         stats: {
@@ -61,9 +61,6 @@ module.exports = (_, { mode }) => {
                 },
             ],
         },
-        plugins: [
-            new CleanWebpackPlugin(),
-            new CopyPlugin({ patterns: [{ from: typeshedFallback, to: 'typeshed-fallback' }] }),
-        ],
+        plugins: [new CopyPlugin({ patterns: [{ from: typeshedFallback, to: 'typeshed-fallback' }] })],
     };
 };


### PR DESCRIPTION
Rollup of:

- Add a binding/parsing mode that processes module-level symbols only (for indexing).
- Improve perf of `normalizeSlashes` (avoid replace call when string is normalized).
- Remove `clean-webpack-plugin` (webpack 5 does this natively).