### PR TITLE
minor change to assert, execute command

### DIFF
--- a/packages/pyright-internal/src/analyzer/program.ts
+++ b/packages/pyright-internal/src/analyzer/program.ts
@@ -364,6 +364,10 @@ export class Program {
         return this._sourceFileList.length;
     }
 
+    getTracked(): SourceFileInfo[] {
+        return this._sourceFileList.filter((s) => s.isTracked);
+    }
+
     getFilesToAnalyzeCount() {
         let sourceFileCount = 0;
 

--- a/packages/pyright-internal/src/commands/commandResult.ts
+++ b/packages/pyright-internal/src/commands/commandResult.ts
@@ -1,0 +1,12 @@
+import { WorkspaceEdit } from 'vscode-languageserver-types';
+
+export interface CommandResult {
+    data?: any;
+    edits: WorkspaceEdit;
+}
+
+export namespace CommandResult {
+    export function is(value: any): value is CommandResult {
+        return value && value.edits && WorkspaceEdit.is(value.edits);
+    }
+}

--- a/packages/pyright-internal/src/commands/commandResult.ts
+++ b/packages/pyright-internal/src/commands/commandResult.ts
@@ -1,3 +1,11 @@
+/*
+ * commandResult.ts
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT license.
+ *
+ * wrapper for returning custom command data
+ */
+
 import { WorkspaceEdit } from 'vscode-languageserver-types';
 
 export interface CommandResult {

--- a/packages/pyright-internal/src/common/debug.ts
+++ b/packages/pyright-internal/src/common/debug.ts
@@ -10,11 +10,11 @@ import { stableSort } from './collectionUtils';
 import { AnyFunction, compareValues, hasProperty, isString } from './core';
 
 export function assert(
-    expression: boolean,
+    expression: any,
     message?: string,
     verboseDebugInfo?: string | (() => string),
     stackCrawlMark?: AnyFunction
-): void {
+): asserts expression {
     if (!expression) {
         if (verboseDebugInfo) {
             message +=


### PR DESCRIPTION
Rollup of:
 - ExecuteCommand now can return a result instead of just applying workspaceEdits
 - New CommandResult wrapper for returning custom data along with workspaceEdits
 - Changed Program API to expose tracked files
 - updated assert signature