### PR TITLE
Fix bytes mixin labled as str in urllib.parse.pyi stub

### DIFF
--- a/packages/pyright-internal/typeshed-fallback/stdlib/urllib/parse.pyi
+++ b/packages/pyright-internal/typeshed-fallback/stdlib/urllib/parse.pyi
@@ -21,7 +21,7 @@ class _ResultMixinBase(Generic[AnyStr]):
 class _ResultMixinStr(_ResultMixinBase[str]):
     def encode(self, encoding: str = ..., errors: str = ...) -> _ResultMixinBytes: ...
 
-class _ResultMixinBytes(_ResultMixinBase[str]):
+class _ResultMixinBytes(_ResultMixinBase[bytes]):
     def decode(self, encoding: str = ..., errors: str = ...) -> _ResultMixinStr: ...
 
 class _NetlocResultMixinBase(Generic[AnyStr]):


### PR DESCRIPTION
This was causing ParseResultBytes.geturl() to be labelled  with the return type str when it returns bytes.