### PR TITLE
Update dependencies, eliminate broken webpack plugin, begin browser refactorings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -73,6 +73,29 @@
                 }
             }
         },
+        "@humanwhocodes/config-array": {
+            "version": "0.5.0",
+            "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.5.0.tgz",
+            "integrity": "sha512-FagtKFz74XrTl7y6HCzQpwDfXP0yhxe9lHLD1UZxjvZIcbyRz8zTFF/yYNfSfzU414eDwZ1SrO0Qvtyf+wFMQg==",
+            "dev": true,
+            "requires": {
+                "@humanwhocodes/object-schema": "^1.2.0",
+                "debug": "^4.1.1",
+                "minimatch": "^3.0.4"
+            }
+        },
+        "@humanwhocodes/object-schema": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.0.tgz",
+            "integrity": "sha512-wdppn25U8z/2yiaT6YGquE6X8sSv7hNMWSXYSSU1jGv/yd6XqjXgTDJ8KP4NgjTXfJ3GbRjeeb8RTV7a/VpM+w==",
+            "dev": true
+        },
+        "@hutson/parse-repository-url": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/@hutson/parse-repository-url/-/parse-repository-url-3.0.2.tgz",
+            "integrity": "sha512-H9XAx3hc0BQHY6l+IFSWHDySypcXsvsuLhgYLUGywmJ5pswRVQJUHpOsobnLYp2ZUaUlKiKDrgWWhosOwAEM8Q==",
+            "dev": true
+        },
         "@lerna/add": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/@lerna/add/-/add-4.0.0.tgz",
@@ -1193,9 +1216,9 @@
             "dev": true
         },
         "@nodelib/fs.walk": {
-            "version": "1.2.7",
-            "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.7.tgz",
-            "integrity": "sha512-BTIhocbPBSrRmHxOAJFtR18oLhxTtAFDAvL8hY1S3iU8k+E60W/YFs4jrixGzQjMpF4qPXxIQHcjVD9dz1C2QA==",
+            "version": "1.2.8",
+            "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+            "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
             "dev": true,
             "requires": {
                 "@nodelib/fs.scandir": "2.1.5",
@@ -1209,9 +1232,9 @@
             "dev": true
         },
         "@npmcli/git": {
-            "version": "2.0.9",
-            "resolved": "https://registry.npmjs.org/@npmcli/git/-/git-2.0.9.tgz",
-            "integrity": "sha512-hTMbMryvOqGLwnmMBKs5usbPsJtyEsMsgXwJbmNrsEuQQh1LAIMDU77IoOrwkCg+NgQWl+ySlarJASwM3SutCA==",
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/@npmcli/git/-/git-2.1.0.tgz",
+            "integrity": "sha512-/hBFX/QG1b+N7PZBFs0bi+evgRZcK9nWBxQKZkGoXUT5hJSwl5c4d7y8/hm+NQZRPhQ67RzFaj5UM9YeyKoryw==",
             "dev": true,
             "requires": {
                 "@npmcli/promise-spawn": "^1.3.2",
@@ -1381,14 +1404,14 @@
             }
         },
         "@octokit/core": {
-            "version": "3.4.0",
-            "resolved": "https://registry.npmjs.org/@octokit/core/-/core-3.4.0.tgz",
-            "integrity": "sha512-6/vlKPP8NF17cgYXqucdshWqmMZGXkuvtcrWCgU5NOI0Pl2GjlmZyWgBMrU8zJ3v2MJlM6++CiB45VKYmhiWWg==",
+            "version": "3.5.1",
+            "resolved": "https://registry.npmjs.org/@octokit/core/-/core-3.5.1.tgz",
+            "integrity": "sha512-omncwpLVxMP+GLpLPgeGJBF6IWJFjXDS5flY5VbppePYX9XehevbDykRH9PdCdvqt9TS5AOTiDide7h0qrkHjw==",
             "dev": true,
             "requires": {
                 "@octokit/auth-token": "^2.4.4",
                 "@octokit/graphql": "^4.5.8",
-                "@octokit/request": "^5.4.12",
+                "@octokit/request": "^5.6.0",
                 "@octokit/request-error": "^2.0.5",
                 "@octokit/types": "^6.0.3",
                 "before-after-hook": "^2.2.0",
@@ -1415,20 +1438,20 @@
             }
         },
         "@octokit/graphql": {
-            "version": "4.6.3",
-            "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-4.6.3.tgz",
-            "integrity": "sha512-ww2fYpuPPWhlKENk7g3Ynbqm6R5zqXOnbXuyELCiM/zjZq+hMlNOsiV/LgwCH81+i5FkeZA/IB/BgWGoAuXJwA==",
+            "version": "4.6.4",
+            "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-4.6.4.tgz",
+            "integrity": "sha512-SWTdXsVheRmlotWNjKzPOb6Js6tjSqA2a8z9+glDJng0Aqjzti8MEWOtuT8ZSu6wHnci7LZNuarE87+WJBG4vg==",
             "dev": true,
             "requires": {
-                "@octokit/request": "^5.3.0",
+                "@octokit/request": "^5.6.0",
                 "@octokit/types": "^6.0.3",
                 "universal-user-agent": "^6.0.0"
             }
         },
         "@octokit/openapi-types": {
-            "version": "7.3.2",
-            "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-7.3.2.tgz",
-            "integrity": "sha512-oJhK/yhl9Gt430OrZOzAl2wJqR0No9445vmZ9Ey8GjUZUpwuu/vmEFP0TDhDXdpGDoxD6/EIFHJEcY8nHXpDTA==",
+            "version": "8.3.0",
+            "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-8.3.0.tgz",
+            "integrity": "sha512-ZFyQ30tNpoATI7o+Z9MWFUzUgWisB8yduhcky7S4UYsRijgIGSnwUKzPBDGzf/Xkx1DuvUtqzvmuFlDSqPJqmQ==",
             "dev": true
         },
         "@octokit/plugin-enterprise-rest": {
@@ -1438,12 +1461,12 @@
             "dev": true
         },
         "@octokit/plugin-paginate-rest": {
-            "version": "2.13.4",
-            "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-2.13.4.tgz",
-            "integrity": "sha512-jlewlILzooEkxhUxSV64Iwe8I+KGzY4C7KwxoA6MAoOv/cV4z/9LuAO88EL9ulB8JglLu1HFBm3bDwgNIQQdSA==",
+            "version": "2.14.0",
+            "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-2.14.0.tgz",
+            "integrity": "sha512-S2uEu2uHeI7Vf+Lvj8tv3O5/5TCAa8GHS0dUQN7gdM7vKA6ZHAbR6HkAVm5yMb1mbedLEbxOuQ+Fa0SQ7tCDLA==",
             "dev": true,
             "requires": {
-                "@octokit/types": "^6.13.0"
+                "@octokit/types": "^6.18.0"
             }
         },
         "@octokit/plugin-request-log": {
@@ -1453,23 +1476,23 @@
             "dev": true
         },
         "@octokit/plugin-rest-endpoint-methods": {
-            "version": "5.3.1",
-            "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-5.3.1.tgz",
-            "integrity": "sha512-3B2iguGmkh6bQQaVOtCsS0gixrz8Lg0v4JuXPqBcFqLKuJtxAUf3K88RxMEf/naDOI73spD+goJ/o7Ie7Cvdjg==",
+            "version": "5.4.1",
+            "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-5.4.1.tgz",
+            "integrity": "sha512-Nx0g7I5ayAYghsLJP4Q1Ch2W9jYYM0FlWWWZocUro8rNxVwuZXGfFd7Rcqi9XDWepSXjg1WByiNJnZza2hIOvQ==",
             "dev": true,
             "requires": {
-                "@octokit/types": "^6.16.2",
+                "@octokit/types": "^6.18.1",
                 "deprecation": "^2.3.1"
             }
         },
         "@octokit/request": {
-            "version": "5.5.0",
-            "resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.5.0.tgz",
-            "integrity": "sha512-jxbMLQdQ3heFMZUaTLSCqcKs2oAHEYh7SnLLXyxbZmlULExZ/RXai7QUWWFKowcGGPlCZuKTZg0gSKHWrfYEoQ==",
+            "version": "5.6.0",
+            "resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.6.0.tgz",
+            "integrity": "sha512-4cPp/N+NqmaGQwbh3vUsYqokQIzt7VjsgTYVXiwpUP2pxd5YiZB2XuTedbb0SPtv9XS7nzAKjAuQxmY8/aZkiA==",
             "dev": true,
             "requires": {
                 "@octokit/endpoint": "^6.0.1",
-                "@octokit/request-error": "^2.0.0",
+                "@octokit/request-error": "^2.1.0",
                 "@octokit/types": "^6.16.1",
                 "is-plain-object": "^5.0.0",
                 "node-fetch": "^2.6.1",
@@ -1485,9 +1508,9 @@
             }
         },
         "@octokit/request-error": {
-            "version": "2.0.6",
-            "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-2.0.6.tgz",
-            "integrity": "sha512-oGQkw2/m+bVUM8h5xO8qDWDELgTKvWy6MwM5kjJyibnQBO09TXHgodB4ym7JVrFDHkQSWt47UeP9GsE8a6Fj3Q==",
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-2.1.0.tgz",
+            "integrity": "sha512-1VIvgXxs9WHSjicsRwq8PlR2LR2x6DwsJAaFgzdi0JfJoGSO8mYI/cHJQ+9FbN21aa+DrgNLnwObmyeSC8Rmpg==",
             "dev": true,
             "requires": {
                 "@octokit/types": "^6.0.3",
@@ -1496,24 +1519,24 @@
             }
         },
         "@octokit/rest": {
-            "version": "18.5.6",
-            "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-18.5.6.tgz",
-            "integrity": "sha512-8HdG6ZjQdZytU6tCt8BQ2XLC7EJ5m4RrbyU/EARSkAM1/HP3ceOzMG/9atEfe17EDMer3IVdHWLedz2wDi73YQ==",
+            "version": "18.6.7",
+            "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-18.6.7.tgz",
+            "integrity": "sha512-Kn6WrI2ZvmAztdx+HEaf88RuJn+LK72S8g6OpciE4kbZddAN84fu4fiPGxcEu052WmqKVnA/cnQsbNlrYC6rqQ==",
             "dev": true,
             "requires": {
-                "@octokit/core": "^3.2.3",
+                "@octokit/core": "^3.5.0",
                 "@octokit/plugin-paginate-rest": "^2.6.2",
                 "@octokit/plugin-request-log": "^1.0.2",
-                "@octokit/plugin-rest-endpoint-methods": "5.3.1"
+                "@octokit/plugin-rest-endpoint-methods": "5.4.1"
             }
         },
         "@octokit/types": {
-            "version": "6.16.4",
-            "resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.16.4.tgz",
-            "integrity": "sha512-UxhWCdSzloULfUyamfOg4dJxV9B+XjgrIZscI0VCbp4eNrjmorGEw+4qdwcpTsu6DIrm9tQsFQS2pK5QkqQ04A==",
+            "version": "6.19.0",
+            "resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.19.0.tgz",
+            "integrity": "sha512-9wdZFiJfonDyU6DjIgDHxAIn92vdSUBOwAXbO2F9rOFt6DJwuAkyGLu1CvdJPphCbPBoV9iSDMX7y4fu0v6AtA==",
             "dev": true,
             "requires": {
-                "@octokit/openapi-types": "^7.3.2"
+                "@octokit/openapi-types": "^8.3.0"
             }
         },
         "@sindresorhus/is": {
@@ -1538,9 +1561,9 @@
             "dev": true
         },
         "@types/glob": {
-            "version": "7.1.3",
-            "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.3.tgz",
-            "integrity": "sha512-SEYeGAIQIQX8NN6LDKprLjbrd5dARM5EXsd8GI/A5l0apYI1fGMWgPHSe4ZKL4eozlAyI+doUE9XbYS4xCkQ1w==",
+            "version": "7.1.4",
+            "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.4.tgz",
+            "integrity": "sha512-w+LsMxKyYQm347Otw+IfBXOv9UWVjpHpCDdbBMt8Kz/xbvCYNjP+0qPh91Km3iKfSRLBB0P7fAMf0KHrPu+MyA==",
             "dev": true,
             "requires": {
                 "@types/minimatch": "*",
@@ -1548,33 +1571,33 @@
             }
         },
         "@types/json-schema": {
-            "version": "7.0.7",
-            "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.7.tgz",
-            "integrity": "sha512-cxWFQVseBm6O9Gbw1IWb8r6OS4OhSt3hPZLkFApLjM8TEXROBuQGLAH2i2gZpcXdLBIrpXuTDhH7Vbm1iXmNGA==",
+            "version": "7.0.8",
+            "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.8.tgz",
+            "integrity": "sha512-YSBPTLTVm2e2OoQIDYx8HaeWJ5tTToLH67kXR7zYNGupXMEHa2++G8k+DczX2cFVgalypqtyZIcU19AFcmOpmg==",
             "dev": true
         },
         "@types/minimatch": {
-            "version": "3.0.4",
-            "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.4.tgz",
-            "integrity": "sha512-1z8k4wzFnNjVK/tlxvrWuK5WMt6mydWWP7+zvH5eFep4oj+UkrfiJTRtjCeBXNpwaA/FYqqtb4/QS4ianFpIRA==",
+            "version": "3.0.5",
+            "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.5.tgz",
+            "integrity": "sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ==",
             "dev": true
         },
         "@types/minimist": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.1.tgz",
-            "integrity": "sha512-fZQQafSREFyuZcdWFAExYjBiCL7AUCdgsk80iO0q4yihYYdcIiH28CcuPTGFgLOCC8RlW49GSQxdHwZP+I7CNg==",
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.2.tgz",
+            "integrity": "sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ==",
             "dev": true
         },
         "@types/node": {
-            "version": "12.20.15",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.15.tgz",
-            "integrity": "sha512-F6S4Chv4JicJmyrwlDkxUdGNSplsQdGwp1A0AJloEVDirWdZOAiRHhovDlsFkKUrquUXhz1imJhXHsf59auyAg==",
+            "version": "12.20.16",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.16.tgz",
+            "integrity": "sha512-6CLxw83vQf6DKqXxMPwl8qpF8I7THFZuIwLt4TnNsumxkp1VsRZWT8txQxncT/Rl2UojTsFzWgDG4FRMwafrlA==",
             "dev": true
         },
         "@types/normalize-package-data": {
-            "version": "2.4.0",
-            "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
-            "integrity": "sha512-f5j5b/Gf71L+dbqxIpQ4Z2WlmI/mPJ0fOkGGmFgtb6sAu97EPczzbS3/tJKxmcYDj55OX6ssqwDAWOHIYDRDGA==",
+            "version": "2.4.1",
+            "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.1.tgz",
+            "integrity": "sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==",
             "dev": true
         },
         "@types/parse-json": {
@@ -1584,86 +1607,85 @@
             "dev": true
         },
         "@types/yargs": {
-            "version": "16.0.3",
-            "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-16.0.3.tgz",
-            "integrity": "sha512-YlFfTGS+zqCgXuXNV26rOIeETOkXnGQXP/pjjL9P0gO/EP9jTmc7pUBhx+jVEIxpq41RX33GQ7N3DzOSfZoglQ==",
+            "version": "16.0.4",
+            "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-16.0.4.tgz",
+            "integrity": "sha512-T8Yc9wt/5LbJyCaLiHPReJa0kApcIgJ7Bn735GjItUfh08Z1pJvu8QZqb9s+mMvKV6WUQRV7K2R46YbjMXTTJw==",
             "dev": true,
             "requires": {
                 "@types/yargs-parser": "*"
             }
         },
         "@types/yargs-parser": {
-            "version": "20.2.0",
-            "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-20.2.0.tgz",
-            "integrity": "sha512-37RSHht+gzzgYeobbG+KWryeAW8J33Nhr69cjTqSYymXVZEN9NbRYWoYlRtDhHKPVT1FyNKwaTPC1NynKZpzRA==",
+            "version": "20.2.1",
+            "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-20.2.1.tgz",
+            "integrity": "sha512-7tFImggNeNBVMsn0vLrpn1H1uPrUBdnARPTpZoitY37ZrdJREzf7I16tMrlK3hen349gr1NYh8CmZQa7CTG6Aw==",
             "dev": true
         },
         "@typescript-eslint/eslint-plugin": {
-            "version": "4.26.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.26.1.tgz",
-            "integrity": "sha512-aoIusj/8CR+xDWmZxARivZjbMBQTT9dImUtdZ8tVCVRXgBUuuZyM5Of5A9D9arQPxbi/0rlJLcuArclz/rCMJw==",
+            "version": "4.28.3",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.28.3.tgz",
+            "integrity": "sha512-jW8sEFu1ZeaV8xzwsfi6Vgtty2jf7/lJmQmDkDruBjYAbx5DA8JtbcMnP0rNPUG+oH5GoQBTSp+9613BzuIpYg==",
             "dev": true,
             "requires": {
-                "@typescript-eslint/experimental-utils": "4.26.1",
-                "@typescript-eslint/scope-manager": "4.26.1",
+                "@typescript-eslint/experimental-utils": "4.28.3",
+                "@typescript-eslint/scope-manager": "4.28.3",
                 "debug": "^4.3.1",
                 "functional-red-black-tree": "^1.0.1",
-                "lodash": "^4.17.21",
                 "regexpp": "^3.1.0",
                 "semver": "^7.3.5",
                 "tsutils": "^3.21.0"
             }
         },
         "@typescript-eslint/experimental-utils": {
-            "version": "4.26.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.26.1.tgz",
-            "integrity": "sha512-sQHBugRhrXzRCs9PaGg6rowie4i8s/iD/DpTB+EXte8OMDfdCG5TvO73XlO9Wc/zi0uyN4qOmX9hIjQEyhnbmQ==",
+            "version": "4.28.3",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.28.3.tgz",
+            "integrity": "sha512-zZYl9TnrxwEPi3FbyeX0ZnE8Hp7j3OCR+ELoUfbwGHGxWnHg9+OqSmkw2MoCVpZksPCZYpQzC559Ee9pJNHTQw==",
             "dev": true,
             "requires": {
                 "@types/json-schema": "^7.0.7",
-                "@typescript-eslint/scope-manager": "4.26.1",
-                "@typescript-eslint/types": "4.26.1",
-                "@typescript-eslint/typescript-estree": "4.26.1",
+                "@typescript-eslint/scope-manager": "4.28.3",
+                "@typescript-eslint/types": "4.28.3",
+                "@typescript-eslint/typescript-estree": "4.28.3",
                 "eslint-scope": "^5.1.1",
                 "eslint-utils": "^3.0.0"
             }
         },
         "@typescript-eslint/parser": {
-            "version": "4.26.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-4.26.1.tgz",
-            "integrity": "sha512-q7F3zSo/nU6YJpPJvQveVlIIzx9/wu75lr6oDbDzoeIRWxpoc/HQ43G4rmMoCc5my/3uSj2VEpg/D83LYZF5HQ==",
+            "version": "4.28.3",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-4.28.3.tgz",
+            "integrity": "sha512-ZyWEn34bJexn/JNYvLQab0Mo5e+qqQNhknxmc8azgNd4XqspVYR5oHq9O11fLwdZMRcj4by15ghSlIEq+H5ltQ==",
             "dev": true,
             "requires": {
-                "@typescript-eslint/scope-manager": "4.26.1",
-                "@typescript-eslint/types": "4.26.1",
-                "@typescript-eslint/typescript-estree": "4.26.1",
+                "@typescript-eslint/scope-manager": "4.28.3",
+                "@typescript-eslint/types": "4.28.3",
+                "@typescript-eslint/typescript-estree": "4.28.3",
                 "debug": "^4.3.1"
             }
         },
         "@typescript-eslint/scope-manager": {
-            "version": "4.26.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.26.1.tgz",
-            "integrity": "sha512-TW1X2p62FQ8Rlne+WEShyd7ac2LA6o27S9i131W4NwDSfyeVlQWhw8ylldNNS8JG6oJB9Ha9Xyc+IUcqipvheQ==",
+            "version": "4.28.3",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.28.3.tgz",
+            "integrity": "sha512-/8lMisZ5NGIzGtJB+QizQ5eX4Xd8uxedFfMBXOKuJGP0oaBBVEMbJVddQKDXyyB0bPlmt8i6bHV89KbwOelJiQ==",
             "dev": true,
             "requires": {
-                "@typescript-eslint/types": "4.26.1",
-                "@typescript-eslint/visitor-keys": "4.26.1"
+                "@typescript-eslint/types": "4.28.3",
+                "@typescript-eslint/visitor-keys": "4.28.3"
             }
         },
         "@typescript-eslint/types": {
-            "version": "4.26.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.26.1.tgz",
-            "integrity": "sha512-STyMPxR3cS+LaNvS8yK15rb8Y0iL0tFXq0uyl6gY45glyI7w0CsyqyEXl/Fa0JlQy+pVANeK3sbwPneCbWE7yg==",
+            "version": "4.28.3",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.28.3.tgz",
+            "integrity": "sha512-kQFaEsQBQVtA9VGVyciyTbIg7S3WoKHNuOp/UF5RG40900KtGqfoiETWD/v0lzRXc+euVE9NXmfer9dLkUJrkA==",
             "dev": true
         },
         "@typescript-eslint/typescript-estree": {
-            "version": "4.26.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.26.1.tgz",
-            "integrity": "sha512-l3ZXob+h0NQzz80lBGaykdScYaiEbFqznEs99uwzm8fPHhDjwaBFfQkjUC/slw6Sm7npFL8qrGEAMxcfBsBJUg==",
+            "version": "4.28.3",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.28.3.tgz",
+            "integrity": "sha512-YAb1JED41kJsqCQt1NcnX5ZdTA93vKFCMP4lQYG6CFxd0VzDJcKttRlMrlG+1qiWAw8+zowmHU1H0OzjWJzR2w==",
             "dev": true,
             "requires": {
-                "@typescript-eslint/types": "4.26.1",
-                "@typescript-eslint/visitor-keys": "4.26.1",
+                "@typescript-eslint/types": "4.28.3",
+                "@typescript-eslint/visitor-keys": "4.28.3",
                 "debug": "^4.3.1",
                 "globby": "^11.0.3",
                 "is-glob": "^4.0.1",
@@ -1672,12 +1694,12 @@
             }
         },
         "@typescript-eslint/visitor-keys": {
-            "version": "4.26.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.26.1.tgz",
-            "integrity": "sha512-IGouNSSd+6x/fHtYRyLOM6/C+QxMDzWlDtN41ea+flWuSF9g02iqcIlX8wM53JkfljoIjP0U+yp7SiTS1onEkw==",
+            "version": "4.28.3",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.28.3.tgz",
+            "integrity": "sha512-ri1OzcLnk1HH4gORmr1dllxDzzrN6goUIz/P4MHFV0YZJDCADPR3RvYNp0PW2SetKTThar6wlbFTL00hV2Q+fg==",
             "dev": true,
             "requires": {
-                "@typescript-eslint/types": "4.26.1",
+                "@typescript-eslint/types": "4.28.3",
                 "eslint-visitor-keys": "^2.0.0"
             }
         },
@@ -1704,9 +1726,9 @@
             "dev": true
         },
         "acorn-jsx": {
-            "version": "5.3.1",
-            "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.1.tgz",
-            "integrity": "sha512-K0Ptm/47OKfQRpNQ2J/oIN/3QYiK6FwW+eJbILhsdxh2WTLdl+30o8aGdTbm5JbffpFFAg/g+zi1E+jvJha5ng==",
+            "version": "5.3.2",
+            "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+            "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
             "dev": true
         },
         "add-stream": {
@@ -1873,12 +1895,6 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-3.0.0.tgz",
             "integrity": "sha512-THtfYS6KtME/yIAhKjZ2ul7XI96lQGHRputJQHO80LAWQnuGP4iCIN8vdMRboGbIEYBwU33q8Tch1os2+X0kMg==",
-            "dev": true
-        },
-        "array-find-index": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
-            "integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E=",
             "dev": true
         },
         "array-ify": {
@@ -2553,16 +2569,16 @@
             }
         },
         "conventional-changelog-core": {
-            "version": "4.2.2",
-            "resolved": "https://registry.npmjs.org/conventional-changelog-core/-/conventional-changelog-core-4.2.2.tgz",
-            "integrity": "sha512-7pDpRUiobQDNkwHyJG7k9f6maPo9tfPzkSWbRq97GGiZqisElhnvUZSvyQH20ogfOjntB5aadvv6NNcKL1sReg==",
+            "version": "4.2.3",
+            "resolved": "https://registry.npmjs.org/conventional-changelog-core/-/conventional-changelog-core-4.2.3.tgz",
+            "integrity": "sha512-MwnZjIoMRL3jtPH5GywVNqetGILC7g6RQFvdb8LRU/fA/338JbeWAku3PZ8yQ+mtVRViiISqJlb0sOz0htBZig==",
             "dev": true,
             "requires": {
                 "add-stream": "^1.0.0",
-                "conventional-changelog-writer": "^4.0.18",
+                "conventional-changelog-writer": "^5.0.0",
                 "conventional-commits-parser": "^3.2.0",
                 "dateformat": "^3.0.0",
-                "get-pkg-repo": "^1.0.0",
+                "get-pkg-repo": "^4.0.0",
                 "git-raw-commits": "^2.0.8",
                 "git-remote-origin-url": "^2.0.0",
                 "git-semver-tags": "^4.1.1",
@@ -2571,7 +2587,6 @@
                 "q": "^1.5.1",
                 "read-pkg": "^3.0.0",
                 "read-pkg-up": "^3.0.0",
-                "shelljs": "^0.8.3",
                 "through2": "^4.0.0"
             },
             "dependencies": {
@@ -2596,12 +2611,11 @@
             "dev": true
         },
         "conventional-changelog-writer": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/conventional-changelog-writer/-/conventional-changelog-writer-4.1.0.tgz",
-            "integrity": "sha512-WwKcUp7WyXYGQmkLsX4QmU42AZ1lqlvRW9mqoyiQzdD+rJWbTepdWoKJuwXTS+yq79XKnQNa93/roViPQrAQgw==",
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/conventional-changelog-writer/-/conventional-changelog-writer-5.0.0.tgz",
+            "integrity": "sha512-HnDh9QHLNWfL6E1uHz6krZEQOgm8hN7z/m7tT16xwd802fwgMN0Wqd7AQYVkhpsjDUx/99oo+nGgvKF657XP5g==",
             "dev": true,
             "requires": {
-                "compare-func": "^2.0.0",
                 "conventional-commits-filter": "^2.0.7",
                 "dateformat": "^3.0.0",
                 "handlebars": "^4.7.6",
@@ -2698,15 +2712,6 @@
             "integrity": "sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA==",
             "dev": true
         },
-        "currently-unhandled": {
-            "version": "0.4.1",
-            "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
-            "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
-            "dev": true,
-            "requires": {
-                "array-find-index": "^1.0.1"
-            }
-        },
         "dargs": {
             "version": "7.0.0",
             "resolved": "https://registry.npmjs.org/dargs/-/dargs-7.0.0.tgz",
@@ -2729,9 +2734,9 @@
             "dev": true
         },
         "debug": {
-            "version": "4.3.1",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
-            "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+            "version": "4.3.2",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
+            "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
             "dev": true,
             "requires": {
                 "ms": "2.1.2"
@@ -3028,13 +3033,14 @@
             "dev": true
         },
         "eslint": {
-            "version": "7.28.0",
-            "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.28.0.tgz",
-            "integrity": "sha512-UMfH0VSjP0G4p3EWirscJEQ/cHqnT/iuH6oNZOB94nBjWbMnhGEPxsZm1eyIW0C/9jLI0Fow4W5DXLjEI7mn1g==",
+            "version": "7.30.0",
+            "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.30.0.tgz",
+            "integrity": "sha512-VLqz80i3as3NdloY44BQSJpFw534L9Oh+6zJOUaViV4JPd+DaHwutqP7tcpkW3YiXbK6s05RZl7yl7cQn+lijg==",
             "dev": true,
             "requires": {
                 "@babel/code-frame": "7.12.11",
                 "@eslint/eslintrc": "^0.4.2",
+                "@humanwhocodes/config-array": "^0.5.0",
                 "ajv": "^6.10.0",
                 "chalk": "^4.0.0",
                 "cross-spawn": "^7.0.2",
@@ -3277,17 +3283,16 @@
             "dev": true
         },
         "fast-glob": {
-            "version": "3.2.5",
-            "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.5.tgz",
-            "integrity": "sha512-2DtFcgT68wiTTiwZ2hNdJfcHNke9XOfnwmBRWXhmeKM8rF0TGwmC/Qto3S7RoZKp5cilZbxzO5iTNTQsJ+EeDg==",
+            "version": "3.2.7",
+            "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.7.tgz",
+            "integrity": "sha512-rYGMRwip6lUMvYD3BTScMwT1HtAs2d71SMv66Vrxs0IekGZEjhM0pcMfjQPnknBt2zeCwQMEupiN02ZP4DiT1Q==",
             "dev": true,
             "requires": {
                 "@nodelib/fs.stat": "^2.0.2",
                 "@nodelib/fs.walk": "^1.2.3",
-                "glob-parent": "^5.1.0",
+                "glob-parent": "^5.1.2",
                 "merge2": "^1.3.0",
-                "micromatch": "^4.0.2",
-                "picomatch": "^2.2.1"
+                "micromatch": "^4.0.4"
             }
         },
         "fast-json-stable-stringify": {
@@ -3302,10 +3307,16 @@
             "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
             "dev": true
         },
+        "fast-memoize": {
+            "version": "2.5.2",
+            "resolved": "https://registry.npmjs.org/fast-memoize/-/fast-memoize-2.5.2.tgz",
+            "integrity": "sha512-Ue0LwpDYErFbmNnZSF0UH6eImUwDmogUO1jyE+JbN2gsQz/jICm1Ve7t9QT0rNSsfJt+Hs4/S3GnsDVjL4HVrw==",
+            "dev": true
+        },
         "fastq": {
-            "version": "1.11.0",
-            "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.11.0.tgz",
-            "integrity": "sha512-7Eczs8gIPDrVzT+EksYBcupqMyxSHXXrHOLRRxU2/DicV8789MRBRR8+Hc2uWzUupOs4YS4JzBmBxjjCVBxD/g==",
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.11.1.tgz",
+            "integrity": "sha512-HOnr8Mc60eNYl1gzwp6r5RoUyAn5/glBolUzP/Ez6IFVPMPirxn/9phgL6zhOtaTy7ISwPvQ+wT+hfcRZh/bzw==",
             "dev": true,
             "requires": {
                 "reusify": "^1.0.4"
@@ -3379,9 +3390,9 @@
             }
         },
         "flatted": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.1.1.tgz",
-            "integrity": "sha512-zAoAQiudy+r5SvnSw3KJy5os/oRJYHzrzja/tBDqrZtNhUw8bt6y8OBzMWcjWr+8liV8Eb6yOhw8WZ7VFZ5ZzA==",
+            "version": "3.2.1",
+            "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.1.tgz",
+            "integrity": "sha512-OMQjaErSFHmHqZe+PSidH5n8j3O0F2DdnVh8JB4j4eUQ2k6KvB0qGfrKIhapvez5JerBbmWkaLYUYWISaESoXg==",
             "dev": true
         },
         "forever-agent": {
@@ -3517,178 +3528,73 @@
             }
         },
         "get-pkg-repo": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/get-pkg-repo/-/get-pkg-repo-1.4.0.tgz",
-            "integrity": "sha1-xztInAbYDMVTbCyFP54FIyBWly0=",
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/get-pkg-repo/-/get-pkg-repo-4.1.2.tgz",
+            "integrity": "sha512-/FjamZL9cBYllEbReZkxF2IMh80d8TJoC4e3bmLNif8ibHw95aj0N/tzqK0kZz9eU/3w3dL6lF4fnnX/sDdW3A==",
             "dev": true,
             "requires": {
-                "hosted-git-info": "^2.1.4",
-                "meow": "^3.3.0",
-                "normalize-package-data": "^2.3.0",
-                "parse-github-repo-url": "^1.3.0",
+                "@hutson/parse-repository-url": "^3.0.0",
+                "hosted-git-info": "^4.0.0",
+                "meow": "^7.0.0",
                 "through2": "^2.0.0"
             },
             "dependencies": {
-                "camelcase": {
-                    "version": "2.1.1",
-                    "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
-                    "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8=",
-                    "dev": true
-                },
-                "camelcase-keys": {
-                    "version": "2.1.0",
-                    "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
-                    "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
-                    "dev": true,
-                    "requires": {
-                        "camelcase": "^2.0.0",
-                        "map-obj": "^1.0.0"
-                    }
-                },
-                "find-up": {
-                    "version": "1.1.2",
-                    "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-                    "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
-                    "dev": true,
-                    "requires": {
-                        "path-exists": "^2.0.0",
-                        "pinkie-promise": "^2.0.0"
-                    }
-                },
-                "hosted-git-info": {
-                    "version": "2.8.9",
-                    "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
-                    "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
-                    "dev": true
-                },
-                "indent-string": {
-                    "version": "2.1.0",
-                    "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
-                    "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
-                    "dev": true,
-                    "requires": {
-                        "repeating": "^2.0.0"
-                    }
-                },
-                "load-json-file": {
-                    "version": "1.1.0",
-                    "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
-                    "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
-                    "dev": true,
-                    "requires": {
-                        "graceful-fs": "^4.1.2",
-                        "parse-json": "^2.2.0",
-                        "pify": "^2.0.0",
-                        "pinkie-promise": "^2.0.0",
-                        "strip-bom": "^2.0.0"
-                    }
-                },
-                "map-obj": {
-                    "version": "1.0.1",
-                    "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
-                    "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
-                    "dev": true
-                },
                 "meow": {
-                    "version": "3.7.0",
-                    "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
-                    "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
+                    "version": "7.1.1",
+                    "resolved": "https://registry.npmjs.org/meow/-/meow-7.1.1.tgz",
+                    "integrity": "sha512-GWHvA5QOcS412WCo8vwKDlTelGLsCGBVevQB5Kva961rmNfun0PCbv5+xta2kUMFJyR8/oWnn7ddeKdosbAPbA==",
                     "dev": true,
                     "requires": {
-                        "camelcase-keys": "^2.0.0",
-                        "decamelize": "^1.1.2",
-                        "loud-rejection": "^1.0.0",
-                        "map-obj": "^1.0.1",
-                        "minimist": "^1.1.3",
-                        "normalize-package-data": "^2.3.4",
-                        "object-assign": "^4.0.1",
-                        "read-pkg-up": "^1.0.1",
-                        "redent": "^1.0.0",
-                        "trim-newlines": "^1.0.0"
+                        "@types/minimist": "^1.2.0",
+                        "camelcase-keys": "^6.2.2",
+                        "decamelize-keys": "^1.1.0",
+                        "hard-rejection": "^2.1.0",
+                        "minimist-options": "4.1.0",
+                        "normalize-package-data": "^2.5.0",
+                        "read-pkg-up": "^7.0.1",
+                        "redent": "^3.0.0",
+                        "trim-newlines": "^3.0.0",
+                        "type-fest": "^0.13.1",
+                        "yargs-parser": "^18.1.3"
                     }
-                },
-                "parse-json": {
-                    "version": "2.2.0",
-                    "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-                    "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
-                    "dev": true,
-                    "requires": {
-                        "error-ex": "^1.2.0"
-                    }
-                },
-                "path-exists": {
-                    "version": "2.1.0",
-                    "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-                    "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
-                    "dev": true,
-                    "requires": {
-                        "pinkie-promise": "^2.0.0"
-                    }
-                },
-                "path-type": {
-                    "version": "1.1.0",
-                    "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
-                    "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
-                    "dev": true,
-                    "requires": {
-                        "graceful-fs": "^4.1.2",
-                        "pify": "^2.0.0",
-                        "pinkie-promise": "^2.0.0"
-                    }
-                },
-                "pify": {
-                    "version": "2.3.0",
-                    "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-                    "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-                    "dev": true
                 },
                 "read-pkg": {
-                    "version": "1.1.0",
-                    "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
-                    "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
+                    "version": "5.2.0",
+                    "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-5.2.0.tgz",
+                    "integrity": "sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==",
                     "dev": true,
                     "requires": {
-                        "load-json-file": "^1.0.0",
-                        "normalize-package-data": "^2.3.2",
-                        "path-type": "^1.0.0"
+                        "@types/normalize-package-data": "^2.4.0",
+                        "normalize-package-data": "^2.5.0",
+                        "parse-json": "^5.0.0",
+                        "type-fest": "^0.6.0"
+                    },
+                    "dependencies": {
+                        "type-fest": {
+                            "version": "0.6.0",
+                            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.6.0.tgz",
+                            "integrity": "sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==",
+                            "dev": true
+                        }
                     }
                 },
                 "read-pkg-up": {
-                    "version": "1.0.1",
-                    "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-                    "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
+                    "version": "7.0.1",
+                    "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-7.0.1.tgz",
+                    "integrity": "sha512-zK0TB7Xd6JpCLmlLmufqykGE+/TlOePD6qKClNW7hHDKFh/J7/7gCWGR7joEQEW1bKq3a3yUZSObOoWLFQ4ohg==",
                     "dev": true,
                     "requires": {
-                        "find-up": "^1.0.0",
-                        "read-pkg": "^1.0.0"
-                    }
-                },
-                "redent": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
-                    "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
-                    "dev": true,
-                    "requires": {
-                        "indent-string": "^2.1.0",
-                        "strip-indent": "^1.0.1"
-                    }
-                },
-                "strip-bom": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-                    "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-                    "dev": true,
-                    "requires": {
-                        "is-utf8": "^0.2.0"
-                    }
-                },
-                "strip-indent": {
-                    "version": "1.0.1",
-                    "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
-                    "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
-                    "dev": true,
-                    "requires": {
-                        "get-stdin": "^4.0.1"
+                        "find-up": "^4.1.0",
+                        "read-pkg": "^5.2.0",
+                        "type-fest": "^0.8.1"
+                    },
+                    "dependencies": {
+                        "type-fest": {
+                            "version": "0.8.1",
+                            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
+                            "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+                            "dev": true
+                        }
                     }
                 },
                 "through2": {
@@ -3701,11 +3607,21 @@
                         "xtend": "~4.0.1"
                     }
                 },
-                "trim-newlines": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
-                    "integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM=",
+                "type-fest": {
+                    "version": "0.13.1",
+                    "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
+                    "integrity": "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==",
                     "dev": true
+                },
+                "yargs-parser": {
+                    "version": "18.1.3",
+                    "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+                    "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+                    "dev": true,
+                    "requires": {
+                        "camelcase": "^5.0.0",
+                        "decamelize": "^1.2.0"
+                    }
                 }
             }
         },
@@ -3716,9 +3632,9 @@
             "dev": true
         },
         "get-stdin": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
-            "integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4=",
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-8.0.0.tgz",
+            "integrity": "sha512-sY22aA6xchAzprjyqmSEQv4UbAAzRN0L2dQB0NlN5acTTK9Don6nhoc3eAbUnpZiCANAMfd/+40kVdKfFygohg==",
             "dev": true
         },
         "get-stream": {
@@ -3786,19 +3702,19 @@
             }
         },
         "git-up": {
-            "version": "4.0.2",
-            "resolved": "https://registry.npmjs.org/git-up/-/git-up-4.0.2.tgz",
-            "integrity": "sha512-kbuvus1dWQB2sSW4cbfTeGpCMd8ge9jx9RKnhXhuJ7tnvT+NIrTVfYZxjtflZddQYcmdOTlkAcjmx7bor+15AQ==",
+            "version": "4.0.5",
+            "resolved": "https://registry.npmjs.org/git-up/-/git-up-4.0.5.tgz",
+            "integrity": "sha512-YUvVDg/vX3d0syBsk/CKUTib0srcQME0JyHkL5BaYdwLsiCslPWmDSi8PUMo9pXYjrryMcmsCoCgsTpSCJEQaA==",
             "dev": true,
             "requires": {
                 "is-ssh": "^1.3.0",
-                "parse-url": "^5.0.0"
+                "parse-url": "^6.0.0"
             }
         },
         "git-url-parse": {
-            "version": "11.4.4",
-            "resolved": "https://registry.npmjs.org/git-url-parse/-/git-url-parse-11.4.4.tgz",
-            "integrity": "sha512-Y4o9o7vQngQDIU9IjyCmRJBin5iYjI5u9ZITnddRZpD7dcCFQj2sL2XuMNbLRE4b4B/4ENPsp2Q8P44fjAZ0Pw==",
+            "version": "11.5.0",
+            "resolved": "https://registry.npmjs.org/git-url-parse/-/git-url-parse-11.5.0.tgz",
+            "integrity": "sha512-TZYSMDeM37r71Lqg1mbnMlOqlHd7BSij9qN7XwTkRqSAYFMihGLGhfHwgqQob3GUhEneKnV4nskN9rbQw2KGxA==",
             "dev": true,
             "requires": {
                 "git-up": "^4.0.0"
@@ -3854,18 +3770,18 @@
             }
         },
         "globals": {
-            "version": "13.9.0",
-            "resolved": "https://registry.npmjs.org/globals/-/globals-13.9.0.tgz",
-            "integrity": "sha512-74/FduwI/JaIrr1H8e71UbDE+5x7pIPs1C2rrwC52SszOo043CsWOZEMW7o2Y58xwm9b+0RBKDxY5n2sUpEFxA==",
+            "version": "13.10.0",
+            "resolved": "https://registry.npmjs.org/globals/-/globals-13.10.0.tgz",
+            "integrity": "sha512-piHC3blgLGFjvOuMmWZX60f+na1lXFDhQXBf1UYp2fXPXqvEUbOhNwi6BsQ0bQishwedgnjkwv1d9zKf+MWw3g==",
             "dev": true,
             "requires": {
                 "type-fest": "^0.20.2"
             }
         },
         "globby": {
-            "version": "11.0.3",
-            "resolved": "https://registry.npmjs.org/globby/-/globby-11.0.3.tgz",
-            "integrity": "sha512-ffdmosjA807y7+lA1NM0jELARVmYul/715xiILEjo3hBLPTcirgQNnXECn5g3mtR8TOLCVbkfua1Hpen25/Xcg==",
+            "version": "11.0.4",
+            "resolved": "https://registry.npmjs.org/globby/-/globby-11.0.4.tgz",
+            "integrity": "sha512-9O4MVG9ioZJ08ffbcyVYyLOJLk5JQ688pJ4eMGLpdWLHq/Wr1D9BlriLQyL0E+jbkuePVZXYFj47QM/v093wHg==",
             "dev": true,
             "requires": {
                 "array-union": "^2.1.0",
@@ -4202,12 +4118,6 @@
                 "through": "^2.3.6"
             }
         },
-        "interpret": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
-            "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==",
-            "dev": true
-        },
         "ip": {
             "version": "1.1.5",
             "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
@@ -4251,9 +4161,9 @@
             }
         },
         "is-core-module": {
-            "version": "2.4.0",
-            "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.4.0.tgz",
-            "integrity": "sha512-6A2fkfq1rfeQZjxrZJGerpLCTHRNEBiSgnu0+obeJpEPZRUooHgsizvzv0ZjJwOz3iWIHdJtVWJ/tmPr3D21/A==",
+            "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.5.0.tgz",
+            "integrity": "sha512-TXCMSDsEHMEEZ6eCA8rwRDbLu55MRGmrctljsBX/2v1d9/GzqHOxW5c5oPSgrUt2vBFXebu9rGqckXGPWOlYpg==",
             "dev": true,
             "requires": {
                 "has": "^1.0.3"
@@ -4269,12 +4179,6 @@
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
             "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
-            "dev": true
-        },
-        "is-finite": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.1.0.tgz",
-            "integrity": "sha512-cdyMtqX/BOqqNBBiKlIVkytNHm49MtMlYyn1zxzvJKWmFMlGzm+ry5BBfYyeY9YmNKbRSo/o7OX9w9ale0wg3w==",
             "dev": true
         },
         "is-fullwidth-code-point": {
@@ -4414,12 +4318,6 @@
             "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
             "dev": true
         },
-        "is-utf8": {
-            "version": "0.2.1",
-            "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
-            "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
-            "dev": true
-        },
         "is-yarn-global": {
             "version": "0.3.0",
             "resolved": "https://registry.npmjs.org/is-yarn-global/-/is-yarn-global-0.3.0.tgz",
@@ -4537,6 +4435,12 @@
             "requires": {
                 "minimist": "^1.2.5"
             }
+        },
+        "jsonc-parser": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.0.0.tgz",
+            "integrity": "sha512-fQzRfAbIBnR0IQvftw9FJveWiHp72Fg20giDrHz6TdfB12UH/uue0D3hm57UB5KgAVuniLMCaS8P1IMj9NR7cA==",
+            "dev": true
         },
         "jsonfile": {
             "version": "6.1.0",
@@ -4831,16 +4735,6 @@
             "integrity": "sha1-WjUNoLERO4N+z//VgSy+WNbq4ZM=",
             "dev": true
         },
-        "loud-rejection": {
-            "version": "1.6.0",
-            "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
-            "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
-            "dev": true,
-            "requires": {
-                "currently-unhandled": "^0.4.1",
-                "signal-exit": "^3.0.0"
-            }
-        },
         "lowercase-keys": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
@@ -4875,9 +4769,9 @@
             }
         },
         "make-fetch-happen": {
-            "version": "9.0.2",
-            "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-9.0.2.tgz",
-            "integrity": "sha512-UkAWAuXPXSSlVviTjH2We20mtj1NnZW2Qq/oTY2dyMbRQ5CR3Xed3akCDMnM7j6axrMY80lhgM7loNE132PfAw==",
+            "version": "9.0.4",
+            "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-9.0.4.tgz",
+            "integrity": "sha512-sQWNKMYqSmbAGXqJg2jZ+PmHh5JAybvwu0xM8mZR/bsTjGiTASj3ldXJV7KFHy1k/IJIBkjxQFoWIVsv9+PQMg==",
             "dev": true,
             "requires": {
                 "agentkeepalive": "^4.1.3",
@@ -4909,38 +4803,11 @@
                 }
             }
         },
-        "map-age-cleaner": {
-            "version": "0.1.3",
-            "resolved": "https://registry.npmjs.org/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz",
-            "integrity": "sha512-bJzx6nMoP6PDLPBFmg7+xRKeFZvFboMrGlxmNj9ClvX53KrmvM5bXFXEWjbz4cz1AFn+jWJ9z/DJSz7hrs0w3w==",
-            "dev": true,
-            "requires": {
-                "p-defer": "^1.0.0"
-            }
-        },
         "map-obj": {
             "version": "4.2.1",
             "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-4.2.1.tgz",
             "integrity": "sha512-+WA2/1sPmDj1dlvvJmB5G6JKfY9dpn7EVBUL06+y6PoljPkh+6V1QihwxNkbcGxCRjt2b0F9K0taiCuo7MbdFQ==",
             "dev": true
-        },
-        "mem": {
-            "version": "8.1.1",
-            "resolved": "https://registry.npmjs.org/mem/-/mem-8.1.1.tgz",
-            "integrity": "sha512-qFCFUDs7U3b8mBDPyz5EToEKoAkgCzqquIgi9nkkR9bixxOVOre+09lbuH7+9Kn2NFpm56M3GUWVbU2hQgdACA==",
-            "dev": true,
-            "requires": {
-                "map-age-cleaner": "^0.1.3",
-                "mimic-fn": "^3.1.0"
-            },
-            "dependencies": {
-                "mimic-fn": {
-                    "version": "3.1.0",
-                    "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-3.1.0.tgz",
-                    "integrity": "sha512-Ysbi9uYW9hFyfrThdDEQuykN4Ey6BuwPD2kpI5ES/nFTDn/98yxYNLZJcgUAKPT/mcrLLKaGzJR9YVxJrIdASQ==",
-                    "dev": true
-                }
-            }
         },
         "meow": {
             "version": "8.1.2",
@@ -5172,9 +5039,9 @@
             }
         },
         "minipass-fetch": {
-            "version": "1.3.3",
-            "resolved": "https://registry.npmjs.org/minipass-fetch/-/minipass-fetch-1.3.3.tgz",
-            "integrity": "sha512-akCrLDWfbdAWkMLBxJEeWTdNsjML+dt5YgOI4gJ53vuO0vrmYQkUPxa6j6V65s9CcePIr2SSWqjT2EcrNseryQ==",
+            "version": "1.3.4",
+            "resolved": "https://registry.npmjs.org/minipass-fetch/-/minipass-fetch-1.3.4.tgz",
+            "integrity": "sha512-TielGogIzbUEtd1LsjZFs47RWuHHfhl6TiCx1InVxApBAmQ8bL0dL5ilkLGcRvuyW/A9nE+Lvn855Ewz8S0PnQ==",
             "dev": true,
             "requires": {
                 "encoding": "^0.1.12",
@@ -5465,9 +5332,9 @@
             }
         },
         "normalize-url": {
-            "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-6.0.1.tgz",
-            "integrity": "sha512-VU4pzAuh7Kip71XEmO9aNREYAdMHFGTVj/i+CaTImS8x0i1d3jUZkXhqluy/PRgjPLMgsLQulYY3PJ/aSbSjpQ==",
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-6.1.0.tgz",
+            "integrity": "sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==",
             "dev": true
         },
         "npm-bundled": {
@@ -5480,28 +5347,28 @@
             }
         },
         "npm-check-updates": {
-            "version": "11.6.0",
-            "resolved": "https://registry.npmjs.org/npm-check-updates/-/npm-check-updates-11.6.0.tgz",
-            "integrity": "sha512-/l4S7Gh+8+Rg5itWsqFya5RRSHtPzw5neyAlbWNJfBfEeRX6lYVxKgs85QFBOKrZj3eL5MGBaUW8228TmjMhrw==",
+            "version": "11.8.3",
+            "resolved": "https://registry.npmjs.org/npm-check-updates/-/npm-check-updates-11.8.3.tgz",
+            "integrity": "sha512-NslIB6Af7GagVrN+bvBkObLyawIZfOnDnl8n9MHE+dFt0aChRYtvR6T2BLJKzOPIepCLmmh0NRR/qha0ExAELQ==",
             "dev": true,
             "requires": {
                 "chalk": "^4.1.1",
                 "cint": "^8.2.1",
                 "cli-table": "^0.3.6",
                 "commander": "^6.2.1",
+                "fast-memoize": "^2.5.2",
                 "find-up": "5.0.0",
                 "fp-and-or": "^0.1.3",
                 "get-stdin": "^8.0.0",
-                "globby": "^11.0.3",
+                "globby": "^11.0.4",
                 "hosted-git-info": "^4.0.2",
                 "json-parse-helpfulerror": "^1.0.3",
                 "jsonlines": "^0.1.1",
                 "libnpmconfig": "^1.2.1",
                 "lodash": "^4.17.21",
-                "mem": "^8.1.1",
                 "minimatch": "^3.0.4",
                 "p-map": "^4.0.0",
-                "pacote": "^11.3.3",
+                "pacote": "^11.3.4",
                 "parse-github-url": "^1.0.2",
                 "progress": "^2.0.3",
                 "prompts": "^2.4.1",
@@ -5523,12 +5390,6 @@
                         "locate-path": "^6.0.0",
                         "path-exists": "^4.0.0"
                     }
-                },
-                "get-stdin": {
-                    "version": "8.0.0",
-                    "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-8.0.0.tgz",
-                    "integrity": "sha512-sY22aA6xchAzprjyqmSEQv4UbAAzRN0L2dQB0NlN5acTTK9Don6nhoc3eAbUnpZiCANAMfd/+40kVdKfFygohg==",
-                    "dev": true
                 },
                 "locate-path": {
                     "version": "6.0.0",
@@ -5602,9 +5463,9 @@
             "dev": true
         },
         "npm-package-arg": {
-            "version": "8.1.4",
-            "resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-8.1.4.tgz",
-            "integrity": "sha512-xLokoCFqj/rPdr3LvcdDL6Kj6ipXGEDHD/QGpzwU6/pibYUOXmp5DBmg76yukFyx4ZDbrXNOTn+BPyd8TD4Jlw==",
+            "version": "8.1.5",
+            "resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-8.1.5.tgz",
+            "integrity": "sha512-LhgZrg0n0VgvzVdSm1oiZworPbTxYHUJCgtsJW8mGvlDpxTM1vSJc3m5QZeUkhAHIzbz3VCHd/R4osi1L1Tg/Q==",
             "dev": true,
             "requires": {
                 "hosted-git-info": "^4.0.1",
@@ -5711,9 +5572,9 @@
             "dev": true
         },
         "object-inspect": {
-            "version": "1.10.3",
-            "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.10.3.tgz",
-            "integrity": "sha512-e5mCJlSH7poANfC8z8S9s9S2IN5/4Zb3aZ33f5s8YqoazCFzNLloLU8r5VCG+G7WoqLvAAZoVMcy3tp/3X0Plw==",
+            "version": "1.11.0",
+            "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.11.0.tgz",
+            "integrity": "sha512-jp7ikS6Sd3GxQfZJPyH3cjcbJF6GZPClgdV+EFygjFLQ5FmW/dRUnTd9PQ9k0JhoNDabWFbpF1yCdSWCC6gexg==",
             "dev": true
         },
         "object-keys": {
@@ -5803,12 +5664,6 @@
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-1.1.0.tgz",
             "integrity": "sha512-s73XxOZ4zpt1edZYZzvhqFa6uvQc1vwUa0K0BdtIZgQMAJj9IbebH+JkgKZc9h+B05PKHLOTl4ajG1BmNrVZlw==",
-            "dev": true
-        },
-        "p-defer": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-1.0.0.tgz",
-            "integrity": "sha1-n26xgvbJqozXQwBKfU+WsZaw+ww=",
             "dev": true
         },
         "p-finally": {
@@ -5917,12 +5772,12 @@
             }
         },
         "pacote": {
-            "version": "11.3.4",
-            "resolved": "https://registry.npmjs.org/pacote/-/pacote-11.3.4.tgz",
-            "integrity": "sha512-RfahPCunM9GI7ryJV/zY0bWQiokZyLqaSNHXtbNSoLb7bwTvBbJBEyCJ01KWs4j1Gj7GmX8crYXQ1sNX6P2VKA==",
+            "version": "11.3.5",
+            "resolved": "https://registry.npmjs.org/pacote/-/pacote-11.3.5.tgz",
+            "integrity": "sha512-fT375Yczn4zi+6Hkk2TBe1x1sP8FgFsEIZ2/iWaXY2r/NkhDJfxbcn5paz1+RTFCyNf+dPnaoBDJoAxXSU8Bkg==",
             "dev": true,
             "requires": {
-                "@npmcli/git": "^2.0.1",
+                "@npmcli/git": "^2.1.0",
                 "@npmcli/installed-package-contents": "^1.0.6",
                 "@npmcli/promise-spawn": "^1.2.0",
                 "@npmcli/run-script": "^1.8.2",
@@ -6008,12 +5863,6 @@
                 "callsites": "^3.0.0"
             }
         },
-        "parse-github-repo-url": {
-            "version": "1.4.1",
-            "resolved": "https://registry.npmjs.org/parse-github-repo-url/-/parse-github-repo-url-1.4.1.tgz",
-            "integrity": "sha1-nn2LslKmy2ukJZUGC3v23z28H1A=",
-            "dev": true
-        },
         "parse-github-url": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/parse-github-url/-/parse-github-url-1.0.2.tgz",
@@ -6056,13 +5905,13 @@
             }
         },
         "parse-url": {
-            "version": "5.0.3",
-            "resolved": "https://registry.npmjs.org/parse-url/-/parse-url-5.0.3.tgz",
-            "integrity": "sha512-nrLCVMJpqo12X8uUJT4GJPd5AFaTOrGx/QpJy3HNcVtq0AZSstVIsnxS5fqNPuoqMUs3MyfBoOP6Zvu2Arok5A==",
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/parse-url/-/parse-url-6.0.0.tgz",
+            "integrity": "sha512-cYyojeX7yIIwuJzledIHeLUBVJ6COVLeT4eF+2P6aKVzwvgKQPndCBv3+yQ7pcWjqToYwaligxzSYNNmGoMAvw==",
             "dev": true,
             "requires": {
                 "is-ssh": "^1.3.0",
-                "normalize-url": "^6.0.1",
+                "normalize-url": "^6.1.0",
                 "parse-path": "^4.0.0",
                 "protocols": "^1.4.0"
             }
@@ -6115,21 +5964,6 @@
             "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
             "dev": true
         },
-        "pinkie": {
-            "version": "2.0.4",
-            "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-            "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
-            "dev": true
-        },
-        "pinkie-promise": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-            "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
-            "dev": true,
-            "requires": {
-                "pinkie": "^2.0.0"
-            }
-        },
         "pkg-dir": {
             "version": "4.2.0",
             "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
@@ -6152,9 +5986,9 @@
             "dev": true
         },
         "prettier": {
-            "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.3.1.tgz",
-            "integrity": "sha512-p+vNbgpLjif/+D+DwAZAbndtRrR0md0MwfmOVN9N+2RgyACMT+7tfaRnT+WDPkqnuVwleyuBIG2XBxKDme3hPA==",
+            "version": "2.3.2",
+            "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.3.2.tgz",
+            "integrity": "sha512-lnJzDfJ66zkMy58OL5/NY5zp70S7Nz6KqcKkXYzn2tMVrNxvbqaBpg7H3qHaLxCJ5lNMsGuM8+ohS7cZrthdLQ==",
             "dev": true
         },
         "process-nextick-args": {
@@ -6544,15 +6378,6 @@
                 "once": "^1.3.0"
             }
         },
-        "rechoir": {
-            "version": "0.6.2",
-            "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
-            "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
-            "dev": true,
-            "requires": {
-                "resolve": "^1.1.6"
-            }
-        },
         "redent": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
@@ -6564,9 +6389,9 @@
             }
         },
         "regexpp": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.1.0.tgz",
-            "integrity": "sha512-ZOIzd8yVsQQA7j8GCSlPGXwg5PfmA1mrq0JP4nGhh54LaKN3xdai/vHUDu74pKwV8OxseMS65u2NImosQcSD0Q==",
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",
+            "integrity": "sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==",
             "dev": true
         },
         "registry-auth-token": {
@@ -6592,15 +6417,6 @@
             "resolved": "https://registry.npmjs.org/remote-git-tags/-/remote-git-tags-3.0.0.tgz",
             "integrity": "sha512-C9hAO4eoEsX+OXA4rla66pXZQ+TLQ8T9dttgQj18yuKlPMTVkIkdYXvlMC55IuUsIkV6DpmQYi10JKFLaU+l7w==",
             "dev": true
-        },
-        "repeating": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
-            "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
-            "dev": true,
-            "requires": {
-                "is-finite": "^1.0.0"
-            }
         },
         "request": {
             "version": "2.88.2",
@@ -6813,17 +6629,6 @@
             "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
             "dev": true
         },
-        "shelljs": {
-            "version": "0.8.4",
-            "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.4.tgz",
-            "integrity": "sha512-7gk3UZ9kOfPLIAbslLzyWeGiEqx9e3rxwZM0KE6EL8GlGwjym9Mrlx5/p33bWTu9YG6vcS4MBxYZDHYr5lr8BQ==",
-            "dev": true,
-            "requires": {
-                "glob": "^7.0.0",
-                "interpret": "^1.0.0",
-                "rechoir": "^0.6.2"
-            }
-        },
         "side-channel": {
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
@@ -6913,12 +6718,12 @@
             }
         },
         "socks-proxy-agent": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-5.0.0.tgz",
-            "integrity": "sha512-lEpa1zsWCChxiynk+lCycKuC502RxDWLKJZoIhnxrWNjLSDGYRFflHA1/228VkRcnv9TIb8w98derGbpKxJRgA==",
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-5.0.1.tgz",
+            "integrity": "sha512-vZdmnjb9a2Tz6WEQVIurybSwElwPxMZaIc7PzqbJTrezcKNznv6giT7J7tZDZ1BojVaa1jvO/UiUdhDVB0ACoQ==",
             "dev": true,
             "requires": {
-                "agent-base": "6",
+                "agent-base": "^6.0.2",
                 "debug": "4",
                 "socks": "^2.3.3"
             }
@@ -7269,9 +7074,9 @@
             },
             "dependencies": {
                 "ajv": {
-                    "version": "8.6.0",
-                    "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.6.0.tgz",
-                    "integrity": "sha512-cnUG4NSBiM4YFBxgZIj/In3/6KX+rQ2l2YPRVcvAMQGWEPKuXoPIhxzwqh31jA3IPbI4qEOp/5ILI4ynioXsGQ==",
+                    "version": "8.6.2",
+                    "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.6.2.tgz",
+                    "integrity": "sha512-9807RlWAgT564wT+DjeyU5OFMPjmzxVobvDFmNAhY+5zD6A2ly3jDp6sgnfyDtlIQ+7H97oc/DGCzzfu9rjw9w==",
                     "dev": true,
                     "requires": {
                         "fast-deep-equal": "^3.1.1",
@@ -7503,15 +7308,15 @@
             }
         },
         "typescript": {
-            "version": "4.3.2",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.2.tgz",
-            "integrity": "sha512-zZ4hShnmnoVnAHpVHWpTcxdv7dWP60S2FsydQLV8V5PbS3FifjWFFRiHSWpDJahly88PRyV5teTSLoq4eG7mKw==",
+            "version": "4.3.5",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.5.tgz",
+            "integrity": "sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==",
             "dev": true
         },
         "uglify-js": {
-            "version": "3.13.9",
-            "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.13.9.tgz",
-            "integrity": "sha512-wZbyTQ1w6Y7fHdt8sJnHfSIuWeDgk6B5rCb4E/AM6QNNPbOMIZph21PW5dRB3h7Df0GszN+t7RuUH6sWK5bF0g==",
+            "version": "3.13.10",
+            "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.13.10.tgz",
+            "integrity": "sha512-57H3ACYFXeo1IaZ1w02sfA71wI60MGco/IQFjOqK+WtKoprh7Go2/yvd2HPtoJILO2Or84ncLccI4xoHMTSbGg==",
             "dev": true,
             "optional": true
         },
@@ -7697,9 +7502,9 @@
             "dev": true
         },
         "whatwg-url": {
-            "version": "8.6.0",
-            "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-8.6.0.tgz",
-            "integrity": "sha512-os0KkeeqUOl7ccdDT1qqUcS4KH4tcBTSKK5Nl5WKb2lyxInIZ/CpjkqKa1Ss12mjfdcRX9mHmPPs7/SxG1Hbdw==",
+            "version": "8.7.0",
+            "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-8.7.0.tgz",
+            "integrity": "sha512-gAojqb/m9Q8a5IV96E3fHJM70AzCkgt4uXYX2O7EmuyOnLrViCQlsEBmF9UQIu3/aeAIp2U17rtbpZWNntQqdg==",
             "dev": true,
             "requires": {
                 "lodash": "^4.7.0",
@@ -7989,9 +7794,9 @@
             }
         },
         "yargs-parser": {
-            "version": "20.2.7",
-            "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.7.tgz",
-            "integrity": "sha512-FiNkvbeHzB/syOjIUxFDCnhSfzAL8R5vs40MgLFBorXACCOAEaWu0gRZl14vG8MR9AOJIZbmkjhusqBYZ3HTHw==",
+            "version": "20.2.9",
+            "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
+            "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
             "dev": true
         },
         "yocto-queue": {

--- a/package.json
+++ b/package.json
@@ -20,22 +20,23 @@
         "check:lockindent": "node ./build/checkLockIndent.js"
     },
     "devDependencies": {
-        "@types/glob": "^7.1.3",
-        "@types/node": "^12.20.15",
-        "@types/yargs": "^16.0.3",
-        "@typescript-eslint/eslint-plugin": "^4.26.1",
-        "@typescript-eslint/parser": "^4.26.1",
+        "@types/glob": "^7.1.4",
+        "@types/node": "^12.20.16",
+        "@types/yargs": "^16.0.4",
+        "@typescript-eslint/eslint-plugin": "^4.28.3",
+        "@typescript-eslint/parser": "^4.28.3",
         "detect-indent": "^6.1.0",
-        "eslint": "^7.28.0",
+        "eslint": "^7.30.0",
         "eslint-config-prettier": "^8.3.0",
         "eslint-plugin-simple-import-sort": "^7.0.0",
         "glob": "^7.1.7",
+        "jsonc-parser": "^3.0.0",
         "lerna": "^4.0.0",
-        "npm-check-updates": "^11.6.0",
+        "npm-check-updates": "^11.8.3",
         "p-queue": "^6.6.2",
-        "prettier": "2.3.1",
+        "prettier": "2.3.2",
         "syncpack": "^5.7.11",
-        "typescript": "~4.3.2",
+        "typescript": "~4.3.5",
         "yargs": "^16.2.0"
     }
 }

--- a/packages/pyright-internal/package-lock.json
+++ b/packages/pyright-internal/package-lock.json
@@ -14,23 +14,23 @@
             }
         },
         "@babel/compat-data": {
-            "version": "7.14.5",
-            "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.14.5.tgz",
-            "integrity": "sha512-kixrYn4JwfAVPa0f2yfzc2AWti6WRRyO3XjWW5PJAvtE11qhSayrrcrEnee05KAtNaPC+EwehE8Qt1UedEVB8w==",
+            "version": "7.14.7",
+            "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.14.7.tgz",
+            "integrity": "sha512-nS6dZaISCXJ3+518CWiBfEr//gHyMO02uDxBkXTKZDN5POruCnOZ1N4YBRZDCabwF8nZMWBpRxIicmXtBs+fvw==",
             "dev": true
         },
         "@babel/core": {
-            "version": "7.14.5",
-            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.14.5.tgz",
-            "integrity": "sha512-RN/AwP2DJmQTZSfiDaD+JQQ/J99KsIpOCfBE5pL+5jJSt7nI3nYGoAXZu+ffYSQ029NLs2DstZb+eR81uuARgg==",
+            "version": "7.14.6",
+            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.14.6.tgz",
+            "integrity": "sha512-gJnOEWSqTk96qG5BoIrl5bVtc23DCycmIePPYnamY9RboYdI4nFy5vAQMSl81O5K/W0sLDWfGysnOECC+KUUCA==",
             "dev": true,
             "requires": {
                 "@babel/code-frame": "^7.14.5",
                 "@babel/generator": "^7.14.5",
                 "@babel/helper-compilation-targets": "^7.14.5",
                 "@babel/helper-module-transforms": "^7.14.5",
-                "@babel/helpers": "^7.14.5",
-                "@babel/parser": "^7.14.5",
+                "@babel/helpers": "^7.14.6",
+                "@babel/parser": "^7.14.6",
                 "@babel/template": "^7.14.5",
                 "@babel/traverse": "^7.14.5",
                 "@babel/types": "^7.14.5",
@@ -111,9 +111,9 @@
             }
         },
         "@babel/helper-member-expression-to-functions": {
-            "version": "7.14.5",
-            "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.14.5.tgz",
-            "integrity": "sha512-UxUeEYPrqH1Q/k0yRku1JE7dyfyehNwT6SVkMHvYvPDv4+uu627VXBckVj891BO8ruKBkiDoGnZf4qPDD8abDQ==",
+            "version": "7.14.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.14.7.tgz",
+            "integrity": "sha512-TMUt4xKxJn6ccjcOW7c4hlwyJArizskAhoSTOCkA0uZ+KghIaci0Qg9R043kUMWI9mtQfgny+NQ5QATnZ+paaA==",
             "dev": true,
             "requires": {
                 "@babel/types": "^7.14.5"
@@ -202,9 +202,9 @@
             "dev": true
         },
         "@babel/helpers": {
-            "version": "7.14.5",
-            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.14.5.tgz",
-            "integrity": "sha512-xtcWOuN9VL6nApgVHtq3PPcQv5qFBJzoSZzJ/2c0QK/IP/gxVcoWSNQwFEGvmbQsuS9rhYqjILDGGXcTkA705Q==",
+            "version": "7.14.6",
+            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.14.6.tgz",
+            "integrity": "sha512-yesp1ENQBiLI+iYHSJdoZKUtRpfTlL1grDIX9NRlAVppljLw/4tTyYupIB7uIYmC3stW/imAv8EqaKaS/ibmeA==",
             "dev": true,
             "requires": {
                 "@babel/template": "^7.14.5",
@@ -276,9 +276,9 @@
             }
         },
         "@babel/parser": {
-            "version": "7.14.5",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.14.5.tgz",
-            "integrity": "sha512-TM8C+xtH/9n1qzX+JNHi7AN2zHMTiPUtspO0ZdHflW8KaskkALhMmuMHb4bCmNdv9VAPzJX3/bXqkVLnAvsPfg==",
+            "version": "7.14.7",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.14.7.tgz",
+            "integrity": "sha512-X67Z5y+VBJuHB/RjwECp8kSl5uYi0BvRbNeWqkaJCVh+LiTPl19WBUfG627psSgp9rSf6ojuXghQM3ha6qHHdA==",
             "dev": true
         },
         "@babel/plugin-syntax-async-generators": {
@@ -410,9 +410,9 @@
             }
         },
         "@babel/traverse": {
-            "version": "7.14.5",
-            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.14.5.tgz",
-            "integrity": "sha512-G3BiS15vevepdmFqmUc9X+64y0viZYygubAMO8SvBmKARuF6CPSZtH4Ng9vi/lrWlZFGe3FWdXNy835akH8Glg==",
+            "version": "7.14.7",
+            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.14.7.tgz",
+            "integrity": "sha512-9vDr5NzHu27wgwejuKL7kIOm4bwEtaPQ4Z6cpCmjSuaRqpH/7xc4qcGEscwMqlkwgcXl6MvqoAjZkQ24uSdIZQ==",
             "dev": true,
             "requires": {
                 "@babel/code-frame": "^7.14.5",
@@ -420,7 +420,7 @@
                 "@babel/helper-function-name": "^7.14.5",
                 "@babel/helper-hoist-variables": "^7.14.5",
                 "@babel/helper-split-export-declaration": "^7.14.5",
-                "@babel/parser": "^7.14.5",
+                "@babel/parser": "^7.14.7",
                 "@babel/types": "^7.14.5",
                 "debug": "^4.1.0",
                 "globals": "^11.1.0"
@@ -467,23 +467,23 @@
             "dev": true
         },
         "@jest/console": {
-            "version": "27.0.2",
-            "resolved": "https://registry.npmjs.org/@jest/console/-/console-27.0.2.tgz",
-            "integrity": "sha512-/zYigssuHLImGeMAACkjI4VLAiiJznHgAl3xnFT19iWyct2LhrH3KXOjHRmxBGTkiPLZKKAJAgaPpiU9EZ9K+w==",
+            "version": "27.0.6",
+            "resolved": "https://registry.npmjs.org/@jest/console/-/console-27.0.6.tgz",
+            "integrity": "sha512-fMlIBocSHPZ3JxgWiDNW/KPj6s+YRd0hicb33IrmelCcjXo/pXPwvuiKFmZz+XuqI/1u7nbUK10zSsWL/1aegg==",
             "dev": true,
             "requires": {
-                "@jest/types": "^27.0.2",
+                "@jest/types": "^27.0.6",
                 "@types/node": "*",
                 "chalk": "^4.0.0",
-                "jest-message-util": "^27.0.2",
-                "jest-util": "^27.0.2",
+                "jest-message-util": "^27.0.6",
+                "jest-util": "^27.0.6",
                 "slash": "^3.0.0"
             },
             "dependencies": {
                 "@jest/types": {
-                    "version": "27.0.2",
-                    "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.0.2.tgz",
-                    "integrity": "sha512-XpjCtJ/99HB4PmyJ2vgmN7vT+JLP7RW1FBT9RgnMFS4Dt7cvIyBee8O3/j98aUZ34ZpenPZFqmaaObWSeL65dg==",
+                    "version": "27.0.6",
+                    "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.0.6.tgz",
+                    "integrity": "sha512-aSquT1qa9Pik26JK5/3rvnYb4bGtm1VFNesHKmNTwmPIgOrixvhL2ghIvFRNEpzy3gU+rUgjIF/KodbkFAl++g==",
                     "dev": true,
                     "requires": {
                         "@types/istanbul-lib-coverage": "^2.0.0",
@@ -494,9 +494,9 @@
                     }
                 },
                 "@types/yargs": {
-                    "version": "16.0.3",
-                    "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-16.0.3.tgz",
-                    "integrity": "sha512-YlFfTGS+zqCgXuXNV26rOIeETOkXnGQXP/pjjL9P0gO/EP9jTmc7pUBhx+jVEIxpq41RX33GQ7N3DzOSfZoglQ==",
+                    "version": "16.0.4",
+                    "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-16.0.4.tgz",
+                    "integrity": "sha512-T8Yc9wt/5LbJyCaLiHPReJa0kApcIgJ7Bn735GjItUfh08Z1pJvu8QZqb9s+mMvKV6WUQRV7K2R46YbjMXTTJw==",
                     "dev": true,
                     "requires": {
                         "@types/yargs-parser": "*"
@@ -505,35 +505,35 @@
             }
         },
         "@jest/core": {
-            "version": "27.0.4",
-            "resolved": "https://registry.npmjs.org/@jest/core/-/core-27.0.4.tgz",
-            "integrity": "sha512-+dsmV8VUs1h/Szb+rEWk8xBM1fp1I///uFy9nk3wXGvRsF2lBp8EVPmtWc+QFRb3MY2b7u2HbkGF1fzoDzQTLA==",
+            "version": "27.0.6",
+            "resolved": "https://registry.npmjs.org/@jest/core/-/core-27.0.6.tgz",
+            "integrity": "sha512-SsYBm3yhqOn5ZLJCtccaBcvD/ccTLCeuDv8U41WJH/V1MW5eKUkeMHT9U+Pw/v1m1AIWlnIW/eM2XzQr0rEmow==",
             "dev": true,
             "requires": {
-                "@jest/console": "^27.0.2",
-                "@jest/reporters": "^27.0.4",
-                "@jest/test-result": "^27.0.2",
-                "@jest/transform": "^27.0.2",
-                "@jest/types": "^27.0.2",
+                "@jest/console": "^27.0.6",
+                "@jest/reporters": "^27.0.6",
+                "@jest/test-result": "^27.0.6",
+                "@jest/transform": "^27.0.6",
+                "@jest/types": "^27.0.6",
                 "@types/node": "*",
                 "ansi-escapes": "^4.2.1",
                 "chalk": "^4.0.0",
                 "emittery": "^0.8.1",
                 "exit": "^0.1.2",
                 "graceful-fs": "^4.2.4",
-                "jest-changed-files": "^27.0.2",
-                "jest-config": "^27.0.4",
-                "jest-haste-map": "^27.0.2",
-                "jest-message-util": "^27.0.2",
-                "jest-regex-util": "^27.0.1",
-                "jest-resolve": "^27.0.4",
-                "jest-resolve-dependencies": "^27.0.4",
-                "jest-runner": "^27.0.4",
-                "jest-runtime": "^27.0.4",
-                "jest-snapshot": "^27.0.4",
-                "jest-util": "^27.0.2",
-                "jest-validate": "^27.0.2",
-                "jest-watcher": "^27.0.2",
+                "jest-changed-files": "^27.0.6",
+                "jest-config": "^27.0.6",
+                "jest-haste-map": "^27.0.6",
+                "jest-message-util": "^27.0.6",
+                "jest-regex-util": "^27.0.6",
+                "jest-resolve": "^27.0.6",
+                "jest-resolve-dependencies": "^27.0.6",
+                "jest-runner": "^27.0.6",
+                "jest-runtime": "^27.0.6",
+                "jest-snapshot": "^27.0.6",
+                "jest-util": "^27.0.6",
+                "jest-validate": "^27.0.6",
+                "jest-watcher": "^27.0.6",
                 "micromatch": "^4.0.4",
                 "p-each-series": "^2.1.0",
                 "rimraf": "^3.0.0",
@@ -542,9 +542,9 @@
             },
             "dependencies": {
                 "@jest/types": {
-                    "version": "27.0.2",
-                    "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.0.2.tgz",
-                    "integrity": "sha512-XpjCtJ/99HB4PmyJ2vgmN7vT+JLP7RW1FBT9RgnMFS4Dt7cvIyBee8O3/j98aUZ34ZpenPZFqmaaObWSeL65dg==",
+                    "version": "27.0.6",
+                    "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.0.6.tgz",
+                    "integrity": "sha512-aSquT1qa9Pik26JK5/3rvnYb4bGtm1VFNesHKmNTwmPIgOrixvhL2ghIvFRNEpzy3gU+rUgjIF/KodbkFAl++g==",
                     "dev": true,
                     "requires": {
                         "@types/istanbul-lib-coverage": "^2.0.0",
@@ -555,9 +555,9 @@
                     }
                 },
                 "@types/yargs": {
-                    "version": "16.0.3",
-                    "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-16.0.3.tgz",
-                    "integrity": "sha512-YlFfTGS+zqCgXuXNV26rOIeETOkXnGQXP/pjjL9P0gO/EP9jTmc7pUBhx+jVEIxpq41RX33GQ7N3DzOSfZoglQ==",
+                    "version": "16.0.4",
+                    "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-16.0.4.tgz",
+                    "integrity": "sha512-T8Yc9wt/5LbJyCaLiHPReJa0kApcIgJ7Bn735GjItUfh08Z1pJvu8QZqb9s+mMvKV6WUQRV7K2R46YbjMXTTJw==",
                     "dev": true,
                     "requires": {
                         "@types/yargs-parser": "*"
@@ -566,21 +566,21 @@
             }
         },
         "@jest/environment": {
-            "version": "27.0.3",
-            "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-27.0.3.tgz",
-            "integrity": "sha512-pN9m7fbKsop5vc3FOfH8NF7CKKdRbEZzcxfIo1n2TT6ucKWLFq0P6gCJH0GpnQp036++yY9utHOxpeT1WnkWTA==",
+            "version": "27.0.6",
+            "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-27.0.6.tgz",
+            "integrity": "sha512-4XywtdhwZwCpPJ/qfAkqExRsERW+UaoSRStSHCCiQTUpoYdLukj+YJbQSFrZjhlUDRZeNiU9SFH0u7iNimdiIg==",
             "dev": true,
             "requires": {
-                "@jest/fake-timers": "^27.0.3",
-                "@jest/types": "^27.0.2",
+                "@jest/fake-timers": "^27.0.6",
+                "@jest/types": "^27.0.6",
                 "@types/node": "*",
-                "jest-mock": "^27.0.3"
+                "jest-mock": "^27.0.6"
             },
             "dependencies": {
                 "@jest/types": {
-                    "version": "27.0.2",
-                    "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.0.2.tgz",
-                    "integrity": "sha512-XpjCtJ/99HB4PmyJ2vgmN7vT+JLP7RW1FBT9RgnMFS4Dt7cvIyBee8O3/j98aUZ34ZpenPZFqmaaObWSeL65dg==",
+                    "version": "27.0.6",
+                    "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.0.6.tgz",
+                    "integrity": "sha512-aSquT1qa9Pik26JK5/3rvnYb4bGtm1VFNesHKmNTwmPIgOrixvhL2ghIvFRNEpzy3gU+rUgjIF/KodbkFAl++g==",
                     "dev": true,
                     "requires": {
                         "@types/istanbul-lib-coverage": "^2.0.0",
@@ -591,9 +591,9 @@
                     }
                 },
                 "@types/yargs": {
-                    "version": "16.0.3",
-                    "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-16.0.3.tgz",
-                    "integrity": "sha512-YlFfTGS+zqCgXuXNV26rOIeETOkXnGQXP/pjjL9P0gO/EP9jTmc7pUBhx+jVEIxpq41RX33GQ7N3DzOSfZoglQ==",
+                    "version": "16.0.4",
+                    "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-16.0.4.tgz",
+                    "integrity": "sha512-T8Yc9wt/5LbJyCaLiHPReJa0kApcIgJ7Bn735GjItUfh08Z1pJvu8QZqb9s+mMvKV6WUQRV7K2R46YbjMXTTJw==",
                     "dev": true,
                     "requires": {
                         "@types/yargs-parser": "*"
@@ -602,23 +602,23 @@
             }
         },
         "@jest/fake-timers": {
-            "version": "27.0.3",
-            "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-27.0.3.tgz",
-            "integrity": "sha512-fQ+UCKRIYKvTCEOyKPnaPnomLATIhMnHC/xPZ7yT1Uldp7yMgMxoYIFidDbpSTgB79+/U+FgfoD30c6wg3IUjA==",
+            "version": "27.0.6",
+            "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-27.0.6.tgz",
+            "integrity": "sha512-sqd+xTWtZ94l3yWDKnRTdvTeZ+A/V7SSKrxsrOKSqdyddb9CeNRF8fbhAU0D7ZJBpTTW2nbp6MftmKJDZfW2LQ==",
             "dev": true,
             "requires": {
-                "@jest/types": "^27.0.2",
+                "@jest/types": "^27.0.6",
                 "@sinonjs/fake-timers": "^7.0.2",
                 "@types/node": "*",
-                "jest-message-util": "^27.0.2",
-                "jest-mock": "^27.0.3",
-                "jest-util": "^27.0.2"
+                "jest-message-util": "^27.0.6",
+                "jest-mock": "^27.0.6",
+                "jest-util": "^27.0.6"
             },
             "dependencies": {
                 "@jest/types": {
-                    "version": "27.0.2",
-                    "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.0.2.tgz",
-                    "integrity": "sha512-XpjCtJ/99HB4PmyJ2vgmN7vT+JLP7RW1FBT9RgnMFS4Dt7cvIyBee8O3/j98aUZ34ZpenPZFqmaaObWSeL65dg==",
+                    "version": "27.0.6",
+                    "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.0.6.tgz",
+                    "integrity": "sha512-aSquT1qa9Pik26JK5/3rvnYb4bGtm1VFNesHKmNTwmPIgOrixvhL2ghIvFRNEpzy3gU+rUgjIF/KodbkFAl++g==",
                     "dev": true,
                     "requires": {
                         "@types/istanbul-lib-coverage": "^2.0.0",
@@ -629,9 +629,9 @@
                     }
                 },
                 "@types/yargs": {
-                    "version": "16.0.3",
-                    "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-16.0.3.tgz",
-                    "integrity": "sha512-YlFfTGS+zqCgXuXNV26rOIeETOkXnGQXP/pjjL9P0gO/EP9jTmc7pUBhx+jVEIxpq41RX33GQ7N3DzOSfZoglQ==",
+                    "version": "16.0.4",
+                    "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-16.0.4.tgz",
+                    "integrity": "sha512-T8Yc9wt/5LbJyCaLiHPReJa0kApcIgJ7Bn735GjItUfh08Z1pJvu8QZqb9s+mMvKV6WUQRV7K2R46YbjMXTTJw==",
                     "dev": true,
                     "requires": {
                         "@types/yargs-parser": "*"
@@ -640,20 +640,20 @@
             }
         },
         "@jest/globals": {
-            "version": "27.0.3",
-            "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-27.0.3.tgz",
-            "integrity": "sha512-OzsIuf7uf+QalqAGbjClyezzEcLQkdZ+7PejUrZgDs+okdAK8GwRCGcYCirHvhMBBQh60Jr3NlIGbn/KBPQLEQ==",
+            "version": "27.0.6",
+            "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-27.0.6.tgz",
+            "integrity": "sha512-DdTGCP606rh9bjkdQ7VvChV18iS7q0IMJVP1piwTWyWskol4iqcVwthZmoJEf7obE1nc34OpIyoVGPeqLC+ryw==",
             "dev": true,
             "requires": {
-                "@jest/environment": "^27.0.3",
-                "@jest/types": "^27.0.2",
-                "expect": "^27.0.2"
+                "@jest/environment": "^27.0.6",
+                "@jest/types": "^27.0.6",
+                "expect": "^27.0.6"
             },
             "dependencies": {
                 "@jest/types": {
-                    "version": "27.0.2",
-                    "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.0.2.tgz",
-                    "integrity": "sha512-XpjCtJ/99HB4PmyJ2vgmN7vT+JLP7RW1FBT9RgnMFS4Dt7cvIyBee8O3/j98aUZ34ZpenPZFqmaaObWSeL65dg==",
+                    "version": "27.0.6",
+                    "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.0.6.tgz",
+                    "integrity": "sha512-aSquT1qa9Pik26JK5/3rvnYb4bGtm1VFNesHKmNTwmPIgOrixvhL2ghIvFRNEpzy3gU+rUgjIF/KodbkFAl++g==",
                     "dev": true,
                     "requires": {
                         "@types/istanbul-lib-coverage": "^2.0.0",
@@ -664,9 +664,9 @@
                     }
                 },
                 "@types/yargs": {
-                    "version": "16.0.3",
-                    "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-16.0.3.tgz",
-                    "integrity": "sha512-YlFfTGS+zqCgXuXNV26rOIeETOkXnGQXP/pjjL9P0gO/EP9jTmc7pUBhx+jVEIxpq41RX33GQ7N3DzOSfZoglQ==",
+                    "version": "16.0.4",
+                    "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-16.0.4.tgz",
+                    "integrity": "sha512-T8Yc9wt/5LbJyCaLiHPReJa0kApcIgJ7Bn735GjItUfh08Z1pJvu8QZqb9s+mMvKV6WUQRV7K2R46YbjMXTTJw==",
                     "dev": true,
                     "requires": {
                         "@types/yargs-parser": "*"
@@ -675,16 +675,16 @@
             }
         },
         "@jest/reporters": {
-            "version": "27.0.4",
-            "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-27.0.4.tgz",
-            "integrity": "sha512-Xa90Nm3JnV0xCe4M6A10M9WuN9krb+WFKxV1A98Y4ePCw40n++r7uxFUNU7DT1i9Behj7fjrAIju9oU0t1QtCg==",
+            "version": "27.0.6",
+            "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-27.0.6.tgz",
+            "integrity": "sha512-TIkBt09Cb2gptji3yJXb3EE+eVltW6BjO7frO7NEfjI9vSIYoISi5R3aI3KpEDXlB1xwB+97NXIqz84qYeYsfA==",
             "dev": true,
             "requires": {
                 "@bcoe/v8-coverage": "^0.2.3",
-                "@jest/console": "^27.0.2",
-                "@jest/test-result": "^27.0.2",
-                "@jest/transform": "^27.0.2",
-                "@jest/types": "^27.0.2",
+                "@jest/console": "^27.0.6",
+                "@jest/test-result": "^27.0.6",
+                "@jest/transform": "^27.0.6",
+                "@jest/types": "^27.0.6",
                 "chalk": "^4.0.0",
                 "collect-v8-coverage": "^1.0.0",
                 "exit": "^0.1.2",
@@ -695,21 +695,21 @@
                 "istanbul-lib-report": "^3.0.0",
                 "istanbul-lib-source-maps": "^4.0.0",
                 "istanbul-reports": "^3.0.2",
-                "jest-haste-map": "^27.0.2",
-                "jest-resolve": "^27.0.4",
-                "jest-util": "^27.0.2",
-                "jest-worker": "^27.0.2",
+                "jest-haste-map": "^27.0.6",
+                "jest-resolve": "^27.0.6",
+                "jest-util": "^27.0.6",
+                "jest-worker": "^27.0.6",
                 "slash": "^3.0.0",
                 "source-map": "^0.6.0",
                 "string-length": "^4.0.1",
                 "terminal-link": "^2.0.0",
-                "v8-to-istanbul": "^7.0.0"
+                "v8-to-istanbul": "^8.0.0"
             },
             "dependencies": {
                 "@jest/types": {
-                    "version": "27.0.2",
-                    "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.0.2.tgz",
-                    "integrity": "sha512-XpjCtJ/99HB4PmyJ2vgmN7vT+JLP7RW1FBT9RgnMFS4Dt7cvIyBee8O3/j98aUZ34ZpenPZFqmaaObWSeL65dg==",
+                    "version": "27.0.6",
+                    "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.0.6.tgz",
+                    "integrity": "sha512-aSquT1qa9Pik26JK5/3rvnYb4bGtm1VFNesHKmNTwmPIgOrixvhL2ghIvFRNEpzy3gU+rUgjIF/KodbkFAl++g==",
                     "dev": true,
                     "requires": {
                         "@types/istanbul-lib-coverage": "^2.0.0",
@@ -720,9 +720,9 @@
                     }
                 },
                 "@types/yargs": {
-                    "version": "16.0.3",
-                    "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-16.0.3.tgz",
-                    "integrity": "sha512-YlFfTGS+zqCgXuXNV26rOIeETOkXnGQXP/pjjL9P0gO/EP9jTmc7pUBhx+jVEIxpq41RX33GQ7N3DzOSfZoglQ==",
+                    "version": "16.0.4",
+                    "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-16.0.4.tgz",
+                    "integrity": "sha512-T8Yc9wt/5LbJyCaLiHPReJa0kApcIgJ7Bn735GjItUfh08Z1pJvu8QZqb9s+mMvKV6WUQRV7K2R46YbjMXTTJw==",
                     "dev": true,
                     "requires": {
                         "@types/yargs-parser": "*"
@@ -731,9 +731,9 @@
             }
         },
         "@jest/source-map": {
-            "version": "27.0.1",
-            "resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-27.0.1.tgz",
-            "integrity": "sha512-yMgkF0f+6WJtDMdDYNavmqvbHtiSpwRN2U/W+6uztgfqgkq/PXdKPqjBTUF1RD/feth4rH5N3NW0T5+wIuln1A==",
+            "version": "27.0.6",
+            "resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-27.0.6.tgz",
+            "integrity": "sha512-Fek4mi5KQrqmlY07T23JRi0e7Z9bXTOOD86V/uS0EIW4PClvPDqZOyFlLpNJheS6QI0FNX1CgmPjtJ4EA/2M+g==",
             "dev": true,
             "requires": {
                 "callsites": "^3.0.0",
@@ -742,21 +742,21 @@
             }
         },
         "@jest/test-result": {
-            "version": "27.0.2",
-            "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-27.0.2.tgz",
-            "integrity": "sha512-gcdWwL3yP5VaIadzwQtbZyZMgpmes8ryBAJp70tuxghiA8qL4imJyZex+i+USQH2H4jeLVVszhwntgdQ97fccA==",
+            "version": "27.0.6",
+            "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-27.0.6.tgz",
+            "integrity": "sha512-ja/pBOMTufjX4JLEauLxE3LQBPaI2YjGFtXexRAjt1I/MbfNlMx0sytSX3tn5hSLzQsR3Qy2rd0hc1BWojtj9w==",
             "dev": true,
             "requires": {
-                "@jest/console": "^27.0.2",
-                "@jest/types": "^27.0.2",
+                "@jest/console": "^27.0.6",
+                "@jest/types": "^27.0.6",
                 "@types/istanbul-lib-coverage": "^2.0.0",
                 "collect-v8-coverage": "^1.0.0"
             },
             "dependencies": {
                 "@jest/types": {
-                    "version": "27.0.2",
-                    "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.0.2.tgz",
-                    "integrity": "sha512-XpjCtJ/99HB4PmyJ2vgmN7vT+JLP7RW1FBT9RgnMFS4Dt7cvIyBee8O3/j98aUZ34ZpenPZFqmaaObWSeL65dg==",
+                    "version": "27.0.6",
+                    "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.0.6.tgz",
+                    "integrity": "sha512-aSquT1qa9Pik26JK5/3rvnYb4bGtm1VFNesHKmNTwmPIgOrixvhL2ghIvFRNEpzy3gU+rUgjIF/KodbkFAl++g==",
                     "dev": true,
                     "requires": {
                         "@types/istanbul-lib-coverage": "^2.0.0",
@@ -767,9 +767,9 @@
                     }
                 },
                 "@types/yargs": {
-                    "version": "16.0.3",
-                    "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-16.0.3.tgz",
-                    "integrity": "sha512-YlFfTGS+zqCgXuXNV26rOIeETOkXnGQXP/pjjL9P0gO/EP9jTmc7pUBhx+jVEIxpq41RX33GQ7N3DzOSfZoglQ==",
+                    "version": "16.0.4",
+                    "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-16.0.4.tgz",
+                    "integrity": "sha512-T8Yc9wt/5LbJyCaLiHPReJa0kApcIgJ7Bn735GjItUfh08Z1pJvu8QZqb9s+mMvKV6WUQRV7K2R46YbjMXTTJw==",
                     "dev": true,
                     "requires": {
                         "@types/yargs-parser": "*"
@@ -778,33 +778,33 @@
             }
         },
         "@jest/test-sequencer": {
-            "version": "27.0.4",
-            "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-27.0.4.tgz",
-            "integrity": "sha512-6UFEVwdmxYdyNffBxVVZxmXEdBE4riSddXYSnFNH0ELFQFk/bvagizim8WfgJTqF4EKd+j1yFxvhb8BMHfOjSQ==",
+            "version": "27.0.6",
+            "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-27.0.6.tgz",
+            "integrity": "sha512-bISzNIApazYOlTHDum9PwW22NOyDa6VI31n6JucpjTVM0jD6JDgqEZ9+yn575nDdPF0+4csYDxNNW13NvFQGZA==",
             "dev": true,
             "requires": {
-                "@jest/test-result": "^27.0.2",
+                "@jest/test-result": "^27.0.6",
                 "graceful-fs": "^4.2.4",
-                "jest-haste-map": "^27.0.2",
-                "jest-runtime": "^27.0.4"
+                "jest-haste-map": "^27.0.6",
+                "jest-runtime": "^27.0.6"
             }
         },
         "@jest/transform": {
-            "version": "27.0.2",
-            "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-27.0.2.tgz",
-            "integrity": "sha512-H8sqKlgtDfVog/s9I4GG2XMbi4Ar7RBxjsKQDUhn2XHAi3NG+GoQwWMER+YfantzExbjNqQvqBHzo/G2pfTiPw==",
+            "version": "27.0.6",
+            "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-27.0.6.tgz",
+            "integrity": "sha512-rj5Dw+mtIcntAUnMlW/Vju5mr73u8yg+irnHwzgtgoeI6cCPOvUwQ0D1uQtc/APmWgvRweEb1g05pkUpxH3iCA==",
             "dev": true,
             "requires": {
                 "@babel/core": "^7.1.0",
-                "@jest/types": "^27.0.2",
+                "@jest/types": "^27.0.6",
                 "babel-plugin-istanbul": "^6.0.0",
                 "chalk": "^4.0.0",
                 "convert-source-map": "^1.4.0",
                 "fast-json-stable-stringify": "^2.0.0",
                 "graceful-fs": "^4.2.4",
-                "jest-haste-map": "^27.0.2",
-                "jest-regex-util": "^27.0.1",
-                "jest-util": "^27.0.2",
+                "jest-haste-map": "^27.0.6",
+                "jest-regex-util": "^27.0.6",
+                "jest-util": "^27.0.6",
                 "micromatch": "^4.0.4",
                 "pirates": "^4.0.1",
                 "slash": "^3.0.0",
@@ -813,9 +813,9 @@
             },
             "dependencies": {
                 "@jest/types": {
-                    "version": "27.0.2",
-                    "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.0.2.tgz",
-                    "integrity": "sha512-XpjCtJ/99HB4PmyJ2vgmN7vT+JLP7RW1FBT9RgnMFS4Dt7cvIyBee8O3/j98aUZ34ZpenPZFqmaaObWSeL65dg==",
+                    "version": "27.0.6",
+                    "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.0.6.tgz",
+                    "integrity": "sha512-aSquT1qa9Pik26JK5/3rvnYb4bGtm1VFNesHKmNTwmPIgOrixvhL2ghIvFRNEpzy3gU+rUgjIF/KodbkFAl++g==",
                     "dev": true,
                     "requires": {
                         "@types/istanbul-lib-coverage": "^2.0.0",
@@ -826,9 +826,9 @@
                     }
                 },
                 "@types/yargs": {
-                    "version": "16.0.3",
-                    "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-16.0.3.tgz",
-                    "integrity": "sha512-YlFfTGS+zqCgXuXNV26rOIeETOkXnGQXP/pjjL9P0gO/EP9jTmc7pUBhx+jVEIxpq41RX33GQ7N3DzOSfZoglQ==",
+                    "version": "16.0.4",
+                    "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-16.0.4.tgz",
+                    "integrity": "sha512-T8Yc9wt/5LbJyCaLiHPReJa0kApcIgJ7Bn735GjItUfh08Z1pJvu8QZqb9s+mMvKV6WUQRV7K2R46YbjMXTTJw==",
                     "dev": true,
                     "requires": {
                         "@types/yargs-parser": "*"
@@ -874,9 +874,9 @@
             "dev": true
         },
         "@types/babel__core": {
-            "version": "7.1.14",
-            "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.14.tgz",
-            "integrity": "sha512-zGZJzzBUVDo/eV6KgbE0f0ZI7dInEYvo12Rb70uNQDshC3SkRMb67ja0GgRHZgAX3Za6rhaWlvbDO8rrGyAb1g==",
+            "version": "7.1.15",
+            "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.15.tgz",
+            "integrity": "sha512-bxlMKPDbY8x5h6HBwVzEOk2C8fb6SLfYQ5Jw3uBYuYF1lfWk/kbLd81la82vrIkBb0l+JdmrZaDikPrNxpS/Ew==",
             "dev": true,
             "requires": {
                 "@babel/parser": "^7.1.0",
@@ -887,18 +887,18 @@
             }
         },
         "@types/babel__generator": {
-            "version": "7.6.2",
-            "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.6.2.tgz",
-            "integrity": "sha512-MdSJnBjl+bdwkLskZ3NGFp9YcXGx5ggLpQQPqtgakVhsWK0hTtNYhjpZLlWQTviGTvF8at+Bvli3jV7faPdgeQ==",
+            "version": "7.6.3",
+            "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.6.3.tgz",
+            "integrity": "sha512-/GWCmzJWqV7diQW54smJZzWbSFf4QYtF71WCKhcx6Ru/tFyQIY2eiiITcCAeuPbNSvT9YCGkVMqqvSk2Z0mXiA==",
             "dev": true,
             "requires": {
                 "@babel/types": "^7.0.0"
             }
         },
         "@types/babel__template": {
-            "version": "7.4.0",
-            "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.0.tgz",
-            "integrity": "sha512-NTPErx4/FiPCGScH7foPyr+/1Dkzkni+rHiYHHoTjvwou7AQzJkNeD60A9CXRy+ZEN2B1bggmkTMCDb+Mv5k+A==",
+            "version": "7.4.1",
+            "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.1.tgz",
+            "integrity": "sha512-azBFKemX6kMg5Io+/rdGT0dkGreboUVR0Cdm3fz9QJWpaQGJRQXl7C+6hOTCZcMll7KFyEQpgbYI2lHdsS4U7g==",
             "dev": true,
             "requires": {
                 "@babel/parser": "^7.1.0",
@@ -906,24 +906,24 @@
             }
         },
         "@types/babel__traverse": {
-            "version": "7.11.1",
-            "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.11.1.tgz",
-            "integrity": "sha512-Vs0hm0vPahPMYi9tDjtP66llufgO3ST16WXaSTtDGEl9cewAl3AibmxWw6TINOqHPT9z0uABKAYjT9jNSg4npw==",
+            "version": "7.14.2",
+            "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.14.2.tgz",
+            "integrity": "sha512-K2waXdXBi2302XUdcHcR1jCeU0LL4TD9HRs/gk0N2Xvrht+G/BfJa4QObBQZfhMdxiCpV3COl5Nfq4uKTeTnJA==",
             "dev": true,
             "requires": {
                 "@babel/types": "^7.3.0"
             }
         },
         "@types/command-line-args": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/@types/command-line-args/-/command-line-args-5.0.0.tgz",
-            "integrity": "sha512-4eOPXyn5DmP64MCMF8ePDvdlvlzt2a+F8ZaVjqmh2yFCpGjc1kI3kGnCFYX9SCsGTjQcWIyVZ86IHCEyjy/MNg==",
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/@types/command-line-args/-/command-line-args-5.0.1.tgz",
+            "integrity": "sha512-+pAMlf+fHYWFDf4OvzEXPsVKLIahB66drrWXPxMe9IapFxjF5Ir+kFAR9qctKxZW4weuFL5ydm3V5yCGnJieew==",
             "dev": true
         },
         "@types/emscripten": {
-            "version": "1.39.4",
-            "resolved": "https://registry.npmjs.org/@types/emscripten/-/emscripten-1.39.4.tgz",
-            "integrity": "sha512-k3LLVMFrdNA9UCvMDPWMbFrGPNb+GcPyw29ktJTo1RCN7RmxFG5XzPZcPKRlnLuLT/FRm8wp4ohvDwNY7GlROQ=="
+            "version": "1.39.5",
+            "resolved": "https://registry.npmjs.org/@types/emscripten/-/emscripten-1.39.5.tgz",
+            "integrity": "sha512-DIOOg+POSrYl+OlNRHQuIEqCd8DCtynG57H862UCce16nXJX7J8eWxNGgOcf8Eyge8zXeSs27mz1UcFu8L/L7g=="
         },
         "@types/graceful-fs": {
             "version": "4.1.5",
@@ -959,9 +959,9 @@
             }
         },
         "@types/jest": {
-            "version": "26.0.23",
-            "resolved": "https://registry.npmjs.org/@types/jest/-/jest-26.0.23.tgz",
-            "integrity": "sha512-ZHLmWMJ9jJ9PTiT58juykZpL7KjwJywFN3Rr2pTSkyQfydf/rk22yS7W8p5DaVUMQ2BQC7oYiU3FjbTM/mYrOA==",
+            "version": "26.0.24",
+            "resolved": "https://registry.npmjs.org/@types/jest/-/jest-26.0.24.tgz",
+            "integrity": "sha512-E/X5Vib8BWqZNRlDxj9vYXhsDwPYbPINqKF9BsnSoon4RQ0D9moEuLD8txgyypFLH7J4+Lho9Nr/c8H0Fi+17w==",
             "dev": true,
             "requires": {
                 "jest-diff": "^26.0.0",
@@ -969,57 +969,57 @@
             }
         },
         "@types/node": {
-            "version": "12.20.15",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.15.tgz",
-            "integrity": "sha512-F6S4Chv4JicJmyrwlDkxUdGNSplsQdGwp1A0AJloEVDirWdZOAiRHhovDlsFkKUrquUXhz1imJhXHsf59auyAg==",
+            "version": "12.20.16",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.16.tgz",
+            "integrity": "sha512-6CLxw83vQf6DKqXxMPwl8qpF8I7THFZuIwLt4TnNsumxkp1VsRZWT8txQxncT/Rl2UojTsFzWgDG4FRMwafrlA==",
             "dev": true
         },
         "@types/prettier": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.3.0.tgz",
-            "integrity": "sha512-hkc1DATxFLQo4VxPDpMH1gCkPpBbpOoJ/4nhuXw4n63/0R6bCpQECj4+K226UJ4JO/eJQz+1mC2I7JsWanAdQw==",
+            "version": "2.3.2",
+            "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.3.2.tgz",
+            "integrity": "sha512-eI5Yrz3Qv4KPUa/nSIAi0h+qX0XyewOliug5F2QAtuRg6Kjg6jfmxe1GIwoIRhZspD1A0RP8ANrPwvEXXtRFog==",
             "dev": true
         },
         "@types/stack-utils": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.0.tgz",
-            "integrity": "sha512-RJJrrySY7A8havqpGObOB4W92QXKJo63/jFLLgpvOtsGUqbQZ9Sbgl35KMm1DjC6j7AvmmU2bIno+3IyEaemaw==",
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.1.tgz",
+            "integrity": "sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==",
             "dev": true
         },
         "@types/tmp": {
-            "version": "0.2.0",
-            "resolved": "https://registry.npmjs.org/@types/tmp/-/tmp-0.2.0.tgz",
-            "integrity": "sha512-flgpHJjntpBAdJD43ShRosQvNC0ME97DCfGvZEDlAThQmnerRXrLbX6YgzRBQCZTthET9eAWFAMaYP0m0Y4HzQ==",
+            "version": "0.2.1",
+            "resolved": "https://registry.npmjs.org/@types/tmp/-/tmp-0.2.1.tgz",
+            "integrity": "sha512-7cTXwKP/HLOPVgjg+YhBdQ7bMiobGMuoBmrGmqwIWJv8elC6t1DfVc/mn4fD9UE1IjhwmhaQ5pGVXkmXbH0rhg==",
             "dev": true
         },
         "@types/yargs": {
-            "version": "15.0.13",
-            "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.13.tgz",
-            "integrity": "sha512-kQ5JNTrbDv3Rp5X2n/iUu37IJBDU2gsZ5R/g1/KHOOEc5IKfUFjXT6DENPGduh08I/pamwtEq4oul7gUqKTQDQ==",
+            "version": "15.0.14",
+            "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.14.tgz",
+            "integrity": "sha512-yEJzHoxf6SyQGhBhIYGXQDSCkJjB6HohDShto7m8vaKg9Yp0Yn8+71J9eakh2bnPg6BfsH9PRMhiRTZnd4eXGQ==",
             "dev": true,
             "requires": {
                 "@types/yargs-parser": "*"
             }
         },
         "@types/yargs-parser": {
-            "version": "20.2.0",
-            "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-20.2.0.tgz",
-            "integrity": "sha512-37RSHht+gzzgYeobbG+KWryeAW8J33Nhr69cjTqSYymXVZEN9NbRYWoYlRtDhHKPVT1FyNKwaTPC1NynKZpzRA==",
+            "version": "20.2.1",
+            "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-20.2.1.tgz",
+            "integrity": "sha512-7tFImggNeNBVMsn0vLrpn1H1uPrUBdnARPTpZoitY37ZrdJREzf7I16tMrlK3hen349gr1NYh8CmZQa7CTG6Aw==",
             "dev": true
         },
         "@yarnpkg/fslib": {
-            "version": "2.5.0-rc.5",
-            "resolved": "https://registry.npmjs.org/@yarnpkg/fslib/-/fslib-2.5.0-rc.5.tgz",
-            "integrity": "sha512-cEnNGGpcUyARnd7PRZc49pSHP6lUGFZegcH8ln2c8VOTwJ8H4r2w6+Ms/D2mGKukaA2cICKVq9fBPonh35LAQA==",
+            "version": "2.5.0-rc.9",
+            "resolved": "https://registry.npmjs.org/@yarnpkg/fslib/-/fslib-2.5.0-rc.9.tgz",
+            "integrity": "sha512-PM33+MnorKgrxCfom0tJCwbp/T/pD528rS9eqxIWv1AEqD2El3YzNpVqSatngcTBEDf3X4vqE8rlO8el20/qjQ==",
             "requires": {
-                "@yarnpkg/libzip": "^2.2.2-rc.3",
+                "@yarnpkg/libzip": "^2.2.2-rc.7",
                 "tslib": "^1.13.0"
             }
         },
         "@yarnpkg/libzip": {
-            "version": "2.2.2-rc.3",
-            "resolved": "https://registry.npmjs.org/@yarnpkg/libzip/-/libzip-2.2.2-rc.3.tgz",
-            "integrity": "sha512-YiS1eQE6mgNbI3Sqxd8ogJg4Yw4QhW9JBBdVAwytINm1p7BPrQfn3iSqEzbEIWYIUddmxC4TVG/KrFyUDPtWow==",
+            "version": "2.2.2-rc.7",
+            "resolved": "https://registry.npmjs.org/@yarnpkg/libzip/-/libzip-2.2.2-rc.7.tgz",
+            "integrity": "sha512-JYoLfZefRR0H89VYX4ecxT4GdL1j68/yJF8wp+iyI/P1ODArlTWwlRwxZKvjh0Q2MRqNROvi0mX1zRDwNj3ZIA==",
             "requires": {
                 "@types/emscripten": "^1.38.0",
                 "tslib": "^1.13.0"
@@ -1032,9 +1032,9 @@
             "dev": true
         },
         "acorn": {
-            "version": "8.4.0",
-            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.4.0.tgz",
-            "integrity": "sha512-ULr0LDaEqQrMFGyQ3bhJkLsbtrQ8QibAseGZeaSUiT/6zb9IvIkomWHJIvgvwad+hinRAgsI51JcWk2yvwyL+w==",
+            "version": "8.4.1",
+            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.4.1.tgz",
+            "integrity": "sha512-asabaBSkEKosYKMITunzX177CXxQ4Q8BSSzMTKD+FefUhipQC70gfW5SiUDhYQ3vk8G+81HqQk7Fv9OXwwn9KA==",
             "dev": true
         },
         "acorn-globals": {
@@ -1139,25 +1139,25 @@
             "integrity": "sha512-SA5mXJWrId1TaQjfxUYghbqQ/hYioKmLJvPJyDuYRtXXenFNMjj4hSSt1Cf1xsuXSXrtxrVC5Ot4eU6cOtBDdA=="
         },
         "babel-jest": {
-            "version": "27.0.2",
-            "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-27.0.2.tgz",
-            "integrity": "sha512-9OThPl3/IQbo4Yul2vMz4FYwILPQak8XelX4YGowygfHaOl5R5gfjm4iVx4d8aUugkW683t8aq0A74E7b5DU1Q==",
+            "version": "27.0.6",
+            "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-27.0.6.tgz",
+            "integrity": "sha512-iTJyYLNc4wRofASmofpOc5NK9QunwMk+TLFgGXsTFS8uEqmd8wdI7sga0FPe2oVH3b5Agt/EAK1QjPEuKL8VfA==",
             "dev": true,
             "requires": {
-                "@jest/transform": "^27.0.2",
-                "@jest/types": "^27.0.2",
+                "@jest/transform": "^27.0.6",
+                "@jest/types": "^27.0.6",
                 "@types/babel__core": "^7.1.14",
                 "babel-plugin-istanbul": "^6.0.0",
-                "babel-preset-jest": "^27.0.1",
+                "babel-preset-jest": "^27.0.6",
                 "chalk": "^4.0.0",
                 "graceful-fs": "^4.2.4",
                 "slash": "^3.0.0"
             },
             "dependencies": {
                 "@jest/types": {
-                    "version": "27.0.2",
-                    "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.0.2.tgz",
-                    "integrity": "sha512-XpjCtJ/99HB4PmyJ2vgmN7vT+JLP7RW1FBT9RgnMFS4Dt7cvIyBee8O3/j98aUZ34ZpenPZFqmaaObWSeL65dg==",
+                    "version": "27.0.6",
+                    "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.0.6.tgz",
+                    "integrity": "sha512-aSquT1qa9Pik26JK5/3rvnYb4bGtm1VFNesHKmNTwmPIgOrixvhL2ghIvFRNEpzy3gU+rUgjIF/KodbkFAl++g==",
                     "dev": true,
                     "requires": {
                         "@types/istanbul-lib-coverage": "^2.0.0",
@@ -1168,9 +1168,9 @@
                     }
                 },
                 "@types/yargs": {
-                    "version": "16.0.3",
-                    "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-16.0.3.tgz",
-                    "integrity": "sha512-YlFfTGS+zqCgXuXNV26rOIeETOkXnGQXP/pjjL9P0gO/EP9jTmc7pUBhx+jVEIxpq41RX33GQ7N3DzOSfZoglQ==",
+                    "version": "16.0.4",
+                    "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-16.0.4.tgz",
+                    "integrity": "sha512-T8Yc9wt/5LbJyCaLiHPReJa0kApcIgJ7Bn735GjItUfh08Z1pJvu8QZqb9s+mMvKV6WUQRV7K2R46YbjMXTTJw==",
                     "dev": true,
                     "requires": {
                         "@types/yargs-parser": "*"
@@ -1192,9 +1192,9 @@
             }
         },
         "babel-plugin-jest-hoist": {
-            "version": "27.0.1",
-            "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-27.0.1.tgz",
-            "integrity": "sha512-sqBF0owAcCDBVEDtxqfYr2F36eSHdx7lAVGyYuOBRnKdD6gzcy0I0XrAYCZgOA3CRrLhmR+Uae9nogPzmAtOfQ==",
+            "version": "27.0.6",
+            "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-27.0.6.tgz",
+            "integrity": "sha512-CewFeM9Vv2gM7Yr9n5eyyLVPRSiBnk6lKZRjgwYnGKSl9M14TMn2vkN02wTF04OGuSDLEzlWiMzvjXuW9mB6Gw==",
             "dev": true,
             "requires": {
                 "@babel/template": "^7.3.3",
@@ -1224,12 +1224,12 @@
             }
         },
         "babel-preset-jest": {
-            "version": "27.0.1",
-            "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-27.0.1.tgz",
-            "integrity": "sha512-nIBIqCEpuiyhvjQs2mVNwTxQQa2xk70p9Dd/0obQGBf8FBzbnI8QhQKzLsWMN2i6q+5B0OcWDtrboBX5gmOLyA==",
+            "version": "27.0.6",
+            "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-27.0.6.tgz",
+            "integrity": "sha512-WObA0/Biw2LrVVwZkF/2GqbOdzhKD6Fkdwhoy9ASIrOWr/zodcSpQh72JOkEn6NWyjmnPDjNSqaGN4KnpKzhXw==",
             "dev": true,
             "requires": {
-                "babel-plugin-jest-hoist": "^27.0.1",
+                "babel-plugin-jest-hoist": "^27.0.6",
                 "babel-preset-current-node-syntax": "^1.0.0"
             }
         },
@@ -1324,9 +1324,9 @@
             "dev": true
         },
         "caniuse-lite": {
-            "version": "1.0.30001236",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001236.tgz",
-            "integrity": "sha512-o0PRQSrSCGJKCPZcgMzl5fUaj5xHe8qA2m4QRvnyY4e1lITqoNkr7q/Oh1NcpGSy0Th97UZ35yoKcINPoq7YOQ==",
+            "version": "1.0.30001245",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001245.tgz",
+            "integrity": "sha512-768fM9j1PKXpOCKws6eTo3RHmvTUsG9UrpT4WoREFeZgJBTi4/X9g565azS/rVUGtqb8nt7FjLeF5u4kukERnA==",
             "dev": true
         },
         "chalk": {
@@ -1345,18 +1345,18 @@
             "dev": true
         },
         "chokidar": {
-            "version": "3.5.1",
-            "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.1.tgz",
-            "integrity": "sha512-9+s+Od+W0VJJzawDma/gvBNQqkTiqYTWLuZoyAsivsI4AaWTCzHG06/TMjsf1cYe9Cb97UCEhjz7HvnPk2p/tw==",
+            "version": "3.5.2",
+            "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.2.tgz",
+            "integrity": "sha512-ekGhOnNVPgT77r4K/U3GDhu+FQ2S8TnK/s2KbIGXi0SZWuwkZ2QNyfWdZW+TVfn84DpEP7rLeCt2UI6bJ8GwbQ==",
             "requires": {
-                "anymatch": "~3.1.1",
+                "anymatch": "~3.1.2",
                 "braces": "~3.0.2",
-                "fsevents": "~2.3.1",
-                "glob-parent": "~5.1.0",
+                "fsevents": "~2.3.2",
+                "glob-parent": "~5.1.2",
                 "is-binary-path": "~2.1.0",
                 "is-glob": "~4.0.1",
                 "normalize-path": "~3.0.0",
-                "readdirp": "~3.5.0"
+                "readdirp": "~3.6.0"
             }
         },
         "ci-info": {
@@ -1366,9 +1366,9 @@
             "dev": true
         },
         "cjs-module-lexer": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.2.1.tgz",
-            "integrity": "sha512-jVamGdJPDeuQilKhvVn1h3knuMOZzr8QDnpk+M9aMlCaMkTDd6fBWPhiDqFvFZ07pL0liqabAiuy8SY4jGHeaw==",
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.2.2.tgz",
+            "integrity": "sha512-cOU9usZw8/dXIXKtwa8pM0OTJQuJkxMN6w30csNRUerHfeQ5R6U3kkU/FtJeIf3M202OHfY2U8ccInBG7/xogA==",
             "dev": true
         },
         "cliui": {
@@ -1423,11 +1423,11 @@
             }
         },
         "command-line-args": {
-            "version": "5.1.1",
-            "resolved": "https://registry.npmjs.org/command-line-args/-/command-line-args-5.1.1.tgz",
-            "integrity": "sha512-hL/eG8lrll1Qy1ezvkant+trihbGnaKaeEjj6Scyr3DN+RC7iQ5Rz84IeLERfAWDGo0HBSNAakczwgCilDXnWg==",
+            "version": "5.1.3",
+            "resolved": "https://registry.npmjs.org/command-line-args/-/command-line-args-5.1.3.tgz",
+            "integrity": "sha512-a5tF6mjqRSOBswBwdMkKY47JQ464Dkg9Pcwbxwo9wxRhKWZjtBktmBASllk3AMJ7qBuWgsAGtVa7b2/+EsymOQ==",
             "requires": {
-                "array-back": "^3.0.1",
+                "array-back": "^3.1.0",
                 "find-replace": "^3.0.0",
                 "lodash.camelcase": "^4.3.0",
                 "typical": "^4.0.0"
@@ -1439,9 +1439,9 @@
             "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
         },
         "convert-source-map": {
-            "version": "1.7.0",
-            "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.7.0.tgz",
-            "integrity": "sha512-4FJkXzKXEDB1snCFZlLP4gpC3JILicCpGbzG9f9G7tGqGCzETQ2hWPrcinA9oU4wtf2biUaEH5065UnMeR33oA==",
+            "version": "1.8.0",
+            "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.8.0.tgz",
+            "integrity": "sha512-+OQdjP49zViI/6i7nIJpA8rAl4sV/JdPfU9nZs3VqOwGIgizICvuN2ru6fMd+4llL0tar18UYJXfZ/TWtmhUjA==",
             "dev": true,
             "requires": {
                 "safe-buffer": "~5.1.1"
@@ -1501,18 +1501,18 @@
             }
         },
         "debug": {
-            "version": "4.3.1",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
-            "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+            "version": "4.3.2",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
+            "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
             "dev": true,
             "requires": {
                 "ms": "2.1.2"
             }
         },
         "decimal.js": {
-            "version": "10.2.1",
-            "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.2.1.tgz",
-            "integrity": "sha512-KaL7+6Fw6i5A2XSnsbhm/6B+NuEA7TZ4vqxnd5tXz9sbKtrN9Srj8ab4vKVdK8YAqZO9P1kg45Y6YLoduPf+kw==",
+            "version": "10.3.1",
+            "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.3.1.tgz",
+            "integrity": "sha512-V0pfhfr8suzyPGOx3nmq4aHqabehUZn6Ch9kyFpV79TGDTWFmHqUqXdabR7QHqxzrYolF4+tVmJhUG4OURg5dQ==",
             "dev": true
         },
         "dedent": {
@@ -1577,9 +1577,9 @@
             }
         },
         "electron-to-chromium": {
-            "version": "1.3.752",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.752.tgz",
-            "integrity": "sha512-2Tg+7jSl3oPxgsBsWKh5H83QazTkmWG/cnNwJplmyZc7KcN61+I10oUgaXSVk/NwfvN3BdkKDR4FYuRBQQ2v0A==",
+            "version": "1.3.777",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.777.tgz",
+            "integrity": "sha512-gO0VEU2esNUOu51DTtp7E7xy0d+yZdbC06EACvou1cbPM9Wwyz8ixPa6T1tqDXlT4/AefXtzx0i9OLwKkLOHQA==",
             "dev": true
         },
         "emittery": {
@@ -1699,23 +1699,23 @@
             "dev": true
         },
         "expect": {
-            "version": "27.0.2",
-            "resolved": "https://registry.npmjs.org/expect/-/expect-27.0.2.tgz",
-            "integrity": "sha512-YJFNJe2+P2DqH+ZrXy+ydRQYO87oxRUonZImpDodR1G7qo3NYd3pL+NQ9Keqpez3cehczYwZDBC3A7xk3n7M/w==",
+            "version": "27.0.6",
+            "resolved": "https://registry.npmjs.org/expect/-/expect-27.0.6.tgz",
+            "integrity": "sha512-psNLt8j2kwg42jGBDSfAlU49CEZxejN1f1PlANWDZqIhBOVU/c2Pm888FcjWJzFewhIsNWfZJeLjUjtKGiPuSw==",
             "dev": true,
             "requires": {
-                "@jest/types": "^27.0.2",
+                "@jest/types": "^27.0.6",
                 "ansi-styles": "^5.0.0",
-                "jest-get-type": "^27.0.1",
-                "jest-matcher-utils": "^27.0.2",
-                "jest-message-util": "^27.0.2",
-                "jest-regex-util": "^27.0.1"
+                "jest-get-type": "^27.0.6",
+                "jest-matcher-utils": "^27.0.6",
+                "jest-message-util": "^27.0.6",
+                "jest-regex-util": "^27.0.6"
             },
             "dependencies": {
                 "@jest/types": {
-                    "version": "27.0.2",
-                    "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.0.2.tgz",
-                    "integrity": "sha512-XpjCtJ/99HB4PmyJ2vgmN7vT+JLP7RW1FBT9RgnMFS4Dt7cvIyBee8O3/j98aUZ34ZpenPZFqmaaObWSeL65dg==",
+                    "version": "27.0.6",
+                    "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.0.6.tgz",
+                    "integrity": "sha512-aSquT1qa9Pik26JK5/3rvnYb4bGtm1VFNesHKmNTwmPIgOrixvhL2ghIvFRNEpzy3gU+rUgjIF/KodbkFAl++g==",
                     "dev": true,
                     "requires": {
                         "@types/istanbul-lib-coverage": "^2.0.0",
@@ -1726,9 +1726,9 @@
                     }
                 },
                 "@types/yargs": {
-                    "version": "16.0.3",
-                    "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-16.0.3.tgz",
-                    "integrity": "sha512-YlFfTGS+zqCgXuXNV26rOIeETOkXnGQXP/pjjL9P0gO/EP9jTmc7pUBhx+jVEIxpq41RX33GQ7N3DzOSfZoglQ==",
+                    "version": "16.0.4",
+                    "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-16.0.4.tgz",
+                    "integrity": "sha512-T8Yc9wt/5LbJyCaLiHPReJa0kApcIgJ7Bn735GjItUfh08Z1pJvu8QZqb9s+mMvKV6WUQRV7K2R46YbjMXTTJw==",
                     "dev": true,
                     "requires": {
                         "@types/yargs-parser": "*"
@@ -1741,9 +1741,9 @@
                     "dev": true
                 },
                 "jest-get-type": {
-                    "version": "27.0.1",
-                    "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-27.0.1.tgz",
-                    "integrity": "sha512-9Tggo9zZbu0sHKebiAijyt1NM77Z0uO4tuWOxUCujAiSeXv30Vb5D4xVF4UR4YWNapcftj+PbByU54lKD7/xMg==",
+                    "version": "27.0.6",
+                    "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-27.0.6.tgz",
+                    "integrity": "sha512-XTkK5exIeUbbveehcSR8w0bhH+c0yloW/Wpl+9vZrjzztCPWrxhHwkIFpZzCt71oRBsgxmuUfxEqOYoZI2macg==",
                     "dev": true
                 }
             }
@@ -2048,9 +2048,9 @@
             }
         },
         "is-core-module": {
-            "version": "2.4.0",
-            "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.4.0.tgz",
-            "integrity": "sha512-6A2fkfq1rfeQZjxrZJGerpLCTHRNEBiSgnu0+obeJpEPZRUooHgsizvzv0ZjJwOz3iWIHdJtVWJ/tmPr3D21/A==",
+            "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.5.0.tgz",
+            "integrity": "sha512-TXCMSDsEHMEEZ6eCA8rwRDbLu55MRGmrctljsBX/2v1d9/GzqHOxW5c5oPSgrUt2vBFXebu9rGqckXGPWOlYpg==",
             "dev": true,
             "requires": {
                 "has": "^1.0.3"
@@ -2224,20 +2224,20 @@
             }
         },
         "jest": {
-            "version": "27.0.4",
-            "resolved": "https://registry.npmjs.org/jest/-/jest-27.0.4.tgz",
-            "integrity": "sha512-Px1iKFooXgGSkk1H8dJxxBIrM3tsc5SIuI4kfKYK2J+4rvCvPGr/cXktxh0e9zIPQ5g09kOMNfHQEmusBUf/ZA==",
+            "version": "27.0.6",
+            "resolved": "https://registry.npmjs.org/jest/-/jest-27.0.6.tgz",
+            "integrity": "sha512-EjV8aETrsD0wHl7CKMibKwQNQc3gIRBXlTikBmmHUeVMKaPFxdcUIBfoDqTSXDoGJIivAYGqCWVlzCSaVjPQsA==",
             "dev": true,
             "requires": {
-                "@jest/core": "^27.0.4",
+                "@jest/core": "^27.0.6",
                 "import-local": "^3.0.2",
-                "jest-cli": "^27.0.4"
+                "jest-cli": "^27.0.6"
             },
             "dependencies": {
                 "@jest/types": {
-                    "version": "27.0.2",
-                    "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.0.2.tgz",
-                    "integrity": "sha512-XpjCtJ/99HB4PmyJ2vgmN7vT+JLP7RW1FBT9RgnMFS4Dt7cvIyBee8O3/j98aUZ34ZpenPZFqmaaObWSeL65dg==",
+                    "version": "27.0.6",
+                    "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.0.6.tgz",
+                    "integrity": "sha512-aSquT1qa9Pik26JK5/3rvnYb4bGtm1VFNesHKmNTwmPIgOrixvhL2ghIvFRNEpzy3gU+rUgjIF/KodbkFAl++g==",
                     "dev": true,
                     "requires": {
                         "@types/istanbul-lib-coverage": "^2.0.0",
@@ -2248,30 +2248,30 @@
                     }
                 },
                 "@types/yargs": {
-                    "version": "16.0.3",
-                    "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-16.0.3.tgz",
-                    "integrity": "sha512-YlFfTGS+zqCgXuXNV26rOIeETOkXnGQXP/pjjL9P0gO/EP9jTmc7pUBhx+jVEIxpq41RX33GQ7N3DzOSfZoglQ==",
+                    "version": "16.0.4",
+                    "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-16.0.4.tgz",
+                    "integrity": "sha512-T8Yc9wt/5LbJyCaLiHPReJa0kApcIgJ7Bn735GjItUfh08Z1pJvu8QZqb9s+mMvKV6WUQRV7K2R46YbjMXTTJw==",
                     "dev": true,
                     "requires": {
                         "@types/yargs-parser": "*"
                     }
                 },
                 "jest-cli": {
-                    "version": "27.0.4",
-                    "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-27.0.4.tgz",
-                    "integrity": "sha512-E0T+/i2lxsWAzV7LKYd0SB7HUAvePqaeIh5vX43/G5jXLhv1VzjYzJAGEkTfvxV774ll9cyE2ljcL73PVMEOXQ==",
+                    "version": "27.0.6",
+                    "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-27.0.6.tgz",
+                    "integrity": "sha512-qUUVlGb9fdKir3RDE+B10ULI+LQrz+MCflEH2UJyoUjoHHCbxDrMxSzjQAPUMsic4SncI62ofYCcAvW6+6rhhg==",
                     "dev": true,
                     "requires": {
-                        "@jest/core": "^27.0.4",
-                        "@jest/test-result": "^27.0.2",
-                        "@jest/types": "^27.0.2",
+                        "@jest/core": "^27.0.6",
+                        "@jest/test-result": "^27.0.6",
+                        "@jest/types": "^27.0.6",
                         "chalk": "^4.0.0",
                         "exit": "^0.1.2",
                         "graceful-fs": "^4.2.4",
                         "import-local": "^3.0.2",
-                        "jest-config": "^27.0.4",
-                        "jest-util": "^27.0.2",
-                        "jest-validate": "^27.0.2",
+                        "jest-config": "^27.0.6",
+                        "jest-util": "^27.0.6",
+                        "jest-validate": "^27.0.6",
                         "prompts": "^2.0.1",
                         "yargs": "^16.0.3"
                     }
@@ -2279,20 +2279,20 @@
             }
         },
         "jest-changed-files": {
-            "version": "27.0.2",
-            "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-27.0.2.tgz",
-            "integrity": "sha512-eMeb1Pn7w7x3wue5/vF73LPCJ7DKQuC9wQUR5ebP9hDPpk5hzcT/3Hmz3Q5BOFpR3tgbmaWhJcMTVgC8Z1NuMw==",
+            "version": "27.0.6",
+            "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-27.0.6.tgz",
+            "integrity": "sha512-BuL/ZDauaq5dumYh5y20sn4IISnf1P9A0TDswTxUi84ORGtVa86ApuBHqICL0vepqAnZiY6a7xeSPWv2/yy4eA==",
             "dev": true,
             "requires": {
-                "@jest/types": "^27.0.2",
+                "@jest/types": "^27.0.6",
                 "execa": "^5.0.0",
                 "throat": "^6.0.1"
             },
             "dependencies": {
                 "@jest/types": {
-                    "version": "27.0.2",
-                    "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.0.2.tgz",
-                    "integrity": "sha512-XpjCtJ/99HB4PmyJ2vgmN7vT+JLP7RW1FBT9RgnMFS4Dt7cvIyBee8O3/j98aUZ34ZpenPZFqmaaObWSeL65dg==",
+                    "version": "27.0.6",
+                    "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.0.6.tgz",
+                    "integrity": "sha512-aSquT1qa9Pik26JK5/3rvnYb4bGtm1VFNesHKmNTwmPIgOrixvhL2ghIvFRNEpzy3gU+rUgjIF/KodbkFAl++g==",
                     "dev": true,
                     "requires": {
                         "@types/istanbul-lib-coverage": "^2.0.0",
@@ -2303,9 +2303,9 @@
                     }
                 },
                 "@types/yargs": {
-                    "version": "16.0.3",
-                    "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-16.0.3.tgz",
-                    "integrity": "sha512-YlFfTGS+zqCgXuXNV26rOIeETOkXnGQXP/pjjL9P0gO/EP9jTmc7pUBhx+jVEIxpq41RX33GQ7N3DzOSfZoglQ==",
+                    "version": "16.0.4",
+                    "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-16.0.4.tgz",
+                    "integrity": "sha512-T8Yc9wt/5LbJyCaLiHPReJa0kApcIgJ7Bn735GjItUfh08Z1pJvu8QZqb9s+mMvKV6WUQRV7K2R46YbjMXTTJw==",
                     "dev": true,
                     "requires": {
                         "@types/yargs-parser": "*"
@@ -2314,36 +2314,36 @@
             }
         },
         "jest-circus": {
-            "version": "27.0.4",
-            "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-27.0.4.tgz",
-            "integrity": "sha512-QD+eblDiRphta630WRKewuASLs/oY1Zki2G4bccntRvrTHQ63ljwFR5TLduuK4Zg0ZPzW0+8o6AP7KRd1yKOjw==",
+            "version": "27.0.6",
+            "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-27.0.6.tgz",
+            "integrity": "sha512-OJlsz6BBeX9qR+7O9lXefWoc2m9ZqcZ5Ohlzz0pTEAG4xMiZUJoacY8f4YDHxgk0oKYxj277AfOk9w6hZYvi1Q==",
             "dev": true,
             "requires": {
-                "@jest/environment": "^27.0.3",
-                "@jest/test-result": "^27.0.2",
-                "@jest/types": "^27.0.2",
+                "@jest/environment": "^27.0.6",
+                "@jest/test-result": "^27.0.6",
+                "@jest/types": "^27.0.6",
                 "@types/node": "*",
                 "chalk": "^4.0.0",
                 "co": "^4.6.0",
                 "dedent": "^0.7.0",
-                "expect": "^27.0.2",
+                "expect": "^27.0.6",
                 "is-generator-fn": "^2.0.0",
-                "jest-each": "^27.0.2",
-                "jest-matcher-utils": "^27.0.2",
-                "jest-message-util": "^27.0.2",
-                "jest-runtime": "^27.0.4",
-                "jest-snapshot": "^27.0.4",
-                "jest-util": "^27.0.2",
-                "pretty-format": "^27.0.2",
+                "jest-each": "^27.0.6",
+                "jest-matcher-utils": "^27.0.6",
+                "jest-message-util": "^27.0.6",
+                "jest-runtime": "^27.0.6",
+                "jest-snapshot": "^27.0.6",
+                "jest-util": "^27.0.6",
+                "pretty-format": "^27.0.6",
                 "slash": "^3.0.0",
                 "stack-utils": "^2.0.3",
                 "throat": "^6.0.1"
             },
             "dependencies": {
                 "@jest/types": {
-                    "version": "27.0.2",
-                    "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.0.2.tgz",
-                    "integrity": "sha512-XpjCtJ/99HB4PmyJ2vgmN7vT+JLP7RW1FBT9RgnMFS4Dt7cvIyBee8O3/j98aUZ34ZpenPZFqmaaObWSeL65dg==",
+                    "version": "27.0.6",
+                    "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.0.6.tgz",
+                    "integrity": "sha512-aSquT1qa9Pik26JK5/3rvnYb4bGtm1VFNesHKmNTwmPIgOrixvhL2ghIvFRNEpzy3gU+rUgjIF/KodbkFAl++g==",
                     "dev": true,
                     "requires": {
                         "@types/istanbul-lib-coverage": "^2.0.0",
@@ -2354,9 +2354,9 @@
                     }
                 },
                 "@types/yargs": {
-                    "version": "16.0.3",
-                    "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-16.0.3.tgz",
-                    "integrity": "sha512-YlFfTGS+zqCgXuXNV26rOIeETOkXnGQXP/pjjL9P0gO/EP9jTmc7pUBhx+jVEIxpq41RX33GQ7N3DzOSfZoglQ==",
+                    "version": "16.0.4",
+                    "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-16.0.4.tgz",
+                    "integrity": "sha512-T8Yc9wt/5LbJyCaLiHPReJa0kApcIgJ7Bn735GjItUfh08Z1pJvu8QZqb9s+mMvKV6WUQRV7K2R46YbjMXTTJw==",
                     "dev": true,
                     "requires": {
                         "@types/yargs-parser": "*"
@@ -2369,12 +2369,12 @@
                     "dev": true
                 },
                 "pretty-format": {
-                    "version": "27.0.2",
-                    "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.0.2.tgz",
-                    "integrity": "sha512-mXKbbBPnYTG7Yra9qFBtqj+IXcsvxsvOBco3QHxtxTl+hHKq6QdzMZ+q0CtL4ORHZgwGImRr2XZUX2EWzORxig==",
+                    "version": "27.0.6",
+                    "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.0.6.tgz",
+                    "integrity": "sha512-8tGD7gBIENgzqA+UBzObyWqQ5B778VIFZA/S66cclyd5YkFLYs2Js7gxDKf0MXtTc9zcS7t1xhdfcElJ3YIvkQ==",
                     "dev": true,
                     "requires": {
-                        "@jest/types": "^27.0.2",
+                        "@jest/types": "^27.0.6",
                         "ansi-regex": "^5.0.0",
                         "ansi-styles": "^5.0.0",
                         "react-is": "^17.0.1"
@@ -2383,38 +2383,38 @@
             }
         },
         "jest-config": {
-            "version": "27.0.4",
-            "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-27.0.4.tgz",
-            "integrity": "sha512-VkQFAHWnPQefdvHU9A+G3H/Z3NrrTKqWpvxgQz3nkUdkDTWeKJE6e//BL+R7z79dXOMVksYgM/z6ndtN0hfChg==",
+            "version": "27.0.6",
+            "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-27.0.6.tgz",
+            "integrity": "sha512-JZRR3I1Plr2YxPBhgqRspDE2S5zprbga3swYNrvY3HfQGu7p/GjyLOqwrYad97tX3U3mzT53TPHVmozacfP/3w==",
             "dev": true,
             "requires": {
                 "@babel/core": "^7.1.0",
-                "@jest/test-sequencer": "^27.0.4",
-                "@jest/types": "^27.0.2",
-                "babel-jest": "^27.0.2",
+                "@jest/test-sequencer": "^27.0.6",
+                "@jest/types": "^27.0.6",
+                "babel-jest": "^27.0.6",
                 "chalk": "^4.0.0",
                 "deepmerge": "^4.2.2",
                 "glob": "^7.1.1",
                 "graceful-fs": "^4.2.4",
                 "is-ci": "^3.0.0",
-                "jest-circus": "^27.0.4",
-                "jest-environment-jsdom": "^27.0.3",
-                "jest-environment-node": "^27.0.3",
-                "jest-get-type": "^27.0.1",
-                "jest-jasmine2": "^27.0.4",
-                "jest-regex-util": "^27.0.1",
-                "jest-resolve": "^27.0.4",
-                "jest-runner": "^27.0.4",
-                "jest-util": "^27.0.2",
-                "jest-validate": "^27.0.2",
+                "jest-circus": "^27.0.6",
+                "jest-environment-jsdom": "^27.0.6",
+                "jest-environment-node": "^27.0.6",
+                "jest-get-type": "^27.0.6",
+                "jest-jasmine2": "^27.0.6",
+                "jest-regex-util": "^27.0.6",
+                "jest-resolve": "^27.0.6",
+                "jest-runner": "^27.0.6",
+                "jest-util": "^27.0.6",
+                "jest-validate": "^27.0.6",
                 "micromatch": "^4.0.4",
-                "pretty-format": "^27.0.2"
+                "pretty-format": "^27.0.6"
             },
             "dependencies": {
                 "@jest/types": {
-                    "version": "27.0.2",
-                    "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.0.2.tgz",
-                    "integrity": "sha512-XpjCtJ/99HB4PmyJ2vgmN7vT+JLP7RW1FBT9RgnMFS4Dt7cvIyBee8O3/j98aUZ34ZpenPZFqmaaObWSeL65dg==",
+                    "version": "27.0.6",
+                    "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.0.6.tgz",
+                    "integrity": "sha512-aSquT1qa9Pik26JK5/3rvnYb4bGtm1VFNesHKmNTwmPIgOrixvhL2ghIvFRNEpzy3gU+rUgjIF/KodbkFAl++g==",
                     "dev": true,
                     "requires": {
                         "@types/istanbul-lib-coverage": "^2.0.0",
@@ -2425,9 +2425,9 @@
                     }
                 },
                 "@types/yargs": {
-                    "version": "16.0.3",
-                    "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-16.0.3.tgz",
-                    "integrity": "sha512-YlFfTGS+zqCgXuXNV26rOIeETOkXnGQXP/pjjL9P0gO/EP9jTmc7pUBhx+jVEIxpq41RX33GQ7N3DzOSfZoglQ==",
+                    "version": "16.0.4",
+                    "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-16.0.4.tgz",
+                    "integrity": "sha512-T8Yc9wt/5LbJyCaLiHPReJa0kApcIgJ7Bn735GjItUfh08Z1pJvu8QZqb9s+mMvKV6WUQRV7K2R46YbjMXTTJw==",
                     "dev": true,
                     "requires": {
                         "@types/yargs-parser": "*"
@@ -2440,18 +2440,18 @@
                     "dev": true
                 },
                 "jest-get-type": {
-                    "version": "27.0.1",
-                    "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-27.0.1.tgz",
-                    "integrity": "sha512-9Tggo9zZbu0sHKebiAijyt1NM77Z0uO4tuWOxUCujAiSeXv30Vb5D4xVF4UR4YWNapcftj+PbByU54lKD7/xMg==",
+                    "version": "27.0.6",
+                    "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-27.0.6.tgz",
+                    "integrity": "sha512-XTkK5exIeUbbveehcSR8w0bhH+c0yloW/Wpl+9vZrjzztCPWrxhHwkIFpZzCt71oRBsgxmuUfxEqOYoZI2macg==",
                     "dev": true
                 },
                 "pretty-format": {
-                    "version": "27.0.2",
-                    "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.0.2.tgz",
-                    "integrity": "sha512-mXKbbBPnYTG7Yra9qFBtqj+IXcsvxsvOBco3QHxtxTl+hHKq6QdzMZ+q0CtL4ORHZgwGImRr2XZUX2EWzORxig==",
+                    "version": "27.0.6",
+                    "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.0.6.tgz",
+                    "integrity": "sha512-8tGD7gBIENgzqA+UBzObyWqQ5B778VIFZA/S66cclyd5YkFLYs2Js7gxDKf0MXtTc9zcS7t1xhdfcElJ3YIvkQ==",
                     "dev": true,
                     "requires": {
-                        "@jest/types": "^27.0.2",
+                        "@jest/types": "^27.0.6",
                         "ansi-regex": "^5.0.0",
                         "ansi-styles": "^5.0.0",
                         "react-is": "^17.0.1"
@@ -2472,31 +2472,31 @@
             }
         },
         "jest-docblock": {
-            "version": "27.0.1",
-            "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-27.0.1.tgz",
-            "integrity": "sha512-TA4+21s3oebURc7VgFV4r7ltdIJ5rtBH1E3Tbovcg7AV+oLfD5DcJ2V2vJ5zFA9sL5CFd/d2D6IpsAeSheEdrA==",
+            "version": "27.0.6",
+            "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-27.0.6.tgz",
+            "integrity": "sha512-Fid6dPcjwepTFraz0YxIMCi7dejjJ/KL9FBjPYhBp4Sv1Y9PdhImlKZqYU555BlN4TQKaTc+F2Av1z+anVyGkA==",
             "dev": true,
             "requires": {
                 "detect-newline": "^3.0.0"
             }
         },
         "jest-each": {
-            "version": "27.0.2",
-            "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-27.0.2.tgz",
-            "integrity": "sha512-OLMBZBZ6JkoXgUenDtseFRWA43wVl2BwmZYIWQws7eS7pqsIvePqj/jJmEnfq91ALk3LNphgwNK/PRFBYi7ITQ==",
+            "version": "27.0.6",
+            "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-27.0.6.tgz",
+            "integrity": "sha512-m6yKcV3bkSWrUIjxkE9OC0mhBZZdhovIW5ergBYirqnkLXkyEn3oUUF/QZgyecA1cF1QFyTE8bRRl8Tfg1pfLA==",
             "dev": true,
             "requires": {
-                "@jest/types": "^27.0.2",
+                "@jest/types": "^27.0.6",
                 "chalk": "^4.0.0",
-                "jest-get-type": "^27.0.1",
-                "jest-util": "^27.0.2",
-                "pretty-format": "^27.0.2"
+                "jest-get-type": "^27.0.6",
+                "jest-util": "^27.0.6",
+                "pretty-format": "^27.0.6"
             },
             "dependencies": {
                 "@jest/types": {
-                    "version": "27.0.2",
-                    "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.0.2.tgz",
-                    "integrity": "sha512-XpjCtJ/99HB4PmyJ2vgmN7vT+JLP7RW1FBT9RgnMFS4Dt7cvIyBee8O3/j98aUZ34ZpenPZFqmaaObWSeL65dg==",
+                    "version": "27.0.6",
+                    "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.0.6.tgz",
+                    "integrity": "sha512-aSquT1qa9Pik26JK5/3rvnYb4bGtm1VFNesHKmNTwmPIgOrixvhL2ghIvFRNEpzy3gU+rUgjIF/KodbkFAl++g==",
                     "dev": true,
                     "requires": {
                         "@types/istanbul-lib-coverage": "^2.0.0",
@@ -2507,9 +2507,9 @@
                     }
                 },
                 "@types/yargs": {
-                    "version": "16.0.3",
-                    "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-16.0.3.tgz",
-                    "integrity": "sha512-YlFfTGS+zqCgXuXNV26rOIeETOkXnGQXP/pjjL9P0gO/EP9jTmc7pUBhx+jVEIxpq41RX33GQ7N3DzOSfZoglQ==",
+                    "version": "16.0.4",
+                    "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-16.0.4.tgz",
+                    "integrity": "sha512-T8Yc9wt/5LbJyCaLiHPReJa0kApcIgJ7Bn735GjItUfh08Z1pJvu8QZqb9s+mMvKV6WUQRV7K2R46YbjMXTTJw==",
                     "dev": true,
                     "requires": {
                         "@types/yargs-parser": "*"
@@ -2522,18 +2522,18 @@
                     "dev": true
                 },
                 "jest-get-type": {
-                    "version": "27.0.1",
-                    "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-27.0.1.tgz",
-                    "integrity": "sha512-9Tggo9zZbu0sHKebiAijyt1NM77Z0uO4tuWOxUCujAiSeXv30Vb5D4xVF4UR4YWNapcftj+PbByU54lKD7/xMg==",
+                    "version": "27.0.6",
+                    "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-27.0.6.tgz",
+                    "integrity": "sha512-XTkK5exIeUbbveehcSR8w0bhH+c0yloW/Wpl+9vZrjzztCPWrxhHwkIFpZzCt71oRBsgxmuUfxEqOYoZI2macg==",
                     "dev": true
                 },
                 "pretty-format": {
-                    "version": "27.0.2",
-                    "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.0.2.tgz",
-                    "integrity": "sha512-mXKbbBPnYTG7Yra9qFBtqj+IXcsvxsvOBco3QHxtxTl+hHKq6QdzMZ+q0CtL4ORHZgwGImRr2XZUX2EWzORxig==",
+                    "version": "27.0.6",
+                    "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.0.6.tgz",
+                    "integrity": "sha512-8tGD7gBIENgzqA+UBzObyWqQ5B778VIFZA/S66cclyd5YkFLYs2Js7gxDKf0MXtTc9zcS7t1xhdfcElJ3YIvkQ==",
                     "dev": true,
                     "requires": {
-                        "@jest/types": "^27.0.2",
+                        "@jest/types": "^27.0.6",
                         "ansi-regex": "^5.0.0",
                         "ansi-styles": "^5.0.0",
                         "react-is": "^17.0.1"
@@ -2542,24 +2542,24 @@
             }
         },
         "jest-environment-jsdom": {
-            "version": "27.0.3",
-            "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-27.0.3.tgz",
-            "integrity": "sha512-5KLmgv1bhiimpSA8oGTnZYk6g4fsNyZiA/6gI2tAZUgrufd7heRUSVh4gRokzZVEj8zlwAQYT0Zs6tuJSW/ECA==",
+            "version": "27.0.6",
+            "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-27.0.6.tgz",
+            "integrity": "sha512-FvetXg7lnXL9+78H+xUAsra3IeZRTiegA3An01cWeXBspKXUhAwMM9ycIJ4yBaR0L7HkoMPaZsozCLHh4T8fuw==",
             "dev": true,
             "requires": {
-                "@jest/environment": "^27.0.3",
-                "@jest/fake-timers": "^27.0.3",
-                "@jest/types": "^27.0.2",
+                "@jest/environment": "^27.0.6",
+                "@jest/fake-timers": "^27.0.6",
+                "@jest/types": "^27.0.6",
                 "@types/node": "*",
-                "jest-mock": "^27.0.3",
-                "jest-util": "^27.0.2",
+                "jest-mock": "^27.0.6",
+                "jest-util": "^27.0.6",
                 "jsdom": "^16.6.0"
             },
             "dependencies": {
                 "@jest/types": {
-                    "version": "27.0.2",
-                    "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.0.2.tgz",
-                    "integrity": "sha512-XpjCtJ/99HB4PmyJ2vgmN7vT+JLP7RW1FBT9RgnMFS4Dt7cvIyBee8O3/j98aUZ34ZpenPZFqmaaObWSeL65dg==",
+                    "version": "27.0.6",
+                    "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.0.6.tgz",
+                    "integrity": "sha512-aSquT1qa9Pik26JK5/3rvnYb4bGtm1VFNesHKmNTwmPIgOrixvhL2ghIvFRNEpzy3gU+rUgjIF/KodbkFAl++g==",
                     "dev": true,
                     "requires": {
                         "@types/istanbul-lib-coverage": "^2.0.0",
@@ -2570,9 +2570,9 @@
                     }
                 },
                 "@types/yargs": {
-                    "version": "16.0.3",
-                    "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-16.0.3.tgz",
-                    "integrity": "sha512-YlFfTGS+zqCgXuXNV26rOIeETOkXnGQXP/pjjL9P0gO/EP9jTmc7pUBhx+jVEIxpq41RX33GQ7N3DzOSfZoglQ==",
+                    "version": "16.0.4",
+                    "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-16.0.4.tgz",
+                    "integrity": "sha512-T8Yc9wt/5LbJyCaLiHPReJa0kApcIgJ7Bn735GjItUfh08Z1pJvu8QZqb9s+mMvKV6WUQRV7K2R46YbjMXTTJw==",
                     "dev": true,
                     "requires": {
                         "@types/yargs-parser": "*"
@@ -2581,23 +2581,23 @@
             }
         },
         "jest-environment-node": {
-            "version": "27.0.3",
-            "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-27.0.3.tgz",
-            "integrity": "sha512-co2/IVnIFL3cItpFULCvXFg9us4gvWXgs7mutAMPCbFhcqh56QAOdKhNzC2+RycsC/k4mbMj1VF+9F/NzA0ROg==",
+            "version": "27.0.6",
+            "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-27.0.6.tgz",
+            "integrity": "sha512-+Vi6yLrPg/qC81jfXx3IBlVnDTI6kmRr08iVa2hFCWmJt4zha0XW7ucQltCAPhSR0FEKEoJ3i+W4E6T0s9is0w==",
             "dev": true,
             "requires": {
-                "@jest/environment": "^27.0.3",
-                "@jest/fake-timers": "^27.0.3",
-                "@jest/types": "^27.0.2",
+                "@jest/environment": "^27.0.6",
+                "@jest/fake-timers": "^27.0.6",
+                "@jest/types": "^27.0.6",
                 "@types/node": "*",
-                "jest-mock": "^27.0.3",
-                "jest-util": "^27.0.2"
+                "jest-mock": "^27.0.6",
+                "jest-util": "^27.0.6"
             },
             "dependencies": {
                 "@jest/types": {
-                    "version": "27.0.2",
-                    "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.0.2.tgz",
-                    "integrity": "sha512-XpjCtJ/99HB4PmyJ2vgmN7vT+JLP7RW1FBT9RgnMFS4Dt7cvIyBee8O3/j98aUZ34ZpenPZFqmaaObWSeL65dg==",
+                    "version": "27.0.6",
+                    "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.0.6.tgz",
+                    "integrity": "sha512-aSquT1qa9Pik26JK5/3rvnYb4bGtm1VFNesHKmNTwmPIgOrixvhL2ghIvFRNEpzy3gU+rUgjIF/KodbkFAl++g==",
                     "dev": true,
                     "requires": {
                         "@types/istanbul-lib-coverage": "^2.0.0",
@@ -2608,9 +2608,9 @@
                     }
                 },
                 "@types/yargs": {
-                    "version": "16.0.3",
-                    "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-16.0.3.tgz",
-                    "integrity": "sha512-YlFfTGS+zqCgXuXNV26rOIeETOkXnGQXP/pjjL9P0gO/EP9jTmc7pUBhx+jVEIxpq41RX33GQ7N3DzOSfZoglQ==",
+                    "version": "16.0.4",
+                    "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-16.0.4.tgz",
+                    "integrity": "sha512-T8Yc9wt/5LbJyCaLiHPReJa0kApcIgJ7Bn735GjItUfh08Z1pJvu8QZqb9s+mMvKV6WUQRV7K2R46YbjMXTTJw==",
                     "dev": true,
                     "requires": {
                         "@types/yargs-parser": "*"
@@ -2625,30 +2625,30 @@
             "dev": true
         },
         "jest-haste-map": {
-            "version": "27.0.2",
-            "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-27.0.2.tgz",
-            "integrity": "sha512-37gYfrYjjhEfk37C4bCMWAC0oPBxDpG0qpl8lYg8BT//wf353YT/fzgA7+Dq0EtM7rPFS3JEcMsxdtDwNMi2cA==",
+            "version": "27.0.6",
+            "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-27.0.6.tgz",
+            "integrity": "sha512-4ldjPXX9h8doB2JlRzg9oAZ2p6/GpQUNAeiYXqcpmrKbP0Qev0wdZlxSMOmz8mPOEnt4h6qIzXFLDi8RScX/1w==",
             "dev": true,
             "requires": {
-                "@jest/types": "^27.0.2",
+                "@jest/types": "^27.0.6",
                 "@types/graceful-fs": "^4.1.2",
                 "@types/node": "*",
                 "anymatch": "^3.0.3",
                 "fb-watchman": "^2.0.0",
                 "fsevents": "^2.3.2",
                 "graceful-fs": "^4.2.4",
-                "jest-regex-util": "^27.0.1",
-                "jest-serializer": "^27.0.1",
-                "jest-util": "^27.0.2",
-                "jest-worker": "^27.0.2",
+                "jest-regex-util": "^27.0.6",
+                "jest-serializer": "^27.0.6",
+                "jest-util": "^27.0.6",
+                "jest-worker": "^27.0.6",
                 "micromatch": "^4.0.4",
                 "walker": "^1.0.7"
             },
             "dependencies": {
                 "@jest/types": {
-                    "version": "27.0.2",
-                    "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.0.2.tgz",
-                    "integrity": "sha512-XpjCtJ/99HB4PmyJ2vgmN7vT+JLP7RW1FBT9RgnMFS4Dt7cvIyBee8O3/j98aUZ34ZpenPZFqmaaObWSeL65dg==",
+                    "version": "27.0.6",
+                    "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.0.6.tgz",
+                    "integrity": "sha512-aSquT1qa9Pik26JK5/3rvnYb4bGtm1VFNesHKmNTwmPIgOrixvhL2ghIvFRNEpzy3gU+rUgjIF/KodbkFAl++g==",
                     "dev": true,
                     "requires": {
                         "@types/istanbul-lib-coverage": "^2.0.0",
@@ -2659,9 +2659,9 @@
                     }
                 },
                 "@types/yargs": {
-                    "version": "16.0.3",
-                    "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-16.0.3.tgz",
-                    "integrity": "sha512-YlFfTGS+zqCgXuXNV26rOIeETOkXnGQXP/pjjL9P0gO/EP9jTmc7pUBhx+jVEIxpq41RX33GQ7N3DzOSfZoglQ==",
+                    "version": "16.0.4",
+                    "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-16.0.4.tgz",
+                    "integrity": "sha512-T8Yc9wt/5LbJyCaLiHPReJa0kApcIgJ7Bn735GjItUfh08Z1pJvu8QZqb9s+mMvKV6WUQRV7K2R46YbjMXTTJw==",
                     "dev": true,
                     "requires": {
                         "@types/yargs-parser": "*"
@@ -2670,35 +2670,35 @@
             }
         },
         "jest-jasmine2": {
-            "version": "27.0.4",
-            "resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-27.0.4.tgz",
-            "integrity": "sha512-yj3WrjjquZwkJw+eA4c9yucHw4/+EHndHWSqgHbHGQfT94ihaaQsa009j1a0puU8CNxPDk0c1oAPeOpdJUElwA==",
+            "version": "27.0.6",
+            "resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-27.0.6.tgz",
+            "integrity": "sha512-cjpH2sBy+t6dvCeKBsHpW41mjHzXgsavaFMp+VWRf0eR4EW8xASk1acqmljFtK2DgyIECMv2yCdY41r2l1+4iA==",
             "dev": true,
             "requires": {
                 "@babel/traverse": "^7.1.0",
-                "@jest/environment": "^27.0.3",
-                "@jest/source-map": "^27.0.1",
-                "@jest/test-result": "^27.0.2",
-                "@jest/types": "^27.0.2",
+                "@jest/environment": "^27.0.6",
+                "@jest/source-map": "^27.0.6",
+                "@jest/test-result": "^27.0.6",
+                "@jest/types": "^27.0.6",
                 "@types/node": "*",
                 "chalk": "^4.0.0",
                 "co": "^4.6.0",
-                "expect": "^27.0.2",
+                "expect": "^27.0.6",
                 "is-generator-fn": "^2.0.0",
-                "jest-each": "^27.0.2",
-                "jest-matcher-utils": "^27.0.2",
-                "jest-message-util": "^27.0.2",
-                "jest-runtime": "^27.0.4",
-                "jest-snapshot": "^27.0.4",
-                "jest-util": "^27.0.2",
-                "pretty-format": "^27.0.2",
+                "jest-each": "^27.0.6",
+                "jest-matcher-utils": "^27.0.6",
+                "jest-message-util": "^27.0.6",
+                "jest-runtime": "^27.0.6",
+                "jest-snapshot": "^27.0.6",
+                "jest-util": "^27.0.6",
+                "pretty-format": "^27.0.6",
                 "throat": "^6.0.1"
             },
             "dependencies": {
                 "@jest/types": {
-                    "version": "27.0.2",
-                    "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.0.2.tgz",
-                    "integrity": "sha512-XpjCtJ/99HB4PmyJ2vgmN7vT+JLP7RW1FBT9RgnMFS4Dt7cvIyBee8O3/j98aUZ34ZpenPZFqmaaObWSeL65dg==",
+                    "version": "27.0.6",
+                    "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.0.6.tgz",
+                    "integrity": "sha512-aSquT1qa9Pik26JK5/3rvnYb4bGtm1VFNesHKmNTwmPIgOrixvhL2ghIvFRNEpzy3gU+rUgjIF/KodbkFAl++g==",
                     "dev": true,
                     "requires": {
                         "@types/istanbul-lib-coverage": "^2.0.0",
@@ -2709,9 +2709,9 @@
                     }
                 },
                 "@types/yargs": {
-                    "version": "16.0.3",
-                    "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-16.0.3.tgz",
-                    "integrity": "sha512-YlFfTGS+zqCgXuXNV26rOIeETOkXnGQXP/pjjL9P0gO/EP9jTmc7pUBhx+jVEIxpq41RX33GQ7N3DzOSfZoglQ==",
+                    "version": "16.0.4",
+                    "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-16.0.4.tgz",
+                    "integrity": "sha512-T8Yc9wt/5LbJyCaLiHPReJa0kApcIgJ7Bn735GjItUfh08Z1pJvu8QZqb9s+mMvKV6WUQRV7K2R46YbjMXTTJw==",
                     "dev": true,
                     "requires": {
                         "@types/yargs-parser": "*"
@@ -2724,12 +2724,12 @@
                     "dev": true
                 },
                 "pretty-format": {
-                    "version": "27.0.2",
-                    "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.0.2.tgz",
-                    "integrity": "sha512-mXKbbBPnYTG7Yra9qFBtqj+IXcsvxsvOBco3QHxtxTl+hHKq6QdzMZ+q0CtL4ORHZgwGImRr2XZUX2EWzORxig==",
+                    "version": "27.0.6",
+                    "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.0.6.tgz",
+                    "integrity": "sha512-8tGD7gBIENgzqA+UBzObyWqQ5B778VIFZA/S66cclyd5YkFLYs2Js7gxDKf0MXtTc9zcS7t1xhdfcElJ3YIvkQ==",
                     "dev": true,
                     "requires": {
-                        "@jest/types": "^27.0.2",
+                        "@jest/types": "^27.0.6",
                         "ansi-regex": "^5.0.0",
                         "ansi-styles": "^5.0.0",
                         "react-is": "^17.0.1"
@@ -2767,19 +2767,19 @@
             }
         },
         "jest-leak-detector": {
-            "version": "27.0.2",
-            "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-27.0.2.tgz",
-            "integrity": "sha512-TZA3DmCOfe8YZFIMD1GxFqXUkQnIoOGQyy4hFCA2mlHtnAaf+FeOMxi0fZmfB41ZL+QbFG6BVaZF5IeFIVy53Q==",
+            "version": "27.0.6",
+            "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-27.0.6.tgz",
+            "integrity": "sha512-2/d6n2wlH5zEcdctX4zdbgX8oM61tb67PQt4Xh8JFAIy6LRKUnX528HulkaG6nD5qDl5vRV1NXejCe1XRCH5gQ==",
             "dev": true,
             "requires": {
-                "jest-get-type": "^27.0.1",
-                "pretty-format": "^27.0.2"
+                "jest-get-type": "^27.0.6",
+                "pretty-format": "^27.0.6"
             },
             "dependencies": {
                 "@jest/types": {
-                    "version": "27.0.2",
-                    "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.0.2.tgz",
-                    "integrity": "sha512-XpjCtJ/99HB4PmyJ2vgmN7vT+JLP7RW1FBT9RgnMFS4Dt7cvIyBee8O3/j98aUZ34ZpenPZFqmaaObWSeL65dg==",
+                    "version": "27.0.6",
+                    "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.0.6.tgz",
+                    "integrity": "sha512-aSquT1qa9Pik26JK5/3rvnYb4bGtm1VFNesHKmNTwmPIgOrixvhL2ghIvFRNEpzy3gU+rUgjIF/KodbkFAl++g==",
                     "dev": true,
                     "requires": {
                         "@types/istanbul-lib-coverage": "^2.0.0",
@@ -2790,9 +2790,9 @@
                     }
                 },
                 "@types/yargs": {
-                    "version": "16.0.3",
-                    "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-16.0.3.tgz",
-                    "integrity": "sha512-YlFfTGS+zqCgXuXNV26rOIeETOkXnGQXP/pjjL9P0gO/EP9jTmc7pUBhx+jVEIxpq41RX33GQ7N3DzOSfZoglQ==",
+                    "version": "16.0.4",
+                    "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-16.0.4.tgz",
+                    "integrity": "sha512-T8Yc9wt/5LbJyCaLiHPReJa0kApcIgJ7Bn735GjItUfh08Z1pJvu8QZqb9s+mMvKV6WUQRV7K2R46YbjMXTTJw==",
                     "dev": true,
                     "requires": {
                         "@types/yargs-parser": "*"
@@ -2805,18 +2805,18 @@
                     "dev": true
                 },
                 "jest-get-type": {
-                    "version": "27.0.1",
-                    "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-27.0.1.tgz",
-                    "integrity": "sha512-9Tggo9zZbu0sHKebiAijyt1NM77Z0uO4tuWOxUCujAiSeXv30Vb5D4xVF4UR4YWNapcftj+PbByU54lKD7/xMg==",
+                    "version": "27.0.6",
+                    "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-27.0.6.tgz",
+                    "integrity": "sha512-XTkK5exIeUbbveehcSR8w0bhH+c0yloW/Wpl+9vZrjzztCPWrxhHwkIFpZzCt71oRBsgxmuUfxEqOYoZI2macg==",
                     "dev": true
                 },
                 "pretty-format": {
-                    "version": "27.0.2",
-                    "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.0.2.tgz",
-                    "integrity": "sha512-mXKbbBPnYTG7Yra9qFBtqj+IXcsvxsvOBco3QHxtxTl+hHKq6QdzMZ+q0CtL4ORHZgwGImRr2XZUX2EWzORxig==",
+                    "version": "27.0.6",
+                    "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.0.6.tgz",
+                    "integrity": "sha512-8tGD7gBIENgzqA+UBzObyWqQ5B778VIFZA/S66cclyd5YkFLYs2Js7gxDKf0MXtTc9zcS7t1xhdfcElJ3YIvkQ==",
                     "dev": true,
                     "requires": {
-                        "@jest/types": "^27.0.2",
+                        "@jest/types": "^27.0.6",
                         "ansi-regex": "^5.0.0",
                         "ansi-styles": "^5.0.0",
                         "react-is": "^17.0.1"
@@ -2825,21 +2825,21 @@
             }
         },
         "jest-matcher-utils": {
-            "version": "27.0.2",
-            "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-27.0.2.tgz",
-            "integrity": "sha512-Qczi5xnTNjkhcIB0Yy75Txt+Ez51xdhOxsukN7awzq2auZQGPHcQrJ623PZj0ECDEMOk2soxWx05EXdXGd1CbA==",
+            "version": "27.0.6",
+            "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-27.0.6.tgz",
+            "integrity": "sha512-OFgF2VCQx9vdPSYTHWJ9MzFCehs20TsyFi6bIHbk5V1u52zJOnvF0Y/65z3GLZHKRuTgVPY4Z6LVePNahaQ+tA==",
             "dev": true,
             "requires": {
                 "chalk": "^4.0.0",
-                "jest-diff": "^27.0.2",
-                "jest-get-type": "^27.0.1",
-                "pretty-format": "^27.0.2"
+                "jest-diff": "^27.0.6",
+                "jest-get-type": "^27.0.6",
+                "pretty-format": "^27.0.6"
             },
             "dependencies": {
                 "@jest/types": {
-                    "version": "27.0.2",
-                    "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.0.2.tgz",
-                    "integrity": "sha512-XpjCtJ/99HB4PmyJ2vgmN7vT+JLP7RW1FBT9RgnMFS4Dt7cvIyBee8O3/j98aUZ34ZpenPZFqmaaObWSeL65dg==",
+                    "version": "27.0.6",
+                    "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.0.6.tgz",
+                    "integrity": "sha512-aSquT1qa9Pik26JK5/3rvnYb4bGtm1VFNesHKmNTwmPIgOrixvhL2ghIvFRNEpzy3gU+rUgjIF/KodbkFAl++g==",
                     "dev": true,
                     "requires": {
                         "@types/istanbul-lib-coverage": "^2.0.0",
@@ -2850,9 +2850,9 @@
                     }
                 },
                 "@types/yargs": {
-                    "version": "16.0.3",
-                    "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-16.0.3.tgz",
-                    "integrity": "sha512-YlFfTGS+zqCgXuXNV26rOIeETOkXnGQXP/pjjL9P0gO/EP9jTmc7pUBhx+jVEIxpq41RX33GQ7N3DzOSfZoglQ==",
+                    "version": "16.0.4",
+                    "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-16.0.4.tgz",
+                    "integrity": "sha512-T8Yc9wt/5LbJyCaLiHPReJa0kApcIgJ7Bn735GjItUfh08Z1pJvu8QZqb9s+mMvKV6WUQRV7K2R46YbjMXTTJw==",
                     "dev": true,
                     "requires": {
                         "@types/yargs-parser": "*"
@@ -2865,36 +2865,36 @@
                     "dev": true
                 },
                 "diff-sequences": {
-                    "version": "27.0.1",
-                    "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-27.0.1.tgz",
-                    "integrity": "sha512-XPLijkfJUh/PIBnfkcSHgvD6tlYixmcMAn3osTk6jt+H0v/mgURto1XUiD9DKuGX5NDoVS6dSlA23gd9FUaCFg==",
+                    "version": "27.0.6",
+                    "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-27.0.6.tgz",
+                    "integrity": "sha512-ag6wfpBFyNXZ0p8pcuIDS//D8H062ZQJ3fzYxjpmeKjnz8W4pekL3AI8VohmyZmsWW2PWaHgjsmqR6L13101VQ==",
                     "dev": true
                 },
                 "jest-diff": {
-                    "version": "27.0.2",
-                    "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-27.0.2.tgz",
-                    "integrity": "sha512-BFIdRb0LqfV1hBt8crQmw6gGQHVDhM87SpMIZ45FPYKReZYG5er1+5pIn2zKqvrJp6WNox0ylR8571Iwk2Dmgw==",
+                    "version": "27.0.6",
+                    "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-27.0.6.tgz",
+                    "integrity": "sha512-Z1mqgkTCSYaFgwTlP/NUiRzdqgxmmhzHY1Tq17zL94morOHfHu3K4bgSgl+CR4GLhpV8VxkuOYuIWnQ9LnFqmg==",
                     "dev": true,
                     "requires": {
                         "chalk": "^4.0.0",
-                        "diff-sequences": "^27.0.1",
-                        "jest-get-type": "^27.0.1",
-                        "pretty-format": "^27.0.2"
+                        "diff-sequences": "^27.0.6",
+                        "jest-get-type": "^27.0.6",
+                        "pretty-format": "^27.0.6"
                     }
                 },
                 "jest-get-type": {
-                    "version": "27.0.1",
-                    "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-27.0.1.tgz",
-                    "integrity": "sha512-9Tggo9zZbu0sHKebiAijyt1NM77Z0uO4tuWOxUCujAiSeXv30Vb5D4xVF4UR4YWNapcftj+PbByU54lKD7/xMg==",
+                    "version": "27.0.6",
+                    "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-27.0.6.tgz",
+                    "integrity": "sha512-XTkK5exIeUbbveehcSR8w0bhH+c0yloW/Wpl+9vZrjzztCPWrxhHwkIFpZzCt71oRBsgxmuUfxEqOYoZI2macg==",
                     "dev": true
                 },
                 "pretty-format": {
-                    "version": "27.0.2",
-                    "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.0.2.tgz",
-                    "integrity": "sha512-mXKbbBPnYTG7Yra9qFBtqj+IXcsvxsvOBco3QHxtxTl+hHKq6QdzMZ+q0CtL4ORHZgwGImRr2XZUX2EWzORxig==",
+                    "version": "27.0.6",
+                    "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.0.6.tgz",
+                    "integrity": "sha512-8tGD7gBIENgzqA+UBzObyWqQ5B778VIFZA/S66cclyd5YkFLYs2Js7gxDKf0MXtTc9zcS7t1xhdfcElJ3YIvkQ==",
                     "dev": true,
                     "requires": {
-                        "@jest/types": "^27.0.2",
+                        "@jest/types": "^27.0.6",
                         "ansi-regex": "^5.0.0",
                         "ansi-styles": "^5.0.0",
                         "react-is": "^17.0.1"
@@ -2903,26 +2903,26 @@
             }
         },
         "jest-message-util": {
-            "version": "27.0.2",
-            "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-27.0.2.tgz",
-            "integrity": "sha512-rTqWUX42ec2LdMkoUPOzrEd1Tcm+R1KfLOmFK+OVNo4MnLsEaxO5zPDb2BbdSmthdM/IfXxOZU60P/WbWF8BTw==",
+            "version": "27.0.6",
+            "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-27.0.6.tgz",
+            "integrity": "sha512-rBxIs2XK7rGy+zGxgi+UJKP6WqQ+KrBbD1YMj517HYN3v2BG66t3Xan3FWqYHKZwjdB700KiAJ+iES9a0M+ixw==",
             "dev": true,
             "requires": {
                 "@babel/code-frame": "^7.12.13",
-                "@jest/types": "^27.0.2",
+                "@jest/types": "^27.0.6",
                 "@types/stack-utils": "^2.0.0",
                 "chalk": "^4.0.0",
                 "graceful-fs": "^4.2.4",
                 "micromatch": "^4.0.4",
-                "pretty-format": "^27.0.2",
+                "pretty-format": "^27.0.6",
                 "slash": "^3.0.0",
                 "stack-utils": "^2.0.3"
             },
             "dependencies": {
                 "@jest/types": {
-                    "version": "27.0.2",
-                    "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.0.2.tgz",
-                    "integrity": "sha512-XpjCtJ/99HB4PmyJ2vgmN7vT+JLP7RW1FBT9RgnMFS4Dt7cvIyBee8O3/j98aUZ34ZpenPZFqmaaObWSeL65dg==",
+                    "version": "27.0.6",
+                    "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.0.6.tgz",
+                    "integrity": "sha512-aSquT1qa9Pik26JK5/3rvnYb4bGtm1VFNesHKmNTwmPIgOrixvhL2ghIvFRNEpzy3gU+rUgjIF/KodbkFAl++g==",
                     "dev": true,
                     "requires": {
                         "@types/istanbul-lib-coverage": "^2.0.0",
@@ -2933,9 +2933,9 @@
                     }
                 },
                 "@types/yargs": {
-                    "version": "16.0.3",
-                    "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-16.0.3.tgz",
-                    "integrity": "sha512-YlFfTGS+zqCgXuXNV26rOIeETOkXnGQXP/pjjL9P0gO/EP9jTmc7pUBhx+jVEIxpq41RX33GQ7N3DzOSfZoglQ==",
+                    "version": "16.0.4",
+                    "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-16.0.4.tgz",
+                    "integrity": "sha512-T8Yc9wt/5LbJyCaLiHPReJa0kApcIgJ7Bn735GjItUfh08Z1pJvu8QZqb9s+mMvKV6WUQRV7K2R46YbjMXTTJw==",
                     "dev": true,
                     "requires": {
                         "@types/yargs-parser": "*"
@@ -2948,12 +2948,12 @@
                     "dev": true
                 },
                 "pretty-format": {
-                    "version": "27.0.2",
-                    "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.0.2.tgz",
-                    "integrity": "sha512-mXKbbBPnYTG7Yra9qFBtqj+IXcsvxsvOBco3QHxtxTl+hHKq6QdzMZ+q0CtL4ORHZgwGImRr2XZUX2EWzORxig==",
+                    "version": "27.0.6",
+                    "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.0.6.tgz",
+                    "integrity": "sha512-8tGD7gBIENgzqA+UBzObyWqQ5B778VIFZA/S66cclyd5YkFLYs2Js7gxDKf0MXtTc9zcS7t1xhdfcElJ3YIvkQ==",
                     "dev": true,
                     "requires": {
-                        "@jest/types": "^27.0.2",
+                        "@jest/types": "^27.0.6",
                         "ansi-regex": "^5.0.0",
                         "ansi-styles": "^5.0.0",
                         "react-is": "^17.0.1"
@@ -2962,19 +2962,19 @@
             }
         },
         "jest-mock": {
-            "version": "27.0.3",
-            "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-27.0.3.tgz",
-            "integrity": "sha512-O5FZn5XDzEp+Xg28mUz4ovVcdwBBPfAhW9+zJLO0Efn2qNbYcDaJvSlRiQ6BCZUCVOJjALicuJQI9mRFjv1o9Q==",
+            "version": "27.0.6",
+            "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-27.0.6.tgz",
+            "integrity": "sha512-lzBETUoK8cSxts2NYXSBWT+EJNzmUVtVVwS1sU9GwE1DLCfGsngg+ZVSIe0yd0ZSm+y791esiuo+WSwpXJQ5Bw==",
             "dev": true,
             "requires": {
-                "@jest/types": "^27.0.2",
+                "@jest/types": "^27.0.6",
                 "@types/node": "*"
             },
             "dependencies": {
                 "@jest/types": {
-                    "version": "27.0.2",
-                    "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.0.2.tgz",
-                    "integrity": "sha512-XpjCtJ/99HB4PmyJ2vgmN7vT+JLP7RW1FBT9RgnMFS4Dt7cvIyBee8O3/j98aUZ34ZpenPZFqmaaObWSeL65dg==",
+                    "version": "27.0.6",
+                    "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.0.6.tgz",
+                    "integrity": "sha512-aSquT1qa9Pik26JK5/3rvnYb4bGtm1VFNesHKmNTwmPIgOrixvhL2ghIvFRNEpzy3gU+rUgjIF/KodbkFAl++g==",
                     "dev": true,
                     "requires": {
                         "@types/istanbul-lib-coverage": "^2.0.0",
@@ -2985,9 +2985,9 @@
                     }
                 },
                 "@types/yargs": {
-                    "version": "16.0.3",
-                    "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-16.0.3.tgz",
-                    "integrity": "sha512-YlFfTGS+zqCgXuXNV26rOIeETOkXnGQXP/pjjL9P0gO/EP9jTmc7pUBhx+jVEIxpq41RX33GQ7N3DzOSfZoglQ==",
+                    "version": "16.0.4",
+                    "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-16.0.4.tgz",
+                    "integrity": "sha512-T8Yc9wt/5LbJyCaLiHPReJa0kApcIgJ7Bn735GjItUfh08Z1pJvu8QZqb9s+mMvKV6WUQRV7K2R46YbjMXTTJw==",
                     "dev": true,
                     "requires": {
                         "@types/yargs-parser": "*"
@@ -3002,32 +3002,32 @@
             "dev": true
         },
         "jest-regex-util": {
-            "version": "27.0.1",
-            "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-27.0.1.tgz",
-            "integrity": "sha512-6nY6QVcpTgEKQy1L41P4pr3aOddneK17kn3HJw6SdwGiKfgCGTvH02hVXL0GU8GEKtPH83eD2DIDgxHXOxVohQ==",
+            "version": "27.0.6",
+            "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-27.0.6.tgz",
+            "integrity": "sha512-SUhPzBsGa1IKm8hx2F4NfTGGp+r7BXJ4CulsZ1k2kI+mGLG+lxGrs76veN2LF/aUdGosJBzKgXmNCw+BzFqBDQ==",
             "dev": true
         },
         "jest-resolve": {
-            "version": "27.0.4",
-            "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-27.0.4.tgz",
-            "integrity": "sha512-BcfyK2i3cG79PDb/6gB6zFeFQlcqLsQjGBqznFCpA0L/3l1L/oOsltdUjs5eISAWA9HS9qtj8v2PSZr/yWxONQ==",
+            "version": "27.0.6",
+            "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-27.0.6.tgz",
+            "integrity": "sha512-yKmIgw2LgTh7uAJtzv8UFHGF7Dm7XfvOe/LQ3Txv101fLM8cx2h1QVwtSJ51Q/SCxpIiKfVn6G2jYYMDNHZteA==",
             "dev": true,
             "requires": {
-                "@jest/types": "^27.0.2",
+                "@jest/types": "^27.0.6",
                 "chalk": "^4.0.0",
                 "escalade": "^3.1.1",
                 "graceful-fs": "^4.2.4",
                 "jest-pnp-resolver": "^1.2.2",
-                "jest-util": "^27.0.2",
-                "jest-validate": "^27.0.2",
+                "jest-util": "^27.0.6",
+                "jest-validate": "^27.0.6",
                 "resolve": "^1.20.0",
                 "slash": "^3.0.0"
             },
             "dependencies": {
                 "@jest/types": {
-                    "version": "27.0.2",
-                    "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.0.2.tgz",
-                    "integrity": "sha512-XpjCtJ/99HB4PmyJ2vgmN7vT+JLP7RW1FBT9RgnMFS4Dt7cvIyBee8O3/j98aUZ34ZpenPZFqmaaObWSeL65dg==",
+                    "version": "27.0.6",
+                    "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.0.6.tgz",
+                    "integrity": "sha512-aSquT1qa9Pik26JK5/3rvnYb4bGtm1VFNesHKmNTwmPIgOrixvhL2ghIvFRNEpzy3gU+rUgjIF/KodbkFAl++g==",
                     "dev": true,
                     "requires": {
                         "@types/istanbul-lib-coverage": "^2.0.0",
@@ -3038,9 +3038,9 @@
                     }
                 },
                 "@types/yargs": {
-                    "version": "16.0.3",
-                    "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-16.0.3.tgz",
-                    "integrity": "sha512-YlFfTGS+zqCgXuXNV26rOIeETOkXnGQXP/pjjL9P0gO/EP9jTmc7pUBhx+jVEIxpq41RX33GQ7N3DzOSfZoglQ==",
+                    "version": "16.0.4",
+                    "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-16.0.4.tgz",
+                    "integrity": "sha512-T8Yc9wt/5LbJyCaLiHPReJa0kApcIgJ7Bn735GjItUfh08Z1pJvu8QZqb9s+mMvKV6WUQRV7K2R46YbjMXTTJw==",
                     "dev": true,
                     "requires": {
                         "@types/yargs-parser": "*"
@@ -3049,20 +3049,20 @@
             }
         },
         "jest-resolve-dependencies": {
-            "version": "27.0.4",
-            "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-27.0.4.tgz",
-            "integrity": "sha512-F33UPfw1YGWCV2uxJl7wD6TvcQn5IC0LtguwY3r4L7R6H4twpLkp5Q2ZfzRx9A2I3G8feiy0O0sqcn/Qoym71A==",
+            "version": "27.0.6",
+            "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-27.0.6.tgz",
+            "integrity": "sha512-mg9x9DS3BPAREWKCAoyg3QucCr0n6S8HEEsqRCKSPjPcu9HzRILzhdzY3imsLoZWeosEbJZz6TKasveczzpJZA==",
             "dev": true,
             "requires": {
-                "@jest/types": "^27.0.2",
-                "jest-regex-util": "^27.0.1",
-                "jest-snapshot": "^27.0.4"
+                "@jest/types": "^27.0.6",
+                "jest-regex-util": "^27.0.6",
+                "jest-snapshot": "^27.0.6"
             },
             "dependencies": {
                 "@jest/types": {
-                    "version": "27.0.2",
-                    "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.0.2.tgz",
-                    "integrity": "sha512-XpjCtJ/99HB4PmyJ2vgmN7vT+JLP7RW1FBT9RgnMFS4Dt7cvIyBee8O3/j98aUZ34ZpenPZFqmaaObWSeL65dg==",
+                    "version": "27.0.6",
+                    "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.0.6.tgz",
+                    "integrity": "sha512-aSquT1qa9Pik26JK5/3rvnYb4bGtm1VFNesHKmNTwmPIgOrixvhL2ghIvFRNEpzy3gU+rUgjIF/KodbkFAl++g==",
                     "dev": true,
                     "requires": {
                         "@types/istanbul-lib-coverage": "^2.0.0",
@@ -3073,9 +3073,9 @@
                     }
                 },
                 "@types/yargs": {
-                    "version": "16.0.3",
-                    "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-16.0.3.tgz",
-                    "integrity": "sha512-YlFfTGS+zqCgXuXNV26rOIeETOkXnGQXP/pjjL9P0gO/EP9jTmc7pUBhx+jVEIxpq41RX33GQ7N3DzOSfZoglQ==",
+                    "version": "16.0.4",
+                    "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-16.0.4.tgz",
+                    "integrity": "sha512-T8Yc9wt/5LbJyCaLiHPReJa0kApcIgJ7Bn735GjItUfh08Z1pJvu8QZqb9s+mMvKV6WUQRV7K2R46YbjMXTTJw==",
                     "dev": true,
                     "requires": {
                         "@types/yargs-parser": "*"
@@ -3084,39 +3084,39 @@
             }
         },
         "jest-runner": {
-            "version": "27.0.4",
-            "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-27.0.4.tgz",
-            "integrity": "sha512-NfmvSYLCsCJk2AG8Ar2NAh4PhsJJpO+/r+g4bKR5L/5jFzx/indUpnVBdrfDvuqhGLLAvrKJ9FM/Nt8o1dsqxg==",
+            "version": "27.0.6",
+            "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-27.0.6.tgz",
+            "integrity": "sha512-W3Bz5qAgaSChuivLn+nKOgjqNxM7O/9JOJoKDCqThPIg2sH/d4A/lzyiaFgnb9V1/w29Le11NpzTJSzga1vyYQ==",
             "dev": true,
             "requires": {
-                "@jest/console": "^27.0.2",
-                "@jest/environment": "^27.0.3",
-                "@jest/test-result": "^27.0.2",
-                "@jest/transform": "^27.0.2",
-                "@jest/types": "^27.0.2",
+                "@jest/console": "^27.0.6",
+                "@jest/environment": "^27.0.6",
+                "@jest/test-result": "^27.0.6",
+                "@jest/transform": "^27.0.6",
+                "@jest/types": "^27.0.6",
                 "@types/node": "*",
                 "chalk": "^4.0.0",
                 "emittery": "^0.8.1",
                 "exit": "^0.1.2",
                 "graceful-fs": "^4.2.4",
-                "jest-docblock": "^27.0.1",
-                "jest-environment-jsdom": "^27.0.3",
-                "jest-environment-node": "^27.0.3",
-                "jest-haste-map": "^27.0.2",
-                "jest-leak-detector": "^27.0.2",
-                "jest-message-util": "^27.0.2",
-                "jest-resolve": "^27.0.4",
-                "jest-runtime": "^27.0.4",
-                "jest-util": "^27.0.2",
-                "jest-worker": "^27.0.2",
+                "jest-docblock": "^27.0.6",
+                "jest-environment-jsdom": "^27.0.6",
+                "jest-environment-node": "^27.0.6",
+                "jest-haste-map": "^27.0.6",
+                "jest-leak-detector": "^27.0.6",
+                "jest-message-util": "^27.0.6",
+                "jest-resolve": "^27.0.6",
+                "jest-runtime": "^27.0.6",
+                "jest-util": "^27.0.6",
+                "jest-worker": "^27.0.6",
                 "source-map-support": "^0.5.6",
                 "throat": "^6.0.1"
             },
             "dependencies": {
                 "@jest/types": {
-                    "version": "27.0.2",
-                    "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.0.2.tgz",
-                    "integrity": "sha512-XpjCtJ/99HB4PmyJ2vgmN7vT+JLP7RW1FBT9RgnMFS4Dt7cvIyBee8O3/j98aUZ34ZpenPZFqmaaObWSeL65dg==",
+                    "version": "27.0.6",
+                    "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.0.6.tgz",
+                    "integrity": "sha512-aSquT1qa9Pik26JK5/3rvnYb4bGtm1VFNesHKmNTwmPIgOrixvhL2ghIvFRNEpzy3gU+rUgjIF/KodbkFAl++g==",
                     "dev": true,
                     "requires": {
                         "@types/istanbul-lib-coverage": "^2.0.0",
@@ -3127,9 +3127,9 @@
                     }
                 },
                 "@types/yargs": {
-                    "version": "16.0.3",
-                    "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-16.0.3.tgz",
-                    "integrity": "sha512-YlFfTGS+zqCgXuXNV26rOIeETOkXnGQXP/pjjL9P0gO/EP9jTmc7pUBhx+jVEIxpq41RX33GQ7N3DzOSfZoglQ==",
+                    "version": "16.0.4",
+                    "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-16.0.4.tgz",
+                    "integrity": "sha512-T8Yc9wt/5LbJyCaLiHPReJa0kApcIgJ7Bn735GjItUfh08Z1pJvu8QZqb9s+mMvKV6WUQRV7K2R46YbjMXTTJw==",
                     "dev": true,
                     "requires": {
                         "@types/yargs-parser": "*"
@@ -3138,19 +3138,19 @@
             }
         },
         "jest-runtime": {
-            "version": "27.0.4",
-            "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-27.0.4.tgz",
-            "integrity": "sha512-voJB4xbAjS/qYPboV+e+gmg3jfvHJJY4CagFWBOM9dQKtlaiTjcpD2tWwla84Z7PtXSQPeIpXY0qksA9Dum29A==",
+            "version": "27.0.6",
+            "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-27.0.6.tgz",
+            "integrity": "sha512-BhvHLRVfKibYyqqEFkybsznKwhrsu7AWx2F3y9G9L95VSIN3/ZZ9vBpm/XCS2bS+BWz3sSeNGLzI3TVQ0uL85Q==",
             "dev": true,
             "requires": {
-                "@jest/console": "^27.0.2",
-                "@jest/environment": "^27.0.3",
-                "@jest/fake-timers": "^27.0.3",
-                "@jest/globals": "^27.0.3",
-                "@jest/source-map": "^27.0.1",
-                "@jest/test-result": "^27.0.2",
-                "@jest/transform": "^27.0.2",
-                "@jest/types": "^27.0.2",
+                "@jest/console": "^27.0.6",
+                "@jest/environment": "^27.0.6",
+                "@jest/fake-timers": "^27.0.6",
+                "@jest/globals": "^27.0.6",
+                "@jest/source-map": "^27.0.6",
+                "@jest/test-result": "^27.0.6",
+                "@jest/transform": "^27.0.6",
+                "@jest/types": "^27.0.6",
                 "@types/yargs": "^16.0.0",
                 "chalk": "^4.0.0",
                 "cjs-module-lexer": "^1.0.0",
@@ -3158,23 +3158,23 @@
                 "exit": "^0.1.2",
                 "glob": "^7.1.3",
                 "graceful-fs": "^4.2.4",
-                "jest-haste-map": "^27.0.2",
-                "jest-message-util": "^27.0.2",
-                "jest-mock": "^27.0.3",
-                "jest-regex-util": "^27.0.1",
-                "jest-resolve": "^27.0.4",
-                "jest-snapshot": "^27.0.4",
-                "jest-util": "^27.0.2",
-                "jest-validate": "^27.0.2",
+                "jest-haste-map": "^27.0.6",
+                "jest-message-util": "^27.0.6",
+                "jest-mock": "^27.0.6",
+                "jest-regex-util": "^27.0.6",
+                "jest-resolve": "^27.0.6",
+                "jest-snapshot": "^27.0.6",
+                "jest-util": "^27.0.6",
+                "jest-validate": "^27.0.6",
                 "slash": "^3.0.0",
                 "strip-bom": "^4.0.0",
                 "yargs": "^16.0.3"
             },
             "dependencies": {
                 "@jest/types": {
-                    "version": "27.0.2",
-                    "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.0.2.tgz",
-                    "integrity": "sha512-XpjCtJ/99HB4PmyJ2vgmN7vT+JLP7RW1FBT9RgnMFS4Dt7cvIyBee8O3/j98aUZ34ZpenPZFqmaaObWSeL65dg==",
+                    "version": "27.0.6",
+                    "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.0.6.tgz",
+                    "integrity": "sha512-aSquT1qa9Pik26JK5/3rvnYb4bGtm1VFNesHKmNTwmPIgOrixvhL2ghIvFRNEpzy3gU+rUgjIF/KodbkFAl++g==",
                     "dev": true,
                     "requires": {
                         "@types/istanbul-lib-coverage": "^2.0.0",
@@ -3185,9 +3185,9 @@
                     }
                 },
                 "@types/yargs": {
-                    "version": "16.0.3",
-                    "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-16.0.3.tgz",
-                    "integrity": "sha512-YlFfTGS+zqCgXuXNV26rOIeETOkXnGQXP/pjjL9P0gO/EP9jTmc7pUBhx+jVEIxpq41RX33GQ7N3DzOSfZoglQ==",
+                    "version": "16.0.4",
+                    "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-16.0.4.tgz",
+                    "integrity": "sha512-T8Yc9wt/5LbJyCaLiHPReJa0kApcIgJ7Bn735GjItUfh08Z1pJvu8QZqb9s+mMvKV6WUQRV7K2R46YbjMXTTJw==",
                     "dev": true,
                     "requires": {
                         "@types/yargs-parser": "*"
@@ -3196,9 +3196,9 @@
             }
         },
         "jest-serializer": {
-            "version": "27.0.1",
-            "resolved": "https://registry.npmjs.org/jest-serializer/-/jest-serializer-27.0.1.tgz",
-            "integrity": "sha512-svy//5IH6bfQvAbkAEg1s7xhhgHTtXu0li0I2fdKHDsLP2P2MOiscPQIENQep8oU2g2B3jqLyxKKzotZOz4CwQ==",
+            "version": "27.0.6",
+            "resolved": "https://registry.npmjs.org/jest-serializer/-/jest-serializer-27.0.6.tgz",
+            "integrity": "sha512-PtGdVK9EGC7dsaziskfqaAPib6wTViY3G8E5wz9tLVPhHyiDNTZn/xjZ4khAw+09QkoOVpn7vF5nPSN6dtBexA==",
             "dev": true,
             "requires": {
                 "@types/node": "*",
@@ -3206,9 +3206,9 @@
             }
         },
         "jest-snapshot": {
-            "version": "27.0.4",
-            "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-27.0.4.tgz",
-            "integrity": "sha512-hnjrvpKGdSMvKfbHyaG5Kul7pDJGZvjVy0CKpzhu28MmAssDXS6GpynhXzgst1wBQoKD8c9b2VS2a5yhDLQRCA==",
+            "version": "27.0.6",
+            "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-27.0.6.tgz",
+            "integrity": "sha512-NTHaz8He+ATUagUgE7C/UtFcRoHqR2Gc+KDfhQIyx+VFgwbeEMjeP+ILpUTLosZn/ZtbNdCF5LkVnN/l+V751A==",
             "dev": true,
             "requires": {
                 "@babel/core": "^7.7.2",
@@ -3217,30 +3217,30 @@
                 "@babel/plugin-syntax-typescript": "^7.7.2",
                 "@babel/traverse": "^7.7.2",
                 "@babel/types": "^7.0.0",
-                "@jest/transform": "^27.0.2",
-                "@jest/types": "^27.0.2",
+                "@jest/transform": "^27.0.6",
+                "@jest/types": "^27.0.6",
                 "@types/babel__traverse": "^7.0.4",
                 "@types/prettier": "^2.1.5",
                 "babel-preset-current-node-syntax": "^1.0.0",
                 "chalk": "^4.0.0",
-                "expect": "^27.0.2",
+                "expect": "^27.0.6",
                 "graceful-fs": "^4.2.4",
-                "jest-diff": "^27.0.2",
-                "jest-get-type": "^27.0.1",
-                "jest-haste-map": "^27.0.2",
-                "jest-matcher-utils": "^27.0.2",
-                "jest-message-util": "^27.0.2",
-                "jest-resolve": "^27.0.4",
-                "jest-util": "^27.0.2",
+                "jest-diff": "^27.0.6",
+                "jest-get-type": "^27.0.6",
+                "jest-haste-map": "^27.0.6",
+                "jest-matcher-utils": "^27.0.6",
+                "jest-message-util": "^27.0.6",
+                "jest-resolve": "^27.0.6",
+                "jest-util": "^27.0.6",
                 "natural-compare": "^1.4.0",
-                "pretty-format": "^27.0.2",
+                "pretty-format": "^27.0.6",
                 "semver": "^7.3.2"
             },
             "dependencies": {
                 "@jest/types": {
-                    "version": "27.0.2",
-                    "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.0.2.tgz",
-                    "integrity": "sha512-XpjCtJ/99HB4PmyJ2vgmN7vT+JLP7RW1FBT9RgnMFS4Dt7cvIyBee8O3/j98aUZ34ZpenPZFqmaaObWSeL65dg==",
+                    "version": "27.0.6",
+                    "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.0.6.tgz",
+                    "integrity": "sha512-aSquT1qa9Pik26JK5/3rvnYb4bGtm1VFNesHKmNTwmPIgOrixvhL2ghIvFRNEpzy3gU+rUgjIF/KodbkFAl++g==",
                     "dev": true,
                     "requires": {
                         "@types/istanbul-lib-coverage": "^2.0.0",
@@ -3251,9 +3251,9 @@
                     }
                 },
                 "@types/yargs": {
-                    "version": "16.0.3",
-                    "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-16.0.3.tgz",
-                    "integrity": "sha512-YlFfTGS+zqCgXuXNV26rOIeETOkXnGQXP/pjjL9P0gO/EP9jTmc7pUBhx+jVEIxpq41RX33GQ7N3DzOSfZoglQ==",
+                    "version": "16.0.4",
+                    "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-16.0.4.tgz",
+                    "integrity": "sha512-T8Yc9wt/5LbJyCaLiHPReJa0kApcIgJ7Bn735GjItUfh08Z1pJvu8QZqb9s+mMvKV6WUQRV7K2R46YbjMXTTJw==",
                     "dev": true,
                     "requires": {
                         "@types/yargs-parser": "*"
@@ -3266,36 +3266,36 @@
                     "dev": true
                 },
                 "diff-sequences": {
-                    "version": "27.0.1",
-                    "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-27.0.1.tgz",
-                    "integrity": "sha512-XPLijkfJUh/PIBnfkcSHgvD6tlYixmcMAn3osTk6jt+H0v/mgURto1XUiD9DKuGX5NDoVS6dSlA23gd9FUaCFg==",
+                    "version": "27.0.6",
+                    "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-27.0.6.tgz",
+                    "integrity": "sha512-ag6wfpBFyNXZ0p8pcuIDS//D8H062ZQJ3fzYxjpmeKjnz8W4pekL3AI8VohmyZmsWW2PWaHgjsmqR6L13101VQ==",
                     "dev": true
                 },
                 "jest-diff": {
-                    "version": "27.0.2",
-                    "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-27.0.2.tgz",
-                    "integrity": "sha512-BFIdRb0LqfV1hBt8crQmw6gGQHVDhM87SpMIZ45FPYKReZYG5er1+5pIn2zKqvrJp6WNox0ylR8571Iwk2Dmgw==",
+                    "version": "27.0.6",
+                    "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-27.0.6.tgz",
+                    "integrity": "sha512-Z1mqgkTCSYaFgwTlP/NUiRzdqgxmmhzHY1Tq17zL94morOHfHu3K4bgSgl+CR4GLhpV8VxkuOYuIWnQ9LnFqmg==",
                     "dev": true,
                     "requires": {
                         "chalk": "^4.0.0",
-                        "diff-sequences": "^27.0.1",
-                        "jest-get-type": "^27.0.1",
-                        "pretty-format": "^27.0.2"
+                        "diff-sequences": "^27.0.6",
+                        "jest-get-type": "^27.0.6",
+                        "pretty-format": "^27.0.6"
                     }
                 },
                 "jest-get-type": {
-                    "version": "27.0.1",
-                    "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-27.0.1.tgz",
-                    "integrity": "sha512-9Tggo9zZbu0sHKebiAijyt1NM77Z0uO4tuWOxUCujAiSeXv30Vb5D4xVF4UR4YWNapcftj+PbByU54lKD7/xMg==",
+                    "version": "27.0.6",
+                    "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-27.0.6.tgz",
+                    "integrity": "sha512-XTkK5exIeUbbveehcSR8w0bhH+c0yloW/Wpl+9vZrjzztCPWrxhHwkIFpZzCt71oRBsgxmuUfxEqOYoZI2macg==",
                     "dev": true
                 },
                 "pretty-format": {
-                    "version": "27.0.2",
-                    "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.0.2.tgz",
-                    "integrity": "sha512-mXKbbBPnYTG7Yra9qFBtqj+IXcsvxsvOBco3QHxtxTl+hHKq6QdzMZ+q0CtL4ORHZgwGImRr2XZUX2EWzORxig==",
+                    "version": "27.0.6",
+                    "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.0.6.tgz",
+                    "integrity": "sha512-8tGD7gBIENgzqA+UBzObyWqQ5B778VIFZA/S66cclyd5YkFLYs2Js7gxDKf0MXtTc9zcS7t1xhdfcElJ3YIvkQ==",
                     "dev": true,
                     "requires": {
-                        "@jest/types": "^27.0.2",
+                        "@jest/types": "^27.0.6",
                         "ansi-regex": "^5.0.0",
                         "ansi-styles": "^5.0.0",
                         "react-is": "^17.0.1"
@@ -3313,12 +3313,12 @@
             }
         },
         "jest-util": {
-            "version": "27.0.2",
-            "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-27.0.2.tgz",
-            "integrity": "sha512-1d9uH3a00OFGGWSibpNYr+jojZ6AckOMCXV2Z4K3YXDnzpkAaXQyIpY14FOJPiUmil7CD+A6Qs+lnnh6ctRbIA==",
+            "version": "27.0.6",
+            "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-27.0.6.tgz",
+            "integrity": "sha512-1JjlaIh+C65H/F7D11GNkGDDZtDfMEM8EBXsvd+l/cxtgQ6QhxuloOaiayt89DxUvDarbVhqI98HhgrM1yliFQ==",
             "dev": true,
             "requires": {
-                "@jest/types": "^27.0.2",
+                "@jest/types": "^27.0.6",
                 "@types/node": "*",
                 "chalk": "^4.0.0",
                 "graceful-fs": "^4.2.4",
@@ -3327,9 +3327,9 @@
             },
             "dependencies": {
                 "@jest/types": {
-                    "version": "27.0.2",
-                    "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.0.2.tgz",
-                    "integrity": "sha512-XpjCtJ/99HB4PmyJ2vgmN7vT+JLP7RW1FBT9RgnMFS4Dt7cvIyBee8O3/j98aUZ34ZpenPZFqmaaObWSeL65dg==",
+                    "version": "27.0.6",
+                    "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.0.6.tgz",
+                    "integrity": "sha512-aSquT1qa9Pik26JK5/3rvnYb4bGtm1VFNesHKmNTwmPIgOrixvhL2ghIvFRNEpzy3gU+rUgjIF/KodbkFAl++g==",
                     "dev": true,
                     "requires": {
                         "@types/istanbul-lib-coverage": "^2.0.0",
@@ -3340,9 +3340,9 @@
                     }
                 },
                 "@types/yargs": {
-                    "version": "16.0.3",
-                    "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-16.0.3.tgz",
-                    "integrity": "sha512-YlFfTGS+zqCgXuXNV26rOIeETOkXnGQXP/pjjL9P0gO/EP9jTmc7pUBhx+jVEIxpq41RX33GQ7N3DzOSfZoglQ==",
+                    "version": "16.0.4",
+                    "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-16.0.4.tgz",
+                    "integrity": "sha512-T8Yc9wt/5LbJyCaLiHPReJa0kApcIgJ7Bn735GjItUfh08Z1pJvu8QZqb9s+mMvKV6WUQRV7K2R46YbjMXTTJw==",
                     "dev": true,
                     "requires": {
                         "@types/yargs-parser": "*"
@@ -3351,23 +3351,23 @@
             }
         },
         "jest-validate": {
-            "version": "27.0.2",
-            "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-27.0.2.tgz",
-            "integrity": "sha512-UgBF6/oVu1ofd1XbaSotXKihi8nZhg0Prm8twQ9uCuAfo59vlxCXMPI/RKmrZEVgi3Nd9dS0I8A0wzWU48pOvg==",
+            "version": "27.0.6",
+            "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-27.0.6.tgz",
+            "integrity": "sha512-yhZZOaMH3Zg6DC83n60pLmdU1DQE46DW+KLozPiPbSbPhlXXaiUTDlhHQhHFpaqIFRrInko1FHXjTRpjWRuWfA==",
             "dev": true,
             "requires": {
-                "@jest/types": "^27.0.2",
+                "@jest/types": "^27.0.6",
                 "camelcase": "^6.2.0",
                 "chalk": "^4.0.0",
-                "jest-get-type": "^27.0.1",
+                "jest-get-type": "^27.0.6",
                 "leven": "^3.1.0",
-                "pretty-format": "^27.0.2"
+                "pretty-format": "^27.0.6"
             },
             "dependencies": {
                 "@jest/types": {
-                    "version": "27.0.2",
-                    "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.0.2.tgz",
-                    "integrity": "sha512-XpjCtJ/99HB4PmyJ2vgmN7vT+JLP7RW1FBT9RgnMFS4Dt7cvIyBee8O3/j98aUZ34ZpenPZFqmaaObWSeL65dg==",
+                    "version": "27.0.6",
+                    "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.0.6.tgz",
+                    "integrity": "sha512-aSquT1qa9Pik26JK5/3rvnYb4bGtm1VFNesHKmNTwmPIgOrixvhL2ghIvFRNEpzy3gU+rUgjIF/KodbkFAl++g==",
                     "dev": true,
                     "requires": {
                         "@types/istanbul-lib-coverage": "^2.0.0",
@@ -3378,9 +3378,9 @@
                     }
                 },
                 "@types/yargs": {
-                    "version": "16.0.3",
-                    "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-16.0.3.tgz",
-                    "integrity": "sha512-YlFfTGS+zqCgXuXNV26rOIeETOkXnGQXP/pjjL9P0gO/EP9jTmc7pUBhx+jVEIxpq41RX33GQ7N3DzOSfZoglQ==",
+                    "version": "16.0.4",
+                    "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-16.0.4.tgz",
+                    "integrity": "sha512-T8Yc9wt/5LbJyCaLiHPReJa0kApcIgJ7Bn735GjItUfh08Z1pJvu8QZqb9s+mMvKV6WUQRV7K2R46YbjMXTTJw==",
                     "dev": true,
                     "requires": {
                         "@types/yargs-parser": "*"
@@ -3399,18 +3399,18 @@
                     "dev": true
                 },
                 "jest-get-type": {
-                    "version": "27.0.1",
-                    "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-27.0.1.tgz",
-                    "integrity": "sha512-9Tggo9zZbu0sHKebiAijyt1NM77Z0uO4tuWOxUCujAiSeXv30Vb5D4xVF4UR4YWNapcftj+PbByU54lKD7/xMg==",
+                    "version": "27.0.6",
+                    "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-27.0.6.tgz",
+                    "integrity": "sha512-XTkK5exIeUbbveehcSR8w0bhH+c0yloW/Wpl+9vZrjzztCPWrxhHwkIFpZzCt71oRBsgxmuUfxEqOYoZI2macg==",
                     "dev": true
                 },
                 "pretty-format": {
-                    "version": "27.0.2",
-                    "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.0.2.tgz",
-                    "integrity": "sha512-mXKbbBPnYTG7Yra9qFBtqj+IXcsvxsvOBco3QHxtxTl+hHKq6QdzMZ+q0CtL4ORHZgwGImRr2XZUX2EWzORxig==",
+                    "version": "27.0.6",
+                    "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.0.6.tgz",
+                    "integrity": "sha512-8tGD7gBIENgzqA+UBzObyWqQ5B778VIFZA/S66cclyd5YkFLYs2Js7gxDKf0MXtTc9zcS7t1xhdfcElJ3YIvkQ==",
                     "dev": true,
                     "requires": {
-                        "@jest/types": "^27.0.2",
+                        "@jest/types": "^27.0.6",
                         "ansi-regex": "^5.0.0",
                         "ansi-styles": "^5.0.0",
                         "react-is": "^17.0.1"
@@ -3419,24 +3419,24 @@
             }
         },
         "jest-watcher": {
-            "version": "27.0.2",
-            "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-27.0.2.tgz",
-            "integrity": "sha512-8nuf0PGuTxWj/Ytfw5fyvNn/R80iXY8QhIT0ofyImUvdnoaBdT6kob0GmhXR+wO+ALYVnh8bQxN4Tjfez0JgkA==",
+            "version": "27.0.6",
+            "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-27.0.6.tgz",
+            "integrity": "sha512-/jIoKBhAP00/iMGnTwUBLgvxkn7vsOweDrOTSPzc7X9uOyUtJIDthQBTI1EXz90bdkrxorUZVhJwiB69gcHtYQ==",
             "dev": true,
             "requires": {
-                "@jest/test-result": "^27.0.2",
-                "@jest/types": "^27.0.2",
+                "@jest/test-result": "^27.0.6",
+                "@jest/types": "^27.0.6",
                 "@types/node": "*",
                 "ansi-escapes": "^4.2.1",
                 "chalk": "^4.0.0",
-                "jest-util": "^27.0.2",
+                "jest-util": "^27.0.6",
                 "string-length": "^4.0.1"
             },
             "dependencies": {
                 "@jest/types": {
-                    "version": "27.0.2",
-                    "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.0.2.tgz",
-                    "integrity": "sha512-XpjCtJ/99HB4PmyJ2vgmN7vT+JLP7RW1FBT9RgnMFS4Dt7cvIyBee8O3/j98aUZ34ZpenPZFqmaaObWSeL65dg==",
+                    "version": "27.0.6",
+                    "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.0.6.tgz",
+                    "integrity": "sha512-aSquT1qa9Pik26JK5/3rvnYb4bGtm1VFNesHKmNTwmPIgOrixvhL2ghIvFRNEpzy3gU+rUgjIF/KodbkFAl++g==",
                     "dev": true,
                     "requires": {
                         "@types/istanbul-lib-coverage": "^2.0.0",
@@ -3447,9 +3447,9 @@
                     }
                 },
                 "@types/yargs": {
-                    "version": "16.0.3",
-                    "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-16.0.3.tgz",
-                    "integrity": "sha512-YlFfTGS+zqCgXuXNV26rOIeETOkXnGQXP/pjjL9P0gO/EP9jTmc7pUBhx+jVEIxpq41RX33GQ7N3DzOSfZoglQ==",
+                    "version": "16.0.4",
+                    "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-16.0.4.tgz",
+                    "integrity": "sha512-T8Yc9wt/5LbJyCaLiHPReJa0kApcIgJ7Bn735GjItUfh08Z1pJvu8QZqb9s+mMvKV6WUQRV7K2R46YbjMXTTJw==",
                     "dev": true,
                     "requires": {
                         "@types/yargs-parser": "*"
@@ -3458,9 +3458,9 @@
             }
         },
         "jest-worker": {
-            "version": "27.0.2",
-            "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.0.2.tgz",
-            "integrity": "sha512-EoBdilOTTyOgmHXtw/cPc+ZrCA0KJMrkXzkrPGNwLmnvvlN1nj7MPrxpT7m+otSv2e1TLaVffzDnE/LB14zJMg==",
+            "version": "27.0.6",
+            "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.0.6.tgz",
+            "integrity": "sha512-qupxcj/dRuA3xHPMUd40gr2EaAurFbkwzOh7wfPaeE9id7hyjURRQoqNfHifHK3XjJU6YJJUQKILGUnwGPEOCA==",
             "dev": true,
             "requires": {
                 "@types/node": "*",
@@ -3732,9 +3732,9 @@
             "dev": true
         },
         "object-inspect": {
-            "version": "1.10.3",
-            "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.10.3.tgz",
-            "integrity": "sha512-e5mCJlSH7poANfC8z8S9s9S2IN5/4Zb3aZ33f5s8YqoazCFzNLloLU8r5VCG+G7WoqLvAAZoVMcy3tp/3X0Plw=="
+            "version": "1.11.0",
+            "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.11.0.tgz",
+            "integrity": "sha512-jp7ikS6Sd3GxQfZJPyH3cjcbJF6GZPClgdV+EFygjFLQ5FmW/dRUnTd9PQ9k0JhoNDabWFbpF1yCdSWCC6gexg=="
         },
         "object-is": {
             "version": "1.1.5",
@@ -3921,9 +3921,9 @@
             "dev": true
         },
         "readdirp": {
-            "version": "3.5.0",
-            "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.5.0.tgz",
-            "integrity": "sha512-cMhu7c/8rdhkHXWsY+osBhfSy0JikwpHK/5+imo+LpeasTF8ouErHrlYkwT0++njiyuDvc7OFY5T3ukvZ8qmFQ==",
+            "version": "3.6.0",
+            "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+            "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
             "requires": {
                 "picomatch": "^2.2.1"
             }
@@ -4317,9 +4317,9 @@
             }
         },
         "typescript": {
-            "version": "4.3.2",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.2.tgz",
-            "integrity": "sha512-zZ4hShnmnoVnAHpVHWpTcxdv7dWP60S2FsydQLV8V5PbS3FifjWFFRiHSWpDJahly88PRyV5teTSLoq4eG7mKw==",
+            "version": "4.3.5",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.5.tgz",
+            "integrity": "sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==",
             "dev": true
         },
         "typescript-char": {
@@ -4369,9 +4369,9 @@
             "dev": true
         },
         "v8-to-istanbul": {
-            "version": "7.1.2",
-            "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-7.1.2.tgz",
-            "integrity": "sha512-TxNb7YEUwkLXCQYeudi6lgQ/SZrzNO4kMdlqVxaZPUIUjCv6iSSypUQX70kNBSERpQ8fk48+d61FXk+tgqcWow==",
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-8.0.0.tgz",
+            "integrity": "sha512-LkmXi8UUNxnCC+JlH7/fsfsKr5AU110l+SYGJimWNkWhxbN5EyeOtm1MJ0hhvqMMOhGwBj1Fp70Yv9i+hX0QAg==",
             "dev": true,
             "requires": {
                 "@types/istanbul-lib-coverage": "^2.0.1",
@@ -4473,9 +4473,9 @@
             "dev": true
         },
         "whatwg-url": {
-            "version": "8.6.0",
-            "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-8.6.0.tgz",
-            "integrity": "sha512-os0KkeeqUOl7ccdDT1qqUcS4KH4tcBTSKK5Nl5WKb2lyxInIZ/CpjkqKa1Ss12mjfdcRX9mHmPPs7/SxG1Hbdw==",
+            "version": "8.7.0",
+            "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-8.7.0.tgz",
+            "integrity": "sha512-gAojqb/m9Q8a5IV96E3fHJM70AzCkgt4uXYX2O7EmuyOnLrViCQlsEBmF9UQIu3/aeAIp2U17rtbpZWNntQqdg==",
             "dev": true,
             "requires": {
                 "lodash": "^4.7.0",
@@ -4553,9 +4553,9 @@
             }
         },
         "ws": {
-            "version": "7.4.6",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.6.tgz",
-            "integrity": "sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==",
+            "version": "7.5.3",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.3.tgz",
+            "integrity": "sha512-kQ/dHIzuLrS6Je9+uv81ueZomEwH0qVYstcAQ4/Z93K8zeko9gtAbttJWzoC5ukqXY1PpoouV3+VSOqEAFt5wg==",
             "dev": true
         },
         "xml": {
@@ -4604,9 +4604,9 @@
             }
         },
         "yargs-parser": {
-            "version": "20.2.7",
-            "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.7.tgz",
-            "integrity": "sha512-FiNkvbeHzB/syOjIUxFDCnhSfzAL8R5vs40MgLFBorXACCOAEaWu0gRZl14vG8MR9AOJIZbmkjhusqBYZ3HTHw==",
+            "version": "20.2.9",
+            "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
+            "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
             "dev": true
         }
     }

--- a/packages/pyright-internal/package.json
+++ b/packages/pyright-internal/package.json
@@ -16,12 +16,12 @@
     },
     "dependencies": {
         "@iarna/toml": "2.2.5",
-        "@yarnpkg/fslib": "2.5.0-rc.5",
-        "@yarnpkg/libzip": "2.2.2-rc.3",
+        "@yarnpkg/fslib": "2.5.0-rc.9",
+        "@yarnpkg/libzip": "2.2.2-rc.7",
         "assert": "^2.0.0",
         "chalk": "^4.1.1",
-        "chokidar": "^3.5.1",
-        "command-line-args": "^5.1.1",
+        "chokidar": "^3.5.2",
+        "command-line-args": "^5.1.3",
         "jsonc-parser": "^3.0.0",
         "leven": "^3.1.0",
         "source-map-support": "^0.5.19",
@@ -34,14 +34,14 @@
         "vscode-uri": "^3.0.2"
     },
     "devDependencies": {
-        "@types/command-line-args": "^5.0.0",
-        "@types/jest": "^26.0.23",
-        "@types/node": "^12.20.15",
-        "@types/tmp": "^0.2.0",
-        "jest": "^27.0.4",
+        "@types/command-line-args": "^5.0.1",
+        "@types/jest": "^26.0.24",
+        "@types/node": "^12.20.16",
+        "@types/tmp": "^0.2.1",
+        "jest": "^27.0.6",
         "jest-junit": "^12.2.0",
         "shx": "^0.3.3",
         "ts-jest": "^27.0.3",
-        "typescript": "~4.3.2"
+        "typescript": "~4.3.5"
     }
 }

--- a/packages/pyright-internal/src/backgroundAnalysisBase.ts
+++ b/packages/pyright-internal/src/backgroundAnalysisBase.ts
@@ -6,7 +6,7 @@
  * run analyzer from background thread
  */
 
-import { CancellationToken } from 'vscode-languageserver/node';
+import { CancellationToken } from 'vscode-languageserver';
 import { TextDocumentContentChangeEvent } from 'vscode-languageserver-textdocument';
 import { MessageChannel, MessagePort, parentPort, threadId, Worker, workerData } from 'worker_threads';
 

--- a/packages/pyright-internal/src/languageServerBase.ts
+++ b/packages/pyright-internal/src/languageServerBase.ts
@@ -24,8 +24,6 @@ import {
     CompletionTriggerKind,
     ConfigurationItem,
     Connection,
-    ConnectionOptions,
-    createConnection,
     Diagnostic,
     DiagnosticRelatedInformation,
     DiagnosticSeverity,
@@ -48,7 +46,7 @@ import {
     WorkDoneProgressReporter,
     WorkspaceEdit,
     WorkspaceFolder,
-} from 'vscode-languageserver/node';
+} from 'vscode-languageserver';
 
 import { AnalysisResults } from './analyzer/analysis';
 import { BackgroundAnalysisProgram } from './analyzer/backgroundAnalysisProgram';
@@ -57,7 +55,7 @@ import { MaxAnalysisTime } from './analyzer/program';
 import { AnalyzerService, configFileNames } from './analyzer/service';
 import { BackgroundAnalysisBase } from './backgroundAnalysisBase';
 import { CommandResult } from './commands/commandResult';
-import { CancelAfter, getCancellationStrategyFromArgv } from './common/cancellationUtils';
+import { CancelAfter } from './common/cancellationUtils';
 import { getNestedProperty } from './common/collectionUtils';
 import {
     DiagnosticSeverityOverrides,
@@ -182,8 +180,6 @@ interface ClientCapabilities {
 }
 
 export abstract class LanguageServerBase implements LanguageServerInterface {
-    // Create a connection for the server. The connection type can be changed by the process's arguments
-    protected _connection: Connection = createConnection(this._GetConnectionOptions());
     protected _workspaceMap: WorkspaceMap;
     protected _defaultClientConfig: any;
 
@@ -226,7 +222,7 @@ export abstract class LanguageServerBase implements LanguageServerInterface {
 
     readonly console: ConsoleInterface;
 
-    constructor(private _serverOptions: ServerOptions) {
+    constructor(private _serverOptions: ServerOptions, protected _connection: Connection) {
         // Stash the base directory into a global variable.
         // This must happen before fs.getModulePath().
         (global as any).__rootDirectory = _serverOptions.rootDirectory;
@@ -1281,10 +1277,6 @@ export abstract class LanguageServerBase implements LanguageServerInterface {
             reporter: serverInitiatedReporter,
             token: serverInitiatedReporter.token,
         };
-    }
-
-    private _GetConnectionOptions(): ConnectionOptions {
-        return { cancellationStrategy: getCancellationStrategyFromArgv(process.argv) };
     }
 
     private _convertDiagnostics(diags: AnalyzerDiagnostic[]): Diagnostic[] {

--- a/packages/pyright-internal/src/nodeMain.ts
+++ b/packages/pyright-internal/src/nodeMain.ts
@@ -1,0 +1,13 @@
+import { BackgroundAnalysisRunner } from './backgroundAnalysis';
+import { run } from './nodeServer';
+import { PyrightServer } from './server';
+
+export function main() {
+    run(
+        (conn) => new PyrightServer(conn),
+        () => {
+            const runner = new BackgroundAnalysisRunner();
+            runner.start();
+        }
+    );
+}

--- a/packages/pyright-internal/src/nodeServer.ts
+++ b/packages/pyright-internal/src/nodeServer.ts
@@ -1,0 +1,30 @@
+/*
+ * nodeServer.ts
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT license.
+ *
+ * Implements utilities for starting the langauge server in a node environment.
+ */
+
+import { Connection, ConnectionOptions } from 'vscode-languageserver';
+import { createConnection } from 'vscode-languageserver/node';
+import { isMainThread } from 'worker_threads';
+
+import { getCancellationStrategyFromArgv } from './common/cancellationUtils';
+
+export function run(runServer: (connection: Connection) => void, runBackgroundThread: () => void) {
+    if (process.env.NODE_ENV === 'production') {
+        // eslint-disable-next-line @typescript-eslint/no-var-requires
+        require('source-map-support').install();
+    }
+
+    if (isMainThread) {
+        runServer(createConnection(getConnectionOptions()));
+    } else {
+        runBackgroundThread();
+    }
+}
+
+export function getConnectionOptions(): ConnectionOptions {
+    return { cancellationStrategy: getCancellationStrategyFromArgv(process.argv) };
+}

--- a/packages/pyright-internal/src/pyright.ts
+++ b/packages/pyright-internal/src/pyright.ts
@@ -606,7 +606,7 @@ function printUsage() {
 
 function getVersionString() {
     // eslint-disable-next-line @typescript-eslint/no-var-requires
-    const version = require('package.json').version;
+    const version = require('../package.json').version;
     return version.toString();
 }
 

--- a/packages/pyright-internal/src/pyrightFileSystem.ts
+++ b/packages/pyright-internal/src/pyrightFileSystem.ts
@@ -9,7 +9,7 @@
  * files is treated as one.
  */
 
-import * as fs from 'fs';
+import type * as fs from 'fs';
 
 import { getPyTypedInfo } from './analyzer/pyTypedUtils';
 import { ExecutionEnvironment } from './common/configOptions';
@@ -353,39 +353,38 @@ export class PyrightFileSystem implements FileSystem {
     }
 }
 
-class FakeFile extends fs.Dirent {
-    override name: string;
+class FakeFile {
+    name: string;
 
     constructor(name: string) {
-        super();
         this.name = name;
     }
 
-    override isFile(): boolean {
+    isFile(): boolean {
         return true;
     }
 
-    override isDirectory(): boolean {
+    isDirectory(): boolean {
         return false;
     }
 
-    override isBlockDevice(): boolean {
+    isBlockDevice(): boolean {
         return false;
     }
 
-    override isCharacterDevice(): boolean {
+    isCharacterDevice(): boolean {
         return false;
     }
 
-    override isSymbolicLink(): boolean {
+    isSymbolicLink(): boolean {
         return false;
     }
 
-    override isFIFO(): boolean {
+    isFIFO(): boolean {
         return false;
     }
 
-    override isSocket(): boolean {
+    isSocket(): boolean {
         return false;
     }
 }

--- a/packages/pyright/package-lock.json
+++ b/packages/pyright/package-lock.json
@@ -27,9 +27,9 @@
             "dev": true
         },
         "@nodelib/fs.walk": {
-            "version": "1.2.7",
-            "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.7.tgz",
-            "integrity": "sha512-BTIhocbPBSrRmHxOAJFtR18oLhxTtAFDAvL8hY1S3iU8k+E60W/YFs4jrixGzQjMpF4qPXxIQHcjVD9dz1C2QA==",
+            "version": "1.2.8",
+            "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+            "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
             "dev": true,
             "requires": {
                 "@nodelib/fs.scandir": "2.1.5",
@@ -37,9 +37,9 @@
             }
         },
         "@types/copy-webpack-plugin": {
-            "version": "8.0.0",
-            "resolved": "https://registry.npmjs.org/@types/copy-webpack-plugin/-/copy-webpack-plugin-8.0.0.tgz",
-            "integrity": "sha512-EJ9Nd0a628uwvgCEt7bN4F6f2jA0O+i+ajAyq9F4jRTqJJ0ro13C22GL/bnvnsSoKuN/O93yfXqZWhn2R70b/g==",
+            "version": "8.0.1",
+            "resolved": "https://registry.npmjs.org/@types/copy-webpack-plugin/-/copy-webpack-plugin-8.0.1.tgz",
+            "integrity": "sha512-TwEeGse0/wq+t3SFW0DEwroMS/cDkwVZT+vj7tMAYTp7llt/yz6NuW2n04X2M5P/kSfBQOORhrHAN2mqZdmybg==",
             "dev": true,
             "requires": {
                 "@types/node": "*",
@@ -48,9 +48,9 @@
             }
         },
         "@types/eslint": {
-            "version": "7.2.13",
-            "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-7.2.13.tgz",
-            "integrity": "sha512-LKmQCWAlnVHvvXq4oasNUMTJJb2GwSyTY8+1C7OH5ILR8mPLaljv1jxL1bXW3xB3jFbQxTKxJAvI8PyjB09aBg==",
+            "version": "7.28.0",
+            "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-7.28.0.tgz",
+            "integrity": "sha512-07XlgzX0YJUn4iG1ocY4IX9DzKSmMGUs6ESKlxWhZRaa0fatIWaHWUVapcuGa8r5HFnTqzj+4OCjd5f7EZ/i/A==",
             "dev": true,
             "requires": {
                 "@types/estree": "*",
@@ -58,9 +58,9 @@
             }
         },
         "@types/eslint-scope": {
-            "version": "3.7.0",
-            "resolved": "https://registry.npmjs.org/@types/eslint-scope/-/eslint-scope-3.7.0.tgz",
-            "integrity": "sha512-O/ql2+rrCUe2W2rs7wMR+GqPRcgB6UiqN5RhrR5xruFlY7l9YLMn0ZkDzjoHLeiFkR8MCQZVudUuuvQ2BLC9Qw==",
+            "version": "3.7.1",
+            "resolved": "https://registry.npmjs.org/@types/eslint-scope/-/eslint-scope-3.7.1.tgz",
+            "integrity": "sha512-SCFeogqiptms4Fg29WpOTk5nHIzfpKCemSN63ksBQYKTcXoJEmJagV+DhVmbapZzY4/5YaOV1nZwrsU79fFm1g==",
             "dev": true,
             "requires": {
                 "@types/eslint": "*",
@@ -68,172 +68,166 @@
             }
         },
         "@types/estree": {
-            "version": "0.0.47",
-            "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.47.tgz",
-            "integrity": "sha512-c5ciR06jK8u9BstrmJyO97m+klJrrhCf9u3rLu3DEAJBirxRqSCvDQoYKmxuYwQI5SZChAWu+tq9oVlGRuzPAg==",
+            "version": "0.0.50",
+            "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.50.tgz",
+            "integrity": "sha512-C6N5s2ZFtuZRj54k2/zyRhNDjJwwcViAM3Nbm8zjBpbqAdZ00mr0CFxvSKeO8Y/e03WVFLpQMdHYVfUd6SB+Hw==",
             "dev": true
         },
         "@types/json-schema": {
-            "version": "7.0.7",
-            "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.7.tgz",
-            "integrity": "sha512-cxWFQVseBm6O9Gbw1IWb8r6OS4OhSt3hPZLkFApLjM8TEXROBuQGLAH2i2gZpcXdLBIrpXuTDhH7Vbm1iXmNGA==",
-            "dev": true
-        },
-        "@types/json5": {
-            "version": "0.0.29",
-            "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
-            "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4=",
+            "version": "7.0.8",
+            "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.8.tgz",
+            "integrity": "sha512-YSBPTLTVm2e2OoQIDYx8HaeWJ5tTToLH67kXR7zYNGupXMEHa2++G8k+DczX2cFVgalypqtyZIcU19AFcmOpmg==",
             "dev": true
         },
         "@types/node": {
-            "version": "12.20.15",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.15.tgz",
-            "integrity": "sha512-F6S4Chv4JicJmyrwlDkxUdGNSplsQdGwp1A0AJloEVDirWdZOAiRHhovDlsFkKUrquUXhz1imJhXHsf59auyAg==",
+            "version": "12.20.16",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.16.tgz",
+            "integrity": "sha512-6CLxw83vQf6DKqXxMPwl8qpF8I7THFZuIwLt4TnNsumxkp1VsRZWT8txQxncT/Rl2UojTsFzWgDG4FRMwafrlA==",
             "dev": true
         },
         "@webassemblyjs/ast": {
-            "version": "1.11.0",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.11.0.tgz",
-            "integrity": "sha512-kX2W49LWsbthrmIRMbQZuQDhGtjyqXfEmmHyEi4XWnSZtPmxY0+3anPIzsnRb45VH/J55zlOfWvZuY47aJZTJg==",
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.11.1.tgz",
+            "integrity": "sha512-ukBh14qFLjxTQNTXocdyksN5QdM28S1CxHt2rdskFyL+xFV7VremuBLVbmCePj+URalXBENx/9Lm7lnhihtCSw==",
             "dev": true,
             "requires": {
-                "@webassemblyjs/helper-numbers": "1.11.0",
-                "@webassemblyjs/helper-wasm-bytecode": "1.11.0"
+                "@webassemblyjs/helper-numbers": "1.11.1",
+                "@webassemblyjs/helper-wasm-bytecode": "1.11.1"
             }
         },
         "@webassemblyjs/floating-point-hex-parser": {
-            "version": "1.11.0",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.11.0.tgz",
-            "integrity": "sha512-Q/aVYs/VnPDVYvsCBL/gSgwmfjeCb4LW8+TMrO3cSzJImgv8lxxEPM2JA5jMrivE7LSz3V+PFqtMbls3m1exDA==",
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.11.1.tgz",
+            "integrity": "sha512-iGRfyc5Bq+NnNuX8b5hwBrRjzf0ocrJPI6GWFodBFzmFnyvrQ83SHKhmilCU/8Jv67i4GJZBMhEzltxzcNagtQ==",
             "dev": true
         },
         "@webassemblyjs/helper-api-error": {
-            "version": "1.11.0",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.11.0.tgz",
-            "integrity": "sha512-baT/va95eXiXb2QflSx95QGT5ClzWpGaa8L7JnJbgzoYeaA27FCvuBXU758l+KXWRndEmUXjP0Q5fibhavIn8w==",
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.11.1.tgz",
+            "integrity": "sha512-RlhS8CBCXfRUR/cwo2ho9bkheSXG0+NwooXcc3PAILALf2QLdFyj7KGsKRbVc95hZnhnERon4kW/D3SZpp6Tcg==",
             "dev": true
         },
         "@webassemblyjs/helper-buffer": {
-            "version": "1.11.0",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.11.0.tgz",
-            "integrity": "sha512-u9HPBEl4DS+vA8qLQdEQ6N/eJQ7gT7aNvMIo8AAWvAl/xMrcOSiI2M0MAnMCy3jIFke7bEee/JwdX1nUpCtdyA==",
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.11.1.tgz",
+            "integrity": "sha512-gwikF65aDNeeXa8JxXa2BAk+REjSyhrNC9ZwdT0f8jc4dQQeDQ7G4m0f2QCLPJiMTTO6wfDmRmj/pW0PsUvIcA==",
             "dev": true
         },
         "@webassemblyjs/helper-numbers": {
-            "version": "1.11.0",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-numbers/-/helper-numbers-1.11.0.tgz",
-            "integrity": "sha512-DhRQKelIj01s5IgdsOJMKLppI+4zpmcMQ3XboFPLwCpSNH6Hqo1ritgHgD0nqHeSYqofA6aBN/NmXuGjM1jEfQ==",
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-numbers/-/helper-numbers-1.11.1.tgz",
+            "integrity": "sha512-vDkbxiB8zfnPdNK9Rajcey5C0w+QJugEglN0of+kmO8l7lDb77AnlKYQF7aarZuCrv+l0UvqL+68gSDr3k9LPQ==",
             "dev": true,
             "requires": {
-                "@webassemblyjs/floating-point-hex-parser": "1.11.0",
-                "@webassemblyjs/helper-api-error": "1.11.0",
+                "@webassemblyjs/floating-point-hex-parser": "1.11.1",
+                "@webassemblyjs/helper-api-error": "1.11.1",
                 "@xtuc/long": "4.2.2"
             }
         },
         "@webassemblyjs/helper-wasm-bytecode": {
-            "version": "1.11.0",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.11.0.tgz",
-            "integrity": "sha512-MbmhvxXExm542tWREgSFnOVo07fDpsBJg3sIl6fSp9xuu75eGz5lz31q7wTLffwL3Za7XNRCMZy210+tnsUSEA==",
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.11.1.tgz",
+            "integrity": "sha512-PvpoOGiJwXeTrSf/qfudJhwlvDQxFgelbMqtq52WWiXC6Xgg1IREdngmPN3bs4RoO83PnL/nFrxucXj1+BX62Q==",
             "dev": true
         },
         "@webassemblyjs/helper-wasm-section": {
-            "version": "1.11.0",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.11.0.tgz",
-            "integrity": "sha512-3Eb88hcbfY/FCukrg6i3EH8H2UsD7x8Vy47iVJrP967A9JGqgBVL9aH71SETPx1JrGsOUVLo0c7vMCN22ytJew==",
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.11.1.tgz",
+            "integrity": "sha512-10P9No29rYX1j7F3EVPX3JvGPQPae+AomuSTPiF9eBQeChHI6iqjMIwR9JmOJXwpnn/oVGDk7I5IlskuMwU/pg==",
             "dev": true,
             "requires": {
-                "@webassemblyjs/ast": "1.11.0",
-                "@webassemblyjs/helper-buffer": "1.11.0",
-                "@webassemblyjs/helper-wasm-bytecode": "1.11.0",
-                "@webassemblyjs/wasm-gen": "1.11.0"
+                "@webassemblyjs/ast": "1.11.1",
+                "@webassemblyjs/helper-buffer": "1.11.1",
+                "@webassemblyjs/helper-wasm-bytecode": "1.11.1",
+                "@webassemblyjs/wasm-gen": "1.11.1"
             }
         },
         "@webassemblyjs/ieee754": {
-            "version": "1.11.0",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.11.0.tgz",
-            "integrity": "sha512-KXzOqpcYQwAfeQ6WbF6HXo+0udBNmw0iXDmEK5sFlmQdmND+tr773Ti8/5T/M6Tl/413ArSJErATd8In3B+WBA==",
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.11.1.tgz",
+            "integrity": "sha512-hJ87QIPtAMKbFq6CGTkZYJivEwZDbQUgYd3qKSadTNOhVY7p+gfP6Sr0lLRVTaG1JjFj+r3YchoqRYxNH3M0GQ==",
             "dev": true,
             "requires": {
                 "@xtuc/ieee754": "^1.2.0"
             }
         },
         "@webassemblyjs/leb128": {
-            "version": "1.11.0",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.11.0.tgz",
-            "integrity": "sha512-aqbsHa1mSQAbeeNcl38un6qVY++hh8OpCOzxhixSYgbRfNWcxJNJQwe2rezK9XEcssJbbWIkblaJRwGMS9zp+g==",
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.11.1.tgz",
+            "integrity": "sha512-BJ2P0hNZ0u+Th1YZXJpzW6miwqQUGcIHT1G/sf72gLVD9DZ5AdYTqPNbHZh6K1M5VmKvFXwGSWZADz+qBWxeRw==",
             "dev": true,
             "requires": {
                 "@xtuc/long": "4.2.2"
             }
         },
         "@webassemblyjs/utf8": {
-            "version": "1.11.0",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.11.0.tgz",
-            "integrity": "sha512-A/lclGxH6SpSLSyFowMzO/+aDEPU4hvEiooCMXQPcQFPPJaYcPQNKGOCLUySJsYJ4trbpr+Fs08n4jelkVTGVw==",
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.11.1.tgz",
+            "integrity": "sha512-9kqcxAEdMhiwQkHpkNiorZzqpGrodQQ2IGrHHxCy+Ozng0ofyMA0lTqiLkVs1uzTRejX+/O0EOT7KxqVPuXosQ==",
             "dev": true
         },
         "@webassemblyjs/wasm-edit": {
-            "version": "1.11.0",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.11.0.tgz",
-            "integrity": "sha512-JHQ0damXy0G6J9ucyKVXO2j08JVJ2ntkdJlq1UTiUrIgfGMmA7Ik5VdC/L8hBK46kVJgujkBIoMtT8yVr+yVOQ==",
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.11.1.tgz",
+            "integrity": "sha512-g+RsupUC1aTHfR8CDgnsVRVZFJqdkFHpsHMfJuWQzWU3tvnLC07UqHICfP+4XyL2tnr1amvl1Sdp06TnYCmVkA==",
             "dev": true,
             "requires": {
-                "@webassemblyjs/ast": "1.11.0",
-                "@webassemblyjs/helper-buffer": "1.11.0",
-                "@webassemblyjs/helper-wasm-bytecode": "1.11.0",
-                "@webassemblyjs/helper-wasm-section": "1.11.0",
-                "@webassemblyjs/wasm-gen": "1.11.0",
-                "@webassemblyjs/wasm-opt": "1.11.0",
-                "@webassemblyjs/wasm-parser": "1.11.0",
-                "@webassemblyjs/wast-printer": "1.11.0"
+                "@webassemblyjs/ast": "1.11.1",
+                "@webassemblyjs/helper-buffer": "1.11.1",
+                "@webassemblyjs/helper-wasm-bytecode": "1.11.1",
+                "@webassemblyjs/helper-wasm-section": "1.11.1",
+                "@webassemblyjs/wasm-gen": "1.11.1",
+                "@webassemblyjs/wasm-opt": "1.11.1",
+                "@webassemblyjs/wasm-parser": "1.11.1",
+                "@webassemblyjs/wast-printer": "1.11.1"
             }
         },
         "@webassemblyjs/wasm-gen": {
-            "version": "1.11.0",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.11.0.tgz",
-            "integrity": "sha512-BEUv1aj0WptCZ9kIS30th5ILASUnAPEvE3tVMTrItnZRT9tXCLW2LEXT8ezLw59rqPP9klh9LPmpU+WmRQmCPQ==",
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.11.1.tgz",
+            "integrity": "sha512-F7QqKXwwNlMmsulj6+O7r4mmtAlCWfO/0HdgOxSklZfQcDu0TpLiD1mRt/zF25Bk59FIjEuGAIyn5ei4yMfLhA==",
             "dev": true,
             "requires": {
-                "@webassemblyjs/ast": "1.11.0",
-                "@webassemblyjs/helper-wasm-bytecode": "1.11.0",
-                "@webassemblyjs/ieee754": "1.11.0",
-                "@webassemblyjs/leb128": "1.11.0",
-                "@webassemblyjs/utf8": "1.11.0"
+                "@webassemblyjs/ast": "1.11.1",
+                "@webassemblyjs/helper-wasm-bytecode": "1.11.1",
+                "@webassemblyjs/ieee754": "1.11.1",
+                "@webassemblyjs/leb128": "1.11.1",
+                "@webassemblyjs/utf8": "1.11.1"
             }
         },
         "@webassemblyjs/wasm-opt": {
-            "version": "1.11.0",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.11.0.tgz",
-            "integrity": "sha512-tHUSP5F4ywyh3hZ0+fDQuWxKx3mJiPeFufg+9gwTpYp324mPCQgnuVKwzLTZVqj0duRDovnPaZqDwoyhIO8kYg==",
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.11.1.tgz",
+            "integrity": "sha512-VqnkNqnZlU5EB64pp1l7hdm3hmQw7Vgqa0KF/KCNO9sIpI6Fk6brDEiX+iCOYrvMuBWDws0NkTOxYEb85XQHHw==",
             "dev": true,
             "requires": {
-                "@webassemblyjs/ast": "1.11.0",
-                "@webassemblyjs/helper-buffer": "1.11.0",
-                "@webassemblyjs/wasm-gen": "1.11.0",
-                "@webassemblyjs/wasm-parser": "1.11.0"
+                "@webassemblyjs/ast": "1.11.1",
+                "@webassemblyjs/helper-buffer": "1.11.1",
+                "@webassemblyjs/wasm-gen": "1.11.1",
+                "@webassemblyjs/wasm-parser": "1.11.1"
             }
         },
         "@webassemblyjs/wasm-parser": {
-            "version": "1.11.0",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.11.0.tgz",
-            "integrity": "sha512-6L285Sgu9gphrcpDXINvm0M9BskznnzJTE7gYkjDbxET28shDqp27wpruyx3C2S/dvEwiigBwLA1cz7lNUi0kw==",
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.11.1.tgz",
+            "integrity": "sha512-rrBujw+dJu32gYB7/Lup6UhdkPx9S9SnobZzRVL7VcBH9Bt9bCBLEuX/YXOOtBsOZ4NQrRykKhffRWHvigQvOA==",
             "dev": true,
             "requires": {
-                "@webassemblyjs/ast": "1.11.0",
-                "@webassemblyjs/helper-api-error": "1.11.0",
-                "@webassemblyjs/helper-wasm-bytecode": "1.11.0",
-                "@webassemblyjs/ieee754": "1.11.0",
-                "@webassemblyjs/leb128": "1.11.0",
-                "@webassemblyjs/utf8": "1.11.0"
+                "@webassemblyjs/ast": "1.11.1",
+                "@webassemblyjs/helper-api-error": "1.11.1",
+                "@webassemblyjs/helper-wasm-bytecode": "1.11.1",
+                "@webassemblyjs/ieee754": "1.11.1",
+                "@webassemblyjs/leb128": "1.11.1",
+                "@webassemblyjs/utf8": "1.11.1"
             }
         },
         "@webassemblyjs/wast-printer": {
-            "version": "1.11.0",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.11.0.tgz",
-            "integrity": "sha512-Fg5OX46pRdTgB7rKIUojkh9vXaVN6sGYCnEiJN1GYkb0RPwShZXp6KTDqmoMdQPKhcroOXh3fEzmkWmCYaKYhQ==",
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.11.1.tgz",
+            "integrity": "sha512-IQboUWM4eKzWW+N/jij2sRatKMh99QEelo3Eb2q0qXkvPRISAj8Qxtmw5itwqK+TTkBuUIE45AxYPToqPtL5gg==",
             "dev": true,
             "requires": {
-                "@webassemblyjs/ast": "1.11.0",
+                "@webassemblyjs/ast": "1.11.1",
                 "@xtuc/long": "4.2.2"
             }
         },
@@ -271,9 +265,9 @@
             "dev": true
         },
         "acorn": {
-            "version": "8.4.0",
-            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.4.0.tgz",
-            "integrity": "sha512-ULr0LDaEqQrMFGyQ3bhJkLsbtrQ8QibAseGZeaSUiT/6zb9IvIkomWHJIvgvwad+hinRAgsI51JcWk2yvwyL+w==",
+            "version": "8.4.1",
+            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.4.1.tgz",
+            "integrity": "sha512-asabaBSkEKosYKMITunzX177CXxQ4Q8BSSzMTKD+FefUhipQC70gfW5SiUDhYQ3vk8G+81HqQk7Fv9OXwwn9KA==",
             "dev": true
         },
         "ajv": {
@@ -354,9 +348,9 @@
             "dev": true
         },
         "caniuse-lite": {
-            "version": "1.0.30001236",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001236.tgz",
-            "integrity": "sha512-o0PRQSrSCGJKCPZcgMzl5fUaj5xHe8qA2m4QRvnyY4e1lITqoNkr7q/Oh1NcpGSy0Th97UZ35yoKcINPoq7YOQ==",
+            "version": "1.0.30001245",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001245.tgz",
+            "integrity": "sha512-768fM9j1PKXpOCKws6eTo3RHmvTUsG9UrpT4WoREFeZgJBTi4/X9g565azS/rVUGtqb8nt7FjLeF5u4kukERnA==",
             "dev": true
         },
         "chalk": {
@@ -431,9 +425,9 @@
             "dev": true
         },
         "copy-webpack-plugin": {
-            "version": "9.0.0",
-            "resolved": "https://registry.npmjs.org/copy-webpack-plugin/-/copy-webpack-plugin-9.0.0.tgz",
-            "integrity": "sha512-k8UB2jLIb1Jip2nZbCz83T/XfhfjX6mB1yLJNYKrpYi7FQimfOoFv/0//iT6HV1K8FwUB5yUbCcnpLebJXJTug==",
+            "version": "9.0.1",
+            "resolved": "https://registry.npmjs.org/copy-webpack-plugin/-/copy-webpack-plugin-9.0.1.tgz",
+            "integrity": "sha512-14gHKKdYIxF84jCEgPgYXCPpldbwpxxLbCmA7LReY7gvbaT555DgeBWBgBZM116tv/fO6RRJrsivBqRyRlukhw==",
             "dev": true,
             "requires": {
                 "fast-glob": "^3.2.5",
@@ -442,7 +436,7 @@
                 "normalize-path": "^3.0.0",
                 "p-limit": "^3.1.0",
                 "schema-utils": "^3.0.0",
-                "serialize-javascript": "^5.0.1"
+                "serialize-javascript": "^6.0.0"
             }
         },
         "cross-spawn": {
@@ -466,9 +460,9 @@
             }
         },
         "electron-to-chromium": {
-            "version": "1.3.752",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.752.tgz",
-            "integrity": "sha512-2Tg+7jSl3oPxgsBsWKh5H83QazTkmWG/cnNwJplmyZc7KcN61+I10oUgaXSVk/NwfvN3BdkKDR4FYuRBQQ2v0A==",
+            "version": "1.3.777",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.777.tgz",
+            "integrity": "sha512-gO0VEU2esNUOu51DTtp7E7xy0d+yZdbC06EACvou1cbPM9Wwyz8ixPa6T1tqDXlT4/AefXtzx0i9OLwKkLOHQA==",
             "dev": true
         },
         "enhanced-resolve": {
@@ -488,9 +482,9 @@
             "dev": true
         },
         "es-module-lexer": {
-            "version": "0.4.1",
-            "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-0.4.1.tgz",
-            "integrity": "sha512-ooYciCUtfw6/d2w56UVeqHPcoCFAiJdz5XOkYpv/Txl1HMUozpXjz/2RIQgqwKdXNDPSF1W7mJCFse3G+HDyAA==",
+            "version": "0.7.1",
+            "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-0.7.1.tgz",
+            "integrity": "sha512-MgtWFl5No+4S3TmhDmCz2ObFGm6lEpTnzbQi+Dd+pw4mlTIZTmM2iAs5gRlmx5zS9luzobCSBSI90JM/1/JgOw==",
             "dev": true
         },
         "escalade": {
@@ -562,17 +556,16 @@
             "dev": true
         },
         "fast-glob": {
-            "version": "3.2.5",
-            "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.5.tgz",
-            "integrity": "sha512-2DtFcgT68wiTTiwZ2hNdJfcHNke9XOfnwmBRWXhmeKM8rF0TGwmC/Qto3S7RoZKp5cilZbxzO5iTNTQsJ+EeDg==",
+            "version": "3.2.7",
+            "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.7.tgz",
+            "integrity": "sha512-rYGMRwip6lUMvYD3BTScMwT1HtAs2d71SMv66Vrxs0IekGZEjhM0pcMfjQPnknBt2zeCwQMEupiN02ZP4DiT1Q==",
             "dev": true,
             "requires": {
                 "@nodelib/fs.stat": "^2.0.2",
                 "@nodelib/fs.walk": "^1.2.3",
-                "glob-parent": "^5.1.0",
+                "glob-parent": "^5.1.2",
                 "merge2": "^1.3.0",
-                "micromatch": "^4.0.2",
-                "picomatch": "^2.2.1"
+                "micromatch": "^4.0.4"
             },
             "dependencies": {
                 "glob-parent": {
@@ -599,9 +592,9 @@
             "dev": true
         },
         "fastq": {
-            "version": "1.11.0",
-            "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.11.0.tgz",
-            "integrity": "sha512-7Eczs8gIPDrVzT+EksYBcupqMyxSHXXrHOLRRxU2/DicV8789MRBRR8+Hc2uWzUupOs4YS4JzBmBxjjCVBxD/g==",
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.11.1.tgz",
+            "integrity": "sha512-HOnr8Mc60eNYl1gzwp6r5RoUyAn5/glBolUzP/Ez6IFVPMPirxn/9phgL6zhOtaTy7ISwPvQ+wT+hfcRZh/bzw==",
             "dev": true,
             "requires": {
                 "reusify": "^1.0.4"
@@ -674,9 +667,9 @@
             "dev": true
         },
         "globby": {
-            "version": "11.0.3",
-            "resolved": "https://registry.npmjs.org/globby/-/globby-11.0.3.tgz",
-            "integrity": "sha512-ffdmosjA807y7+lA1NM0jELARVmYul/715xiILEjo3hBLPTcirgQNnXECn5g3mtR8TOLCVbkfua1Hpen25/Xcg==",
+            "version": "11.0.4",
+            "resolved": "https://registry.npmjs.org/globby/-/globby-11.0.4.tgz",
+            "integrity": "sha512-9O4MVG9ioZJ08ffbcyVYyLOJLk5JQ688pJ4eMGLpdWLHq/Wr1D9BlriLQyL0E+jbkuePVZXYFj47QM/v093wHg==",
             "dev": true,
             "requires": {
                 "array-union": "^2.1.0",
@@ -753,9 +746,9 @@
             "dev": true
         },
         "is-core-module": {
-            "version": "2.4.0",
-            "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.4.0.tgz",
-            "integrity": "sha512-6A2fkfq1rfeQZjxrZJGerpLCTHRNEBiSgnu0+obeJpEPZRUooHgsizvzv0ZjJwOz3iWIHdJtVWJ/tmPr3D21/A==",
+            "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.5.0.tgz",
+            "integrity": "sha512-TXCMSDsEHMEEZ6eCA8rwRDbLu55MRGmrctljsBX/2v1d9/GzqHOxW5c5oPSgrUt2vBFXebu9rGqckXGPWOlYpg==",
             "dev": true,
             "requires": {
                 "has": "^1.0.3"
@@ -810,9 +803,9 @@
             "dev": true
         },
         "jest-worker": {
-            "version": "27.0.2",
-            "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.0.2.tgz",
-            "integrity": "sha512-EoBdilOTTyOgmHXtw/cPc+ZrCA0KJMrkXzkrPGNwLmnvvlN1nj7MPrxpT7m+otSv2e1TLaVffzDnE/LB14zJMg==",
+            "version": "27.0.6",
+            "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.0.6.tgz",
+            "integrity": "sha512-qupxcj/dRuA3xHPMUd40gr2EaAurFbkwzOh7wfPaeE9id7hyjURRQoqNfHifHK3XjJU6YJJUQKILGUnwGPEOCA==",
             "dev": true,
             "requires": {
                 "@types/node": "*",
@@ -831,15 +824,6 @@
             "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
             "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
             "dev": true
-        },
-        "json5": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-            "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
-            "dev": true,
-            "requires": {
-                "minimist": "^1.2.0"
-            }
         },
         "kind-of": {
             "version": "6.0.3",
@@ -1131,12 +1115,12 @@
             "dev": true
         },
         "schema-utils": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.0.0.tgz",
-            "integrity": "sha512-6D82/xSzO094ajanoOSbe4YvXWMfn2A//8Y1+MUqFAJul5Bs+yn36xbK9OtNDcRVSBJ9jjeoXftM6CfztsjOAA==",
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.1.0.tgz",
+            "integrity": "sha512-tTEaeYkyIhEZ9uWgAjDerWov3T9MgX8dhhy2r0IGeeX4W8ngtGl1++dUve/RUqzuaASSh7shwCDJjEzthxki8w==",
             "dev": true,
             "requires": {
-                "@types/json-schema": "^7.0.6",
+                "@types/json-schema": "^7.0.7",
                 "ajv": "^6.12.5",
                 "ajv-keywords": "^3.5.2"
             }
@@ -1151,9 +1135,9 @@
             }
         },
         "serialize-javascript": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-5.0.1.tgz",
-            "integrity": "sha512-SaaNal9imEO737H2c05Og0/8LUXG7EnsZyMa8MzkmuHoELfT6txuj0cMqRj6zfPKnmQ1yasR4PCJc8x+M4JSPA==",
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.0.tgz",
+            "integrity": "sha512-Qr3TosvguFt8ePWqsvRfrKyQXIiW+nGbYpy8XK24NQHE83caxWt+mIymTT19DGFbNWNLfEwsrkSmN64lVWB9ag==",
             "dev": true,
             "requires": {
                 "randombytes": "^2.1.0"
@@ -1238,12 +1222,6 @@
                 "source-map": "^0.6.0"
             }
         },
-        "strip-bom": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-            "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
-            "dev": true
-        },
         "strip-final-newline": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
@@ -1266,9 +1244,9 @@
             "dev": true
         },
         "terser": {
-            "version": "5.7.0",
-            "resolved": "https://registry.npmjs.org/terser/-/terser-5.7.0.tgz",
-            "integrity": "sha512-HP5/9hp2UaZt5fYkuhNBR8YyRcT8juw8+uFbAme53iN9hblvKnLUTKkmwJG6ocWpIKf8UK4DoeWG4ty0J6S6/g==",
+            "version": "5.7.1",
+            "resolved": "https://registry.npmjs.org/terser/-/terser-5.7.1.tgz",
+            "integrity": "sha512-b3e+d5JbHAe/JSjwsC3Zn55wsBIM7AsHLjKxT31kGCldgbpFePaFo+PiddtO6uwRZWRw7sPXmAN8dTW61xmnSg==",
             "dev": true,
             "requires": {
                 "commander": "^2.20.0",
@@ -1285,15 +1263,15 @@
             }
         },
         "terser-webpack-plugin": {
-            "version": "5.1.3",
-            "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.1.3.tgz",
-            "integrity": "sha512-cxGbMqr6+A2hrIB5ehFIF+F/iST5ZOxvOmy9zih9ySbP1C2oEWQSOUS+2SNBTjzx5xLKO4xnod9eywdfq1Nb9A==",
+            "version": "5.1.4",
+            "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.1.4.tgz",
+            "integrity": "sha512-C2WkFwstHDhVEmsmlCxrXUtVklS+Ir1A7twrYzrDrQQOIMOaVAYykaoo/Aq1K0QRkMoY2hhvDQY1cm4jnIMFwA==",
             "dev": true,
             "requires": {
                 "jest-worker": "^27.0.2",
                 "p-limit": "^3.1.0",
                 "schema-utils": "^3.0.0",
-                "serialize-javascript": "^5.0.1",
+                "serialize-javascript": "^6.0.0",
                 "source-map": "^0.6.1",
                 "terser": "^5.7.0"
             }
@@ -1319,33 +1297,10 @@
                 "semver": "^7.3.4"
             }
         },
-        "tsconfig-paths": {
-            "version": "3.9.0",
-            "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.9.0.tgz",
-            "integrity": "sha512-dRcuzokWhajtZWkQsDVKbWyY+jgcLC5sqJhg2PSgf4ZkH2aHPvaOY8YWGhmjb68b5qqTfasSsDO9k7RUiEmZAw==",
-            "dev": true,
-            "requires": {
-                "@types/json5": "^0.0.29",
-                "json5": "^1.0.1",
-                "minimist": "^1.2.0",
-                "strip-bom": "^3.0.0"
-            }
-        },
-        "tsconfig-paths-webpack-plugin": {
-            "version": "3.5.1",
-            "resolved": "https://registry.npmjs.org/tsconfig-paths-webpack-plugin/-/tsconfig-paths-webpack-plugin-3.5.1.tgz",
-            "integrity": "sha512-n5CMlUUj+N5pjBhBACLq4jdr9cPTitySCjIosoQm0zwK99gmrcTGAfY9CwxRFT9+9OleNWXPRUcxsKP4AYExxQ==",
-            "dev": true,
-            "requires": {
-                "chalk": "^4.1.0",
-                "enhanced-resolve": "^5.7.0",
-                "tsconfig-paths": "^3.9.0"
-            }
-        },
         "typescript": {
-            "version": "4.3.2",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.2.tgz",
-            "integrity": "sha512-zZ4hShnmnoVnAHpVHWpTcxdv7dWP60S2FsydQLV8V5PbS3FifjWFFRiHSWpDJahly88PRyV5teTSLoq4eG7mKw==",
+            "version": "4.3.5",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.5.tgz",
+            "integrity": "sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==",
             "dev": true
         },
         "uri-js": {
@@ -1374,21 +1329,21 @@
             }
         },
         "webpack": {
-            "version": "5.38.1",
-            "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.38.1.tgz",
-            "integrity": "sha512-OqRmYD1OJbHZph6RUMD93GcCZy4Z4wC0ele4FXyYF0J6AxO1vOSuIlU1hkS/lDlR9CDYBz64MZRmdbdnFFoT2g==",
+            "version": "5.44.0",
+            "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.44.0.tgz",
+            "integrity": "sha512-I1S1w4QLoKmH19pX6YhYN0NiSXaWY8Ou00oA+aMcr9IUGeF5azns+IKBkfoAAG9Bu5zOIzZt/mN35OffBya8AQ==",
             "dev": true,
             "requires": {
                 "@types/eslint-scope": "^3.7.0",
-                "@types/estree": "^0.0.47",
-                "@webassemblyjs/ast": "1.11.0",
-                "@webassemblyjs/wasm-edit": "1.11.0",
-                "@webassemblyjs/wasm-parser": "1.11.0",
-                "acorn": "^8.2.1",
+                "@types/estree": "^0.0.50",
+                "@webassemblyjs/ast": "1.11.1",
+                "@webassemblyjs/wasm-edit": "1.11.1",
+                "@webassemblyjs/wasm-parser": "1.11.1",
+                "acorn": "^8.4.1",
                 "browserslist": "^4.14.5",
                 "chrome-trace-event": "^1.0.2",
                 "enhanced-resolve": "^5.8.0",
-                "es-module-lexer": "^0.4.0",
+                "es-module-lexer": "^0.7.1",
                 "eslint-scope": "5.1.1",
                 "events": "^3.2.0",
                 "glob-to-regexp": "^0.4.1",
@@ -1399,7 +1354,7 @@
                 "neo-async": "^2.6.2",
                 "schema-utils": "^3.0.0",
                 "tapable": "^2.1.1",
-                "terser-webpack-plugin": "^5.1.1",
+                "terser-webpack-plugin": "^5.1.3",
                 "watchpack": "^2.2.0",
                 "webpack-sources": "^2.3.0"
             }

--- a/packages/pyright/package.json
+++ b/packages/pyright/package.json
@@ -23,14 +23,13 @@
         "webpack": "webpack --mode development --progress"
     },
     "devDependencies": {
-        "@types/copy-webpack-plugin": "^8.0.0",
-        "@types/node": "^12.20.15",
-        "copy-webpack-plugin": "^9.0.0",
+        "@types/copy-webpack-plugin": "^8.0.1",
+        "@types/node": "^12.20.16",
+        "copy-webpack-plugin": "^9.0.1",
         "shx": "^0.3.3",
         "ts-loader": "^9.2.3",
-        "tsconfig-paths-webpack-plugin": "^3.5.1",
-        "typescript": "~4.3.2",
-        "webpack": "^5.38.1",
+        "typescript": "~4.3.5",
+        "webpack": "^5.44.0",
         "webpack-cli": "^4.7.2"
     },
     "files": [

--- a/packages/pyright/src/langserver.ts
+++ b/packages/pyright/src/langserver.ts
@@ -1,3 +1,3 @@
-import { main } from 'pyright-internal/server';
+import { main } from 'pyright-internal/nodeMain';
 
 main();

--- a/packages/pyright/tsconfig.withBaseUrl.json
+++ b/packages/pyright/tsconfig.withBaseUrl.json
@@ -1,9 +1,0 @@
-{
-    "extends": "./tsconfig.json",
-    "compilerOptions": {
-        "baseUrl": ".",
-        "paths": {
-            "pyright-internal/*": ["../pyright-internal/src/*"]
-        }
-    }
-}

--- a/packages/pyright/webpack.config.js
+++ b/packages/pyright/webpack.config.js
@@ -5,8 +5,7 @@
 
 const path = require('path');
 const CopyPlugin = require('copy-webpack-plugin');
-const { TsconfigPathsPlugin } = require('tsconfig-paths-webpack-plugin');
-const { cacheConfig, monorepoResourceNameMapper } = require('../../build/lib/webpack');
+const { cacheConfig, monorepoResourceNameMapper, tsconfigResolveAliases } = require('../../build/lib/webpack');
 
 const outPath = path.resolve(__dirname, 'dist');
 const typeshedFallback = path.resolve(__dirname, '..', 'pyright-internal', 'typeshed-fallback');
@@ -36,12 +35,7 @@ module.exports = (_, { mode }) => {
         },
         resolve: {
             extensions: ['.ts', '.js'],
-            plugins: [
-                new TsconfigPathsPlugin({
-                    configFile: 'tsconfig.withBaseUrl.json', // TODO: Remove once the plugin understands TS 4.1's implicit baseUrl.
-                    extensions: ['.ts', '.js'],
-                }),
-            ],
+            alias: tsconfigResolveAliases('tsconfig.json'),
         },
         externals: {
             fsevents: 'commonjs2 fsevents',

--- a/packages/vscode-pyright/package-lock.json
+++ b/packages/vscode-pyright/package-lock.json
@@ -32,9 +32,9 @@
             "dev": true
         },
         "@nodelib/fs.walk": {
-            "version": "1.2.7",
-            "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.7.tgz",
-            "integrity": "sha512-BTIhocbPBSrRmHxOAJFtR18oLhxTtAFDAvL8hY1S3iU8k+E60W/YFs4jrixGzQjMpF4qPXxIQHcjVD9dz1C2QA==",
+            "version": "1.2.8",
+            "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+            "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
             "dev": true,
             "requires": {
                 "@nodelib/fs.scandir": "2.1.5",
@@ -42,9 +42,9 @@
             }
         },
         "@types/copy-webpack-plugin": {
-            "version": "8.0.0",
-            "resolved": "https://registry.npmjs.org/@types/copy-webpack-plugin/-/copy-webpack-plugin-8.0.0.tgz",
-            "integrity": "sha512-EJ9Nd0a628uwvgCEt7bN4F6f2jA0O+i+ajAyq9F4jRTqJJ0ro13C22GL/bnvnsSoKuN/O93yfXqZWhn2R70b/g==",
+            "version": "8.0.1",
+            "resolved": "https://registry.npmjs.org/@types/copy-webpack-plugin/-/copy-webpack-plugin-8.0.1.tgz",
+            "integrity": "sha512-TwEeGse0/wq+t3SFW0DEwroMS/cDkwVZT+vj7tMAYTp7llt/yz6NuW2n04X2M5P/kSfBQOORhrHAN2mqZdmybg==",
             "dev": true,
             "requires": {
                 "@types/node": "*",
@@ -53,9 +53,9 @@
             }
         },
         "@types/eslint": {
-            "version": "7.2.13",
-            "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-7.2.13.tgz",
-            "integrity": "sha512-LKmQCWAlnVHvvXq4oasNUMTJJb2GwSyTY8+1C7OH5ILR8mPLaljv1jxL1bXW3xB3jFbQxTKxJAvI8PyjB09aBg==",
+            "version": "7.28.0",
+            "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-7.28.0.tgz",
+            "integrity": "sha512-07XlgzX0YJUn4iG1ocY4IX9DzKSmMGUs6ESKlxWhZRaa0fatIWaHWUVapcuGa8r5HFnTqzj+4OCjd5f7EZ/i/A==",
             "dev": true,
             "requires": {
                 "@types/estree": "*",
@@ -63,9 +63,9 @@
             }
         },
         "@types/eslint-scope": {
-            "version": "3.7.0",
-            "resolved": "https://registry.npmjs.org/@types/eslint-scope/-/eslint-scope-3.7.0.tgz",
-            "integrity": "sha512-O/ql2+rrCUe2W2rs7wMR+GqPRcgB6UiqN5RhrR5xruFlY7l9YLMn0ZkDzjoHLeiFkR8MCQZVudUuuvQ2BLC9Qw==",
+            "version": "3.7.1",
+            "resolved": "https://registry.npmjs.org/@types/eslint-scope/-/eslint-scope-3.7.1.tgz",
+            "integrity": "sha512-SCFeogqiptms4Fg29WpOTk5nHIzfpKCemSN63ksBQYKTcXoJEmJagV+DhVmbapZzY4/5YaOV1nZwrsU79fFm1g==",
             "dev": true,
             "requires": {
                 "@types/eslint": "*",
@@ -73,27 +73,21 @@
             }
         },
         "@types/estree": {
-            "version": "0.0.47",
-            "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.47.tgz",
-            "integrity": "sha512-c5ciR06jK8u9BstrmJyO97m+klJrrhCf9u3rLu3DEAJBirxRqSCvDQoYKmxuYwQI5SZChAWu+tq9oVlGRuzPAg==",
+            "version": "0.0.50",
+            "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.50.tgz",
+            "integrity": "sha512-C6N5s2ZFtuZRj54k2/zyRhNDjJwwcViAM3Nbm8zjBpbqAdZ00mr0CFxvSKeO8Y/e03WVFLpQMdHYVfUd6SB+Hw==",
             "dev": true
         },
         "@types/json-schema": {
-            "version": "7.0.7",
-            "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.7.tgz",
-            "integrity": "sha512-cxWFQVseBm6O9Gbw1IWb8r6OS4OhSt3hPZLkFApLjM8TEXROBuQGLAH2i2gZpcXdLBIrpXuTDhH7Vbm1iXmNGA==",
-            "dev": true
-        },
-        "@types/json5": {
-            "version": "0.0.29",
-            "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
-            "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4=",
+            "version": "7.0.8",
+            "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.8.tgz",
+            "integrity": "sha512-YSBPTLTVm2e2OoQIDYx8HaeWJ5tTToLH67kXR7zYNGupXMEHa2++G8k+DczX2cFVgalypqtyZIcU19AFcmOpmg==",
             "dev": true
         },
         "@types/node": {
-            "version": "12.20.15",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.15.tgz",
-            "integrity": "sha512-F6S4Chv4JicJmyrwlDkxUdGNSplsQdGwp1A0AJloEVDirWdZOAiRHhovDlsFkKUrquUXhz1imJhXHsf59auyAg==",
+            "version": "12.20.16",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.16.tgz",
+            "integrity": "sha512-6CLxw83vQf6DKqXxMPwl8qpF8I7THFZuIwLt4TnNsumxkp1VsRZWT8txQxncT/Rl2UojTsFzWgDG4FRMwafrlA==",
             "dev": true
         },
         "@types/vscode": {
@@ -103,148 +97,148 @@
             "dev": true
         },
         "@webassemblyjs/ast": {
-            "version": "1.11.0",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.11.0.tgz",
-            "integrity": "sha512-kX2W49LWsbthrmIRMbQZuQDhGtjyqXfEmmHyEi4XWnSZtPmxY0+3anPIzsnRb45VH/J55zlOfWvZuY47aJZTJg==",
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.11.1.tgz",
+            "integrity": "sha512-ukBh14qFLjxTQNTXocdyksN5QdM28S1CxHt2rdskFyL+xFV7VremuBLVbmCePj+URalXBENx/9Lm7lnhihtCSw==",
             "dev": true,
             "requires": {
-                "@webassemblyjs/helper-numbers": "1.11.0",
-                "@webassemblyjs/helper-wasm-bytecode": "1.11.0"
+                "@webassemblyjs/helper-numbers": "1.11.1",
+                "@webassemblyjs/helper-wasm-bytecode": "1.11.1"
             }
         },
         "@webassemblyjs/floating-point-hex-parser": {
-            "version": "1.11.0",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.11.0.tgz",
-            "integrity": "sha512-Q/aVYs/VnPDVYvsCBL/gSgwmfjeCb4LW8+TMrO3cSzJImgv8lxxEPM2JA5jMrivE7LSz3V+PFqtMbls3m1exDA==",
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.11.1.tgz",
+            "integrity": "sha512-iGRfyc5Bq+NnNuX8b5hwBrRjzf0ocrJPI6GWFodBFzmFnyvrQ83SHKhmilCU/8Jv67i4GJZBMhEzltxzcNagtQ==",
             "dev": true
         },
         "@webassemblyjs/helper-api-error": {
-            "version": "1.11.0",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.11.0.tgz",
-            "integrity": "sha512-baT/va95eXiXb2QflSx95QGT5ClzWpGaa8L7JnJbgzoYeaA27FCvuBXU758l+KXWRndEmUXjP0Q5fibhavIn8w==",
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.11.1.tgz",
+            "integrity": "sha512-RlhS8CBCXfRUR/cwo2ho9bkheSXG0+NwooXcc3PAILALf2QLdFyj7KGsKRbVc95hZnhnERon4kW/D3SZpp6Tcg==",
             "dev": true
         },
         "@webassemblyjs/helper-buffer": {
-            "version": "1.11.0",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.11.0.tgz",
-            "integrity": "sha512-u9HPBEl4DS+vA8qLQdEQ6N/eJQ7gT7aNvMIo8AAWvAl/xMrcOSiI2M0MAnMCy3jIFke7bEee/JwdX1nUpCtdyA==",
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.11.1.tgz",
+            "integrity": "sha512-gwikF65aDNeeXa8JxXa2BAk+REjSyhrNC9ZwdT0f8jc4dQQeDQ7G4m0f2QCLPJiMTTO6wfDmRmj/pW0PsUvIcA==",
             "dev": true
         },
         "@webassemblyjs/helper-numbers": {
-            "version": "1.11.0",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-numbers/-/helper-numbers-1.11.0.tgz",
-            "integrity": "sha512-DhRQKelIj01s5IgdsOJMKLppI+4zpmcMQ3XboFPLwCpSNH6Hqo1ritgHgD0nqHeSYqofA6aBN/NmXuGjM1jEfQ==",
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-numbers/-/helper-numbers-1.11.1.tgz",
+            "integrity": "sha512-vDkbxiB8zfnPdNK9Rajcey5C0w+QJugEglN0of+kmO8l7lDb77AnlKYQF7aarZuCrv+l0UvqL+68gSDr3k9LPQ==",
             "dev": true,
             "requires": {
-                "@webassemblyjs/floating-point-hex-parser": "1.11.0",
-                "@webassemblyjs/helper-api-error": "1.11.0",
+                "@webassemblyjs/floating-point-hex-parser": "1.11.1",
+                "@webassemblyjs/helper-api-error": "1.11.1",
                 "@xtuc/long": "4.2.2"
             }
         },
         "@webassemblyjs/helper-wasm-bytecode": {
-            "version": "1.11.0",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.11.0.tgz",
-            "integrity": "sha512-MbmhvxXExm542tWREgSFnOVo07fDpsBJg3sIl6fSp9xuu75eGz5lz31q7wTLffwL3Za7XNRCMZy210+tnsUSEA==",
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.11.1.tgz",
+            "integrity": "sha512-PvpoOGiJwXeTrSf/qfudJhwlvDQxFgelbMqtq52WWiXC6Xgg1IREdngmPN3bs4RoO83PnL/nFrxucXj1+BX62Q==",
             "dev": true
         },
         "@webassemblyjs/helper-wasm-section": {
-            "version": "1.11.0",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.11.0.tgz",
-            "integrity": "sha512-3Eb88hcbfY/FCukrg6i3EH8H2UsD7x8Vy47iVJrP967A9JGqgBVL9aH71SETPx1JrGsOUVLo0c7vMCN22ytJew==",
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.11.1.tgz",
+            "integrity": "sha512-10P9No29rYX1j7F3EVPX3JvGPQPae+AomuSTPiF9eBQeChHI6iqjMIwR9JmOJXwpnn/oVGDk7I5IlskuMwU/pg==",
             "dev": true,
             "requires": {
-                "@webassemblyjs/ast": "1.11.0",
-                "@webassemblyjs/helper-buffer": "1.11.0",
-                "@webassemblyjs/helper-wasm-bytecode": "1.11.0",
-                "@webassemblyjs/wasm-gen": "1.11.0"
+                "@webassemblyjs/ast": "1.11.1",
+                "@webassemblyjs/helper-buffer": "1.11.1",
+                "@webassemblyjs/helper-wasm-bytecode": "1.11.1",
+                "@webassemblyjs/wasm-gen": "1.11.1"
             }
         },
         "@webassemblyjs/ieee754": {
-            "version": "1.11.0",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.11.0.tgz",
-            "integrity": "sha512-KXzOqpcYQwAfeQ6WbF6HXo+0udBNmw0iXDmEK5sFlmQdmND+tr773Ti8/5T/M6Tl/413ArSJErATd8In3B+WBA==",
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.11.1.tgz",
+            "integrity": "sha512-hJ87QIPtAMKbFq6CGTkZYJivEwZDbQUgYd3qKSadTNOhVY7p+gfP6Sr0lLRVTaG1JjFj+r3YchoqRYxNH3M0GQ==",
             "dev": true,
             "requires": {
                 "@xtuc/ieee754": "^1.2.0"
             }
         },
         "@webassemblyjs/leb128": {
-            "version": "1.11.0",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.11.0.tgz",
-            "integrity": "sha512-aqbsHa1mSQAbeeNcl38un6qVY++hh8OpCOzxhixSYgbRfNWcxJNJQwe2rezK9XEcssJbbWIkblaJRwGMS9zp+g==",
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.11.1.tgz",
+            "integrity": "sha512-BJ2P0hNZ0u+Th1YZXJpzW6miwqQUGcIHT1G/sf72gLVD9DZ5AdYTqPNbHZh6K1M5VmKvFXwGSWZADz+qBWxeRw==",
             "dev": true,
             "requires": {
                 "@xtuc/long": "4.2.2"
             }
         },
         "@webassemblyjs/utf8": {
-            "version": "1.11.0",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.11.0.tgz",
-            "integrity": "sha512-A/lclGxH6SpSLSyFowMzO/+aDEPU4hvEiooCMXQPcQFPPJaYcPQNKGOCLUySJsYJ4trbpr+Fs08n4jelkVTGVw==",
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.11.1.tgz",
+            "integrity": "sha512-9kqcxAEdMhiwQkHpkNiorZzqpGrodQQ2IGrHHxCy+Ozng0ofyMA0lTqiLkVs1uzTRejX+/O0EOT7KxqVPuXosQ==",
             "dev": true
         },
         "@webassemblyjs/wasm-edit": {
-            "version": "1.11.0",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.11.0.tgz",
-            "integrity": "sha512-JHQ0damXy0G6J9ucyKVXO2j08JVJ2ntkdJlq1UTiUrIgfGMmA7Ik5VdC/L8hBK46kVJgujkBIoMtT8yVr+yVOQ==",
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.11.1.tgz",
+            "integrity": "sha512-g+RsupUC1aTHfR8CDgnsVRVZFJqdkFHpsHMfJuWQzWU3tvnLC07UqHICfP+4XyL2tnr1amvl1Sdp06TnYCmVkA==",
             "dev": true,
             "requires": {
-                "@webassemblyjs/ast": "1.11.0",
-                "@webassemblyjs/helper-buffer": "1.11.0",
-                "@webassemblyjs/helper-wasm-bytecode": "1.11.0",
-                "@webassemblyjs/helper-wasm-section": "1.11.0",
-                "@webassemblyjs/wasm-gen": "1.11.0",
-                "@webassemblyjs/wasm-opt": "1.11.0",
-                "@webassemblyjs/wasm-parser": "1.11.0",
-                "@webassemblyjs/wast-printer": "1.11.0"
+                "@webassemblyjs/ast": "1.11.1",
+                "@webassemblyjs/helper-buffer": "1.11.1",
+                "@webassemblyjs/helper-wasm-bytecode": "1.11.1",
+                "@webassemblyjs/helper-wasm-section": "1.11.1",
+                "@webassemblyjs/wasm-gen": "1.11.1",
+                "@webassemblyjs/wasm-opt": "1.11.1",
+                "@webassemblyjs/wasm-parser": "1.11.1",
+                "@webassemblyjs/wast-printer": "1.11.1"
             }
         },
         "@webassemblyjs/wasm-gen": {
-            "version": "1.11.0",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.11.0.tgz",
-            "integrity": "sha512-BEUv1aj0WptCZ9kIS30th5ILASUnAPEvE3tVMTrItnZRT9tXCLW2LEXT8ezLw59rqPP9klh9LPmpU+WmRQmCPQ==",
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.11.1.tgz",
+            "integrity": "sha512-F7QqKXwwNlMmsulj6+O7r4mmtAlCWfO/0HdgOxSklZfQcDu0TpLiD1mRt/zF25Bk59FIjEuGAIyn5ei4yMfLhA==",
             "dev": true,
             "requires": {
-                "@webassemblyjs/ast": "1.11.0",
-                "@webassemblyjs/helper-wasm-bytecode": "1.11.0",
-                "@webassemblyjs/ieee754": "1.11.0",
-                "@webassemblyjs/leb128": "1.11.0",
-                "@webassemblyjs/utf8": "1.11.0"
+                "@webassemblyjs/ast": "1.11.1",
+                "@webassemblyjs/helper-wasm-bytecode": "1.11.1",
+                "@webassemblyjs/ieee754": "1.11.1",
+                "@webassemblyjs/leb128": "1.11.1",
+                "@webassemblyjs/utf8": "1.11.1"
             }
         },
         "@webassemblyjs/wasm-opt": {
-            "version": "1.11.0",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.11.0.tgz",
-            "integrity": "sha512-tHUSP5F4ywyh3hZ0+fDQuWxKx3mJiPeFufg+9gwTpYp324mPCQgnuVKwzLTZVqj0duRDovnPaZqDwoyhIO8kYg==",
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.11.1.tgz",
+            "integrity": "sha512-VqnkNqnZlU5EB64pp1l7hdm3hmQw7Vgqa0KF/KCNO9sIpI6Fk6brDEiX+iCOYrvMuBWDws0NkTOxYEb85XQHHw==",
             "dev": true,
             "requires": {
-                "@webassemblyjs/ast": "1.11.0",
-                "@webassemblyjs/helper-buffer": "1.11.0",
-                "@webassemblyjs/wasm-gen": "1.11.0",
-                "@webassemblyjs/wasm-parser": "1.11.0"
+                "@webassemblyjs/ast": "1.11.1",
+                "@webassemblyjs/helper-buffer": "1.11.1",
+                "@webassemblyjs/wasm-gen": "1.11.1",
+                "@webassemblyjs/wasm-parser": "1.11.1"
             }
         },
         "@webassemblyjs/wasm-parser": {
-            "version": "1.11.0",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.11.0.tgz",
-            "integrity": "sha512-6L285Sgu9gphrcpDXINvm0M9BskznnzJTE7gYkjDbxET28shDqp27wpruyx3C2S/dvEwiigBwLA1cz7lNUi0kw==",
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.11.1.tgz",
+            "integrity": "sha512-rrBujw+dJu32gYB7/Lup6UhdkPx9S9SnobZzRVL7VcBH9Bt9bCBLEuX/YXOOtBsOZ4NQrRykKhffRWHvigQvOA==",
             "dev": true,
             "requires": {
-                "@webassemblyjs/ast": "1.11.0",
-                "@webassemblyjs/helper-api-error": "1.11.0",
-                "@webassemblyjs/helper-wasm-bytecode": "1.11.0",
-                "@webassemblyjs/ieee754": "1.11.0",
-                "@webassemblyjs/leb128": "1.11.0",
-                "@webassemblyjs/utf8": "1.11.0"
+                "@webassemblyjs/ast": "1.11.1",
+                "@webassemblyjs/helper-api-error": "1.11.1",
+                "@webassemblyjs/helper-wasm-bytecode": "1.11.1",
+                "@webassemblyjs/ieee754": "1.11.1",
+                "@webassemblyjs/leb128": "1.11.1",
+                "@webassemblyjs/utf8": "1.11.1"
             }
         },
         "@webassemblyjs/wast-printer": {
-            "version": "1.11.0",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.11.0.tgz",
-            "integrity": "sha512-Fg5OX46pRdTgB7rKIUojkh9vXaVN6sGYCnEiJN1GYkb0RPwShZXp6KTDqmoMdQPKhcroOXh3fEzmkWmCYaKYhQ==",
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.11.1.tgz",
+            "integrity": "sha512-IQboUWM4eKzWW+N/jij2sRatKMh99QEelo3Eb2q0qXkvPRISAj8Qxtmw5itwqK+TTkBuUIE45AxYPToqPtL5gg==",
             "dev": true,
             "requires": {
-                "@webassemblyjs/ast": "1.11.0",
+                "@webassemblyjs/ast": "1.11.1",
                 "@xtuc/long": "4.2.2"
             }
         },
@@ -282,9 +276,9 @@
             "dev": true
         },
         "acorn": {
-            "version": "8.4.0",
-            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.4.0.tgz",
-            "integrity": "sha512-ULr0LDaEqQrMFGyQ3bhJkLsbtrQ8QibAseGZeaSUiT/6zb9IvIkomWHJIvgvwad+hinRAgsI51JcWk2yvwyL+w==",
+            "version": "8.4.1",
+            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.4.1.tgz",
+            "integrity": "sha512-asabaBSkEKosYKMITunzX177CXxQ4Q8BSSzMTKD+FefUhipQC70gfW5SiUDhYQ3vk8G+81HqQk7Fv9OXwwn9KA==",
             "dev": true
         },
         "ajv": {
@@ -330,9 +324,9 @@
             "dev": true
         },
         "azure-devops-node-api": {
-            "version": "10.2.2",
-            "resolved": "https://registry.npmjs.org/azure-devops-node-api/-/azure-devops-node-api-10.2.2.tgz",
-            "integrity": "sha512-4TVv2X7oNStT0vLaEfExmy3J4/CzfuXolEcQl/BRUmvGySqKStTG2O55/hUQ0kM7UJlZBLgniM0SBq4d/WkKow==",
+            "version": "11.0.1",
+            "resolved": "https://registry.npmjs.org/azure-devops-node-api/-/azure-devops-node-api-11.0.1.tgz",
+            "integrity": "sha512-YMdjAw9l5p/6leiyIloxj3k7VIvYThKjvqgiQn88r3nhT93ENwsoDS3A83CyJ4uTWzCZ5f5jCi6c27rTU5Pz+A==",
             "dev": true,
             "requires": {
                 "tunnel": "0.0.6",
@@ -404,9 +398,9 @@
             }
         },
         "caniuse-lite": {
-            "version": "1.0.30001236",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001236.tgz",
-            "integrity": "sha512-o0PRQSrSCGJKCPZcgMzl5fUaj5xHe8qA2m4QRvnyY4e1lITqoNkr7q/Oh1NcpGSy0Th97UZ35yoKcINPoq7YOQ==",
+            "version": "1.0.30001245",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001245.tgz",
+            "integrity": "sha512-768fM9j1PKXpOCKws6eTo3RHmvTUsG9UrpT4WoREFeZgJBTi4/X9g565azS/rVUGtqb8nt7FjLeF5u4kukERnA==",
             "dev": true
         },
         "chalk": {
@@ -508,9 +502,9 @@
             "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
         },
         "copy-webpack-plugin": {
-            "version": "9.0.0",
-            "resolved": "https://registry.npmjs.org/copy-webpack-plugin/-/copy-webpack-plugin-9.0.0.tgz",
-            "integrity": "sha512-k8UB2jLIb1Jip2nZbCz83T/XfhfjX6mB1yLJNYKrpYi7FQimfOoFv/0//iT6HV1K8FwUB5yUbCcnpLebJXJTug==",
+            "version": "9.0.1",
+            "resolved": "https://registry.npmjs.org/copy-webpack-plugin/-/copy-webpack-plugin-9.0.1.tgz",
+            "integrity": "sha512-14gHKKdYIxF84jCEgPgYXCPpldbwpxxLbCmA7LReY7gvbaT555DgeBWBgBZM116tv/fO6RRJrsivBqRyRlukhw==",
             "dev": true,
             "requires": {
                 "fast-glob": "^3.2.5",
@@ -519,7 +513,7 @@
                 "normalize-path": "^3.0.0",
                 "p-limit": "^3.1.0",
                 "schema-utils": "^3.0.0",
-                "serialize-javascript": "^5.0.1"
+                "serialize-javascript": "^6.0.0"
             }
         },
         "cross-spawn": {
@@ -611,9 +605,9 @@
             }
         },
         "electron-to-chromium": {
-            "version": "1.3.752",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.752.tgz",
-            "integrity": "sha512-2Tg+7jSl3oPxgsBsWKh5H83QazTkmWG/cnNwJplmyZc7KcN61+I10oUgaXSVk/NwfvN3BdkKDR4FYuRBQQ2v0A==",
+            "version": "1.3.777",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.777.tgz",
+            "integrity": "sha512-gO0VEU2esNUOu51DTtp7E7xy0d+yZdbC06EACvou1cbPM9Wwyz8ixPa6T1tqDXlT4/AefXtzx0i9OLwKkLOHQA==",
             "dev": true
         },
         "enhanced-resolve": {
@@ -639,9 +633,9 @@
             "dev": true
         },
         "es-module-lexer": {
-            "version": "0.4.1",
-            "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-0.4.1.tgz",
-            "integrity": "sha512-ooYciCUtfw6/d2w56UVeqHPcoCFAiJdz5XOkYpv/Txl1HMUozpXjz/2RIQgqwKdXNDPSF1W7mJCFse3G+HDyAA==",
+            "version": "0.7.1",
+            "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-0.7.1.tgz",
+            "integrity": "sha512-MgtWFl5No+4S3TmhDmCz2ObFGm6lEpTnzbQi+Dd+pw4mlTIZTmM2iAs5gRlmx5zS9luzobCSBSI90JM/1/JgOw==",
             "dev": true
         },
         "escalade": {
@@ -719,17 +713,16 @@
             "dev": true
         },
         "fast-glob": {
-            "version": "3.2.5",
-            "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.5.tgz",
-            "integrity": "sha512-2DtFcgT68wiTTiwZ2hNdJfcHNke9XOfnwmBRWXhmeKM8rF0TGwmC/Qto3S7RoZKp5cilZbxzO5iTNTQsJ+EeDg==",
+            "version": "3.2.7",
+            "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.7.tgz",
+            "integrity": "sha512-rYGMRwip6lUMvYD3BTScMwT1HtAs2d71SMv66Vrxs0IekGZEjhM0pcMfjQPnknBt2zeCwQMEupiN02ZP4DiT1Q==",
             "dev": true,
             "requires": {
                 "@nodelib/fs.stat": "^2.0.2",
                 "@nodelib/fs.walk": "^1.2.3",
-                "glob-parent": "^5.1.0",
+                "glob-parent": "^5.1.2",
                 "merge2": "^1.3.0",
-                "micromatch": "^4.0.2",
-                "picomatch": "^2.2.1"
+                "micromatch": "^4.0.4"
             },
             "dependencies": {
                 "glob-parent": {
@@ -756,9 +749,9 @@
             "dev": true
         },
         "fastq": {
-            "version": "1.11.0",
-            "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.11.0.tgz",
-            "integrity": "sha512-7Eczs8gIPDrVzT+EksYBcupqMyxSHXXrHOLRRxU2/DicV8789MRBRR8+Hc2uWzUupOs4YS4JzBmBxjjCVBxD/g==",
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.11.1.tgz",
+            "integrity": "sha512-HOnr8Mc60eNYl1gzwp6r5RoUyAn5/glBolUzP/Ez6IFVPMPirxn/9phgL6zhOtaTy7ISwPvQ+wT+hfcRZh/bzw==",
             "dev": true,
             "requires": {
                 "reusify": "^1.0.4"
@@ -851,9 +844,9 @@
             "dev": true
         },
         "globby": {
-            "version": "11.0.3",
-            "resolved": "https://registry.npmjs.org/globby/-/globby-11.0.3.tgz",
-            "integrity": "sha512-ffdmosjA807y7+lA1NM0jELARVmYul/715xiILEjo3hBLPTcirgQNnXECn5g3mtR8TOLCVbkfua1Hpen25/Xcg==",
+            "version": "11.0.4",
+            "resolved": "https://registry.npmjs.org/globby/-/globby-11.0.4.tgz",
+            "integrity": "sha512-9O4MVG9ioZJ08ffbcyVYyLOJLk5JQ688pJ4eMGLpdWLHq/Wr1D9BlriLQyL0E+jbkuePVZXYFj47QM/v093wHg==",
             "dev": true,
             "requires": {
                 "array-union": "^2.1.0",
@@ -948,9 +941,9 @@
             "dev": true
         },
         "is-core-module": {
-            "version": "2.4.0",
-            "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.4.0.tgz",
-            "integrity": "sha512-6A2fkfq1rfeQZjxrZJGerpLCTHRNEBiSgnu0+obeJpEPZRUooHgsizvzv0ZjJwOz3iWIHdJtVWJ/tmPr3D21/A==",
+            "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.5.0.tgz",
+            "integrity": "sha512-TXCMSDsEHMEEZ6eCA8rwRDbLu55MRGmrctljsBX/2v1d9/GzqHOxW5c5oPSgrUt2vBFXebu9rGqckXGPWOlYpg==",
             "dev": true,
             "requires": {
                 "has": "^1.0.3"
@@ -1005,9 +998,9 @@
             "dev": true
         },
         "jest-worker": {
-            "version": "27.0.2",
-            "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.0.2.tgz",
-            "integrity": "sha512-EoBdilOTTyOgmHXtw/cPc+ZrCA0KJMrkXzkrPGNwLmnvvlN1nj7MPrxpT7m+otSv2e1TLaVffzDnE/LB14zJMg==",
+            "version": "27.0.6",
+            "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.0.6.tgz",
+            "integrity": "sha512-qupxcj/dRuA3xHPMUd40gr2EaAurFbkwzOh7wfPaeE9id7hyjURRQoqNfHifHK3XjJU6YJJUQKILGUnwGPEOCA==",
             "dev": true,
             "requires": {
                 "@types/node": "*",
@@ -1026,15 +1019,6 @@
             "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
             "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
             "dev": true
-        },
-        "json5": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-            "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
-            "dev": true,
-            "requires": {
-                "minimist": "^1.2.0"
-            }
         },
         "kind-of": {
             "version": "6.0.3",
@@ -1219,9 +1203,9 @@
             }
         },
         "object-inspect": {
-            "version": "1.10.3",
-            "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.10.3.tgz",
-            "integrity": "sha512-e5mCJlSH7poANfC8z8S9s9S2IN5/4Zb3aZ33f5s8YqoazCFzNLloLU8r5VCG+G7WoqLvAAZoVMcy3tp/3X0Plw==",
+            "version": "1.11.0",
+            "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.11.0.tgz",
+            "integrity": "sha512-jp7ikS6Sd3GxQfZJPyH3cjcbJF6GZPClgdV+EFygjFLQ5FmW/dRUnTd9PQ9k0JhoNDabWFbpF1yCdSWCC6gexg==",
             "dev": true
         },
         "once": {
@@ -1486,12 +1470,12 @@
             "dev": true
         },
         "schema-utils": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.0.0.tgz",
-            "integrity": "sha512-6D82/xSzO094ajanoOSbe4YvXWMfn2A//8Y1+MUqFAJul5Bs+yn36xbK9OtNDcRVSBJ9jjeoXftM6CfztsjOAA==",
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.1.0.tgz",
+            "integrity": "sha512-tTEaeYkyIhEZ9uWgAjDerWov3T9MgX8dhhy2r0IGeeX4W8ngtGl1++dUve/RUqzuaASSh7shwCDJjEzthxki8w==",
             "dev": true,
             "requires": {
-                "@types/json-schema": "^7.0.6",
+                "@types/json-schema": "^7.0.7",
                 "ajv": "^6.12.5",
                 "ajv-keywords": "^3.5.2"
             }
@@ -1505,9 +1489,9 @@
             }
         },
         "serialize-javascript": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-5.0.1.tgz",
-            "integrity": "sha512-SaaNal9imEO737H2c05Og0/8LUXG7EnsZyMa8MzkmuHoELfT6txuj0cMqRj6zfPKnmQ1yasR4PCJc8x+M4JSPA==",
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.0.tgz",
+            "integrity": "sha512-Qr3TosvguFt8ePWqsvRfrKyQXIiW+nGbYpy8XK24NQHE83caxWt+mIymTT19DGFbNWNLfEwsrkSmN64lVWB9ag==",
             "dev": true,
             "requires": {
                 "randombytes": "^2.1.0"
@@ -1609,12 +1593,6 @@
             "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
             "dev": true
         },
-        "strip-bom": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-            "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
-            "dev": true
-        },
         "strip-final-newline": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
@@ -1637,9 +1615,9 @@
             "dev": true
         },
         "terser": {
-            "version": "5.7.0",
-            "resolved": "https://registry.npmjs.org/terser/-/terser-5.7.0.tgz",
-            "integrity": "sha512-HP5/9hp2UaZt5fYkuhNBR8YyRcT8juw8+uFbAme53iN9hblvKnLUTKkmwJG6ocWpIKf8UK4DoeWG4ty0J6S6/g==",
+            "version": "5.7.1",
+            "resolved": "https://registry.npmjs.org/terser/-/terser-5.7.1.tgz",
+            "integrity": "sha512-b3e+d5JbHAe/JSjwsC3Zn55wsBIM7AsHLjKxT31kGCldgbpFePaFo+PiddtO6uwRZWRw7sPXmAN8dTW61xmnSg==",
             "dev": true,
             "requires": {
                 "commander": "^2.20.0",
@@ -1656,15 +1634,15 @@
             }
         },
         "terser-webpack-plugin": {
-            "version": "5.1.3",
-            "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.1.3.tgz",
-            "integrity": "sha512-cxGbMqr6+A2hrIB5ehFIF+F/iST5ZOxvOmy9zih9ySbP1C2oEWQSOUS+2SNBTjzx5xLKO4xnod9eywdfq1Nb9A==",
+            "version": "5.1.4",
+            "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.1.4.tgz",
+            "integrity": "sha512-C2WkFwstHDhVEmsmlCxrXUtVklS+Ir1A7twrYzrDrQQOIMOaVAYykaoo/Aq1K0QRkMoY2hhvDQY1cm4jnIMFwA==",
             "dev": true,
             "requires": {
                 "jest-worker": "^27.0.2",
                 "p-limit": "^3.1.0",
                 "schema-utils": "^3.0.0",
-                "serialize-javascript": "^5.0.1",
+                "serialize-javascript": "^6.0.0",
                 "source-map": "^0.6.1",
                 "terser": "^5.7.0"
             }
@@ -1699,33 +1677,10 @@
                 "semver": "^7.3.4"
             }
         },
-        "tsconfig-paths": {
-            "version": "3.9.0",
-            "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.9.0.tgz",
-            "integrity": "sha512-dRcuzokWhajtZWkQsDVKbWyY+jgcLC5sqJhg2PSgf4ZkH2aHPvaOY8YWGhmjb68b5qqTfasSsDO9k7RUiEmZAw==",
-            "dev": true,
-            "requires": {
-                "@types/json5": "^0.0.29",
-                "json5": "^1.0.1",
-                "minimist": "^1.2.0",
-                "strip-bom": "^3.0.0"
-            }
-        },
-        "tsconfig-paths-webpack-plugin": {
-            "version": "3.5.1",
-            "resolved": "https://registry.npmjs.org/tsconfig-paths-webpack-plugin/-/tsconfig-paths-webpack-plugin-3.5.1.tgz",
-            "integrity": "sha512-n5CMlUUj+N5pjBhBACLq4jdr9cPTitySCjIosoQm0zwK99gmrcTGAfY9CwxRFT9+9OleNWXPRUcxsKP4AYExxQ==",
-            "dev": true,
-            "requires": {
-                "chalk": "^4.1.0",
-                "enhanced-resolve": "^5.7.0",
-                "tsconfig-paths": "^3.9.0"
-            }
-        },
         "tslib": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
-            "integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w==",
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+            "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==",
             "dev": true
         },
         "tunnel": {
@@ -1746,9 +1701,9 @@
             }
         },
         "typescript": {
-            "version": "4.3.2",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.2.tgz",
-            "integrity": "sha512-zZ4hShnmnoVnAHpVHWpTcxdv7dWP60S2FsydQLV8V5PbS3FifjWFFRiHSWpDJahly88PRyV5teTSLoq4eG7mKw==",
+            "version": "4.3.5",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.5.tgz",
+            "integrity": "sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==",
             "dev": true
         },
         "uc.micro": {
@@ -1785,22 +1740,22 @@
             "dev": true
         },
         "vsce": {
-            "version": "1.93.0",
-            "resolved": "https://registry.npmjs.org/vsce/-/vsce-1.93.0.tgz",
-            "integrity": "sha512-RgmxwybXenP6tTF0PLh97b/RRLp1RkzjAHNya3QAfv1EZVg+lfoBiAaXogpmOGjYr8OskkqP5tIa3D/Q6X9lrw==",
+            "version": "1.95.1",
+            "resolved": "https://registry.npmjs.org/vsce/-/vsce-1.95.1.tgz",
+            "integrity": "sha512-2v8g3ZtZkaOTscRjjCAtM3Au6YYWJtg9UNt1iyyWko7ZHejbt5raClcNzQ7/WYVLYhYHc+otHQifV0gCBREgNg==",
             "dev": true,
             "requires": {
-                "azure-devops-node-api": "^10.2.2",
+                "azure-devops-node-api": "^11.0.1",
                 "chalk": "^2.4.2",
                 "cheerio": "^1.0.0-rc.9",
                 "commander": "^6.1.0",
                 "denodeify": "^1.2.1",
                 "glob": "^7.0.6",
-                "ignore": "^5.1.8",
                 "leven": "^3.1.0",
                 "lodash": "^4.17.15",
                 "markdown-it": "^10.0.0",
                 "mime": "^1.3.4",
+                "minimatch": "^3.0.3",
                 "osenv": "^0.1.3",
                 "parse-semver": "^1.1.1",
                 "read": "^1.0.7",
@@ -1924,21 +1879,21 @@
             }
         },
         "webpack": {
-            "version": "5.38.1",
-            "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.38.1.tgz",
-            "integrity": "sha512-OqRmYD1OJbHZph6RUMD93GcCZy4Z4wC0ele4FXyYF0J6AxO1vOSuIlU1hkS/lDlR9CDYBz64MZRmdbdnFFoT2g==",
+            "version": "5.44.0",
+            "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.44.0.tgz",
+            "integrity": "sha512-I1S1w4QLoKmH19pX6YhYN0NiSXaWY8Ou00oA+aMcr9IUGeF5azns+IKBkfoAAG9Bu5zOIzZt/mN35OffBya8AQ==",
             "dev": true,
             "requires": {
                 "@types/eslint-scope": "^3.7.0",
-                "@types/estree": "^0.0.47",
-                "@webassemblyjs/ast": "1.11.0",
-                "@webassemblyjs/wasm-edit": "1.11.0",
-                "@webassemblyjs/wasm-parser": "1.11.0",
-                "acorn": "^8.2.1",
+                "@types/estree": "^0.0.50",
+                "@webassemblyjs/ast": "1.11.1",
+                "@webassemblyjs/wasm-edit": "1.11.1",
+                "@webassemblyjs/wasm-parser": "1.11.1",
+                "acorn": "^8.4.1",
                 "browserslist": "^4.14.5",
                 "chrome-trace-event": "^1.0.2",
                 "enhanced-resolve": "^5.8.0",
-                "es-module-lexer": "^0.4.0",
+                "es-module-lexer": "^0.7.1",
                 "eslint-scope": "5.1.1",
                 "events": "^3.2.0",
                 "glob-to-regexp": "^0.4.1",
@@ -1949,7 +1904,7 @@
                 "neo-async": "^2.6.2",
                 "schema-utils": "^3.0.0",
                 "tapable": "^2.1.1",
-                "terser-webpack-plugin": "^5.1.1",
+                "terser-webpack-plugin": "^5.1.3",
                 "watchpack": "^2.2.0",
                 "webpack-sources": "^2.3.0"
             }

--- a/packages/vscode-pyright/package.json
+++ b/packages/vscode-pyright/package.json
@@ -774,17 +774,16 @@
         "vscode-languageserver-protocol": "3.16.0"
     },
     "devDependencies": {
-        "@types/copy-webpack-plugin": "^8.0.0",
-        "@types/node": "^12.20.15",
+        "@types/copy-webpack-plugin": "^8.0.1",
+        "@types/node": "^12.20.16",
         "@types/vscode": "~1.54.0",
-        "copy-webpack-plugin": "^9.0.0",
+        "copy-webpack-plugin": "^9.0.1",
         "detect-indent": "^6.1.0",
         "shx": "^0.3.3",
         "ts-loader": "^9.2.3",
-        "tsconfig-paths-webpack-plugin": "^3.5.1",
-        "typescript": "~4.3.2",
-        "vsce": "^1.93.0",
-        "webpack": "^5.38.1",
+        "typescript": "~4.3.5",
+        "vsce": "^1.95.1",
+        "webpack": "^5.44.0",
         "webpack-cli": "^4.7.2"
     }
 }

--- a/packages/vscode-pyright/src/server.ts
+++ b/packages/vscode-pyright/src/server.ts
@@ -1,3 +1,3 @@
-import { main } from 'pyright-internal/server';
+import { main } from 'pyright-internal/nodeMain';
 
 main();

--- a/packages/vscode-pyright/tsconfig.withBaseUrl.json
+++ b/packages/vscode-pyright/tsconfig.withBaseUrl.json
@@ -1,9 +1,0 @@
-{
-    "extends": "./tsconfig.json",
-    "compilerOptions": {
-        "baseUrl": ".",
-        "paths": {
-            "pyright-internal/*": ["../pyright-internal/src/*"]
-        }
-    }
-}

--- a/packages/vscode-pyright/webpack.config.js
+++ b/packages/vscode-pyright/webpack.config.js
@@ -5,8 +5,7 @@
 
 const path = require('path');
 const CopyPlugin = require('copy-webpack-plugin');
-const { TsconfigPathsPlugin } = require('tsconfig-paths-webpack-plugin');
-const { cacheConfig, monorepoResourceNameMapper } = require('../../build/lib/webpack');
+const { cacheConfig, monorepoResourceNameMapper, tsconfigResolveAliases } = require('../../build/lib/webpack');
 
 const outPath = path.resolve(__dirname, 'dist');
 const typeshedFallback = path.resolve(__dirname, '..', 'pyright-internal', 'typeshed-fallback');
@@ -37,12 +36,7 @@ module.exports = (_, { mode }) => {
         },
         resolve: {
             extensions: ['.ts', '.js'],
-            plugins: [
-                new TsconfigPathsPlugin({
-                    configFile: 'tsconfig.withBaseUrl.json', // TODO: Remove once the plugin understands TS 4.1's implicit baseUrl.
-                    extensions: ['.ts', '.js'],
-                }),
-            ],
+            alias: tsconfigResolveAliases('tsconfig.json'),
         },
         externals: {
             vscode: 'commonjs vscode',


### PR DESCRIPTION
Rollup of:

- Update dependencies, which fixes outstanding `npm audit` problems.
- Eliminate `tsconfig-paths-webpack-plugin`, which has a number of bugs, including one that silently breaks packaging when two files have the same name in two of our packages.
- Begin refactorings for de-nodifying codebase.