### PR TITLE
Avoid reanalyzing a file when it is opened in the editor if we have a…

### DIFF
--- a/packages/pyright-internal/src/analyzer/sourceFile.ts
+++ b/packages/pyright-internal/src/analyzer/sourceFile.ts
@@ -421,7 +421,17 @@ export class SourceFile {
                 this._clientDocument = TextDocument.create(this._filePath, 'python', version, '');
             }
             this._clientDocument = TextDocument.update(this._clientDocument, contents, version);
-            this.markDirty();
+
+            const fileContents = this._clientDocument.getText();
+            const contentsHash = StringUtils.hashString(fileContents);
+
+            // Have the contents of the file changed?
+            if (fileContents.length !== this._lastFileContentLength || contentsHash !== this._lastFileContentHash) {
+                this.markDirty();
+            }
+
+            this._lastFileContentLength = fileContents.length;
+            this._lastFileContentHash = contentsHash;
         }
     }
 


### PR DESCRIPTION
…lready analyzed it and the file contents are the same as before. This restores the behavior that existed prior to this change: https://github.com/microsoft/pyright/commit/2d90df325fd9ffb6bd72e727ec59039b50cdf537#diff-32dc01623d13bd967864d6e0b14c73f5e490534e7bb337a1d182169b8c670a79R426.