### PR TITLE
Prefer py.typed libraries over typeshed, minor helper cleanups

### DIFF
--- a/packages/pyright-internal/src/analyzer/importResolver.ts
+++ b/packages/pyright-internal/src/analyzer/importResolver.ts
@@ -1120,6 +1120,11 @@ export class ImportResolver {
             importFailureInfo.push('No python interpreter search path');
         }
 
+        if (bestResultSoFar?.pyTypedInfo && !bestResultSoFar.isPartlyResolved) {
+            // If a library is fully py.typed, then we have found the best match.
+            return bestResultSoFar;
+        }
+
         const extraResults = this.resolveImportEx(
             sourceFilePath,
             execEnv,

--- a/packages/pyright-internal/src/common/positionUtils.ts
+++ b/packages/pyright-internal/src/common/positionUtils.ts
@@ -73,6 +73,6 @@ export function convertRangeToTextRange(range: Range, lines: TextRangeCollection
     return TextRange.fromBounds(start, end);
 }
 
-export function convertTextRangeToRange(range: TextRange, lines: TextRangeCollection<TextRange>): Range | undefined {
+export function convertTextRangeToRange(range: TextRange, lines: TextRangeCollection<TextRange>): Range {
     return convertOffsetsToRange(range.start, TextRange.getEnd(range), lines);
 }


### PR DESCRIPTION
Rollup of:

- Prefer `py.typed` libraries over typeshed (#1764, https://github.com/microsoft/pylance-release/issues/1197).
- Minor helper cleanup.