### PR TITLE
Improve suite 'Expected ":"' knock-on errors

### DIFF
--- a/packages/pyright-internal/src/parser/parser.ts
+++ b/packages/pyright-internal/src/parser/parser.ts
@@ -1180,10 +1180,16 @@ export class Parser {
         if (!this._consumeTokenIfType(TokenType.Colon)) {
             this._addError(Localizer.Diagnostic.expectedColon(), nextToken);
 
-            // Try to perform parse recovery by consuming tokens until
-            // we find the end of the line.
+            // Try to perform parse recovery by consuming tokens.
             if (this._consumeTokensUntilType([TokenType.NewLine, TokenType.Colon])) {
-                this._getNextToken();
+                if (this._peekTokenType() === TokenType.Colon) {
+                    this._getNextToken();
+                } else if (this._peekToken(1).type !== TokenType.Indent) {
+                    // Bail so we resume the at the next statement.
+                    // We can't parse as a simple statement as we've skipped all but the newline.
+                    this._getNextToken();
+                    return suite;
+                }
             }
         }
 

--- a/packages/pyright-internal/src/tests/parser.test.ts
+++ b/packages/pyright-internal/src/tests/parser.test.ts
@@ -35,3 +35,21 @@ test('FStringEmptyTuple', () => {
         TestUtils.parseSampleFile('fstring6.py', diagSink);
     });
 });
+
+test('SuiteExpectedColon1', () => {
+    const diagSink = new DiagnosticSink();
+    TestUtils.parseSampleFile('suiteExpectedColon1.py', diagSink);
+    assert.strictEqual(diagSink.getErrors().length, 1);
+});
+
+test('SuiteExpectedColon2', () => {
+    const diagSink = new DiagnosticSink();
+    TestUtils.parseSampleFile('suiteExpectedColon2.py', diagSink);
+    assert.strictEqual(diagSink.getErrors().length, 1);
+});
+
+test('SuiteExpectedColon3', () => {
+    const diagSink = new DiagnosticSink();
+    TestUtils.parseSampleFile('suiteExpectedColon3.py', diagSink);
+    assert.strictEqual(diagSink.getErrors().length, 1);
+});

--- a/packages/pyright-internal/src/tests/samples/suiteExpectedColon1.py
+++ b/packages/pyright-internal/src/tests/samples/suiteExpectedColon1.py
@@ -1,0 +1,4 @@
+if True True
+    pass
+
+pass

--- a/packages/pyright-internal/src/tests/samples/suiteExpectedColon2.py
+++ b/packages/pyright-internal/src/tests/samples/suiteExpectedColon2.py
@@ -1,0 +1,2 @@
+# Error recovery should consume to colon inclusive
+if True True: pass

--- a/packages/pyright-internal/src/tests/samples/suiteExpectedColon3.py
+++ b/packages/pyright-internal/src/tests/samples/suiteExpectedColon3.py
@@ -1,0 +1,2 @@
+# Error recovery should consume the whole line
+if True pass


### PR DESCRIPTION
Before this change, simple scripts with missing colons such as:

```python
if True
    pass
```

result in quite a lot of diagnostic output:

- Expected ":"
- Expected expression
- Unindent not expected
- Expected expression
- Statements must be separated by newlines or semicolons

Some of this output is also seen when part way through writing (eventually) valid code.

The parser consumes the newline in error recovery which causes some onward confusion as it tries to parse the indent as a simple statement.

The PR avoids consuming the newline in error recovery, giving it a chance to parse the following indented block which first looks for that newline. I've also avoided parsing as a simple statement if the parser has consumed the line in the error recovery, as I can't see how that can succeed. After the change we just get the first error.

I wasn't sure how best to approach the testing. Most of the parser tests are indirect but it seemed worth having direct tests for error recovery.

I hope the error recovery doesn't add too much complexity. I think it's worthwhile here as the knock-on errors can be quite confusing and can be intimidating to new programmers.