### PR TITLE
Sort auto-imports by import symbol type

### DIFF
--- a/packages/pyright-internal/src/tests/fourslash/completions.autoimport.fromImport.fourslash.ts
+++ b/packages/pyright-internal/src/tests/fourslash/completions.autoimport.fromImport.fourslash.ts
@@ -1,0 +1,100 @@
+/// <reference path="fourslash.ts" />
+
+// @filename: test.py
+//// from lib import (
+////     [|/*import1*/|]MY_CONST_VAR[|/*import2*/|],
+////     ClsOther[|/*import3*/|],
+////     my_afunc[|/*import4*/|],
+//// )
+////
+//// [|A_CONST/*marker1*/|]
+//// [|MY_CONST_VAR2/*marker2*/|]
+//// [|Cls/*marker3*/|]
+//// [|ClsList/*marker4*/|]
+//// [|my_func/*marker5*/|]
+
+// @filename: lib.py
+//// A_CONST = 1
+//// MY_CONST_VAR = 2
+//// MY_CONST_VAR2 = 3
+//// class Cls: ...
+//// class ClsOther: ...
+//// ClsOtherList = list[ClsOther]
+//// def my_afunc(): ...
+//// def my_func(): ...
+
+{
+    const import1Range = helper.getPositionRange('import1');
+    const import2Range = helper.getPositionRange('import2');
+    const import3Range = helper.getPositionRange('import3');
+    const import4Range = helper.getPositionRange('import4');
+    const marker1Range = helper.getPositionRange('marker1');
+    const marker2Range = helper.getPositionRange('marker2');
+    const marker3Range = helper.getPositionRange('marker3');
+    const marker4Range = helper.getPositionRange('marker4');
+    const marker5Range = helper.getPositionRange('marker5');
+
+    // @ts-ignore
+    await helper.verifyCompletion('included', 'markdown', {
+        marker1: {
+            completions: [
+                {
+                    label: 'A_CONST',
+                    kind: Consts.CompletionItemKind.Constant,
+                    documentation: '```\nfrom lib import A_CONST\n```',
+                    detail: 'Auto-import',
+                    textEdit: { range: marker1Range, newText: 'A_CONST' },
+                    additionalTextEdits: [{ range: import1Range, newText: 'A_CONST,\n    ' }],
+                },
+            ],
+        },
+        marker2: {
+            completions: [
+                {
+                    label: 'MY_CONST_VAR2',
+                    kind: Consts.CompletionItemKind.Constant,
+                    documentation: '```\nfrom lib import MY_CONST_VAR2\n```',
+                    detail: 'Auto-import',
+                    textEdit: { range: marker2Range, newText: 'MY_CONST_VAR2' },
+                    additionalTextEdits: [{ range: import2Range, newText: ',\n    MY_CONST_VAR2' }],
+                },
+            ],
+        },
+        marker3: {
+            completions: [
+                {
+                    label: 'Cls',
+                    kind: Consts.CompletionItemKind.Class,
+                    documentation: '```\nfrom lib import Cls\n```',
+                    detail: 'Auto-import',
+                    textEdit: { range: marker3Range, newText: 'Cls' },
+                    additionalTextEdits: [{ range: import2Range, newText: ',\n    Cls' }],
+                },
+            ],
+        },
+        marker4: {
+            completions: [
+                {
+                    label: 'ClsOtherList',
+                    kind: Consts.CompletionItemKind.Variable,
+                    documentation: '```\nfrom lib import ClsOtherList\n```',
+                    detail: 'Auto-import',
+                    textEdit: { range: marker4Range, newText: 'ClsOtherList' },
+                    additionalTextEdits: [{ range: import3Range, newText: ',\n    ClsOtherList' }],
+                },
+            ],
+        },
+        marker5: {
+            completions: [
+                {
+                    label: 'my_func',
+                    kind: Consts.CompletionItemKind.Function,
+                    documentation: '```\nfrom lib import my_func\n```',
+                    detail: 'Auto-import',
+                    textEdit: { range: marker5Range, newText: 'my_func' },
+                    additionalTextEdits: [{ range: import4Range, newText: ',\n    my_func' }],
+                },
+            ],
+        },
+    });
+}


### PR DESCRIPTION
https://github.com/microsoft/pylance-release/issues/1675
https://pycqa.github.io/isort/docs/configuration/options.html#order-by-type

I wasn't sure where or if I should add tests for it. Please let me know and I'd be happy to do them.