### PR TITLE
Added support for reporting the use of types deprecated in PEP 585, etc.

### DIFF
--- a/packages/pyright-internal/src/analyzer/checker.ts
+++ b/packages/pyright-internal/src/analyzer/checker.ts
@@ -2598,7 +2598,7 @@ export class Checker extends ParseTreeWalker {
             return;
         }
 
-        if (isClass(type)) {
+        if (isInstantiableClass(type)) {
             let deprecatedForm: DeprecatedForm | undefined;
 
             if (type.aliasName) {

--- a/packages/pyright-internal/src/analyzer/sourceFile.ts
+++ b/packages/pyright-internal/src/analyzer/sourceFile.ts
@@ -260,7 +260,7 @@ export class SourceFile {
         if (options.diagnosticRuleSet.enableTypeIgnoreComments) {
             if (Object.keys(this._typeIgnoreLines).length > 0) {
                 diagList = diagList.filter((d) => {
-                    if (d.category !== DiagnosticCategory.UnusedCode) {
+                    if (d.category !== DiagnosticCategory.UnusedCode && d.category !== DiagnosticCategory.Deprecated) {
                         for (let line = d.range.start.line; line <= d.range.end.line; line++) {
                             if (this._typeIgnoreLines[line]) {
                                 return false;
@@ -317,9 +317,12 @@ export class SourceFile {
 
         // If we're not returning any diagnostics, filter out all of
         // the errors and warnings, leaving only the unreachable code
-        // diagnostics.
+        // and deprecated diagnostics.
         if (!includeWarningsAndErrors) {
-            diagList = diagList.filter((diag) => diag.category === DiagnosticCategory.UnusedCode);
+            diagList = diagList.filter(
+                (diag) =>
+                    diag.category === DiagnosticCategory.UnusedCode || diag.category === DiagnosticCategory.Deprecated
+            );
         }
 
         return diagList;

--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -2058,6 +2058,13 @@ export function createTypeEvaluator(importLookup: ImportLookup, evaluatorOptions
         }
     }
 
+    function addDeprecated(message: string, node: ParseNode) {
+        if (!isDiagnosticSuppressedForNode(node)) {
+            const fileInfo = AnalyzerNodeInfo.getFileInfo(node);
+            fileInfo.diagnosticSink.addDeprecatedWithTextRange(message, node);
+        }
+    }
+
     function addDiagnosticWithSuppressionCheck(
         diagLevel: DiagnosticLevel,
         message: string,
@@ -21029,6 +21036,7 @@ export function createTypeEvaluator(importLookup: ImportLookup, evaluatorOptions
         addWarning,
         addInformation,
         addUnusedCode,
+        addDeprecated,
         addDiagnostic,
         addDiagnosticForTextRange,
         printType,

--- a/packages/pyright-internal/src/analyzer/typeEvaluatorTypes.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluatorTypes.ts
@@ -330,6 +330,7 @@ export interface TypeEvaluator {
     addWarning: (message: string, node: ParseNode) => Diagnostic | undefined;
     addInformation: (message: string, node: ParseNode) => Diagnostic | undefined;
     addUnusedCode: (node: ParseNode, textRange: TextRange) => void;
+    addDeprecated: (message: string, node: ParseNode) => void;
 
     addDiagnostic: (
         diagLevel: DiagnosticLevel,

--- a/packages/pyright-internal/src/analyzer/typeEvaluatorWithTracker.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluatorWithTracker.ts
@@ -129,6 +129,7 @@ export function createTypeEvaluatorWithTracker(
         addWarning: (m, n) => run('addWarning', () => typeEvaluator.addWarning(m, n), n),
         addInformation: (m, n) => run('addInformation', () => typeEvaluator.addInformation(m, n), n),
         addUnusedCode: (n, t) => run('addUnusedCode', () => typeEvaluator.addUnusedCode(n, t), n),
+        addDeprecated: (m, n) => run('addDeprecated', () => typeEvaluator.addDeprecated(m, n), n),
         addDiagnostic: (d, r, m, n) => run('addDiagnostic', () => typeEvaluator.addDiagnostic(d, r, m, n), n),
         addDiagnosticForTextRange: (f, d, r, m, g) =>
             run('addDiagnosticForTextRange', () => typeEvaluator.addDiagnosticForTextRange(f, d, r, m, g)),

--- a/packages/pyright-internal/src/common/diagnostic.ts
+++ b/packages/pyright-internal/src/common/diagnostic.ts
@@ -20,6 +20,7 @@ export const enum DiagnosticCategory {
     Warning,
     Information,
     UnusedCode,
+    Deprecated,
 }
 
 export function convertLevelToCategory(level: DiagnosticLevel) {

--- a/packages/pyright-internal/src/common/diagnosticSink.ts
+++ b/packages/pyright-internal/src/common/diagnosticSink.ts
@@ -58,6 +58,14 @@ export class DiagnosticSink {
         return this.addDiagnostic(diag);
     }
 
+    addDeprecated(message: string, range: Range, action?: DiagnosticAction) {
+        const diag = new Diagnostic(DiagnosticCategory.Deprecated, message, range);
+        if (action) {
+            diag.addAction(action);
+        }
+        return this.addDiagnostic(diag);
+    }
+
     addDiagnostic(diag: Diagnostic) {
         // Create a unique key for the diagnostic to prevent
         // adding duplicates.
@@ -90,6 +98,10 @@ export class DiagnosticSink {
     getUnusedCode() {
         return this._diagnosticList.filter((diag) => diag.category === DiagnosticCategory.UnusedCode);
     }
+
+    getDeprecated() {
+        return this._diagnosticList.filter((diag) => diag.category === DiagnosticCategory.Deprecated);
+    }
 }
 
 // Specialized version of DiagnosticSink that works with TextRange objects
@@ -121,6 +133,14 @@ export class TextRangeDiagnosticSink extends DiagnosticSink {
 
     addUnusedCodeWithTextRange(message: string, range: TextRange, action?: DiagnosticAction) {
         return this.addUnusedCode(
+            message,
+            convertOffsetsToRange(range.start, range.start + range.length, this._lines),
+            action
+        );
+    }
+
+    addDeprecatedWithTextRange(message: string, range: TextRange, action?: DiagnosticAction) {
+        return this.addDeprecated(
             message,
             convertOffsetsToRange(range.start, range.start + range.length, this._lines),
             action

--- a/packages/pyright-internal/src/localization/localize.ts
+++ b/packages/pyright-internal/src/localization/localize.ts
@@ -267,6 +267,10 @@ export namespace Localizer {
         export const defaultValueContainsCall = () => getRawString('Diagnostic.defaultValueContainsCall');
         export const defaultValueNotAllowed = () => getRawString('Diagnostic.defaultValueNotAllowed');
         export const defaultValueNotEllipsis = () => getRawString('Diagnostic.defaultValueNotEllipsis');
+        export const deprecatedType = () =>
+            new ParameterizedString<{ version: string; replacement: string }>(
+                getRawString('Diagnostic.deprecatedType')
+            );
         export const dictExpandIllegalInComprehension = () =>
             getRawString('Diagnostic.dictExpandIllegalInComprehension');
         export const dictInAnnotation = () => getRawString('Diagnostic.dictInAnnotation');

--- a/packages/pyright-internal/src/localization/package.nls.en-us.json
+++ b/packages/pyright-internal/src/localization/package.nls.en-us.json
@@ -65,6 +65,7 @@
         "defaultValueContainsCall": "Function calls and mutable objects not allowed within parameter default value expression",
         "defaultValueNotAllowed": "Parameter with \"*\" or \"**\" cannot have default value",
         "defaultValueNotEllipsis": "Default values in stub files should be specified as \"...\"",
+        "deprecatedType": "This type is deprecated as of Python {version}; use \"{replacement}\" instead",
         "delTargetExpr": "Expression cannot be deleted",
         "dictExpandIllegalInComprehension": "Dictionary expansion not allowed in comprehension",
         "dictInAnnotation": "Dictionary expression not allowed in type annotation",

--- a/packages/pyright-internal/src/pyright.ts
+++ b/packages/pyright-internal/src/pyright.ts
@@ -677,9 +677,9 @@ function reportDiagnosticsAsText(fileDiagnostics: FileDiagnostics[]): Diagnostic
     let informationCount = 0;
 
     fileDiagnostics.forEach((fileDiagnostics) => {
-        // Don't report unused code diagnostics.
+        // Don't report unused code or deprecated diagnostics.
         const fileErrorsAndWarnings = fileDiagnostics.diagnostics.filter(
-            (diag) => diag.category !== DiagnosticCategory.UnusedCode
+            (diag) => diag.category !== DiagnosticCategory.UnusedCode && diag.category !== DiagnosticCategory.Deprecated
         );
 
         if (fileErrorsAndWarnings.length > 0) {

--- a/packages/pyright-internal/src/tests/checker.test.ts
+++ b/packages/pyright-internal/src/tests/checker.test.ts
@@ -314,3 +314,19 @@ test('DuplicateDeclaration2', () => {
 
     TestUtils.validateResults(analysisResults, 4);
 });
+
+test('Deprecated1', () => {
+    const configOptions = new ConfigOptions('.');
+
+    configOptions.defaultPythonVersion = PythonVersion.V3_8;
+    const analysisResults1 = TestUtils.typeAnalyzeSampleFiles(['deprecated1.py'], configOptions);
+    TestUtils.validateResults(analysisResults1, 0, 0, 0, 0, 0);
+
+    configOptions.defaultPythonVersion = PythonVersion.V3_9;
+    const analysisResults2 = TestUtils.typeAnalyzeSampleFiles(['deprecated1.py'], configOptions);
+    TestUtils.validateResults(analysisResults2, 0, 0, 0, 0, 11);
+
+    configOptions.defaultPythonVersion = PythonVersion.V3_10;
+    const analysisResults3 = TestUtils.typeAnalyzeSampleFiles(['deprecated1.py'], configOptions);
+    TestUtils.validateResults(analysisResults3, 0, 0, 0, 0, 13);
+});

--- a/packages/pyright-internal/src/tests/samples/deprecated1.py
+++ b/packages/pyright-internal/src/tests/samples/deprecated1.py
@@ -1,0 +1,37 @@
+# This sample tests the detection of deprecated classes from the typing
+# module.
+
+
+from typing import (
+    ChainMap,
+    Counter,
+    DefaultDict,
+    Deque,
+    Dict,
+    FrozenSet,
+    List,
+    Optional,
+    OrderedDict,
+    Set,
+    Tuple,
+    Type,
+    Union,
+)
+
+
+# These should be marked deprecated for Python >= 3.9
+v1: List[int] = [1, 2, 3]
+v2: Dict[int, str] = {}
+v3: Set[int] = set()
+v4: Tuple[int] = (3,)
+v5: FrozenSet[int] = frozenset()
+v6: Type[int] = int
+v7 = Deque()
+v8 = DefaultDict()
+v9 = OrderedDict()
+v10 = Counter()
+v11 = ChainMap()
+
+# These should be marked deprecated for Python >= 3.10
+v20: Union[int, str]
+v21: Optional[int]

--- a/packages/pyright-internal/src/tests/testUtils.ts
+++ b/packages/pyright-internal/src/tests/testUtils.ts
@@ -227,7 +227,8 @@ export function validateResults(
     errorCount: number,
     warningCount = 0,
     infoCount?: number,
-    unusedCode?: number
+    unusedCode?: number,
+    deprecated?: number
 ) {
     assert.strictEqual(results.length, 1);
     assert.strictEqual(results[0].errors.length, errorCount);
@@ -239,5 +240,9 @@ export function validateResults(
 
     if (unusedCode !== undefined) {
         assert.strictEqual(results[0].unusedCodes.length, unusedCode);
+    }
+
+    if (deprecated !== undefined) {
+        assert.strictEqual(results[0].deprecateds.length, deprecated);
     }
 }

--- a/packages/pyright-internal/src/tests/testUtils.ts
+++ b/packages/pyright-internal/src/tests/testUtils.ts
@@ -38,6 +38,7 @@ export interface FileAnalysisResult {
     warnings: Diagnostic[];
     infos: Diagnostic[];
     unusedCodes: Diagnostic[];
+    deprecateds: Diagnostic[];
 }
 
 export interface FileParseResult {
@@ -143,6 +144,7 @@ export function bindSampleFile(fileName: string, configOptions = new ConfigOptio
         warnings: fileInfo.diagnosticSink.getWarnings(),
         infos: fileInfo.diagnosticSink.getInformation(),
         unusedCodes: fileInfo.diagnosticSink.getUnusedCode(),
+        deprecateds: fileInfo.diagnosticSink.getDeprecated(),
     };
 }
 
@@ -184,6 +186,7 @@ export function typeAnalyzeSampleFiles(
                 warnings: diagnostics.filter((diag) => diag.category === DiagnosticCategory.Warning),
                 infos: diagnostics.filter((diag) => diag.category === DiagnosticCategory.Information),
                 unusedCodes: diagnostics.filter((diag) => diag.category === DiagnosticCategory.UnusedCode),
+                deprecateds: diagnostics.filter((diag) => diag.category === DiagnosticCategory.Deprecated),
             };
             return analysisResult;
         } else {
@@ -196,6 +199,7 @@ export function typeAnalyzeSampleFiles(
                 warnings: [],
                 infos: [],
                 unusedCodes: [],
+                deprecateds: [],
             };
             return analysisResult;
         }


### PR DESCRIPTION
This PR adds the use of the "Deprecated" hint tag. In VS Code, these are styled with a strike-through effect. Deprecated symbols are not flagged at the time they are imported, but rather when they are used. 

![Screen Shot 2021-09-21 at 11 48 03 PM](https://user-images.githubusercontent.com/7040122/134296774-e686f2f7-ce49-4b49-9c55-078d0e67a5ca.png)


I found what appears to be a bug in VS Code. It is applying the strike-through style for text ranges that were not included in the hint's text range. We will need to work with the VS Code team to diagnose and fix this issue.

![Screen Shot 2021-09-21 at 11 47 27 PM](https://user-images.githubusercontent.com/7040122/134296748-e74943fc-63a1-4473-8215-2dd17e1038ce.png)

