### PR TITLE
Verify that import completions can resolve, remove unused similarityLimit

### DIFF
--- a/packages/pyright-internal/src/languageService/completionProvider.ts
+++ b/packages/pyright-internal/src/languageService/completionProvider.ts
@@ -2438,8 +2438,7 @@ export class CompletionProvider {
         const completions = this._importResolver.getCompletionSuggestions(
             this._filePath,
             this._execEnv,
-            moduleDescriptor,
-            similarityLimit
+            moduleDescriptor
         );
 
         const completionList = CompletionList.create();

--- a/packages/pyright-internal/src/tests/fourslash/completions.importSubmodule.fourslash.ts
+++ b/packages/pyright-internal/src/tests/fourslash/completions.importSubmodule.fourslash.ts
@@ -1,0 +1,29 @@
+/// <reference path="fourslash.ts" />
+
+// @filename: test.py
+//// from submodule.[|/*marker1*/|]
+
+// @filename: pyrightconfig.json
+//// {
+////   "extraPaths": ["submodule"]
+//// }
+
+// @filename: submodule/submodule/__init__.py
+////
+
+// @filename: submodule/submodule/submodule1.py
+//// def test_function():
+////     pass
+
+// @filename: submodule/setup.py
+////
+
+// @ts-ignore
+await helper.verifyCompletion('included', 'markdown', {
+    marker1: {
+        completions: [
+            { label: 'setup', kind: Consts.CompletionItemKind.Module },
+            { label: 'submodule1', kind: Consts.CompletionItemKind.Module },
+        ],
+    },
+});


### PR DESCRIPTION
Rollup of:

- Verify import completions before returning them; in some cases, we can find a folder that could be a module, but would not resolve due to namespace package handling (which the existing import suggestion code is unaware of). This should not hurt performance, as the info is already cached.
- Remove the unused parameter `similarityLimit`.