### PR TITLE
Fixed bug in tokenizer which treated 'constructor' as a keyword

### DIFF
--- a/packages/pyright-internal/src/analyzer/backgroundAnalysisProgram.ts
+++ b/packages/pyright-internal/src/analyzer/backgroundAnalysisProgram.ts
@@ -24,9 +24,7 @@ import { Indices, MaxAnalysisTime, Program } from './program';
 
 export class BackgroundAnalysisProgram {
     private _program: Program;
-    private _backgroundAnalysis: BackgroundAnalysisBase | undefined;
     private _onAnalysisCompletion: AnalysisCompleteCallback | undefined;
-    private _maxAnalysisTime: MaxAnalysisTime | undefined;
     private _indices: Indices | undefined;
 
     constructor(
@@ -34,12 +32,18 @@ export class BackgroundAnalysisProgram {
         private _configOptions: ConfigOptions,
         private _importResolver: ImportResolver,
         extension?: LanguageServiceExtension,
-        backgroundAnalysis?: BackgroundAnalysisBase,
-        maxAnalysisTime?: MaxAnalysisTime
+        private _backgroundAnalysis?: BackgroundAnalysisBase,
+        private _maxAnalysisTime?: MaxAnalysisTime,
+        private _disableChecker?: boolean
     ) {
-        this._program = new Program(this._importResolver, this._configOptions, this._console, extension);
-        this._backgroundAnalysis = backgroundAnalysis;
-        this._maxAnalysisTime = maxAnalysisTime;
+        this._program = new Program(
+            this._importResolver,
+            this._configOptions,
+            this._console,
+            extension,
+            undefined,
+            this._disableChecker
+        );
     }
 
     get configOptions() {

--- a/packages/pyright-internal/src/analyzer/program.ts
+++ b/packages/pyright-internal/src/analyzer/program.ts
@@ -155,7 +155,8 @@ export class Program {
         initialConfigOptions: ConfigOptions,
         console?: ConsoleInterface,
         private _extension?: LanguageServiceExtension,
-        logTracker?: LogTracker
+        logTracker?: LogTracker,
+        private _disableChecker?: boolean
     ) {
         this._console = console || new StandardConsole();
         this._logTracker = logTracker ?? new LogTracker(console, 'FG');
@@ -376,6 +377,10 @@ export class Program {
 
     getFilesToAnalyzeCount() {
         let sourceFileCount = 0;
+
+        if (this._disableChecker) {
+            return sourceFileCount;
+        }
 
         this._sourceFileList.forEach((fileInfo) => {
             if (fileInfo.sourceFile.isCheckingRequired()) {
@@ -884,7 +889,9 @@ export class Program {
                 }
             }
 
-            fileToCheck.sourceFile.check(this._evaluator!);
+            if (!this._disableChecker) {
+                fileToCheck.sourceFile.check(this._evaluator!);
+            }
 
             // For very large programs, we may need to discard the evaluator and
             // its cached types to avoid running out of heap space.

--- a/packages/pyright-internal/src/languageServerBase.ts
+++ b/packages/pyright-internal/src/languageServerBase.ts
@@ -144,6 +144,7 @@ export interface ServerOptions {
     cancellationProvider: CancellationProvider;
     extension?: LanguageServiceExtension;
     maxAnalysisTimeInForeground?: MaxAnalysisTime;
+    disableChecker?: boolean;
     supportedCommands?: string[];
     supportedCodeActions?: string[];
 }
@@ -207,7 +208,7 @@ export abstract class LanguageServerBase implements LanguageServerInterface {
 
     readonly console: ConsoleInterface;
 
-    constructor(private _serverOptions: ServerOptions, protected _connection: Connection) {
+    constructor(protected _serverOptions: ServerOptions, protected _connection: Connection) {
         // Stash the base directory into a global variable.
         // This must happen before fs.getModulePath().
         (global as any).__rootDirectory = _serverOptions.rootDirectory;

--- a/packages/pyright-internal/src/parser/tokenizer.ts
+++ b/packages/pyright-internal/src/parser/tokenizer.ts
@@ -43,46 +43,47 @@ import {
     TokenType,
 } from './tokenizerTypes';
 
-const _keywords: { [key: string]: KeywordType } = {
-    and: KeywordType.And,
-    as: KeywordType.As,
-    assert: KeywordType.Assert,
-    async: KeywordType.Async,
-    await: KeywordType.Await,
-    break: KeywordType.Break,
-    case: KeywordType.Case,
-    class: KeywordType.Class,
-    continue: KeywordType.Continue,
-    __debug__: KeywordType.Debug,
-    def: KeywordType.Def,
-    del: KeywordType.Del,
-    elif: KeywordType.Elif,
-    else: KeywordType.Else,
-    except: KeywordType.Except,
-    finally: KeywordType.Finally,
-    for: KeywordType.For,
-    from: KeywordType.From,
-    global: KeywordType.Global,
-    if: KeywordType.If,
-    import: KeywordType.Import,
-    in: KeywordType.In,
-    is: KeywordType.Is,
-    lambda: KeywordType.Lambda,
-    match: KeywordType.Match,
-    nonlocal: KeywordType.Nonlocal,
-    not: KeywordType.Not,
-    or: KeywordType.Or,
-    pass: KeywordType.Pass,
-    raise: KeywordType.Raise,
-    return: KeywordType.Return,
-    try: KeywordType.Try,
-    while: KeywordType.While,
-    with: KeywordType.With,
-    yield: KeywordType.Yield,
-    False: KeywordType.False,
-    None: KeywordType.None,
-    True: KeywordType.True,
-};
+// This must be a Map, as operations like {}["constructor"] succeed.
+const _keywords: Map<string, KeywordType> = new Map([
+    ['and', KeywordType.And],
+    ['as', KeywordType.As],
+    ['assert', KeywordType.Assert],
+    ['async', KeywordType.Async],
+    ['await', KeywordType.Await],
+    ['break', KeywordType.Break],
+    ['case', KeywordType.Case],
+    ['class', KeywordType.Class],
+    ['continue', KeywordType.Continue],
+    ['__debug__', KeywordType.Debug],
+    ['def', KeywordType.Def],
+    ['del', KeywordType.Del],
+    ['elif', KeywordType.Elif],
+    ['else', KeywordType.Else],
+    ['except', KeywordType.Except],
+    ['finally', KeywordType.Finally],
+    ['for', KeywordType.For],
+    ['from', KeywordType.From],
+    ['global', KeywordType.Global],
+    ['if', KeywordType.If],
+    ['import', KeywordType.Import],
+    ['in', KeywordType.In],
+    ['is', KeywordType.Is],
+    ['lambda', KeywordType.Lambda],
+    ['match', KeywordType.Match],
+    ['nonlocal', KeywordType.Nonlocal],
+    ['not', KeywordType.Not],
+    ['or', KeywordType.Or],
+    ['pass', KeywordType.Pass],
+    ['raise', KeywordType.Raise],
+    ['return', KeywordType.Return],
+    ['try', KeywordType.Try],
+    ['while', KeywordType.While],
+    ['with', KeywordType.With],
+    ['yield', KeywordType.Yield],
+    ['False', KeywordType.False],
+    ['None', KeywordType.None],
+    ['True', KeywordType.True],
+]);
 
 const _operatorInfo: { [key: number]: OperatorFlags } = {
     [OperatorType.Add]: OperatorFlags.Unary | OperatorFlags.Binary,
@@ -659,9 +660,9 @@ export class Tokenizer {
 
         if (this._cs.position > start) {
             const value = this._cs.getText().substr(start, this._cs.position - start);
-            if (_keywords[value] !== undefined) {
+            if (_keywords.has(value)) {
                 this._tokens.push(
-                    KeywordToken.create(start, this._cs.position - start, _keywords[value], this._getComments())
+                    KeywordToken.create(start, this._cs.position - start, _keywords.get(value)!, this._getComments())
                 );
             } else {
                 this._tokens.push(IdentifierToken.create(start, this._cs.position - start, value, this._getComments()));

--- a/packages/pyright-internal/src/tests/tokenizer.test.ts
+++ b/packages/pyright-internal/src/tests/tokenizer.test.ts
@@ -1487,3 +1487,15 @@ test('TypeIgnoreLine2', () => {
     assert.equal(results.tokens.contains(41), true);
     assert.equal(results.tokens.contains(42), false);
 });
+
+test('Constructor', () => {
+    const t = new Tokenizer();
+    const results = t.tokenize('def constructor');
+    assert.equal(results.tokens.count, 2 + _implicitTokenCount);
+
+    assert.equal(results.tokens.getItemAt(0).type, TokenType.Keyword);
+    assert.equal(results.tokens.getItemAt(0).length, 3);
+
+    assert.equal(results.tokens.getItemAt(1).type, TokenType.Identifier);
+    assert.equal(results.tokens.getItemAt(1).length, 11);
+});


### PR DESCRIPTION
`{}["constructor"]` gives back a function; lookup tables like this are unsafe.

For completeness, I did a jsbench of `Map` versus `Object.hasOwnProperty`, but `hasOwnProperty` is actually 2x slower than `Map.has`.

There are loads of these kinds of lookup tables, especially in the type evaluator for special cases; those should be fixed separately but this fixes a regression.