### PR TITLE
Fix libzip crashes, normalize via native realpath, make resolver function protected

### DIFF
--- a/build/updateDeps.js
+++ b/build/updateDeps.js
@@ -10,7 +10,7 @@ async function main() {
         transitive: { type: 'boolean' },
     }).argv;
 
-    await updateAll(argv.transitive, [
+    await updateAll(!!argv.transitive, [
         // These packages impact compatibility with VS Code and other users;
         // ensure they remained pinned exactly.
         '@types/vscode',

--- a/packages/pyright-internal/src/analyzer/docStringConversion.ts
+++ b/packages/pyright-internal/src/analyzer/docStringConversion.ts
@@ -103,6 +103,7 @@ interface RestTableState {
     header: string;
     inHeader: boolean;
 }
+
 class DocStringConverter {
     private _builder = '';
     private _skipAppendEmptyLine = true;
@@ -635,6 +636,7 @@ class DocStringConverter {
 
         if (EqualHeaderRegExp.test(line)) {
             this._eatLine();
+            this._appendLine('\n<br/>\n');
             this._popState();
             this._tableState = undefined;
             return;

--- a/packages/pyright-internal/src/pyrightFileSystem.ts
+++ b/packages/pyright-internal/src/pyrightFileSystem.ts
@@ -159,6 +159,10 @@ export class PyrightFileSystem implements FileSystem {
         return this._realFS.tmpfile(options);
     }
 
+    realCasePath(path: string): string {
+        return this._realFS.realCasePath(path);
+    }
+
     isPartialStubPackagesScanned(execEnv: ExecutionEnvironment): boolean {
         return this.isPathScanned(execEnv.root);
     }

--- a/packages/pyright-internal/src/tests/docStringConversion.test.ts
+++ b/packages/pyright-internal/src/tests/docStringConversion.test.ts
@@ -731,7 +731,9 @@ default_rng     Default constructor for \`\`Generator\`\`
 |Generator | |
 |---------------|---------------------------------------------------------|
 |Generator       |Class implementing all of the random number distributions|
-|default_rng     |Default constructor for \`\`Generator\`\`|`;
+|default_rng     |Default constructor for \`\`Generator\`\`|
+
+<br/>`;
 
     _testConvertToMarkdown(docstring, markdown);
 });
@@ -749,7 +751,9 @@ rand                 Uniformly distributed values.
     const markdown = `
 |Compatibility <br>functions - removed <br>in the new API | <br> <br> |
 |--------------------|---------------------------------------------------------|
-|rand                 |Uniformly distributed values.|`;
+|rand                 |Uniformly distributed values.|
+
+<br/>`;
 
     _testConvertToMarkdown(docstring, markdown);
 });
@@ -767,7 +771,9 @@ Scalar Type                    Array Type
     const markdown = `|Scalar Type                     |Array Type |
 |------------------------------|-------------------------------------|
 |:class:\`pandas.Interval\`       |:class:\`pandas.arrays.IntervalArray\`|
-|:class:\`pandas.Period\`         |:class:\`pandas.arrays.PeriodArray\`|`;
+|:class:\`pandas.Period\`         |:class:\`pandas.arrays.PeriodArray\`|
+
+<br/>`;
 
     _testConvertToMarkdown(docstring, markdown);
 });
@@ -793,7 +799,9 @@ dtype : str, np.dtype, or ExtensionDtype, optional
 |    Scalar Type                 |    Array Type |
 |------------------------------|-------------------------------------|
 |    :class:\`pandas.Interval\`   |  :class:\`pandas.arrays.IntervalArray\`|
-|    :class:\`pandas.Period\`     |  :class:\`pandas.arrays.PeriodArray\`|`;
+|    :class:\`pandas.Period\`     |  :class:\`pandas.arrays.PeriodArray\`|
+
+<br/>`;
 
     _testConvertToMarkdown(docstring, markdown);
 });

--- a/packages/pyright-internal/src/tests/harness/vfs/filesystem.ts
+++ b/packages/pyright-internal/src/tests/harness/vfs/filesystem.ts
@@ -335,6 +335,10 @@ export class TestFileSystem implements FileSystem {
         return path;
     }
 
+    realCasePath(path: string): string {
+        return path;
+    }
+
     private _scan(path: string, stats: Stats, axis: Axis, traversal: Traversal, noFollow: boolean, results: string[]) {
         if (axis === 'ancestors-or-self' || axis === 'self' || axis === 'descendants-or-self') {
             if (!traversal.accept || traversal.accept(path, stats)) {

--- a/packages/pyright-internal/src/tests/samples/zipfs/bad.egg
+++ b/packages/pyright-internal/src/tests/samples/zipfs/bad.egg
@@ -1,0 +1,1 @@
+This file isn't a zip.

--- a/packages/pyright-internal/src/tests/samples/zipfs/bad.zip
+++ b/packages/pyright-internal/src/tests/samples/zipfs/bad.zip
@@ -1,0 +1,1 @@
+This file isn't a zip.

--- a/packages/pyright-internal/src/tests/zipfs.test.ts
+++ b/packages/pyright-internal/src/tests/zipfs.test.ts
@@ -88,3 +88,17 @@ function runTests(p: string): void {
 
 describe('zip', () => runTests('./samples/zipfs/basic.zip'));
 describe('egg', () => runTests('./samples/zipfs/basic.egg'));
+
+function runBadTests(p: string): void {
+    const zipRoot = path.resolve(path.dirname(module.filename), p);
+    const fs = createFromRealFileSystem();
+
+    test('stat root', () => {
+        const stats = fs.statSync(zipRoot);
+        assert.strictEqual(stats.isDirectory(), false);
+        assert.strictEqual(stats.isFile(), true);
+    });
+}
+
+describe('zip', () => runBadTests('./samples/zipfs/bad.zip'));
+describe('egg', () => runBadTests('./samples/zipfs/bad.egg'));


### PR DESCRIPTION
Rollup of:

- Fix libzip crashes by more carefully checking for zips.
- Normalize paths from python using native realpath, which may fix casing problems.
- Switch an import resolver to protected for Pylance use.