### PR TITLE
Drop unused parse trees in indexing step, small refactorings

### DIFF
--- a/packages/pyright-internal/src/languageService/completionProvider.ts
+++ b/packages/pyright-internal/src/languageService/completionProvider.ts
@@ -101,7 +101,7 @@ import { ParseResults } from '../parser/parser';
 import { Token } from '../parser/tokenizerTypes';
 import { AbbreviationInfo, AutoImporter, AutoImportResult, ModuleSymbolMap } from './autoImporter';
 import { IndexResults } from './documentSymbolProvider';
-import { getFunctionDocStringFromType, getOverloadedFunctionTooltip } from './tooltipUtils';
+import { getAutoImportText, getFunctionDocStringFromType, getOverloadedFunctionTooltip } from './tooltipUtils';
 
 const _keywords: string[] = [
     // Expression keywords
@@ -1936,16 +1936,7 @@ export class CompletionProvider {
     }
 
     private _getAutoImportText(importName: string, importFrom?: string, importAlias?: string) {
-        let autoImportText: string | undefined;
-        if (!importFrom) {
-            autoImportText = `import ${importName}`;
-        } else {
-            autoImportText = `from ${importFrom} import ${importName}`;
-        }
-
-        if (importAlias) {
-            autoImportText = `${autoImportText} as ${importAlias}`;
-        }
+        const autoImportText = getAutoImportText(importName, importFrom, importAlias);
 
         if (this._options.format === MarkupKind.Markdown) {
             return `\`\`\`\n${autoImportText}\n\`\`\``;

--- a/packages/pyright-internal/src/languageService/tooltipUtils.ts
+++ b/packages/pyright-internal/src/languageService/tooltipUtils.ts
@@ -112,3 +112,18 @@ export function getDocumentationPartsForTypeAndDecl(
 
     return [];
 }
+
+export function getAutoImportText(name: string, from?: string, alias?: string): string {
+    let text: string | undefined;
+    if (!from) {
+        text = `import ${name}`;
+    } else {
+        text = `from ${from} import ${name}`;
+    }
+
+    if (alias) {
+        text = `${text} as ${alias}`;
+    }
+
+    return text;
+}


### PR DESCRIPTION
Rollup of:

- Drop unused parse trees in indexing step to save memory. We do this already for library code, but can do the same for workspace files opened only for indexing.
- Small refactorings to support pylance changes.