### PR TITLE
Added missing check for access to a module member that is meant to be…

### DIFF
--- a/packages/pyright-internal/src/analyzer/binder.ts
+++ b/packages/pyright-internal/src/analyzer/binder.ts
@@ -199,13 +199,13 @@ export class Binder extends ParseTreeWalker {
         id: getUniqueFlowNodeId(),
     };
 
-    // Map of symbols at the module level that may be private depending
-    // on whether they are listed in the __all__ list.
-    private _potentialPrivateSymbols = new Map<string, Symbol>();
-
     // Map of symbols at the module level that may be externally
     // hidden depending on whether they are listed in the __all__ list.
     private _potentialHiddenSymbols = new Map<string, Symbol>();
+
+    // Map of symbols at the module level that may be private depending
+    // on whether they are listed in the __all__ list.
+    private _potentialPrivateSymbols = new Map<string, Symbol>();
 
     constructor(fileInfo: AnalyzerFileInfo, private _moduleSymbolOnly = false) {
         super();
@@ -255,7 +255,7 @@ export class Binder extends ParseTreeWalker {
         this._bindDeferred();
 
         // Use the __all__ list to determine whether any potential private
-        // symbols should be made externally invisible.
+        // symbols should be made externally hidden or private.
         this._potentialHiddenSymbols.forEach((symbol, name) => {
             if (!this._dunderAllNames?.some((sym) => sym === name)) {
                 symbol.setIsExternallyHidden();

--- a/packages/pyright-internal/src/analyzer/binder.ts
+++ b/packages/pyright-internal/src/analyzer/binder.ts
@@ -203,6 +203,10 @@ export class Binder extends ParseTreeWalker {
     // on whether they are listed in the __all__ list.
     private _potentialPrivateSymbols = new Map<string, Symbol>();
 
+    // Map of symbols at the module level that may be externally
+    // hidden depending on whether they are listed in the __all__ list.
+    private _potentialHiddenSymbols = new Map<string, Symbol>();
+
     constructor(fileInfo: AnalyzerFileInfo, private _moduleSymbolOnly = false) {
         super();
 
@@ -252,11 +256,15 @@ export class Binder extends ParseTreeWalker {
 
         // Use the __all__ list to determine whether any potential private
         // symbols should be made externally invisible.
-        this._potentialPrivateSymbols.forEach((symbol, name) => {
-            // If this symbol was found in the dunder all, don't mark it
-            // as externally hidden.
+        this._potentialHiddenSymbols.forEach((symbol, name) => {
             if (!this._dunderAllNames?.some((sym) => sym === name)) {
                 symbol.setIsExternallyHidden();
+            }
+        });
+
+        this._potentialPrivateSymbols.forEach((symbol, name) => {
+            if (!this._dunderAllNames?.some((sym) => sym === name)) {
+                symbol.setIsPrivateMember();
             }
         });
 
@@ -1438,18 +1446,17 @@ export class Binder extends ParseTreeWalker {
             const symbol = this._bindNameToScope(this._currentScope, symbolName);
             if (
                 symbol &&
+                (this._currentScope.type === ScopeType.Module || this._currentScope.type === ScopeType.Builtin) &&
                 (!node.alias ||
                     node.module.nameParts.length !== 1 ||
                     node.module.nameParts[0].value !== node.alias.value)
             ) {
-                if (this._fileInfo.isStubFile) {
+                if (this._fileInfo.isStubFile || this._fileInfo.isInPyTypedPackage) {
                     // PEP 484 indicates that imported symbols should not be
                     // considered "reexported" from a type stub file unless
                     // they are imported using the "as" form and the aliased
                     // name is entirely redundant.
-                    symbol.setIsExternallyHidden();
-                } else if (this._fileInfo.isInPyTypedPackage && this._currentScope.type === ScopeType.Module) {
-                    this._potentialPrivateSymbols.set(symbolName, symbol);
+                    this._potentialHiddenSymbols.set(symbolName, symbol);
                 }
             }
 
@@ -1604,21 +1611,21 @@ export class Binder extends ParseTreeWalker {
                     // All import statements of the form `from . import x` treat x
                     // as an externally-visible (not hidden) symbol.
                     if (node.module.nameParts.length > 0) {
-                        if (!importSymbolNode.alias || importSymbolNode.alias.value !== importSymbolNode.name.value) {
-                            if (this._fileInfo.isStubFile) {
-                                // PEP 484 indicates that imported symbols should not be
-                                // considered "reexported" from a type stub file unless
-                                // they are imported using the "as" form using a redundant form.
-                                symbol.setIsExternallyHidden();
-                            } else if (
-                                this._fileInfo.isInPyTypedPackage &&
-                                this._currentScope.type === ScopeType.Module
+                        if (
+                            this._currentScope.type === ScopeType.Module ||
+                            this._currentScope.type === ScopeType.Builtin
+                        ) {
+                            if (
+                                !importSymbolNode.alias ||
+                                importSymbolNode.alias.value !== importSymbolNode.name.value
                             ) {
-                                // Py.typed packages follow the same rule as PEP 484 except
-                                // that if the symbol appears in the __all__ list, it is overridden
-                                // and becomes a externally-visible symbol. For now, add it to
-                                // the "potentially private" map.
-                                this._potentialPrivateSymbols.set(nameNode.value, symbol);
+                                if (this._fileInfo.isStubFile || this._fileInfo.isInPyTypedPackage) {
+                                    // PEP 484 indicates that imported symbols should not be
+                                    // considered "reexported" from a type stub file unless
+                                    // they are imported using the "as" form using a redundant form.
+                                    // Py.typed packages follow the same rule as PEP 484.
+                                    this._potentialHiddenSymbols.set(nameNode.value, symbol);
+                                }
                             }
                         }
                     }
@@ -2952,11 +2959,21 @@ export class Binder extends ParseTreeWalker {
                     }
                 }
 
-                if (isPrivateOrProtectedName(name)) {
-                    if (this._fileInfo.isStubFile || isPrivateName(name)) {
-                        symbol.setIsExternallyHidden();
-                    } else if (this._fileInfo.isInPyTypedPackage && this._currentScope.type === ScopeType.Module) {
-                        this._potentialPrivateSymbols.set(name, symbol);
+                if (this._currentScope.type === ScopeType.Module || this._currentScope.type === ScopeType.Builtin) {
+                    if (isPrivateOrProtectedName(name)) {
+                        if (isPrivateName(name)) {
+                            // Private names are obscured, so they are always externally hidden.
+                            symbol.setIsExternallyHidden();
+                        } else if (this._fileInfo.isStubFile || this._fileInfo.isInPyTypedPackage) {
+                            if (this._currentScope.type === ScopeType.Builtin) {
+                                // Don't include private-named symbols in the builtin scope.
+                                symbol.setIsExternallyHidden();
+                            } else {
+                                this._potentialPrivateSymbols.set(name, symbol);
+                            }
+                        } else {
+                            symbol.setIsPrivateMember();
+                        }
                     }
                 }
 
@@ -3191,7 +3208,10 @@ export class Binder extends ParseTreeWalker {
                         typeAnnotationNode = undefined;
 
                         // Type aliases are allowed only in the global scope.
-                        if (this._currentScope.type !== ScopeType.Module) {
+                        if (
+                            this._currentScope.type !== ScopeType.Module &&
+                            this._currentScope.type !== ScopeType.Builtin
+                        ) {
                             this._addError(Localizer.Diagnostic.typeAliasNotInModule(), typeAnnotation);
                         }
                     } else if (finalInfo.isFinal) {

--- a/packages/pyright-internal/src/analyzer/packageTypeVerifier.ts
+++ b/packages/pyright-internal/src/analyzer/packageTypeVerifier.ts
@@ -239,7 +239,7 @@ export class PackageTypeVerifier {
             ) {
                 const fullName = `${scopeName}.${name}`;
 
-                if (!symbol.isExternallyHidden()) {
+                if (!symbol.isExternallyHidden() && !symbol.isPrivateMember()) {
                     const symbolType = this._program.getTypeForSymbol(symbol);
                     symbolMap.set(fullName, fullName);
 
@@ -435,6 +435,7 @@ export class PackageTypeVerifier {
             if (
                 !isPrivateOrProtectedName(name) &&
                 !symbol.isExternallyHidden() &&
+                !symbol.isPrivateMember() &&
                 !symbol.isIgnoredForProtocolMatch() &&
                 !this._isSymbolTypeImplied(scopeType, name)
             ) {

--- a/packages/pyright-internal/src/analyzer/symbol.ts
+++ b/packages/pyright-internal/src/analyzer/symbol.ts
@@ -33,7 +33,7 @@ export const enum SymbolFlags {
     InstanceMember = 1 << 3,
 
     // Indicates that the symbol is considered "private" to the
-    // class and should not be accessed outside or overridden.
+    // class or module and should not be accessed outside or overridden.
     PrivateMember = 1 << 5,
 
     // Indicates that the symbol is not considered for protocol

--- a/packages/pyright-internal/src/analyzer/typeEvaluatorWithTracker.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluatorWithTracker.ts
@@ -78,6 +78,8 @@ export function createTypeEvaluatorWithTracker(
         getTypeForDeclaration: (n) => run('getTypeForDeclaration', () => typeEvaluator.getTypeForDeclaration(n), n),
         resolveAliasDeclaration: (d, l) =>
             run('resolveAliasDeclaration', () => typeEvaluator.resolveAliasDeclaration(d, l), d),
+        resolveAliasDeclarationWithInfo: (d, l) =>
+            run('resolveAliasDeclarationWithInfo', () => typeEvaluator.resolveAliasDeclarationWithInfo(d, l), d),
         getTypeFromIterable: (t, a, e) =>
             run('getTypeFromIterable', () => typeEvaluator.getTypeFromIterable(t, a, e), t),
         getTypeFromIterator: (t, a, e) =>

--- a/packages/pyright-internal/src/languageService/documentSymbolProvider.ts
+++ b/packages/pyright-internal/src/languageService/documentSymbolProvider.ts
@@ -70,16 +70,24 @@ export function getIndexAliasData(
         return undefined;
     }
 
-    const resolved = resolveAliasDeclaration(importLookup, declaration, /* resolveLocalNames */ true);
-    const nameValue = resolved ? getNameFromDeclaration(resolved) : undefined;
-    if (!nameValue || resolved!.path.length <= 0) {
+    const resolvedInfo = resolveAliasDeclaration(importLookup, declaration, /* resolveLocalNames */ true);
+    if (!resolvedInfo) {
         return undefined;
     }
 
-    const symbolKind = getSymbolKind(nameValue, resolved!) ?? SymbolKind.Module;
+    if (resolvedInfo.isPrivate) {
+        return undefined;
+    }
+
+    const nameValue = getNameFromDeclaration(resolvedInfo.declaration);
+    if (!nameValue || resolvedInfo.declaration.path.length <= 0) {
+        return undefined;
+    }
+
+    const symbolKind = getSymbolKind(nameValue, resolvedInfo.declaration) ?? SymbolKind.Module;
     return {
         originalName: nameValue,
-        modulePath: resolved!.path,
+        modulePath: resolvedInfo.declaration.path,
         kind: symbolKind,
         itemKind: convertSymbolKindToCompletionItemKind(symbolKind),
     };

--- a/packages/pyright-internal/src/tests/fourslash/hover.docFromSrc.pkg-vs-module1.fourslash.ts
+++ b/packages/pyright-internal/src/tests/fourslash/hover.docFromSrc.pkg-vs-module1.fourslash.ts
@@ -11,7 +11,7 @@
 ////     return True
 
 // @filename: typings/package1/__init__.pyi
-//// from .subpackage import func1
+//// from .subpackage import func1 as func1
 
 // @filename: typings/package1/subpackage/__init__.pyi
 //// def func1() -> bool: ...

--- a/packages/pyright-internal/src/tests/fourslash/hover.docFromSrc.pkg-vs-module2.fourslash.ts
+++ b/packages/pyright-internal/src/tests/fourslash/hover.docFromSrc.pkg-vs-module2.fourslash.ts
@@ -11,7 +11,7 @@
 ////     return True
 
 // @filename: typings/package1/__init__.pyi
-//// from .subpackage import func1
+//// from .subpackage import func1 as func1
 
 // @filename: typings/package1/subpackage.pyi
 //// def func1() -> bool: ...

--- a/packages/pyright-internal/src/tests/fourslash/hover.docFromSrc.stubs-package.fourslash.ts
+++ b/packages/pyright-internal/src/tests/fourslash/hover.docFromSrc.stubs-package.fourslash.ts
@@ -2,7 +2,7 @@
 
 // @filename: package1-stubs/__init__.pyi
 // @library: true
-//// from .api import func1
+//// from .api import func1 as func1
 
 // @filename: package1-stubs/api.pyi
 // @library: true
@@ -10,7 +10,7 @@
 
 // @filename: package1/__init__.py
 // @library: true
-//// from .api import func1
+//// from .api import func1 as func1
 
 // @filename: package1/api.py
 // @library: true

--- a/packages/pyright-internal/src/tests/fourslash/hover.docFromSrc.typeshed.fourslash.ts
+++ b/packages/pyright-internal/src/tests/fourslash/hover.docFromSrc.typeshed.fourslash.ts
@@ -2,7 +2,7 @@
 
 // @filename: requests/__init__.pyi
 // @library: true
-//// from .api import head
+//// from .api import head as head
 
 // @filename: requests/api.pyi
 // @library: true

--- a/packages/pyright-internal/src/tests/fourslash/import.pytyped.privateSymbols.fourslash.ts
+++ b/packages/pyright-internal/src/tests/fourslash/import.pytyped.privateSymbols.fourslash.ts
@@ -1,0 +1,62 @@
+/// <reference path="fourslash.ts" />
+
+// @filename: pyrightconfig.json
+//// {
+////   "typeCheckingMode": "basic"
+//// }
+
+// @filename: testLib/py.typed
+// @library: true
+////
+
+// @filename: testLib/__init__.py
+// @library: true
+//// from .module1 import one as one, two, three
+//// four: int = two * two
+//// _five: int = two + three
+//// _six: int = 6
+//// __all__ = ["_six"]
+
+// @filename: testLib/module1.py
+// @library: true
+//// one: int = 1
+//// two: int = 2
+//// three: int = 3
+
+// @filename: .src/test1.py
+//// # pyright: reportPrivateUsage=true
+//// from testLib import one
+//// from testLib import [|/*marker1*/two|] as two_alias
+//// from testLib import [|/*marker2*/three|]
+//// from testLib import four
+//// from testLib import [|/*marker3*/_five|]
+//// from testLib import _six
+//// import testLib
+//// testLib.one
+//// testLib.[|/*marker4*/two|]
+//// testLib.[|/*marker5*/three|]
+//// testLib.four
+//// testLib.[|/*marker6*/_five|]
+//// testLib._six
+
+// @ts-ignore
+await helper.verifyDiagnostics({
+    marker1: { category: 'error', message: `"two" is unknown import symbol` },
+    marker2: {
+        category: 'error',
+        message: `"three" is unknown import symbol`,
+    },
+    marker3: {
+        category: 'error',
+        message: `"_five" is private and used outside of the module in which it is declared`,
+    },
+    marker4: { category: 'error', message: `"two" is not a known member of module` },
+    marker5: {
+        category: 'error',
+        message: `"three" is not a known member of module`,
+    },
+    marker6: {
+        category: 'error',
+        message: `"_five" is private and used outside of the module in which it is declared`,
+    },
+});

--- a/packages/pyright-internal/src/tests/samples/newType4.py
+++ b/packages/pyright-internal/src/tests/samples/newType4.py
@@ -1,5 +1,8 @@
 # This sample tests some error conditions for NewType usage.
 
+from typing import NewType
+
+
 A = NewType("A", Union[int, str])
 B = NewType("B", Literal[1])
 C = NewType("B", Sized)

--- a/packages/pyright-internal/src/tests/typeEvaluator2.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator2.test.ts
@@ -159,7 +159,7 @@ test('NewType3', () => {
 test('NewType4', () => {
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['newType4.py']);
 
-    TestUtils.validateResults(analysisResults, 6);
+    TestUtils.validateResults(analysisResults, 3);
 });
 
 test('isInstance1', () => {


### PR DESCRIPTION
… private to that module — e.g. a private-name type alias, a private-named function in a ".py" file within a py.typed library, or a non-re-exported import within a type stub.