### PR TITLE
Fixed incorrect handling of client-initiated progress reporting for "…

### DIFF
--- a/packages/pyright-internal/src/languageServerBase.ts
+++ b/packages/pyright-internal/src/languageServerBase.ts
@@ -460,7 +460,6 @@ export abstract class LanguageServerBase implements LanguageServerInterface {
             // We provide a progress bar a cancellation button so the user can cancel
             // any long-running actions.
             const progress = await this._getProgressReporter(
-                params.workDoneToken,
                 workDoneReporter,
                 Localizer.CodeAction.findingReferences(),
                 token
@@ -918,7 +917,6 @@ export abstract class LanguageServerBase implements LanguageServerInterface {
             if (this.isLongRunningCommand(params.command)) {
                 // Create a progress dialog for long-running commands.
                 const progress = await this._getProgressReporter(
-                    params.workDoneToken,
                     reporter,
                     Localizer.CodeAction.executingCommand(),
                     token
@@ -1235,13 +1233,12 @@ export abstract class LanguageServerBase implements LanguageServerInterface {
         return MarkupKind.PlainText;
     }
 
-    private async _getProgressReporter(
-        progressId: string | number | undefined,
-        reporter: WorkDoneProgressReporter,
-        title: string,
-        token: CancellationToken
-    ) {
-        if (progressId) {
+    private async _getProgressReporter(reporter: WorkDoneProgressReporter, title: string, token: CancellationToken) {
+        // This is a bit ugly, but we need to determine whether the provided reporter
+        // is an actual client-side progress reporter or a dummy (null) progress reporter
+        // created by the LSP library. If it's the latter, we'll create a server-initiated
+        // progress reporter.
+        if (reporter.constructor.name !== 'NullProgressReporter') {
             return { reporter: reporter, source: CancelAfter(token) };
         }
 

--- a/packages/pyright-internal/src/languageServerBase.ts
+++ b/packages/pyright-internal/src/languageServerBase.ts
@@ -46,6 +46,7 @@ import {
     WorkspaceEdit,
     WorkspaceFolder,
 } from 'vscode-languageserver';
+import { attachWorkDone } from 'vscode-languageserver/lib/common/progress';
 
 import { AnalysisResults } from './analyzer/analysis';
 import { BackgroundAnalysisProgram } from './analyzer/backgroundAnalysisProgram';
@@ -181,6 +182,8 @@ interface ClientCapabilities {
     supportsUnnecessaryDiagnosticTag: boolean;
     completionItemResolveSupportsAdditionalTextEdits: boolean;
 }
+
+const nullProgressReporter = attachWorkDone(undefined as any, undefined);
 
 export abstract class LanguageServerBase implements LanguageServerInterface {
     protected _defaultClientConfig: any;
@@ -1238,7 +1241,7 @@ export abstract class LanguageServerBase implements LanguageServerInterface {
         // is an actual client-side progress reporter or a dummy (null) progress reporter
         // created by the LSP library. If it's the latter, we'll create a server-initiated
         // progress reporter.
-        if (reporter.constructor.name !== 'NullProgressReporter') {
+        if (reporter.constructor !== nullProgressReporter.constructor) {
             return { reporter: reporter, source: CancelAfter(token) };
         }
 


### PR DESCRIPTION
…onReferences" and "onExecuteCommand" handlers in language server.