### PR TITLE
Filter auto-imports like TS, docstring tables, cleanups, testing

### DIFF
--- a/packages/pyright-internal/src/languageService/autoImporter.ts
+++ b/packages/pyright-internal/src/languageService/autoImporter.ts
@@ -189,7 +189,6 @@ export class AutoImporter {
         private _moduleSymbolMap: ModuleSymbolMap,
         private _options: AutoImportOptions
     ) {
-        this._options.patternMatcher = this._options.patternMatcher ?? StringUtils.isPatternInSymbol;
         this._importStatements = getTopLevelImports(this._parseResults.parseTree, true);
 
         this._perfInfo.indexUsed = !!this._options.libraryMap;
@@ -641,7 +640,20 @@ export class AutoImporter {
             return word === name;
         }
 
-        return word.length > 0 && this._options.patternMatcher!(word, name);
+        if (word.length <= 0 || name.length <= 0) {
+            return false;
+        }
+
+        if (!this._options.patternMatcher) {
+            const index = word[0] !== '_' && name[0] === '_' && name.length > 1 ? 1 : 0;
+            if (word[0].toLocaleLowerCase() !== name[index].toLocaleLowerCase()) {
+                return false;
+            }
+
+            return StringUtils.isPatternInSymbol(word, name);
+        }
+
+        return this._options.patternMatcher(word, name);
     }
 
     private _containsName(name: string, source: string | undefined, results: AutoImportResultMap) {

--- a/packages/pyright-internal/src/tests/docStringConversion.test.ts
+++ b/packages/pyright-internal/src/tests/docStringConversion.test.ts
@@ -718,6 +718,86 @@ test('EscapeHtmlTagsOutsideCodeBlocks', () => {
     _testConvertToMarkdown(docstring, markdown);
 });
 
+test('RestTableWithHeader', () => {
+    const docstring = `
+=============== =========================================================
+Generator
+--------------- ---------------------------------------------------------
+Generator       Class implementing all of the random number distributions
+default_rng     Default constructor for \`\`Generator\`\`
+=============== =========================================================`;
+
+    const markdown = `
+|Generator | |
+|---------------|---------------------------------------------------------|
+|Generator       |Class implementing all of the random number distributions|
+|default_rng     |Default constructor for \`\`Generator\`\`|`;
+
+    _testConvertToMarkdown(docstring, markdown);
+});
+
+test('RestTablesMultilineHeader', () => {
+    const docstring = `
+==================== =========================================================
+Compatibility
+functions - removed
+in the new API
+-------------------- ---------------------------------------------------------
+rand                 Uniformly distributed values.
+==================== =========================================================`;
+
+    const markdown = `
+|Compatibility <br>functions - removed <br>in the new API | <br> <br> |
+|--------------------|---------------------------------------------------------|
+|rand                 |Uniformly distributed values.|`;
+
+    _testConvertToMarkdown(docstring, markdown);
+});
+
+test('RestTableSimple', () => {
+    const docstring = `
+============================== =====================================
+Scalar Type                    Array Type
+============================== =====================================
+:class:\`pandas.Interval\`       :class:\`pandas.arrays.IntervalArray\`
+:class:\`pandas.Period\`         :class:\`pandas.arrays.PeriodArray\`
+============================== =====================================
+    `;
+
+    const markdown = `|Scalar Type                     |Array Type |
+|------------------------------|-------------------------------------|
+|:class:\`pandas.Interval\`       |:class:\`pandas.arrays.IntervalArray\`|
+|:class:\`pandas.Period\`         |:class:\`pandas.arrays.PeriodArray\`|`;
+
+    _testConvertToMarkdown(docstring, markdown);
+});
+
+test('ReSTTableIndented', () => {
+    const docstring = `
+    data :
+
+    dtype : str, np.dtype, or ExtensionDtype, optional
+
+        ============================== =====================================
+        Scalar Type                    Array Type
+        ============================== =====================================
+        :class:\`pandas.Interval\`     :class:\`pandas.arrays.IntervalArray\`
+        :class:\`pandas.Period\`       :class:\`pandas.arrays.PeriodArray\`
+        ============================== =====================================`;
+
+    const markdown = `
+data :
+
+dtype : str, np.dtype, or ExtensionDtype, optional
+
+|    Scalar Type                 |    Array Type |
+|------------------------------|-------------------------------------|
+|    :class:\`pandas.Interval\`   |  :class:\`pandas.arrays.IntervalArray\`|
+|    :class:\`pandas.Period\`     |  :class:\`pandas.arrays.PeriodArray\`|`;
+
+    _testConvertToMarkdown(docstring, markdown);
+});
+
 function _testConvertToMarkdown(docstring: string, expectedMarkdown: string) {
     const actualMarkdown = convertDocStringToMarkdown(docstring);
 

--- a/packages/pyright-internal/src/tests/importResolver.test.ts
+++ b/packages/pyright-internal/src/tests/importResolver.test.ts
@@ -246,7 +246,7 @@ test('typeshed fallback folder', () => {
             content: 'partial\n',
         },
         {
-            path: combinePaths(typeshedFallback, 'stubs', 'myLibPackage', 'myLib.pyi'),
+            path: combinePaths('/', typeshedFallback, 'stubs', 'myLibPackage', 'myLib.pyi'),
             content: '# empty',
         },
         {
@@ -289,6 +289,44 @@ test('py.typed file', () => {
     const importResult = getImportResult(files, ['myLib']);
     assert(importResult.isImportFound);
     assert(!importResult.isStubFile);
+});
+
+test('py.typed library', () => {
+    const files = [
+        {
+            path: combinePaths(libraryRoot, 'os', '__init__.py'),
+            content: 'def test(): ...',
+        },
+        {
+            path: combinePaths(libraryRoot, 'os', 'py.typed'),
+            content: '',
+        },
+        {
+            path: combinePaths('/', typeshedFallback, 'stubs', 'os', 'os', '__init__.pyi'),
+            content: '# empty',
+        },
+    ];
+
+    const importResult = getImportResult(files, ['os']);
+    assert(importResult.isImportFound);
+    assert.strictEqual(files[0].path, importResult.resolvedPaths[importResult.resolvedPaths.length - 1]);
+});
+
+test('non py.typed library', () => {
+    const files = [
+        {
+            path: combinePaths(libraryRoot, 'os', '__init__.py'),
+            content: 'def test(): ...',
+        },
+        {
+            path: combinePaths('/', typeshedFallback, 'stubs', 'os', 'os', '__init__.pyi'),
+            content: '# empty',
+        },
+    ];
+
+    const importResult = getImportResult(files, ['os']);
+    assert(importResult.isImportFound);
+    assert.strictEqual(files[1].path, importResult.resolvedPaths[importResult.resolvedPaths.length - 1]);
 });
 
 function getImportResult(


### PR DESCRIPTION
Rollup of:

- Filter auto-imports more strictly in some cases (like TypeScript) to reduce the number of completions returned. Matches require at least the first character to match before fuzzy matching is applied.
- Add support for tables in docstrings.
- Clean up unused code in FS abstraction.
- Add test cases for new `py.typed` behavior.