### PR TITLE
add dynamic evaluation of __all__ as a list comprehension

### DIFF
--- a/packages/pyright-internal/src/parser/parseNodes.ts
+++ b/packages/pyright-internal/src/parser/parseNodes.ts
@@ -152,6 +152,7 @@ export type ParseNodeArray = (ParseNode | undefined)[];
 export interface ModuleNode extends ParseNodeBase {
     readonly nodeType: ParseNodeType.Module;
     statements: StatementNode[];
+    dunderAllNames: string[];
 }
 
 export namespace ModuleNode {
@@ -162,6 +163,7 @@ export namespace ModuleNode {
             nodeType: ParseNodeType.Module,
             id: _nextNodeId++,
             statements: [],
+            dunderAllNames: [],
         };
 
         return node;

--- a/packages/pyright-internal/src/tests/samples/dunderAll1.py
+++ b/packages/pyright-internal/src/tests/samples/dunderAll1.py
@@ -15,6 +15,7 @@ __all__.remove("foo")
 __all__ += ["bar"]
 __all__ += mock.__all__
 __all__.extend(mock.__all__)
+__all__ = [x for x in dir() if not x.startswith("_")]
 
 
 my_string = "foo"

--- a/packages/pyright-internal/src/tests/samples/dunderAll2.py
+++ b/packages/pyright-internal/src/tests/samples/dunderAll2.py
@@ -1,0 +1,12 @@
+# This sample tests dynamic __all__ assignments based on dir()
+
+# pyright: reportMissingModuleSource=false
+
+from typing import Any
+
+__all__: Any
+
+foo = 42
+_bar = "asdf"
+
+__all__ = [x for x in dir()]

--- a/packages/pyright-internal/src/tests/samples/dunderAll3.py
+++ b/packages/pyright-internal/src/tests/samples/dunderAll3.py
@@ -1,0 +1,12 @@
+# This sample tests dynamic __all__ assignments based on dir()
+
+# pyright: reportMissingModuleSource=false
+
+from typing import Any
+
+__all__: Any
+
+foo = 42
+_bar = "asdf"
+
+__all__ = [x for x in dir() if not x.startswith("_")]

--- a/packages/pyright-internal/src/tests/typeEvaluator4.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator4.test.ts
@@ -191,6 +191,17 @@ test('DunderAll1', () => {
     TestUtils.validateResults(analysisResults, 0, 0);
 });
 
+test('DunderAll2', () => {
+    let analysisResults = TestUtils.typeAnalyzeSampleFiles(['dunderAll2.py']);
+    expect(analysisResults[0].parseResults?.parseTree.dunderAllNames).toContain("foo");
+    expect(analysisResults[0].parseResults?.parseTree.dunderAllNames).toContain("_bar");
+})
+
+test('DunderAll3', () => {
+    let analysisResults = TestUtils.typeAnalyzeSampleFiles(['dunderAll3.py']);
+    expect(analysisResults[0].parseResults?.parseTree.dunderAllNames).not.toContain("_bar");
+})
+
 test('Overload1', () => {
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['overload1.py']);
     TestUtils.validateResults(analysisResults, 2);


### PR DESCRIPTION
This PR adds fairly minimal support for dynamically evaluated `__all__` values, specifically when using list comprehensions.

Example:
```python
__all__ = [x for x in dir() if not x.startswith("_")]
```

# Justification

I am working on a project that pylance takes _forever_ to update the type annotations, and frequently stops giving me code suggestions when working with sympy. I suspect its because it has a lot of `*` imports. However, it's not entirely feasible for me to manually add `__all__` to all the modules.

This will allow me to keep using `*` imports, but also limit the import tree, without having to waste time updating `__all__` manually, or setting up some tool to do it automatically. This approach also does not allow arbirary code execution, since the evaluation of the list comprehension is done analytically, not by actually executing any python code.


### Why draft?

I'm looking for feedback before I do any more work on this. Do I have the right approach here? Does pyright already have an expression evaluator or something similar that I should be using instead? Should I move `createFilterFunction` out of the binder?

What should I do for tests? I added a couple, but I had to export a field that was private.


### Additional Context

Fixes:
- https://github.com/microsoft/pylance-release/issues/289
- https://github.com/microsoft/pylance-release/issues/852
- https://github.com/microsoft/pylance-release/issues/1032

Related:
- https://github.com/microsoft/pylance-release/issues/980﻿


