### PR TITLE
Fix non-file schema diagnostics, fix attribute docs in hover

### DIFF
--- a/packages/pyright-internal/src/analyzer/typeDocStringUtils.ts
+++ b/packages/pyright-internal/src/analyzer/typeDocStringUtils.ts
@@ -16,6 +16,7 @@ import {
     FunctionDeclaration,
     isClassDeclaration,
     isFunctionDeclaration,
+    isVariableDeclaration,
     VariableDeclaration,
 } from '../analyzer/declaration';
 import * as ParseTreeUtils from '../analyzer/parseTreeUtils';
@@ -130,9 +131,12 @@ export function getVariableInStubFileDocStrings(decl: VariableDeclaration, sourc
         return docStrings;
     }
 
-    // See whether a variable symbol on the stub is actually a variable. If not, take the doc string.
     for (const implDecl of sourceMapper.findDeclarations(decl)) {
-        if (isClassDeclaration(implDecl) || isFunctionDeclaration(implDecl)) {
+        if (isVariableDeclaration(implDecl) && !!implDecl.docString) {
+            docStrings.push(implDecl.docString);
+        } else if (isClassDeclaration(implDecl) || isFunctionDeclaration(implDecl)) {
+            // It is possible that the variable on the stub is not actually a variable on the corresponding py file.
+            // in that case, get the doc string from original symbol if possible.
             const docString = getFunctionOrClassDeclDocString(implDecl);
             if (docString) {
                 docStrings.push(docString);
@@ -191,6 +195,21 @@ export function getClassDocString(
 
 export function getFunctionOrClassDeclDocString(decl: FunctionDeclaration | ClassDeclaration): string | undefined {
     return ParseTreeUtils.getDocString(decl.node?.suite?.statements ?? []);
+}
+
+export function getVariableDocString(
+    decl: VariableDeclaration | undefined,
+    sourceMapper: SourceMapper
+): string | undefined {
+    if (!decl) {
+        return undefined;
+    }
+
+    if (decl.docString !== undefined) {
+        return decl.docString;
+    } else {
+        return getVariableInStubFileDocStrings(decl, sourceMapper).find((doc) => doc);
+    }
 }
 
 function _getOverloadedFunctionDocStrings(

--- a/packages/pyright-internal/src/common/fileSystem.ts
+++ b/packages/pyright-internal/src/common/fileSystem.ts
@@ -46,6 +46,19 @@ export interface TmpfileOptions {
     prefix?: string;
 }
 
+export interface SupportsCustomUri {
+    addUriMap(uriString: string, path: string): void;
+    removeUriMap(path: string): void;
+    pendingRequest(path: string, hasPendingRequest: boolean): void;
+}
+
+export namespace SupportsCustomUri {
+    export function is(value: any): value is SupportsCustomUri {
+        const customUri = value as SupportsCustomUri;
+        return !!customUri.addUriMap && !!customUri.removeUriMap;
+    }
+}
+
 export interface FileSystem {
     existsSync(path: string): boolean;
     mkdirSync(path: string, options?: MkDirOptions): void;

--- a/packages/pyright-internal/src/languageService/completionProvider.ts
+++ b/packages/pyright-internal/src/languageService/completionProvider.ts
@@ -21,7 +21,13 @@ import {
 
 import { ImportLookup } from '../analyzer/analyzerFileInfo';
 import * as AnalyzerNodeInfo from '../analyzer/analyzerNodeInfo';
-import { Declaration, DeclarationType, FunctionDeclaration, isFunctionDeclaration } from '../analyzer/declaration';
+import {
+    Declaration,
+    DeclarationType,
+    FunctionDeclaration,
+    isFunctionDeclaration,
+    VariableDeclaration,
+} from '../analyzer/declaration';
 import { isDefinedInFile } from '../analyzer/declarationUtils';
 import { convertDocStringToMarkdown, convertDocStringToPlainText } from '../analyzer/docStringConversion';
 import { ImportedModuleDescriptor, ImportResolver } from '../analyzer/importResolver';
@@ -36,7 +42,7 @@ import {
     getModuleDocString,
     getOverloadedFunctionDocStringsInherited,
     getPropertyDocStringInherited,
-    getVariableInStubFileDocStrings,
+    getVariableDocString,
 } from '../analyzer/typeDocStringUtils';
 import { CallSignatureInfo, TypeEvaluator } from '../analyzer/typeEvaluator';
 import { printLiteralValue } from '../analyzer/typePrinter';
@@ -2010,13 +2016,6 @@ export class CompletionProvider {
                                         }
                                     }
                                     typeDetail = name + ': ' + this._evaluator.printType(type, expandTypeAlias);
-
-                                    const declWithDocString = symbol
-                                        .getDeclarations()
-                                        .find((decl) => decl.type === DeclarationType.Variable && !!decl.docString);
-                                    if (declWithDocString?.type === DeclarationType.Variable) {
-                                        documentation = declWithDocString.docString;
-                                    }
                                     break;
                                 }
 
@@ -2105,17 +2104,11 @@ export class CompletionProvider {
                                     this._evaluator
                                 );
                             } else if (primaryDecl?.type === DeclarationType.Variable) {
-                                const declWithDocString = symbol
+                                const decl = (symbol
                                     .getDeclarations()
-                                    .find((decl) => decl.type === DeclarationType.Variable && !!decl.docString);
-                                if (declWithDocString?.type === DeclarationType.Variable) {
-                                    documentation = declWithDocString.docString;
-                                } else {
-                                    documentation = getVariableInStubFileDocStrings(
-                                        primaryDecl,
-                                        this._sourceMapper
-                                    ).find((doc) => doc);
-                                }
+                                    .find((d) => d.type === DeclarationType.Variable && !!d.docString) ??
+                                    primaryDecl) as VariableDeclaration;
+                                documentation = getVariableDocString(decl, this._sourceMapper);
                             }
 
                             if (this._options.format === MarkupKind.Markdown) {

--- a/packages/pyright-internal/src/languageService/tooltipUtils.ts
+++ b/packages/pyright-internal/src/languageService/tooltipUtils.ts
@@ -17,7 +17,7 @@ import {
     getModuleDocString,
     getOverloadedFunctionDocStringsInherited,
     getPropertyDocStringInherited,
-    getVariableInStubFileDocStrings,
+    getVariableDocString,
 } from '../analyzer/typeDocStringUtils';
 import { TypeEvaluator } from '../analyzer/typeEvaluator';
 import {
@@ -102,8 +102,10 @@ export function getDocumentationPartsForTypeAndDecl(
             classResults?.classType
         );
     } else if (resolvedDecl?.type === DeclarationType.Variable) {
-        // See whether a variable symbol on the stub is actually a variable. If not, take the doc string.
-        return getVariableInStubFileDocStrings(resolvedDecl, sourceMapper);
+        const doc = getVariableDocString(resolvedDecl, sourceMapper);
+        if (doc) {
+            return [doc];
+        }
     } else if (resolvedDecl?.type === DeclarationType.Function) {
         // @property functions
         const doc = getPropertyDocStringInherited(resolvedDecl, sourceMapper, evaluator);

--- a/packages/pyright-internal/src/tests/fourslash/hover.variable.docString.fourslash.ts
+++ b/packages/pyright-internal/src/tests/fourslash/hover.variable.docString.fourslash.ts
@@ -1,0 +1,34 @@
+/// <reference path="fourslash.ts" />
+
+// @filename: test.py
+//// class A:
+////     def __init__(self):
+////         self.x = 1
+////         """ test x """
+////
+//// a = A()
+//// a.[|/*marker1*/x|]
+
+// @filename: test2.py
+//// y = 2
+//// """ test y """
+////
+//// [|/*marker2*/y|]
+
+// @filename: test3.py
+//// from stubs import z
+////
+//// [|/*marker3*/z|]
+
+// @filename: stubs.py
+//// z = 3
+//// """ test z """
+
+// @filename: stubs.pyi
+//// z: int = ...
+
+helper.verifyHover('markdown', {
+    marker1: '```python\n(variable) x: int\n```\n---\ntest x',
+    marker2: '```python\n(variable) y: Literal[2]\n```\n---\ntest y',
+    marker3: '```python\n(variable) z: int\n```\n---\ntest z',
+});


### PR DESCRIPTION
Rollup of:

- Fix mapping of non-`file://` schemas, including untitled files.
- Fix attribute docstrings for hover and signature help (previous support only handled completions)