### PR TITLE
Adjust auto-import sorting to better match isort

### DIFF
--- a/packages/pyright-internal/src/analyzer/importStatementUtils.ts
+++ b/packages/pyright-internal/src/analyzer/importStatementUtils.ts
@@ -164,12 +164,12 @@ export function getTextEditsForAutoImportSymbolAddition(
             // This can't be reproduced by a normal string compare in TypeScript, since '_' > 'A'.
             // Replace all '_' with '=' which guarantees '=' < 'A'.
             // Safe to do as '=' is an invalid char in Python names.
-            const symbolNameCompare = symbolName.replace('_', '=');
+            const symbolNameCompare = symbolName.replace(/_/g, '=');
             for (const curImport of importStatement.node.imports) {
                 const curImportNameType = _getImportSymbolNameType(curImport.name.value);
                 if (
                     (curImportNameType === symbolNameType &&
-                        curImport.name.value.replace('_', '=') > symbolNameCompare) ||
+                        curImport.name.value.replace(/_/g, '=') > symbolNameCompare) ||
                     curImportNameType > symbolNameType
                 ) {
                     break;

--- a/packages/pyright-internal/src/analyzer/importStatementUtils.ts
+++ b/packages/pyright-internal/src/analyzer/importStatementUtils.ts
@@ -160,10 +160,16 @@ export function getTextEditsForAutoImportSymbolAddition(
             // Insert new symbol by import symbol type and then alphabetical order.
             // Match isort default behavior.
             const symbolNameType = _getImportSymbolNameType(symbolName);
+            // isort will prefer '_' over alphanumerical chars
+            // This can't be reproduced by a normal string compare in TypeScript, since '_' > 'A'.
+            // Replace all '_' with '=' which guarantees '=' < 'A'.
+            // Safe to do as '=' is an invalid char in Python names.
+            const symbolNameCompare = symbolName.replace('_', '=');
             for (const curImport of importStatement.node.imports) {
                 const curImportNameType = _getImportSymbolNameType(curImport.name.value);
                 if (
-                    (curImportNameType === symbolNameType && curImport.name.value > symbolName) ||
+                    (curImportNameType === symbolNameType &&
+                        curImport.name.value.replace('_', '=') > symbolNameCompare) ||
                     curImportNameType > symbolNameType
                 ) {
                     break;

--- a/packages/pyright-internal/src/tests/fourslash/completions.autoimport.fromImport.fourslash.ts
+++ b/packages/pyright-internal/src/tests/fourslash/completions.autoimport.fromImport.fourslash.ts
@@ -13,11 +13,13 @@
 //// [|ClsList/*marker4*/|]
 //// [|my_func/*marker5*/|]
 //// [|MYA_CONST_VAR/*marker6*/|]
+//// [|MY_CONSTA_VAR/*marker7*/|]
 
 // @filename: lib.py
 //// A_CONST = 1
 //// MY_CONST_VAR = 2
 //// MY_CONST_VAR2 = 3
+//// MY_CONSTA_VAR = 4
 //// MYA_CONST_VAR = 4
 //// class Cls: ...
 //// class ClsOther: ...
@@ -36,6 +38,7 @@
     const marker4Range = helper.getPositionRange('marker4');
     const marker5Range = helper.getPositionRange('marker5');
     const marker6Range = helper.getPositionRange('marker6');
+    const marker7Range = helper.getPositionRange('marker7');
 
     // @ts-ignore
     await helper.verifyCompletion('included', 'markdown', {
@@ -108,6 +111,18 @@
                     detail: 'Auto-import',
                     textEdit: { range: marker6Range, newText: 'MYA_CONST_VAR' },
                     additionalTextEdits: [{ range: import2Range, newText: ',\n    MYA_CONST_VAR' }],
+                },
+            ],
+        },
+        marker7: {
+            completions: [
+                {
+                    label: 'MY_CONSTA_VAR',
+                    kind: Consts.CompletionItemKind.Constant,
+                    documentation: '```\nfrom lib import MY_CONSTA_VAR\n```',
+                    detail: 'Auto-import',
+                    textEdit: { range: marker7Range, newText: 'MY_CONSTA_VAR' },
+                    additionalTextEdits: [{ range: import2Range, newText: ',\n    MY_CONSTA_VAR' }],
                 },
             ],
         },

--- a/packages/pyright-internal/src/tests/fourslash/completions.autoimport.fromImport.fourslash.ts
+++ b/packages/pyright-internal/src/tests/fourslash/completions.autoimport.fromImport.fourslash.ts
@@ -12,11 +12,13 @@
 //// [|Cls/*marker3*/|]
 //// [|ClsList/*marker4*/|]
 //// [|my_func/*marker5*/|]
+//// [|MYA_CONST_VAR/*marker6*/|]
 
 // @filename: lib.py
 //// A_CONST = 1
 //// MY_CONST_VAR = 2
 //// MY_CONST_VAR2 = 3
+//// MYA_CONST_VAR = 4
 //// class Cls: ...
 //// class ClsOther: ...
 //// ClsOtherList = list[ClsOther]
@@ -33,6 +35,7 @@
     const marker3Range = helper.getPositionRange('marker3');
     const marker4Range = helper.getPositionRange('marker4');
     const marker5Range = helper.getPositionRange('marker5');
+    const marker6Range = helper.getPositionRange('marker6');
 
     // @ts-ignore
     await helper.verifyCompletion('included', 'markdown', {
@@ -93,6 +96,18 @@
                     detail: 'Auto-import',
                     textEdit: { range: marker5Range, newText: 'my_func' },
                     additionalTextEdits: [{ range: import4Range, newText: ',\n    my_func' }],
+                },
+            ],
+        },
+        marker6: {
+            completions: [
+                {
+                    label: 'MYA_CONST_VAR',
+                    kind: Consts.CompletionItemKind.Constant,
+                    documentation: '```\nfrom lib import MYA_CONST_VAR\n```',
+                    detail: 'Auto-import',
+                    textEdit: { range: marker6Range, newText: 'MYA_CONST_VAR' },
+                    additionalTextEdits: [{ range: import2Range, newText: ',\n    MYA_CONST_VAR' }],
                 },
             ],
         },


### PR DESCRIPTION
TypeScript and isort handle sorting of `_` differently. This can result in the auto-import insert position not matching the isort behavior.

This PR adds a workaround to better handle underscores when sorting import names.

#### Example
```py
from lib import (
    ...
    # auto-import
    MY_CONST_VAR,
    # isort
    ....
)

MYA_CONST_VAR  # import from lib
```