### PR TITLE
Fix more unresolvable import completions, module refactoring updates, remove getDeclaredTypeForExpression

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -81,11 +81,11 @@
             "type": "node",
             "request": "launch",
             "args": ["${fileBasenameNoExtension}", "--runInBand", "-t", "${selectedText}"],
-            "cwd": "${workspaceRoot}/packages/pyright/packages/pyright-internal",
+            "cwd": "${workspaceRoot}/packages/pyright-internal",
             "console": "integratedTerminal",
             "internalConsoleOptions": "neverOpen",
             "disableOptimisticBPs": true,
-            "program": "${workspaceFolder}/packages/pyright/packages/pyright-internal/node_modules/jest/bin/jest"
+            "program": "${workspaceFolder}/packages/pyright-internal/node_modules/jest/bin/jest"
         },
         {
             "name": "Pyright fourslash current file",

--- a/packages/pyright-internal/src/analyzer/parseTreeUtils.ts
+++ b/packages/pyright-internal/src/analyzer/parseTreeUtils.ts
@@ -1402,15 +1402,25 @@ export function getCallNodeAndActiveParameterIndex(
         }
         return found;
     }
+}
 
-    function getTokenAt(tokens: TextRangeCollection<Token>, position: number) {
-        const index = tokens.getItemAtPosition(position);
-        if (index < 0) {
-            return undefined;
-        }
-
-        return tokens.getItemAt(index);
+export function getTokenAt(tokens: TextRangeCollection<Token>, position: number) {
+    const index = tokens.getItemAtPosition(position);
+    if (index < 0) {
+        return undefined;
     }
+
+    return tokens.getItemAt(index);
+}
+
+export function getTokenOverlapping(tokens: TextRangeCollection<Token>, position: number) {
+    const index = tokens.getItemAtPosition(position);
+    if (index < 0) {
+        return undefined;
+    }
+
+    const token = tokens.getItemAt(index);
+    return TextRange.overlaps(token, position) ? token : undefined;
 }
 
 export function printParseNodeType(type: ParseNodeType) {

--- a/packages/pyright-internal/src/analyzer/program.ts
+++ b/packages/pyright-internal/src/analyzer/program.ts
@@ -33,6 +33,7 @@ import {
     getDirectoryPath,
     getFileName,
     getRelativePath,
+    isFile,
     makeDirectories,
     normalizePath,
     normalizePathCase,
@@ -1570,19 +1571,21 @@ export class Program {
         });
     }
 
-    renameModule(filePath: string, newFilePath: string, token: CancellationToken): FileEditAction[] | undefined {
+    renameModule(path: string, newPath: string, token: CancellationToken): FileEditAction[] | undefined {
         return this._runEvaluatorWithCancellationToken(token, () => {
-            const fileInfo = this._getSourceFileInfoFromPath(filePath);
-            if (!fileInfo) {
-                return undefined;
+            if (isFile(this._fs, path)) {
+                const fileInfo = this._getSourceFileInfoFromPath(path);
+                if (!fileInfo) {
+                    return undefined;
+                }
             }
 
             const renameModuleProvider = RenameModuleProvider.create(
                 this._importResolver,
                 this._configOptions,
                 this._evaluator!,
-                filePath,
-                newFilePath,
+                path,
+                newPath,
                 token
             );
             if (!renameModuleProvider) {
@@ -1610,7 +1613,7 @@ export class Program {
                     continue;
                 }
 
-                renameModuleProvider.renameModuleReferences(currentFileInfo.sourceFile.getFilePath(), parseResult);
+                renameModuleProvider.renameReferences(currentFileInfo.sourceFile.getFilePath(), parseResult);
 
                 // This operation can consume significant memory, so check
                 // for situations where we need to discard the type cache.

--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -11655,7 +11655,6 @@ export function createTypeEvaluator(importLookup: ImportLookup, evaluatorOptions
             if (!rightHandType) {
                 // Determine whether there is a declared type.
                 const declaredType = getDeclaredTypeForExpression(node.leftExpression, { method: 'set' });
-
                 let flags: EvaluatorFlags = EvaluatorFlags.DoNotSpecialize;
                 if (fileInfo.isStubFile) {
                     // An assignment of ellipsis means "Any" within a type stub file.
@@ -21203,7 +21202,6 @@ export function createTypeEvaluator(importLookup: ImportLookup, evaluatorOptions
         getTypeForExpressionExpectingType,
         getExpectedType,
         evaluateTypesForStatement,
-        getDeclaredTypeForExpression,
         verifyRaiseExceptionType,
         verifyDeleteExpression,
         isAfterNodeReachable,

--- a/packages/pyright-internal/src/analyzer/typeEvaluatorTypes.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluatorTypes.ts
@@ -235,7 +235,6 @@ export interface TypeEvaluator {
     evaluateTypesForStatement: (node: ParseNode) => void;
 
     getExpectedType: (node: ExpressionNode) => ExpectedTypeResult | undefined;
-    getDeclaredTypeForExpression: (expression: ExpressionNode) => Type | undefined;
     verifyRaiseExceptionType: (node: RaiseNode) => void;
     verifyDeleteExpression: (node: ExpressionNode) => void;
 

--- a/packages/pyright-internal/src/analyzer/typeEvaluatorWithTracker.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluatorWithTracker.ts
@@ -70,8 +70,6 @@ export function createTypeEvaluatorWithTracker(
         evaluateTypesForStatement: (n) =>
             run('evaluateTypesForStatement', () => typeEvaluator.evaluateTypesForStatement(n), n),
         getExpectedType: (n) => run('getExpectedType', () => typeEvaluator.getExpectedType(n), n),
-        getDeclaredTypeForExpression: (n) =>
-            run('getDeclaredTypeForExpression', () => typeEvaluator.getDeclaredTypeForExpression(n), n),
         verifyRaiseExceptionType: (n) =>
             run('verifyRaiseExceptionType', () => typeEvaluator.verifyRaiseExceptionType(n), n),
         verifyDeleteExpression: (n) => run('verifyDeleteExpression', () => typeEvaluator.verifyDeleteExpression(n), n),

--- a/packages/pyright-internal/src/languageService/documentSymbolCollector.ts
+++ b/packages/pyright-internal/src/languageService/documentSymbolCollector.ts
@@ -330,7 +330,7 @@ export class DocumentSymbolCollector extends ParseTreeWalker {
                 // so that it matches with decls type evaluator returns for "references for X".
                 // ex) import X or from .X import ... in init file and etc.
                 const symbolWithScope = ScopeUtils.getScopeForNode(node)?.lookUpSymbolRecursive(importName);
-                if (symbolWithScope) {
+                if (symbolWithScope && moduleName.nameParts.length === 1) {
                     decls.push(...symbolWithScope.symbol.getDeclarations().filter((d) => isAliasDeclaration(d)));
 
                     // If symbols are re-used, then find one that belong to this import statement.

--- a/packages/pyright-internal/src/tests/fourslash/completions.importSubmodule.fourslash.ts
+++ b/packages/pyright-internal/src/tests/fourslash/completions.importSubmodule.fourslash.ts
@@ -21,9 +21,6 @@
 // @ts-ignore
 await helper.verifyCompletion('exact', 'markdown', {
     marker1: {
-        completions: [
-            { label: 'setup', kind: Consts.CompletionItemKind.Module },
-            { label: 'submodule1', kind: Consts.CompletionItemKind.Module },
-        ],
+        completions: [{ label: 'submodule1', kind: Consts.CompletionItemKind.Module }],
     },
 });

--- a/packages/pyright-internal/src/tests/fourslash/completions.literals.fourslash.ts
+++ b/packages/pyright-internal/src/tests/fourslash/completions.literals.fourslash.ts
@@ -1,0 +1,33 @@
+/// <reference path="fourslash.ts" />
+
+// @filename: test1.py
+//// from typing import Literal
+//// a: Literal["Hello"] = "He[|/*marker1*/|]
+
+// @filename: test2.py
+//// from typing import Literal
+//// a: Literal["Hello"] = [|/*marker2*/|]
+
+{
+    helper.openFiles(helper.getMarkers().map((m) => m.fileName));
+
+    // @ts-ignore
+    await helper.verifyCompletion('included', 'markdown', {
+        marker1: {
+            completions: [
+                {
+                    label: '"Hello"',
+                    kind: Consts.CompletionItemKind.Constant,
+                },
+            ],
+        },
+        marker2: {
+            completions: [
+                {
+                    label: '"Hello"',
+                    kind: Consts.CompletionItemKind.Constant,
+                },
+            ],
+        },
+    });
+}

--- a/packages/pyright-internal/src/tests/fourslash/completions.parentFolders.fourslash.ts
+++ b/packages/pyright-internal/src/tests/fourslash/completions.parentFolders.fourslash.ts
@@ -1,0 +1,77 @@
+/// <reference path="fourslash.ts" />
+
+// @filename: module.py
+//// # empty
+
+// @filename: nested1/__init__.py
+//// # empty
+
+// @filename: nested1/module.py
+//// # empty
+
+// @filename: nested1/nested2/__init__.py
+//// # empty
+
+// @filename: nested1/nested2/test1.py
+//// from .[|/*marker1*/|]
+
+// @filename: nested1/nested2/test2.py
+//// from ..[|/*marker2*/|]
+
+// @filename: nested1/nested2/test3.py
+//// from ..nested2.[|/*marker3*/|]
+
+// @filename: nested1/nested2/test4.py
+//// from ...nested1.[|/*marker4*/|]
+
+// @filename: nested1/nested2/test5.py
+//// from ...nested1.nested2.[|/*marker5*/|]
+
+{
+    helper.openFiles(helper.getMarkers().map((m) => m.fileName));
+
+    // @ts-ignore
+    await helper.verifyCompletion('exact', 'markdown', {
+        marker1: {
+            completions: [
+                { label: 'import', kind: Consts.CompletionItemKind.Keyword },
+                { label: 'test1', kind: Consts.CompletionItemKind.Module },
+                { label: 'test2', kind: Consts.CompletionItemKind.Module },
+                { label: 'test3', kind: Consts.CompletionItemKind.Module },
+                { label: 'test4', kind: Consts.CompletionItemKind.Module },
+                { label: 'test5', kind: Consts.CompletionItemKind.Module },
+            ],
+        },
+        marker2: {
+            completions: [
+                { label: 'import', kind: Consts.CompletionItemKind.Keyword },
+                { label: 'nested2', kind: Consts.CompletionItemKind.Module },
+                { label: 'module', kind: Consts.CompletionItemKind.Module },
+            ],
+        },
+        marker3: {
+            completions: [
+                { label: 'test1', kind: Consts.CompletionItemKind.Module },
+                { label: 'test2', kind: Consts.CompletionItemKind.Module },
+                { label: 'test3', kind: Consts.CompletionItemKind.Module },
+                { label: 'test4', kind: Consts.CompletionItemKind.Module },
+                { label: 'test5', kind: Consts.CompletionItemKind.Module },
+            ],
+        },
+        marker4: {
+            completions: [
+                { label: 'nested2', kind: Consts.CompletionItemKind.Module },
+                { label: 'module', kind: Consts.CompletionItemKind.Module },
+            ],
+        },
+        marker5: {
+            completions: [
+                { label: 'test1', kind: Consts.CompletionItemKind.Module },
+                { label: 'test2', kind: Consts.CompletionItemKind.Module },
+                { label: 'test3', kind: Consts.CompletionItemKind.Module },
+                { label: 'test4', kind: Consts.CompletionItemKind.Module },
+                { label: 'test5', kind: Consts.CompletionItemKind.Module },
+            ],
+        },
+    });
+}

--- a/packages/pyright-internal/src/tests/renameModule.folder.test.ts
+++ b/packages/pyright-internal/src/tests/renameModule.folder.test.ts
@@ -1,0 +1,236 @@
+/*
+ * renameModule.folder.test.ts
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT license.
+ *
+ * Tests Program.RenameModule
+ */
+
+import assert from 'assert';
+import { CancellationToken } from 'vscode-languageserver';
+
+import { combinePaths, getDirectoryPath } from '../common/pathUtils';
+import { parseAndGetTestState } from './harness/fourslash/testState';
+import { testRenameModule } from './renameModuleTestUtils';
+
+test('folder move up', () => {
+    const code = `
+// @filename: nested/__init__.py
+//// [|/*marker*/|]
+
+// @filename: test1.py
+//// from . import ([|nested|])
+    `;
+
+    const state = parseAndGetTestState(code).state;
+    const path = getDirectoryPath(state.getMarkerByName('marker').fileName);
+
+    const edits = state.program.renameModule(path, combinePaths(path, 'sub'), CancellationToken.None);
+    assert(!edits);
+});
+
+test('folder move down', () => {
+    const code = `
+// @filename: nested/__init__.py
+//// [|/*marker*/|]
+
+// @filename: test1.py
+//// from . import ([|nested|])
+    `;
+
+    const state = parseAndGetTestState(code).state;
+    const path = getDirectoryPath(state.getMarkerByName('marker').fileName);
+
+    const edits = state.program.renameModule(path, combinePaths(path, '..'), CancellationToken.None);
+    assert(!edits);
+});
+
+test('folder rename - from import', () => {
+    const code = `
+// @filename: nested/__init__.py
+//// [|/*marker*/|]
+//// def foo():
+////    pass
+
+// @filename: test1.py
+//// from . import ([|nested|])
+//// [|nested|].foo()
+    `;
+
+    const state = parseAndGetTestState(code).state;
+    const path = getDirectoryPath(state.getMarkerByName('marker').fileName);
+
+    testRenameModule(state, path, `${combinePaths(path, '..', 'sub')}`, 'nested', 'sub');
+});
+
+test('folder rename - from ', () => {
+    const code = `
+// @filename: nested/__init__.py
+//// [|/*marker*/|]
+//// def foo():
+////    pass
+
+// @filename: test1.py
+//// from [|nested|] import foo
+    `;
+
+    const state = parseAndGetTestState(code).state;
+    const path = getDirectoryPath(state.getMarkerByName('marker').fileName);
+
+    testRenameModule(state, path, `${combinePaths(path, '..', 'sub')}`, 'nested', 'sub');
+});
+
+test('folder rename - import ', () => {
+    const code = `
+// @filename: nested/__init__.py
+//// [|/*marker*/|]
+//// def foo():
+////    pass
+
+// @filename: test1.py
+//// import [|nested|]
+//// [|nested|].foo()
+    `;
+
+    const state = parseAndGetTestState(code).state;
+    const path = getDirectoryPath(state.getMarkerByName('marker').fileName);
+
+    testRenameModule(state, path, `${combinePaths(path, '..', 'sub')}`, 'nested', 'sub');
+});
+
+test('folder rename - import dotted name', () => {
+    const code = `
+// @filename: nested1/__init__.py
+//// # empty
+
+// @filename: nested1/nested2/__init__.py
+//// [|/*marker*/|]
+//// def foo():
+////    pass
+
+// @filename: test1.py
+//// import nested1.[|nested2|]
+//// nested1.[|nested2|].foo()
+    `;
+
+    const state = parseAndGetTestState(code).state;
+    const path = getDirectoryPath(state.getMarkerByName('marker').fileName);
+
+    testRenameModule(state, path, `${combinePaths(path, '..', 'sub')}`, 'nested2', 'sub');
+});
+
+test('folder rename - multiple files', () => {
+    const code = `
+// @filename: nested/__init__.py
+//// [|/*marker*/|]
+//// def foo():
+////    pass
+
+// @filename: nested/module1.py
+//// def foo1():
+////    pass
+
+// @filename: nested/module2.py
+//// def foo2():
+////    pass
+
+// @filename: test1.py
+//// from [|nested|] import foo, module1
+//// from [|nested|].module2 import foo2
+//// module1.foo()
+        `;
+
+    const state = parseAndGetTestState(code).state;
+    const path = getDirectoryPath(state.getMarkerByName('marker').fileName);
+
+    testRenameModule(state, path, `${combinePaths(path, '..', 'sub')}`, 'nested', 'sub');
+});
+
+test('folder rename - from alias', () => {
+    const code = `
+// @filename: nested/__init__.py
+//// [|/*marker*/|]
+//// def foo():
+////    pass
+
+// @filename: test1.py
+//// from . import [|nested|] as [|nested|]
+//// [|nested|].foo()
+        `;
+
+    const state = parseAndGetTestState(code).state;
+    const path = getDirectoryPath(state.getMarkerByName('marker').fileName);
+
+    testRenameModule(state, path, `${combinePaths(path, '..', 'sub')}`, 'nested', 'sub');
+});
+
+test('folder rename - import alias', () => {
+    const code = `
+// @filename: nested/__init__.py
+//// [|/*marker*/|]
+//// def foo():
+////    pass
+
+// @filename: test1.py
+//// import [|nested|] as [|nested|]
+//// [|nested|].foo()
+        `;
+
+    const state = parseAndGetTestState(code).state;
+    const path = getDirectoryPath(state.getMarkerByName('marker').fileName);
+
+    testRenameModule(state, path, `${combinePaths(path, '..', 'sub')}`, 'nested', 'sub');
+});
+
+test('folder rename - import dotted name alias', () => {
+    const code = `
+// @filename: nested/__init__.py
+//// # empty
+
+// @filename: nested/nested/__init__.py
+//// [|/*marker*/|]
+//// def foo():
+////    pass
+
+// @filename: test1.py
+//// import nested.[|nested|] as [|nested|]
+//// [|nested|].foo()
+        `;
+
+    const state = parseAndGetTestState(code).state;
+    const path = getDirectoryPath(state.getMarkerByName('marker').fileName);
+
+    testRenameModule(state, path, `${combinePaths(path, '..', 'sub')}`, 'nested', 'sub');
+});
+
+test('folder rename - reexport', () => {
+    const code = `
+// @filename: nested/__init__.py
+//// from . import [|nested|]
+//// [|nested|].foo()
+
+// @filename: nested/nested/__init__.py
+//// [|/*marker*/|]
+//// def foo():
+////    pass
+
+// @filename: nested/nested/module.py
+//// from ..[|nested|] import foo
+
+// @filename: nested/nested/reexport.py
+//// from .. import [|nested|] as [|nested|]
+
+// @filename: test1.py
+//// import nested.[|nested|] as [|nested|]
+//// [|nested|].foo()
+
+// @filename: test2.py
+//// import nested.[|nested|].reexport
+//// nested.[|nested|].reexport.[|nested|].foo()
+        `;
+
+    const state = parseAndGetTestState(code).state;
+    const path = getDirectoryPath(state.getMarkerByName('marker').fileName);
+
+    testRenameModule(state, path, `${combinePaths(path, '..', 'sub')}`, 'nested', 'sub');
+});

--- a/packages/pyright-internal/src/tests/renameModule.fromImports.test.ts
+++ b/packages/pyright-internal/src/tests/renameModule.fromImports.test.ts
@@ -856,3 +856,97 @@ test('new import with existing import with wildcard', () => {
 
     testRenameModule(state, fileName, `${combinePaths(getDirectoryPath(fileName), 'sub', 'moduleRenamed.py')}`);
 });
+
+test('simple rename of relative module', () => {
+    const code = `
+// @filename: common/__init__.py
+//// # empty
+
+// @filename: common/module.py
+//// def foo():
+////     [|/*marker*/pass|]
+
+// @filename: common/test1.py
+//// from [|.module|] import foo
+    `;
+
+    const state = parseAndGetTestState(code).state;
+    const fileName = state.getMarkerByName('marker').fileName;
+
+    testRenameModule(
+        state,
+        fileName,
+        `${combinePaths(getDirectoryPath(fileName), 'moduleRenamed.py')}`,
+        '.module',
+        '.moduleRenamed'
+    );
+});
+
+test('relative module move', () => {
+    const code = `
+// @filename: common/__init__.py
+//// # empty
+
+// @filename: common/module.py
+//// def foo():
+////     [|/*marker*/pass|]
+
+// @filename: common/test1.py
+//// from [|.module|] import foo
+    `;
+
+    const state = parseAndGetTestState(code).state;
+    const fileName = state.getMarkerByName('marker').fileName;
+
+    testRenameModule(
+        state,
+        fileName,
+        `${combinePaths(getDirectoryPath(fileName), 'sub', 'moduleRenamed.py')}`,
+        '.module',
+        '.sub.moduleRenamed'
+    );
+});
+
+test('__init__ relative module move', () => {
+    const code = `
+// @filename: common/__init__.py
+//// def foo():
+////     [|/*marker*/pass|]
+
+// @filename: test1.py
+//// from [|.common|] import foo
+    `;
+
+    const state = parseAndGetTestState(code).state;
+    const fileName = state.getMarkerByName('marker').fileName;
+
+    testRenameModule(
+        state,
+        fileName,
+        `${combinePaths(getDirectoryPath(fileName), 'moved', '__init__.py')}`,
+        '.common',
+        '.common.moved'
+    );
+});
+
+test('__init__ relative module rename', () => {
+    const code = `
+// @filename: common/__init__.py
+//// def foo():
+////     [|/*marker*/pass|]
+
+// @filename: test1.py
+//// from [|.common|] import foo
+    `;
+
+    const state = parseAndGetTestState(code).state;
+    const fileName = state.getMarkerByName('marker').fileName;
+
+    testRenameModule(
+        state,
+        fileName,
+        `${combinePaths(getDirectoryPath(fileName), '..', 'moved', '__init__.py')}`,
+        '.common',
+        '.moved'
+    );
+});


### PR DESCRIPTION
Rollup of:

- Fix more unresolvable import completions
- Update of the module refactoring code.
- Remove use of `getDeclaredTypeForExpression` in favor of new `getExpectedType`.
- Fix `launch.json`.