### PR TITLE
Ambiguous tuples become as specific as possible.

### DIFF
--- a/docs/type-inference.md
+++ b/docs/type-inference.md
@@ -103,7 +103,7 @@ var1 = []                       # Type of RHS is ambiguous
 var2: List[int] = []            # Type of LHS now makes type of RHS unambiguous
 var3 = [4]                      # Type is assumed to be List[int] 
 var4: List[float] = [4]         # Type of RHS is now List[float]
-var5 = (3,)                     # Type is assumed to be Tuple[int]
+var5 = (3,)                     # Type is assumed to be Tuple[Literal[3]]
 var6: Tuple[float, ...] = (3,)  # Type of RHS is now Tuple[float, ...]
 ```
 


### PR DESCRIPTION
The rationale is as follows.

>Tuple Expressions
>When inferring the type of a tuple expression (in the absence of bidirectional inference hints), Pyright assumes that the tuple has a fixed length, and each tuple element is >typed as specifically as possible.

```python
# The inferred type is Tuple[Literal[1], Literal["a"], Literal[True]]
var1 = (1, "a", True)

def func1(a: int):
    # The inferred type is Tuple[int, int]
    var2 = (a, a)

    # If you want the type to be Tuple[int, ...]
    # (i.e. a homogenous tuple of indeterminate length),
    # use a type annotation.
    var3: Tuple[int, ...] = (a, a)
```