### PR TITLE
Fix a bug where BG won't cancel analysis chunks

### DIFF
--- a/packages/pyright-internal/src/backgroundAnalysisBase.ts
+++ b/packages/pyright-internal/src/backgroundAnalysisBase.ts
@@ -134,7 +134,6 @@ export class BackgroundAnalysisBase {
                 }
 
                 case 'analysisPaused': {
-                    disposeCancellationToken(token);
                     port2.close();
                     port1.close();
 


### PR DESCRIPTION
When the background thread was time sliced (paused then resumed), we'd dispose of the token, so cancellations in the future wouldn't actually run, leaving the background thread to continue running when its result isn't needed.