### PR TITLE
Don't prefer py.typed libraries when the execution environment is typeshed

### DIFF
--- a/packages/pyright-internal/src/analyzer/importResolver.ts
+++ b/packages/pyright-internal/src/analyzer/importResolver.ts
@@ -80,6 +80,7 @@ export class ImportResolver {
     private _cachedPythonSearchPaths = new Map<string, string[]>();
     private _cachedImportResults = new Map<string, CachedImportResults>();
     private _cachedModuleNameResults = new Map<string, Map<string, ModuleNameAndType>>();
+    private _cachedTypeshedRoot: string | undefined;
     private _cachedTypeshedStdLibPath: string | undefined;
     private _cachedTypeshedStdLibModuleVersions: Map<string, SupportedVersionRange> | undefined;
     private _cachedTypeshedThirdPartyPath: string | undefined;
@@ -1120,9 +1121,13 @@ export class ImportResolver {
             importFailureInfo.push('No python interpreter search path');
         }
 
-        if (bestResultSoFar?.pyTypedInfo && !bestResultSoFar.isPartlyResolved) {
-            // If a library is fully py.typed, then we have found the best match.
-            return bestResultSoFar;
+        // Special case: If the execution environment is typeshed itself, don't
+        // try and use a py.typed library from the search paths.
+        if (execEnv.root !== this._getTypeshedRoot(execEnv, importFailureInfo)) {
+            if (bestResultSoFar?.pyTypedInfo && !bestResultSoFar.isPartlyResolved) {
+                // If a library is fully py.typed, then we have found the best match.
+                return bestResultSoFar;
+            }
         }
 
         const extraResults = this.resolveImportEx(
@@ -1469,16 +1474,9 @@ export class ImportResolver {
         return this._cachedTypeshedThirdPartyPackageRoots!;
     }
 
-    private _getTypeshedSubdirectory(isStdLib: boolean, execEnv: ExecutionEnvironment, importFailureInfo: string[]) {
-        // See if we have it cached.
-        if (isStdLib) {
-            if (this._cachedTypeshedStdLibPath !== undefined) {
-                return this._cachedTypeshedStdLibPath;
-            }
-        } else {
-            if (this._cachedTypeshedThirdPartyPath !== undefined) {
-                return this._cachedTypeshedThirdPartyPath;
-            }
+    private _getTypeshedRoot(execEnv: ExecutionEnvironment, importFailureInfo: string[]) {
+        if (this._cachedTypeshedRoot) {
+            return this._cachedTypeshedRoot;
         }
 
         let typeshedPath = '';
@@ -1506,6 +1504,23 @@ export class ImportResolver {
             typeshedPath = PythonPathUtils.getTypeShedFallbackPath(this.fileSystem) || '';
         }
 
+        this._cachedTypeshedRoot = typeshedPath;
+        return typeshedPath;
+    }
+
+    private _getTypeshedSubdirectory(isStdLib: boolean, execEnv: ExecutionEnvironment, importFailureInfo: string[]) {
+        // See if we have it cached.
+        if (isStdLib) {
+            if (this._cachedTypeshedStdLibPath !== undefined) {
+                return this._cachedTypeshedStdLibPath;
+            }
+        } else {
+            if (this._cachedTypeshedThirdPartyPath !== undefined) {
+                return this._cachedTypeshedThirdPartyPath;
+            }
+        }
+
+        let typeshedPath = this._getTypeshedRoot(execEnv, importFailureInfo);
         typeshedPath = PythonPathUtils.getTypeshedSubdirectory(typeshedPath, isStdLib);
 
         if (!this.dirExistsCached(typeshedPath)) {

--- a/packages/pyright-internal/src/analyzer/importResolver.ts
+++ b/packages/pyright-internal/src/analyzer/importResolver.ts
@@ -1121,11 +1121,11 @@ export class ImportResolver {
             importFailureInfo.push('No python interpreter search path');
         }
 
-        // Special case: If the execution environment is typeshed itself, don't
-        // try and use a py.typed library from the search paths.
+        // If a library is fully py.typed, then we have found the best match,
+        // unless the execution environment is typeshed itself, in which case
+        // we don't want to favor py.typed libraries the typeshed lookup below.
         if (execEnv.root !== this._getTypeshedRoot(execEnv, importFailureInfo)) {
             if (bestResultSoFar?.pyTypedInfo && !bestResultSoFar.isPartlyResolved) {
-                // If a library is fully py.typed, then we have found the best match.
                 return bestResultSoFar;
             }
         }
@@ -1475,7 +1475,7 @@ export class ImportResolver {
     }
 
     private _getTypeshedRoot(execEnv: ExecutionEnvironment, importFailureInfo: string[]) {
-        if (this._cachedTypeshedRoot) {
+        if (this._cachedTypeshedRoot !== undefined) {
             return this._cachedTypeshedRoot;
         }
 


### PR DESCRIPTION
There are stubs in typeshed that are py.typed on PyPI, such as `click`, a dependency of `black`. If pyright is run where python has that in its site-packages (for me, my global interpreter where my package manager has installed `black`), those imports get resolved instead of the ones in typeshed itself, causing resolution problems.

If the execution environment is typeshed itself, then we can skip `py.typed` check we added previously, restoring the old behavior.

We don't need to do anything special for stubPath (aka typings), as the first part of this function already checks there first and returns early; this means we aren't regressing for that use case. But, we can't set typeshed as a stubPath (aka typings) because of its unique folder structure; we rely on the typeshed resolution to resolve imports when working on typeshed itself.

This at least restores the old behavior for this one special case; I don't expect there to be any more. Another approach may be to create a "never call python for its search paths" mode, but that's going to be more invasive and prevent things like source mapping when working on typeshed (which may not be _that_ bad).