### PR TITLE
Fix --skipunannotated flag

### DIFF
--- a/packages/pyright-internal/src/pyright.ts
+++ b/packages/pyright-internal/src/pyright.ts
@@ -244,7 +244,7 @@ async function processArgs(): Promise<ExitStatus> {
         options.typeStubTargetImportName = args.createstub;
     }
 
-    options.analyzeUnannotatedFunctions = !args.skipAnalysisForUnannotatedFunctions;
+    options.analyzeUnannotatedFunctions = !args.skipunannotated;
 
     if (args.verbose) {
         options.verboseOutput = true;


### PR DESCRIPTION
There was a typo in ef773d2407f485f94f6a0fa6fd903267c65ac26c which used the wrong flag.

`command-line-args` doesn't really type any of its arguments, so this was missed.