### PR TITLE
Update command-line.md to emphazise flags with arguments

### DIFF
--- a/docs/command-line.md
+++ b/docs/command-line.md
@@ -6,32 +6,30 @@ Pyright can be run as either a VS Code extension or as a node-based command-line
 
 | Flag                               | Description                                           |
 | :--------------------------------- | :---------------------------------------------------  |
-| --createstub IMPORT                 | Create type stub file(s) for import                  |
-| --dependencies                      | Emit import dependency information                   |
-| -h, --help                          | Show help message                                    |
-| --ignoreexternal                    | Ignore external imports for --verifytypes (2)        |
-| --lib                               | Use library code for types when stubs are missing    |
-| --outputjson                        | Output results in JSON format                        |
-| -p, --project FILE OR DIRECTORY     | Use the configuration file at this location          |
-| --pythonplatform PLATFORM           | Analyze for platform (Darwin, Linux, Windows)        |
-| --pythonversion VERSION             | Analyze for version (3.3, 3.4, etc.)                 |
-| --stats                             | Print detailed performance stats                     |
-| -t, --typeshed-path DIRECTORY       | Use typeshed type stubs at this location (3)         |
-| -v, --venv-path DIRECTORY           | Directory that contains virtual environments (4)     |
-| --verbose                           | Emit verbose diagnostics                             |
-| --verifytypes IMPORT                | Verify completeness of types in py.typed package     |
-| --version                           | Print pyright version                                |
-| -w, --watch                         | Continue to run and watch for changes (5)            |
+| --createstub `<IMPORT>`                 | Create type stub file(s) for import                  |
+| --dependencies                          | Emit import dependency information                   |
+| -h, --help                              | Show help message                                    |
+| --ignoreexternal                        | Ignore external imports for --verifytypes            |
+| --lib                                   | Use library code for types when stubs are missing    |
+| --outputjson                            | Output results in JSON format                        |
+| -p, --project `<FILE OR DIRECTORY>`     | Use the configuration file at this location          |
+| --pythonplatform `<PLATFORM>`           | Analyze for platform (Darwin, Linux, Windows)        |
+| --pythonversion `<VERSION>`             | Analyze for version (3.3, 3.4, etc.)                 |
+| --stats                                 | Print detailed performance stats                     |
+| -t, --typeshed-path `<DIRECTORY>`       | Use typeshed type stubs at this location (2)         |
+| -v, --venv-path `<DIRECTORY>`           | Directory that contains virtual environments (3)     |
+| --verbose                               | Emit verbose diagnostics                             |
+| --verifytypes `<IMPORT>`                | Verify completeness of types in py.typed package     |
+| --version                               | Print pyright version                                |
+| -w, --watch                             | Continue to run and watch for changes (4)            |
 
 (1) If specific files are specified on the command line, the pyrightconfig.json file is ignored.
 
-(2) the `--ignoreexternal` flag has to be placed after [...files].
+(2) Pyright has built-in typeshed type stubs for Python stdlib functionality. To use a different version of typeshed type stubs, specify the directory with this option.
 
-(3) Pyright has built-in typeshed type stubs for Python stdlib functionality. To use a different version of typeshed type stubs, specify the directory with this option.
+(3) This option is used in conjunction with configuration file, which can refer to different virtual environments by name. For more details, refer to the [configuration](/docs/configuration.md) documentation. This allows a common config file to be checked in to the project and shared by everyone on the development team without making assumptions about the local paths to the venv directory on each developer’s computer.
 
-(4) This option is used in conjunction with configuration file, which can refer to different virtual environments by name. For more details, refer to the [configuration](/docs/configuration.md) documentation. This allows a common config file to be checked in to the project and shared by everyone on the development team without making assumptions about the local paths to the venv directory on each developer’s computer.
-
-(5) When running in watch mode, pyright will reanalyze only those files that have been modified. These “deltas” are typically much faster than the initial analysis, which needs to analyze all files in the source tree.
+(4) When running in watch mode, pyright will reanalyze only those files that have been modified. These “deltas” are typically much faster than the initial analysis, which needs to analyze all files in the source tree.
 
 
 # Pyright Exit Codes

--- a/docs/command-line.md
+++ b/docs/command-line.md
@@ -25,7 +25,7 @@ Pyright can be run as either a VS Code extension or as a node-based command-line
 
 (1) If specific files are specified on the command line, the pyrightconfig.json file is ignored.
 
-(2) the `--ignoreexternal` flag is to be places after the files.
+(2) the `--ignoreexternal` flag has to be placed after [...files].
 
 (3) Pyright has built-in typeshed type stubs for Python stdlib functionality. To use a different version of typeshed type stubs, specify the directory with this option.
 

--- a/docs/command-line.md
+++ b/docs/command-line.md
@@ -9,27 +9,29 @@ Pyright can be run as either a VS Code extension or as a node-based command-line
 | --createstub IMPORT                 | Create type stub file(s) for import                  |
 | --dependencies                      | Emit import dependency information                   |
 | -h, --help                          | Show help message                                    |
-| --ignoreexternal                    | Ignore external imports for --verifytypes            |
+| --ignoreexternal                    | Ignore external imports for --verifytypes (2)        |
 | --lib                               | Use library code for types when stubs are missing    |
 | --outputjson                        | Output results in JSON format                        |
 | -p, --project FILE OR DIRECTORY     | Use the configuration file at this location          |
 | --pythonplatform PLATFORM           | Analyze for platform (Darwin, Linux, Windows)        |
 | --pythonversion VERSION             | Analyze for version (3.3, 3.4, etc.)                 |
 | --stats                             | Print detailed performance stats                     |
-| -t, --typeshed-path DIRECTORY       | Use typeshed type stubs at this location (2)         |
-| -v, --venv-path DIRECTORY           | Directory that contains virtual environments (3)     |
+| -t, --typeshed-path DIRECTORY       | Use typeshed type stubs at this location (3)         |
+| -v, --venv-path DIRECTORY           | Directory that contains virtual environments (4)     |
 | --verbose                           | Emit verbose diagnostics                             |
 | --verifytypes IMPORT                | Verify completeness of types in py.typed package     |
 | --version                           | Print pyright version                                |
-| -w, --watch                         | Continue to run and watch for changes (4)            |
+| -w, --watch                         | Continue to run and watch for changes (5)            |
 
 (1) If specific files are specified on the command line, the pyrightconfig.json file is ignored.
 
-(2) Pyright has built-in typeshed type stubs for Python stdlib functionality. To use a different version of typeshed type stubs, specify the directory with this option.
+(2) the `--ignoreexternal` flag is to be places after the files.
 
-(3) This option is used in conjunction with configuration file, which can refer to different virtual environments by name. For more details, refer to the [configuration](/docs/configuration.md) documentation. This allows a common config file to be checked in to the project and shared by everyone on the development team without making assumptions about the local paths to the venv directory on each developer’s computer.
+(3) Pyright has built-in typeshed type stubs for Python stdlib functionality. To use a different version of typeshed type stubs, specify the directory with this option.
 
-(4) When running in watch mode, pyright will reanalyze only those files that have been modified. These “deltas” are typically much faster than the initial analysis, which needs to analyze all files in the source tree.
+(4) This option is used in conjunction with configuration file, which can refer to different virtual environments by name. For more details, refer to the [configuration](/docs/configuration.md) documentation. This allows a common config file to be checked in to the project and shared by everyone on the development team without making assumptions about the local paths to the venv directory on each developer’s computer.
+
+(5) When running in watch mode, pyright will reanalyze only those files that have been modified. These “deltas” are typically much faster than the initial analysis, which needs to analyze all files in the source tree.
 
 
 # Pyright Exit Codes


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/60603110/121781428-42d0b480-cbc2-11eb-82c6-bda1f2563133.png)

As per the usage, , the --ignoreexternal flag must be placed after the package and hence this PR adds a note. I struggled a lot with this and hope it helps other people!