### PR TITLE
Add support for completing keys for TypedDict arguments

### DIFF
--- a/packages/pyright-internal/src/analyzer/parseTreeUtils.ts
+++ b/packages/pyright-internal/src/analyzer/parseTreeUtils.ts
@@ -38,6 +38,7 @@ import {
     SuiteNode,
     TypeAnnotationNode,
 } from '../parser/parseNodes';
+import { ParseResults } from '../parser/parser';
 import { TokenizerOutput } from '../parser/tokenizer';
 import { KeywordType, OperatorType, StringTokenFlags, Token, TokenType } from '../parser/tokenizerTypes';
 import { getScope } from './analyzerNodeInfo';
@@ -1887,4 +1888,22 @@ function _getEndPositionIfMultipleStatementsAreOnSameLine(
     }
 
     return undefined;
+}
+
+export function getTokenAt(parseResults: ParseResults, position: Position) {
+    const tokens = parseResults.tokenizerOutput.tokens;
+    const offset = convertPositionToOffset(position, parseResults.tokenizerOutput.lines)!;
+    const index = tokens.getItemAtPosition(offset);
+    return tokens.getItemAt(index);
+}
+
+export function getPreviousToken(parseResults: ParseResults, token: Token) {
+    const tokens = parseResults.tokenizerOutput.tokens;
+    const tokenIndex = tokens.getItemAtPosition(token.start + 1);
+
+    if (tokenIndex === 0) {
+        return undefined;
+    }
+
+    return tokens.getItemAt(tokenIndex - 1);
 }

--- a/packages/pyright-internal/src/languageService/completionProvider.ts
+++ b/packages/pyright-internal/src/languageService/completionProvider.ts
@@ -59,12 +59,10 @@ import {
     isNone,
     isOverloadedFunction,
     isUnbound,
-    isUnion,
     isUnknown,
     OverloadedFunctionType,
     Type,
     TypeBase,
-    UnionType,
     UnknownType,
 } from '../analyzer/types';
 import {
@@ -92,6 +90,7 @@ import {
     ArgumentCategory,
     DecoratorNode,
     DictionaryKeyEntryNode,
+    DictionaryNode,
     ErrorExpressionCategory,
     ErrorNode,
     ExpressionNode,
@@ -104,6 +103,7 @@ import {
     ParameterNode,
     ParseNode,
     ParseNodeType,
+    SetNode,
     StringNode,
 } from '../parser/parseNodes';
 import { ParseResults } from '../parser/parser';
@@ -298,11 +298,6 @@ interface CompletionDetail {
     edits?: Edits | undefined;
     sortText?: string | undefined;
     itemDetail?: string | undefined;
-}
-
-interface DictPathEntry {
-    key: string;
-    entry: DictionaryKeyEntryNode;
 }
 
 export const autoImportDetail = 'Auto-import';
@@ -1301,8 +1296,6 @@ export class CompletionProvider {
                             priorText,
                             priorWord,
                             postText,
-                            undefined /* TODO: base expression node */,
-                            parseNode,
                             completionList
                         );
                     }
@@ -1386,15 +1379,7 @@ export class CompletionProvider {
                 }
 
                 // Add literals that apply to this parameter.
-                this._addLiteralValuesForArgument(
-                    signatureInfo,
-                    priorText,
-                    priorWord,
-                    postText,
-                    signatureInfo.callNode.arguments[callInfo.activeIndex]?.valueExpression,
-                    parseNode,
-                    completionList
-                );
+                this._addLiteralValuesForArgument(signatureInfo, priorText, priorWord, postText, completionList);
             }
         }
     }
@@ -1404,8 +1389,6 @@ export class CompletionProvider {
         priorText: string,
         priorWord: string,
         postText: string,
-        baseExpressionNode: ExpressionNode,
-        parseNode: ParseNode,
         completionList: CompletionList
     ) {
         signatureInfo.signatures.forEach((signature) => {
@@ -1421,15 +1404,7 @@ export class CompletionProvider {
             }
 
             const paramType = type.details.parameters[paramIndex].type;
-            this._addLiteralValuesForTargetType(
-                paramType,
-                priorText,
-                priorWord,
-                postText,
-                baseExpressionNode,
-                parseNode,
-                completionList
-            );
+            this._addLiteralValuesForTargetType(paramType, priorText, priorWord, postText, completionList);
             return undefined;
         });
     }
@@ -1439,8 +1414,6 @@ export class CompletionProvider {
         priorText: string,
         priorWord: string,
         postText: string,
-        baseExpressionNode: ExpressionNode | undefined,
-        parseNode: ParseNode,
         completionList: CompletionList
     ) {
         const quoteValue = this._getQuoteValueFromPriorText(priorText);
@@ -1462,232 +1435,6 @@ export class CompletionProvider {
                 }
             }
         });
-
-        if (baseExpressionNode === undefined) {
-            return;
-        }
-
-        if (isClassInstance(type) || isUnion(type)) {
-            const typedDicts = this._getTypedDicts(baseExpressionNode, parseNode, type);
-            if (typedDicts.length >= 1) {
-                // ignore already defined keys
-                const excludes = new Set(completionList.items.map((i) => i.label));
-                this._getDictExpressionStringKeys(parseNode).forEach((key) => {
-                    excludes.add(key);
-                });
-                typedDicts.forEach((typedDict) => {
-                    getTypedDictMembersForClass(this._evaluator, typedDict, /* allowNarrowed */ true).forEach(
-                        (_, key) => {
-                            // unions of TypedDicts may define the same key
-                            if (excludes.has(key)) {
-                                return;
-                            }
-                            excludes.add(key);
-
-                            this._addStringLiteralToCompletionList(
-                                key,
-                                quoteValue ? quoteValue.stringValue : undefined,
-                                postText,
-                                quoteValue
-                                    ? quoteValue.quoteCharacter
-                                    : this._parseResults.tokenizerOutput.predominantSingleQuoteCharacter,
-                                completionList
-                            );
-                        }
-                    );
-                });
-            }
-        }
-    }
-
-    private _getTypedDicts(baseExpressionNode: ExpressionNode, parseNode: ParseNode, type: ClassType | UnionType) {
-        if (!(tokenIsAtKey(this) || this._isInDictionaryStringKey(parseNode))) {
-            return [];
-        }
-
-        // path to resolve nested dictionaries
-        let path: DictPathEntry[] = [];
-        let curNode: ParseNode | undefined = parseNode;
-
-        while (curNode && curNode.id !== baseExpressionNode.id) {
-            // List is here as it is a supported container type
-            if (
-                curNode.nodeType === ParseNodeType.Dictionary ||
-                curNode.nodeType === ParseNodeType.Set ||
-                curNode.nodeType === ParseNodeType.List
-            ) {
-                if (
-                    curNode.parent?.nodeType === ParseNodeType.DictionaryKeyEntry &&
-                    curNode.parent?.keyExpression.nodeType === ParseNodeType.StringList
-                ) {
-                    path.push({
-                        entry: curNode.parent,
-                        key: curNode.parent.keyExpression.strings.map((s) => s.value).join(''),
-                    });
-                }
-            }
-
-            curNode = curNode.parent;
-        }
-
-        path = path.reverse();
-        const types = this._getTypedDictsRecursive(baseExpressionNode, parseNode, type, path);
-        const keys = this._getDictExpressionStringKeys(parseNode, new Set([parseNode.parent?.id]));
-        return this._tryNarrowTypedDicts(types, keys);
-
-        function tokenIsAtKey(provider: CompletionProvider): boolean {
-            // this function is only designed return true for states that
-            // are discarded by the parse tree, for example:
-            // {'foo': 'bar', '|}
-            const offset = convertPositionToOffset(provider._position, provider._parseResults.tokenizerOutput.lines)!;
-            const tokens = provider._parseResults.tokenizerOutput.tokens;
-            const index = tokens.getItemAtPosition(offset);
-            const token = tokens.getItemAt(index);
-            const prevToken = tokens.getItemAt(index - 1);
-            return token.type === TokenType.String && prevToken.type === TokenType.Comma;
-        }
-    }
-
-    private _getTypedDictsRecursive(
-        rootExpressionNode: ExpressionNode,
-        parseNode: ParseNode,
-        type: ClassType | UnionType,
-        path: DictPathEntry[]
-    ): ClassType[] {
-        const [expressionNode, typedDicts] = _resolveTypedDicts(type, rootExpressionNode, parseNode);
-        if (typedDicts.length === 0) {
-            return [];
-        }
-
-        if (
-            expressionNode.nodeType === ParseNodeType.Set &&
-            expressionNode.entries.length === 1 &&
-            expressionNode.entries[0].nodeType === ParseNodeType.StringList
-        ) {
-            // if the current expression looks like {''} then it is parsed as a set, however we
-            // should still add completions as it _could_ be a dictionary.
-            return typedDicts;
-        }
-
-        if (expressionNode.nodeType !== ParseNodeType.Dictionary) {
-            return [];
-        }
-
-        if (expressionNode.entries.length === 0 || path.length === 0) {
-            // no keys or nested dictionaries
-            return typedDicts;
-        }
-
-        const item = path.shift()!;
-
-        return typedDicts.flatMap((typedDict) => {
-            const members = getTypedDictMembersForClass(this._evaluator, typedDict, true);
-            const entry = members.get(item.key);
-            if (entry && (isClassInstance(entry.valueType) || isUnion(entry.valueType))) {
-                return this._getTypedDictsRecursive(item.entry.valueExpression, parseNode, entry.valueType, path);
-            }
-
-            return [];
-        });
-
-        function _resolveTypedDicts(
-            type: ClassType | UnionType,
-            expressionNode: ExpressionNode,
-            parseNode: ParseNode
-        ): [ExpressionNode, ClassType[]] {
-            let types: Type[] = [];
-            if (isUnion(type)) {
-                types = type.subtypes;
-            } else {
-                types = [type];
-            }
-
-            const typeNames = new Set<String>();
-            const typedDicts: ClassType[] = [];
-            let newExpression = expressionNode;
-
-            for (let index = 0; index < types.length; index++) {
-                const subtype = types[index];
-
-                if (
-                    isClassInstance(subtype) &&
-                    ClassType.isBuiltIn(subtype, 'list') &&
-                    subtype.typeArguments !== undefined
-                ) {
-                    if (expressionNode.nodeType !== ParseNodeType.List) {
-                        continue;
-                    }
-
-                    const entryNode = _resolveChild(parseNode, expressionNode.id);
-                    if (entryNode.id === expressionNode.id || !isExpressionNode(entryNode)) {
-                        continue;
-                    }
-
-                    newExpression = entryNode;
-                    subtype.typeArguments.forEach((typeArg) => {
-                        doForEachSubtype(typeArg, (subtype) => {
-                            maybeAdd(subtype);
-                        });
-                    });
-                } else {
-                    maybeAdd(subtype);
-                }
-            }
-
-            return [newExpression, typedDicts];
-
-            function maybeAdd(newType: Type) {
-                if (
-                    isClassInstance(newType) &&
-                    ClassType.isTypedDictClass(newType) &&
-                    !typeNames.has(newType.details.fullName)
-                ) {
-                    typedDicts.push(newType);
-                    typeNames.add(newType.details.fullName);
-                }
-            }
-
-            function _resolveChild(parseNode: ParseNode, targetId: number) {
-                // traverse parent nodes until the targetId is reached, returning the last parent node.
-                // this is useful for resolving the corresponding entry node
-                // in a list of nested dictionaries, e.g.
-                // [{'a': 'b'}, {'c': {'d': '|'}}] -> {'c': {'d': '|'}}
-                let curNode: ParseNode | undefined = parseNode;
-                let prevNode: ParseNode = parseNode;
-
-                while (curNode && curNode.id !== targetId) {
-                    prevNode = curNode;
-                    curNode = curNode.parent;
-
-                    if (!curNode) {
-                        break;
-                    }
-                }
-
-                return prevNode;
-            }
-        }
-    }
-
-    private _tryNarrowTypedDicts(types: ClassType[], keys: string[]): ClassType[] {
-        const newTypes = types.flatMap((type) => {
-            const entries = getTypedDictMembersForClass(this._evaluator, type, /* allowNarrowed */ true);
-
-            for (let index = 0; index < keys.length; index++) {
-                if (!entries.has(keys[index])) {
-                    return [];
-                }
-            }
-
-            return [type];
-        });
-
-        if (newTypes.length === 0) {
-            // couldn't narrow to any typed dicts, just include all
-            return types;
-        }
-
-        return newTypes;
     }
 
     private _getDictExpressionStringKeys(parseNode: ParseNode, excludeIds?: Set<number | undefined>) {
@@ -1724,37 +1471,6 @@ export class CompletionProvider {
 
             return curNode;
         }
-    }
-
-    private _isInDictionaryStringKey(parseNode: ParseNode): boolean {
-        if (parseNode.nodeType === ParseNodeType.Dictionary) {
-            return true;
-        }
-
-        if (parseNode.nodeType === ParseNodeType.Set && parseNode.entries.length < 2) {
-            if (parseNode.entries.length === 1) {
-                return parseNode.entries[0].nodeType === ParseNodeType.StringList;
-            }
-            return true;
-        }
-
-        const stringNode =
-            parseNode.nodeType === ParseNodeType.String && parseNode.parent?.nodeType === ParseNodeType.StringList
-                ? parseNode.parent
-                : null;
-        if (!stringNode) {
-            return false;
-        }
-
-        if (stringNode.parent?.nodeType === ParseNodeType.DictionaryKeyEntry) {
-            return stringNode.parent.keyExpression.id === stringNode.id;
-        }
-
-        if (stringNode.parent?.nodeType === ParseNodeType.Set) {
-            return stringNode.parent.entries.length === 1 && stringNode.parent.entries[0].id === stringNode.id;
-        }
-
-        return false;
     }
 
     private _getSubTypesWithLiteralValues(type: Type) {
@@ -1923,10 +1639,12 @@ export class CompletionProvider {
                     priorText,
                     priorWord,
                     postText,
-                    undefined /* TODO: base expression node */,
-                    parseNode,
                     completionList
                 );
+                return { completionList };
+            }
+
+            if (this._tryAddTypedDictKeys(parseNode, priorText, postText, completionList)) {
                 return { completionList };
             }
         }
@@ -1992,6 +1710,147 @@ export class CompletionProvider {
         }
 
         return { completionList };
+    }
+
+    private _tryAddTypedDictKeys(
+        parseNode: ParseNode,
+        priorText: string,
+        postText: string,
+        completionList: CompletionList
+    ) {
+        // TODO: cleanup
+        const offset = convertPositionToOffset(this._position, this._parseResults.tokenizerOutput.lines)!;
+        const tokens = this._parseResults.tokenizerOutput.tokens;
+        const index = tokens.getItemAtPosition(offset);
+        if (index === 0) {
+            return false;
+        }
+
+        const token = tokens.getItemAt(index);
+        const prevToken = tokens.getItemAt(index - 1);
+
+        if (parseNode.nodeType === ParseNodeType.Dictionary) {
+            return this._addTypedDictKeys(parseNode, /* stringNode */ null, priorText, postText, completionList);
+        }
+
+        if (parseNode.nodeType === ParseNodeType.String && parseNode.parent?.nodeType === ParseNodeType.StringList) {
+            // this handles states like {'foo': 'bar', '|'}
+            if (
+                parseNode.token.start !== token.start &&
+                token.type === TokenType.String &&
+                prevToken.type === TokenType.Comma &&
+                parseNode.parent?.parent?.nodeType === ParseNodeType.DictionaryKeyEntry &&
+                parseNode.parent?.parent?.parent?.nodeType === ParseNodeType.Dictionary
+            ) {
+                return this._addTypedDictKeys(
+                    parseNode.parent.parent.parent,
+                    parseNode,
+                    priorText,
+                    postText,
+                    completionList
+                );
+            }
+
+            if (
+                parseNode.parent?.parent?.nodeType === ParseNodeType.DictionaryKeyEntry &&
+                parseNode.parent?.parent?.keyExpression.id === parseNode.parent?.id &&
+                parseNode.parent?.parent?.parent?.nodeType === ParseNodeType.Dictionary
+            ) {
+                return this._addTypedDictKeys(
+                    parseNode.parent.parent.parent,
+                    parseNode,
+                    priorText,
+                    postText,
+                    completionList
+                );
+            } else if (
+                parseNode.parent?.parent?.nodeType === ParseNodeType.Set &&
+                parseNode.parent?.parent?.entries.length === 1
+            ) {
+                return this._addTypedDictKeys(parseNode.parent.parent, parseNode, priorText, postText, completionList);
+            }
+        }
+
+        return false;
+    }
+
+    private _addTypedDictKeys(
+        dictionaryNode: DictionaryNode | SetNode,
+        stringNode: StringNode | null,
+        priorText: string,
+        postText: string,
+        completionList: CompletionList
+    ) {
+        const expectedTypeResult = this._evaluator.getExpectedType(dictionaryNode);
+        if (!expectedTypeResult) {
+            return false;
+        }
+
+        let typedDicts: ClassType[] = [];
+
+        doForEachSubtype(expectedTypeResult.type, (subtype) => {
+            if (isClassInstance(subtype) && ClassType.isTypedDictClass(subtype)) {
+                typedDicts.push(subtype);
+            }
+        });
+
+        if (typedDicts.length === 0) {
+            return false;
+        }
+
+        const keys = this._getDictExpressionStringKeys(
+            dictionaryNode,
+            stringNode ? new Set([stringNode.parent?.id]) : undefined
+        );
+        typedDicts = this._tryNarrowTypedDicts(typedDicts, keys);
+
+        const quoteValue = this._getQuoteValueFromPriorText(priorText);
+        const excludes = new Set(completionList.items.map((i) => i.label));
+        keys.forEach((key) => {
+            excludes.add(key);
+        });
+        typedDicts.forEach((typedDict) => {
+            getTypedDictMembersForClass(this._evaluator, typedDict, /* allowNarrowed */ true).forEach((_, key) => {
+                // unions of TypedDicts may define the same key
+                if (excludes.has(key)) {
+                    return;
+                }
+                excludes.add(key);
+
+                this._addStringLiteralToCompletionList(
+                    key,
+                    quoteValue ? quoteValue.stringValue : undefined,
+                    postText,
+                    quoteValue
+                        ? quoteValue.quoteCharacter
+                        : this._parseResults.tokenizerOutput.predominantSingleQuoteCharacter,
+                    completionList
+                );
+            });
+        });
+
+        return true;
+    }
+
+    private _tryNarrowTypedDicts(types: ClassType[], keys: string[]): ClassType[] {
+        const newTypes = types.flatMap((type) => {
+            const entries = getTypedDictMembersForClass(this._evaluator, type, /* allowNarrowed */ true);
+
+            for (let index = 0; index < keys.length; index++) {
+                if (!entries.has(keys[index])) {
+                    return [];
+                }
+            }
+
+            return [type];
+        });
+
+        if (newTypes.length === 0) {
+            // couldn't narrow to any typed dicts, just include all
+            return types;
+        }
+
+        return newTypes;
     }
 
     // Given a string of text that precedes the current insertion point,

--- a/packages/pyright-internal/src/languageService/completionProvider.ts
+++ b/packages/pyright-internal/src/languageService/completionProvider.ts
@@ -1437,42 +1437,6 @@ export class CompletionProvider {
         });
     }
 
-    private _getDictExpressionStringKeys(parseNode: ParseNode, excludeIds?: Set<number | undefined>) {
-        const node = getDictionaryLikeNode(parseNode);
-        if (!node) {
-            return [];
-        }
-
-        return node.entries.flatMap((entry) => {
-            if (entry.nodeType !== ParseNodeType.DictionaryKeyEntry || excludeIds?.has(entry.keyExpression.id)) {
-                return [];
-            }
-
-            if (entry.keyExpression.nodeType === ParseNodeType.StringList) {
-                return [entry.keyExpression.strings.map((s) => s.value).join('')];
-            }
-
-            return [];
-        });
-
-        function getDictionaryLikeNode(parseNode: ParseNode) {
-            // this method assumes the given parseNode is either a child of a dictionary or a dictionary itself
-            if (parseNode.nodeType === ParseNodeType.Dictionary) {
-                return parseNode;
-            }
-
-            let curNode: ParseNode | undefined = parseNode;
-            while (curNode && curNode.nodeType !== ParseNodeType.Dictionary && curNode.nodeType !== ParseNodeType.Set) {
-                curNode = curNode.parent;
-                if (!curNode) {
-                    return;
-                }
-            }
-
-            return curNode;
-        }
-    }
-
     private _getSubTypesWithLiteralValues(type: Type) {
         const values: ClassType[] = [];
 
@@ -1830,6 +1794,23 @@ export class CompletionProvider {
         });
 
         return true;
+    }
+
+    private _getDictExpressionStringKeys(
+        dictionaryNode: DictionaryNode | SetNode,
+        excludeIds?: Set<number | undefined>
+    ) {
+        return dictionaryNode.entries.flatMap((entry) => {
+            if (entry.nodeType !== ParseNodeType.DictionaryKeyEntry || excludeIds?.has(entry.keyExpression.id)) {
+                return [];
+            }
+
+            if (entry.keyExpression.nodeType === ParseNodeType.StringList) {
+                return [entry.keyExpression.strings.map((s) => s.value).join('')];
+            }
+
+            return [];
+        });
     }
 
     private _tryNarrowTypedDicts(types: ClassType[], keys: string[]): ClassType[] {

--- a/packages/pyright-internal/src/languageService/completionProvider.ts
+++ b/packages/pyright-internal/src/languageService/completionProvider.ts
@@ -1683,26 +1683,19 @@ export class CompletionProvider {
         completionList: CompletionList
     ) {
         // TODO: cleanup
-        const offset = convertPositionToOffset(this._position, this._parseResults.tokenizerOutput.lines)!;
-        const tokens = this._parseResults.tokenizerOutput.tokens;
-        const index = tokens.getItemAtPosition(offset);
-        if (index === 0) {
-            return false;
-        }
-
-        const token = tokens.getItemAt(index);
-        const prevToken = tokens.getItemAt(index - 1);
-
         if (parseNode.nodeType === ParseNodeType.Dictionary) {
             return this._addTypedDictKeys(parseNode, /* stringNode */ null, priorText, postText, completionList);
         }
+
+        const token = ParseTreeUtils.getTokenAt(this._parseResults, this._position);
+        const prevToken = ParseTreeUtils.getPreviousToken(this._parseResults, token);
 
         if (parseNode.nodeType === ParseNodeType.String && parseNode.parent?.nodeType === ParseNodeType.StringList) {
             // this handles states like {'foo': 'bar', '|'}
             if (
                 parseNode.token.start !== token.start &&
                 token.type === TokenType.String &&
-                prevToken.type === TokenType.Comma &&
+                prevToken?.type === TokenType.Comma &&
                 parseNode.parent?.parent?.nodeType === ParseNodeType.DictionaryKeyEntry &&
                 parseNode.parent?.parent?.parent?.nodeType === ParseNodeType.Dictionary
             ) {

--- a/packages/pyright-internal/src/tests/fourslash/completions.call.typedDict.fourslash.ts
+++ b/packages/pyright-internal/src/tests/fourslash/completions.call.typedDict.fourslash.ts
@@ -1,0 +1,234 @@
+/// <reference path="fourslash.ts" />
+
+// @filename: test.py
+//// from typing import TypedDict, Optional, Union, List, Dict, Any
+////
+//// class Movie(TypedDict):
+////     name: str
+////     age: int
+////
+//// def thing(movie: Movie):
+////     pass
+////
+//// thing({'[|/*marker1*/|]'})
+//// thing({'name': '[|/*marker2*/|]'})
+//// thing({'name': 'Robert','[|/*marker3*/|]'})
+//// thing({'name': 'Robert',   '[|/*marker4*/|]'})
+//// thing('[|/*marker5*/|]')
+//// thing({'na[|/*marker6*/|]'})
+//// thing({[|/*marker7*/|]})
+//// thing({'a', '[|/*marker8*/|]'})
+////
+//// class Episode(TypedDict):
+////     title: str
+////     score: int
+////
+//// def thing2(item: Union[Episode, Movie]):
+////    pass
+////
+//// thing2({'[|/*marker9*/|]'})
+//// thing2({'unknown': 'a', '[|/*marker10*/|]': ''})
+//// thing2({'title': 'Episode 01', '[|/*marker11*/|]': ''})
+////
+//// class Wrapper(TypedDict):
+////     age: int
+////     wrapped: Union[bool, Movie]
+////     data: Dict[str, Any]
+////
+//// def thing3(wrapper: Optional[Wrapper]):
+////     pass
+////
+//// thing3({'data': {'[|/*marker12*/|]'}})
+//// thing3({'wrapped': {'[|/*marker13*/|]'}})
+//// thing3({'age': 1, 'wrapped': {'[|/*marker14*/|]'}})
+//// thing3({'unknown': {'[|/*marker15*/|]'}})
+//// thing3({'age': {'[|/*marker16*/|]'}})
+
+{
+    const marker1Range = helper.getStringPositionRange('marker1');
+    const marker3Range = helper.getStringPositionRange('marker3');
+    const marker4Range = helper.getStringPositionRange('marker4');
+    const marker6Range = helper.getStringPositionRange('marker6', /* start */ 3);
+    const marker7Range = helper.getPositionRange('marker7');
+    const marker9Range = helper.getStringPositionRange('marker9');
+    const marker10Range = helper.getStringPositionRange('marker10');
+    const marker11Range = helper.getStringPositionRange('marker11');
+    const marker13Range = helper.getStringPositionRange('marker13');
+    const marker14Range = helper.getStringPositionRange('marker14');
+
+    // @ts-ignore
+    await helper.verifyCompletion('exact', 'markdown', {
+        marker1: {
+            completions: [
+                {
+                    label: "'name'",
+                    kind: Consts.CompletionItemKind.Constant,
+                    textEdit: { range: marker1Range, newText: "'name'" },
+                },
+                {
+                    label: "'age'",
+                    kind: Consts.CompletionItemKind.Constant,
+                    textEdit: { range: marker1Range, newText: "'age'" },
+                },
+            ],
+        },
+        marker2: {
+            completions: [],
+        },
+        marker3: {
+            completions: [
+                // TODO: this first completion is a bug
+                {
+                    label: 'movie=',
+                    kind: Consts.CompletionItemKind.Variable,
+                },
+                {
+                    label: "'age'",
+                    kind: Consts.CompletionItemKind.Constant,
+                    textEdit: { range: marker3Range, newText: "'age'" },
+                },
+            ],
+        },
+        marker4: {
+            completions: [
+                // TODO: this first completion is a bug
+                {
+                    label: 'movie=',
+                    kind: Consts.CompletionItemKind.Variable,
+                },
+                {
+                    label: "'age'",
+                    kind: Consts.CompletionItemKind.Constant,
+                    textEdit: { range: marker4Range, newText: "'age'" },
+                },
+            ],
+        },
+        marker5: {
+            completions: [],
+        },
+        marker6: {
+            completions: [
+                {
+                    label: "'name'",
+                    kind: Consts.CompletionItemKind.Constant,
+                    textEdit: { range: marker6Range, newText: "'name'" },
+                },
+            ],
+        },
+        marker8: {
+            completions: [],
+        },
+        marker9: {
+            completions: [
+                {
+                    label: "'name'",
+                    kind: Consts.CompletionItemKind.Constant,
+                    textEdit: { range: marker9Range, newText: "'name'" },
+                },
+                {
+                    label: "'age'",
+                    kind: Consts.CompletionItemKind.Constant,
+                    textEdit: { range: marker9Range, newText: "'age'" },
+                },
+                {
+                    label: "'title'",
+                    kind: Consts.CompletionItemKind.Constant,
+                    textEdit: { range: marker9Range, newText: "'title'" },
+                },
+                {
+                    label: "'score'",
+                    kind: Consts.CompletionItemKind.Constant,
+                    textEdit: { range: marker9Range, newText: "'score'" },
+                },
+            ],
+        },
+        marker10: {
+            completions: [
+                {
+                    label: "'name'",
+                    kind: Consts.CompletionItemKind.Constant,
+                    textEdit: { range: marker10Range, newText: "'name'" },
+                },
+                {
+                    label: "'age'",
+                    kind: Consts.CompletionItemKind.Constant,
+                    textEdit: { range: marker10Range, newText: "'age'" },
+                },
+                {
+                    label: "'title'",
+                    kind: Consts.CompletionItemKind.Constant,
+                    textEdit: { range: marker10Range, newText: "'title'" },
+                },
+                {
+                    label: "'score'",
+                    kind: Consts.CompletionItemKind.Constant,
+                    textEdit: { range: marker10Range, newText: "'score'" },
+                },
+            ],
+        },
+        marker11: {
+            completions: [
+                {
+                    label: "'score'",
+                    kind: Consts.CompletionItemKind.Constant,
+                    textEdit: { range: marker11Range, newText: "'score'" },
+                },
+            ],
+        },
+        marker12: {
+            completions: [],
+        },
+        marker13: {
+            completions: [
+                {
+                    label: "'name'",
+                    kind: Consts.CompletionItemKind.Constant,
+                    textEdit: { range: marker13Range, newText: "'name'" },
+                },
+                {
+                    label: "'age'",
+                    kind: Consts.CompletionItemKind.Constant,
+                    textEdit: { range: marker13Range, newText: "'age'" },
+                },
+            ],
+        },
+        marker14: {
+            completions: [
+                {
+                    label: "'name'",
+                    kind: Consts.CompletionItemKind.Constant,
+                    textEdit: { range: marker14Range, newText: "'name'" },
+                },
+                {
+                    label: "'age'",
+                    kind: Consts.CompletionItemKind.Constant,
+                    textEdit: { range: marker14Range, newText: "'age'" },
+                },
+            ],
+        },
+        marker15: {
+            completions: [],
+        },
+        marker16: {
+            completions: [],
+        },
+    });
+
+    // @ts-ignore
+    await helper.verifyCompletion('included', 'markdown', {
+        marker7: {
+            completions: [
+                {
+                    label: "'name'",
+                    kind: Consts.CompletionItemKind.Constant,
+                    textEdit: { range: marker7Range, newText: "'name'" },
+                },
+                {
+                    label: "'age'",
+                    kind: Consts.CompletionItemKind.Constant,
+                    textEdit: { range: marker7Range, newText: "'age'" },
+                },
+            ],
+        },
+    });
+}

--- a/packages/pyright-internal/src/tests/fourslash/completions.call.typedDict.fourslash.ts
+++ b/packages/pyright-internal/src/tests/fourslash/completions.call.typedDict.fourslash.ts
@@ -77,11 +77,6 @@
         },
         marker3: {
             completions: [
-                // TODO: this first completion is a bug
-                {
-                    label: 'movie=',
-                    kind: Consts.CompletionItemKind.Variable,
-                },
                 {
                     label: "'age'",
                     kind: Consts.CompletionItemKind.Constant,
@@ -91,11 +86,6 @@
         },
         marker4: {
             completions: [
-                // TODO: this first completion is a bug
-                {
-                    label: 'movie=',
-                    kind: Consts.CompletionItemKind.Variable,
-                },
                 {
                     label: "'age'",
                     kind: Consts.CompletionItemKind.Constant,

--- a/packages/pyright-internal/src/tests/fourslash/completions.call.typedDict.fourslash.ts
+++ b/packages/pyright-internal/src/tests/fourslash/completions.call.typedDict.fourslash.ts
@@ -45,16 +45,16 @@
 //// thing3({'age': {'[|/*marker16*/|]'}})
 
 {
-    const marker1Range = helper.getStringPositionRange('marker1');
-    const marker3Range = helper.getStringPositionRange('marker3');
-    const marker4Range = helper.getStringPositionRange('marker4');
-    const marker6Range = helper.getStringPositionRange('marker6', /* start */ 3);
+    const marker1Range = helper.getPositionRange('marker1', 1, 1);
+    const marker3Range = helper.getPositionRange('marker3', 1, 1);
+    const marker4Range = helper.getPositionRange('marker4', 1, 1);
+    const marker6Range = helper.getPositionRange('marker6', 3, 1);
     const marker7Range = helper.getPositionRange('marker7');
-    const marker9Range = helper.getStringPositionRange('marker9');
-    const marker10Range = helper.getStringPositionRange('marker10');
-    const marker11Range = helper.getStringPositionRange('marker11');
-    const marker13Range = helper.getStringPositionRange('marker13');
-    const marker14Range = helper.getStringPositionRange('marker14');
+    const marker9Range = helper.getPositionRange('marker9', 1, 1);
+    const marker10Range = helper.getPositionRange('marker10', 1, 1);
+    const marker11Range = helper.getPositionRange('marker11', 1, 1);
+    const marker13Range = helper.getPositionRange('marker13', 1, 1);
+    const marker14Range = helper.getPositionRange('marker14', 1, 1);
 
     // @ts-ignore
     await helper.verifyCompletion('exact', 'markdown', {

--- a/packages/pyright-internal/src/tests/fourslash/completions.call.typedDict.list.fourslash.ts
+++ b/packages/pyright-internal/src/tests/fourslash/completions.call.typedDict.list.fourslash.ts
@@ -1,0 +1,163 @@
+/// <reference path="fourslash.ts" />
+
+// @filename: test.py
+//// from typing import TypedDict, Union, List
+////
+//// class Movie(TypedDict):
+////     name: str
+////     age: int
+////
+//// class MultipleInputs(TypedDict):
+////     items: List[Movie]
+////     union: Union[bool, List[Movie]]
+////     unions: Union[Movie, Union[bool, List[Movie]]]
+////
+//// def thing(inputs: MultipleInputs):
+////     pass
+////
+//// thing({'items': ['[|/*marker1*/|]']})
+//// thing({'items': {'[|/*marker2*/|]'}})
+//// thing({'items': [{'[|/*marker3*/|]'}]})
+//// thing({'union': [{'[|/*marker4*/|]'}]})
+//// thing({'unions': {'[|/*marker5*/|]'}})
+//// thing({'unions': [{'[|/*marker6*/|]'}]})
+////
+//// def thing2(movies: List[Movie]):
+////     pass
+////
+//// thing2([{'[|/*marker7*/|]'}])
+//// thing2({'[|/*marker8*/|]'})
+////
+//// class Wrapper(TypedDict):
+////     wrapped: MultipleInputs
+////
+//// def thing3(wrapper: Wrapper):
+////     pass
+////
+//// thing3({'wrapped': {'items': [{'[|/*marker9*/|]'}]}})
+//// thing3({'wrapped': {'items': {'[|/*marker10*/|]'}}})
+//// thing3({'wrapped': {'items': [{'a': 'b'}, {'[|/*marker11*/|]'}]}})
+
+{
+    const marker3Range = helper.getStringPositionRange('marker3');
+    const marker4Range = helper.getStringPositionRange('marker4');
+    const marker5Range = helper.getStringPositionRange('marker5');
+    const marker6Range = helper.getStringPositionRange('marker6');
+    const marker7Range = helper.getStringPositionRange('marker7');
+    const marker9Range = helper.getStringPositionRange('marker9');
+    const marker11Range = helper.getStringPositionRange('marker11');
+
+    // @ts-ignore
+    await helper.verifyCompletion('exact', 'markdown', {
+        marker1: {
+            completions: [],
+        },
+        marker2: {
+            completions: [],
+        },
+        marker3: {
+            completions: [
+                {
+                    label: "'name'",
+                    kind: Consts.CompletionItemKind.Constant,
+                    textEdit: { range: marker3Range, newText: "'name'" },
+                },
+                {
+                    label: "'age'",
+                    kind: Consts.CompletionItemKind.Constant,
+                    textEdit: { range: marker3Range, newText: "'age'" },
+                },
+            ],
+        },
+        marker4: {
+            completions: [
+                {
+                    label: "'name'",
+                    kind: Consts.CompletionItemKind.Constant,
+                    textEdit: { range: marker4Range, newText: "'name'" },
+                },
+                {
+                    label: "'age'",
+                    kind: Consts.CompletionItemKind.Constant,
+                    textEdit: { range: marker4Range, newText: "'age'" },
+                },
+            ],
+        },
+        marker5: {
+            completions: [
+                {
+                    label: "'name'",
+                    kind: Consts.CompletionItemKind.Constant,
+                    textEdit: { range: marker5Range, newText: "'name'" },
+                },
+                {
+                    label: "'age'",
+                    kind: Consts.CompletionItemKind.Constant,
+                    textEdit: { range: marker5Range, newText: "'age'" },
+                },
+            ],
+        },
+        marker6: {
+            completions: [
+                {
+                    label: "'name'",
+                    kind: Consts.CompletionItemKind.Constant,
+                    textEdit: { range: marker6Range, newText: "'name'" },
+                },
+                {
+                    label: "'age'",
+                    kind: Consts.CompletionItemKind.Constant,
+                    textEdit: { range: marker6Range, newText: "'age'" },
+                },
+            ],
+        },
+        marker7: {
+            completions: [
+                {
+                    label: "'name'",
+                    kind: Consts.CompletionItemKind.Constant,
+                    textEdit: { range: marker7Range, newText: "'name'" },
+                },
+                {
+                    label: "'age'",
+                    kind: Consts.CompletionItemKind.Constant,
+                    textEdit: { range: marker7Range, newText: "'age'" },
+                },
+            ],
+        },
+        marker8: {
+            completions: [],
+        },
+        marker9: {
+            completions: [
+                {
+                    label: "'name'",
+                    kind: Consts.CompletionItemKind.Constant,
+                    textEdit: { range: marker9Range, newText: "'name'" },
+                },
+                {
+                    label: "'age'",
+                    kind: Consts.CompletionItemKind.Constant,
+                    textEdit: { range: marker9Range, newText: "'age'" },
+                },
+            ],
+        },
+        marker10: {
+            completions: [],
+        },
+        marker11: {
+            completions: [
+                {
+                    label: "'name'",
+                    kind: Consts.CompletionItemKind.Constant,
+                    textEdit: { range: marker11Range, newText: "'name'" },
+                },
+                {
+                    label: "'age'",
+                    kind: Consts.CompletionItemKind.Constant,
+                    textEdit: { range: marker11Range, newText: "'age'" },
+                },
+            ],
+        },
+    });
+}

--- a/packages/pyright-internal/src/tests/fourslash/completions.call.typedDict.list.fourslash.ts
+++ b/packages/pyright-internal/src/tests/fourslash/completions.call.typedDict.list.fourslash.ts
@@ -39,13 +39,13 @@
 //// thing3({'wrapped': {'items': [{'a': 'b'}, {'[|/*marker11*/|]'}]}})
 
 {
-    const marker3Range = helper.getStringPositionRange('marker3');
-    const marker4Range = helper.getStringPositionRange('marker4');
-    const marker5Range = helper.getStringPositionRange('marker5');
-    const marker6Range = helper.getStringPositionRange('marker6');
-    const marker7Range = helper.getStringPositionRange('marker7');
-    const marker9Range = helper.getStringPositionRange('marker9');
-    const marker11Range = helper.getStringPositionRange('marker11');
+    const marker3Range = helper.getPositionRange('marker3', 1, 1);
+    const marker4Range = helper.getPositionRange('marker4', 1, 1);
+    const marker5Range = helper.getPositionRange('marker5', 1, 1);
+    const marker6Range = helper.getPositionRange('marker6', 1, 1);
+    const marker7Range = helper.getPositionRange('marker7', 1, 1);
+    const marker9Range = helper.getPositionRange('marker9', 1, 1);
+    const marker11Range = helper.getPositionRange('marker11', 1, 1);
 
     // @ts-ignore
     await helper.verifyCompletion('exact', 'markdown', {

--- a/packages/pyright-internal/src/tests/fourslash/completions.call.typedDict.states.fourslash.ts
+++ b/packages/pyright-internal/src/tests/fourslash/completions.call.typedDict.states.fourslash.ts
@@ -1,0 +1,135 @@
+/// <reference path="fourslash.ts" />
+
+// @filename: test.py
+//// from typing import TypedDict
+////
+//// class Movie(TypedDict):
+////     name: str
+////     age: int
+////
+//// def thing(movie: Movie):
+////     pass
+////
+//// thing(movie={'foo': 'a', '[|/*marker1*/|]'})
+//// thing(movie={'foo': 'a', 'a[|/*marker2*/|]'})
+//// thing(
+////     movie={
+////        'name': 'Parasite',
+////        '[|/*marker3*/|]
+////     }
+//// )
+//// thing(
+////     movie={
+////        'name': 'Parasite',
+////        '[|/*marker4*/|]'
+////     }
+//// )
+//// thing({
+////     'name': 'Parasite',
+////     # hello world
+////     '[|/*marker5*/|]'
+//// })
+//// thing({'foo': '[|/*marker6*/|]'})
+
+{
+    // completions that rely on token parsing instead of node parsing
+    const marker1Range = helper.getStringPositionRange('marker1');
+    const marker2Range = helper.getStringPositionRange('marker2', /* start */ 2);
+    const marker3Range = helper.getStringPositionRange('marker3', /* start */ 1, /* end */ 0);
+    const marker4Range = helper.getStringPositionRange('marker4');
+    const marker5Range = helper.getStringPositionRange('marker5');
+
+    // @ts-ignore
+    await helper.verifyCompletion('exact', 'markdown', {
+        marker1: {
+            completions: [
+                {
+                    label: "'name'",
+                    kind: Consts.CompletionItemKind.Constant,
+                    textEdit: { range: marker1Range, newText: "'name'" },
+                },
+                {
+                    label: "'age'",
+                    kind: Consts.CompletionItemKind.Constant,
+                    textEdit: { range: marker1Range, newText: "'age'" },
+                },
+            ],
+        },
+        marker2: {
+            completions: [
+                {
+                    label: "'name'",
+                    kind: Consts.CompletionItemKind.Constant,
+                    textEdit: { range: marker2Range, newText: "'name'" },
+                },
+                {
+                    label: "'age'",
+                    kind: Consts.CompletionItemKind.Constant,
+                    textEdit: { range: marker2Range, newText: "'age'" },
+                },
+            ],
+        },
+        marker6: {
+            completions: [],
+        },
+    });
+
+    // @ts-ignore
+    await helper.verifyCompletion('included', 'markdown', {
+        marker3: {
+            completions: [
+                {
+                    label: "'age'",
+                    kind: Consts.CompletionItemKind.Constant,
+                    textEdit: { range: marker3Range, newText: "'age'" },
+                },
+            ],
+        },
+        marker4: {
+            completions: [
+                {
+                    label: "'age'",
+                    kind: Consts.CompletionItemKind.Constant,
+                    textEdit: { range: marker4Range, newText: "'age'" },
+                },
+            ],
+        },
+        marker5: {
+            completions: [
+                {
+                    label: "'age'",
+                    kind: Consts.CompletionItemKind.Constant,
+                    textEdit: { range: marker5Range, newText: "'age'" },
+                },
+            ],
+        },
+    });
+
+    // @ts-ignore
+    await helper.verifyCompletion('excluded', 'markdown', {
+        marker3: {
+            completions: [
+                {
+                    label: "'name'",
+                    kind: Consts.CompletionItemKind.Constant,
+                },
+            ],
+        },
+        marker4: {
+            completions: [
+                {
+                    label: "'name'",
+                    kind: Consts.CompletionItemKind.Constant,
+                },
+            ],
+        },
+        marker5: {
+            completions: [
+                {
+                    label: "'name'",
+                    kind: Consts.CompletionItemKind.Constant,
+                },
+            ],
+        },
+    });
+}

--- a/packages/pyright-internal/src/tests/fourslash/completions.call.typedDict.states.fourslash.ts
+++ b/packages/pyright-internal/src/tests/fourslash/completions.call.typedDict.states.fourslash.ts
@@ -33,11 +33,11 @@
 
 {
     // completions that rely on token parsing instead of node parsing
-    const marker1Range = helper.getStringPositionRange('marker1');
-    const marker2Range = helper.getStringPositionRange('marker2', /* start */ 2);
-    const marker3Range = helper.getStringPositionRange('marker3', /* start */ 1, /* end */ 0);
-    const marker4Range = helper.getStringPositionRange('marker4');
-    const marker5Range = helper.getStringPositionRange('marker5');
+    const marker1Range = helper.getPositionRange('marker1', 1, 1);
+    const marker2Range = helper.getPositionRange('marker2', 2, 1);
+    const marker3Range = helper.getPositionRange('marker3', 1, 0);
+    const marker4Range = helper.getPositionRange('marker4', 1, 1);
+    const marker5Range = helper.getPositionRange('marker5', 1, 1);
 
     // @ts-ignore
     await helper.verifyCompletion('exact', 'markdown', {

--- a/packages/pyright-internal/src/tests/fourslash/fourslash.ts
+++ b/packages/pyright-internal/src/tests/fourslash/fourslash.ts
@@ -157,6 +157,7 @@ declare namespace _ {
         getFilteredRanges<T extends {}>(
             predicate: (m: Marker | undefined, d: T | undefined, text: string) => boolean
         ): Range[];
+        getStringPositionRange(markerString: string, start?: number, end?: number): PositionRange;
         getPositionRange(markerString: string): PositionRange;
         convertPositionRange(range: Range): PositionRange;
 

--- a/packages/pyright-internal/src/tests/fourslash/fourslash.ts
+++ b/packages/pyright-internal/src/tests/fourslash/fourslash.ts
@@ -157,8 +157,7 @@ declare namespace _ {
         getFilteredRanges<T extends {}>(
             predicate: (m: Marker | undefined, d: T | undefined, text: string) => boolean
         ): Range[];
-        getStringPositionRange(markerString: string, start?: number, end?: number): PositionRange;
-        getPositionRange(markerString: string): PositionRange;
+        getPositionRange(markerString: string, start?: number, end?: number): PositionRange;
         convertPositionRange(range: Range): PositionRange;
 
         goToBOF(): void;

--- a/packages/pyright-internal/src/tests/harness/fourslash/testState.ts
+++ b/packages/pyright-internal/src/tests/harness/fourslash/testState.ts
@@ -274,6 +274,13 @@ export class TestState {
         return [...this.testData.markerPositions.keys()];
     }
 
+    getStringPositionRange(markerString: string, start = 1, end = 1) {
+        const range = this.getPositionRange(markerString);
+        range.start.character -= start;
+        range.end.character += end;
+        return range;
+    }
+
     getPositionRange(markerString: string) {
         const marker = this.getMarkerByName(markerString);
         const ranges = this.getRanges().filter((r) => r.marker === marker);

--- a/packages/pyright-internal/src/tests/harness/fourslash/testState.ts
+++ b/packages/pyright-internal/src/tests/harness/fourslash/testState.ts
@@ -274,22 +274,17 @@ export class TestState {
         return [...this.testData.markerPositions.keys()];
     }
 
-    getStringPositionRange(markerString: string, start = 1, end = 1) {
-        const range = this.getPositionRange(markerString);
-        range.start.character -= start;
-        range.end.character += end;
-        return range;
-    }
-
-    getPositionRange(markerString: string) {
+    getPositionRange(markerString: string, start = 0, end = 0) {
         const marker = this.getMarkerByName(markerString);
         const ranges = this.getRanges().filter((r) => r.marker === marker);
         if (ranges.length !== 1) {
             this.raiseError(`no matching range for ${markerString}`);
         }
 
-        const range = ranges[0];
-        return this.convertPositionRange(range);
+        const range = this.convertPositionRange(ranges[0]);
+        range.start.character -= start;
+        range.end.character += end;
+        return range;
     }
 
     convertPositionRange(range: Range) {


### PR DESCRIPTION
This PR adds support for autocompleting keys for `TypedDict` arguments to functions.

![Image showcasing completions](https://i.gyazo.com/2748daf91f1133114cc34ca371e33b8b.png)

It should be noted that this does _not_ add support for https://github.com/microsoft/pylance-release/issues/654.

## Features

### Nested TypedDicts

![Image of nested TypedDicts](https://i.gyazo.com/a93de06440ac65277b1631302f42b9a8.png)

### Unions of TypedDicts

![Image of unions of TypedDicts](https://i.gyazo.com/e35b6914121ec9cb214d0436945ea3de.png)

### Narrows unions of TypedDicts

If the keys that are already present in the dictionary are not valid for one or more TypedDicts then suggestions will be removed.

![Image of narrowing unions of TypedDicts](https://i.gyazo.com/31ca0bc4032e42486f06dc97c36b9a9e.png)

### Removes redundant completions

Keys that are already present in the dictionary will not be suggested.

![Image showcasing removing redundant completions](https://i.gyazo.com/6ea6cd9babc144992e74582928227301.png)

### Lists of TypedDicts

![Image showcasing completions for lists of TypedDicts](https://i.gyazo.com/87e6fb2311eaaba6c57738eae55dcecc.png)

## Additional notes

### Erroneous parsing

Dictionary expressions that are not fully complete, e.g.

```py
{
    'hello': 'world',
    '.'
}
```

are handled naively, I simply check that the cursor is inside a string inside a dictionary and that the previous token is a comma. I do not know if there is a better method for achieving this.

### Completion bug

While writing tests for this feature I ran into a bug. Parameter arguments are suggested while inside string literals, see [this](https://github.com/microsoft/pyright/compare/main...RobertCraigie:typeddict-arg-complete?expand=1#diff-091452b93d749b8b9475a3aa506d5121c4eb0c67f37b24403fa8812d59ad699bR15) test case.

## Motivation

Adding key completions for TypedDict arguments will significantly improve the experience using https://github.com/RobertCraigie/prisma-client-py
