### PR TITLE
Update lerna.json and package.jsons with version 1.1.222

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -2,7 +2,7 @@
     "packages": [
         "packages/*"
     ],
-    "version": "1.1.221",
+    "version": "1.1.222",
     "command": {
         "version": {
             "push": false,

--- a/packages/pyright-internal/package-lock.json
+++ b/packages/pyright-internal/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "pyright-internal",
-    "version": "1.1.221",
+    "version": "1.1.222",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/packages/pyright-internal/package.json
+++ b/packages/pyright-internal/package.json
@@ -2,7 +2,7 @@
     "name": "pyright-internal",
     "displayName": "pyright",
     "description": "Type checker for the Python language",
-    "version": "1.1.221",
+    "version": "1.1.222",
     "license": "MIT",
     "private": true,
     "files": [

--- a/packages/pyright/package-lock.json
+++ b/packages/pyright/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "pyright",
-    "version": "1.1.221",
+    "version": "1.1.222",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/packages/pyright/package.json
+++ b/packages/pyright/package.json
@@ -2,7 +2,7 @@
     "name": "pyright",
     "displayName": "Pyright",
     "description": "Type checker for the Python language",
-    "version": "1.1.221",
+    "version": "1.1.222",
     "license": "MIT",
     "author": {
         "name": "Microsoft Corporation"

--- a/packages/vscode-pyright/package-lock.json
+++ b/packages/vscode-pyright/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "vscode-pyright",
-    "version": "1.1.221",
+    "version": "1.1.222",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/packages/vscode-pyright/package.json
+++ b/packages/vscode-pyright/package.json
@@ -2,7 +2,7 @@
     "name": "vscode-pyright",
     "displayName": "Pyright",
     "description": "VS Code static type checking for Python",
-    "version": "1.1.221",
+    "version": "1.1.222",
     "private": true,
     "license": "MIT",
     "author": {


### PR DESCRIPTION
You published 1.1.222 last night, but when we pulled pyright this morning I noticed that the versions in package.json and lerna.json are still 1.1.221.

Not sure if taking this PR is the right fix, but wanted to save you some time if it is.

Does Pyright 1.1.222 need to be republished with this change?