### PR TITLE
Fix docs/configuration.md misleading case sensitive `Pyproject.toml` typo

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -229,7 +229,7 @@ The following is an example of a pyright config file:
 }
 ```
 
-## Sample Pyproject.toml File
+## Sample pyproject.toml File
 ```toml
 [tool.pyright]
 include = ["src"]


### PR DESCRIPTION
Creating `Pyproject.toml` as it is currently shown in the docs title will not work,
because the file name is case sensitive. It should be exactly `pyproject.toml`