### PR TITLE
Handle __set__ overloads with transform_descriptor_types

### DIFF
--- a/packages/pyright-internal/src/analyzer/dataClasses.ts
+++ b/packages/pyright-internal/src/analyzer/dataClasses.ts
@@ -547,7 +547,17 @@ function transformDescriptorType(evaluator: TypeEvaluator, type: Type): Type {
         return type;
     }
 
-    const setMethodType = evaluator.getTypeOfMember(setMethodInfo);
+    let setMethodType = evaluator.getTypeOfMember(setMethodInfo);
+
+    if (isOverloadedFunction(setMethodType)) {
+        // Find the implementation, not the overloaded signatures.
+        const setMethodImplType = setMethodType.overloads.find((func) => !FunctionType.isOverloaded(func));
+        if (!setMethodImplType) {
+            return type;
+        }
+        setMethodType = setMethodImplType;
+    }
+
     if (!isFunction(setMethodType)) {
         return type;
     }

--- a/packages/pyright-internal/src/tests/samples/dataclassTransform5.py
+++ b/packages/pyright-internal/src/tests/samples/dataclassTransform5.py
@@ -1,7 +1,7 @@
 # This sample tests the "transform_descriptor_types" parameter of a
 # dataclass_transform.
 
-from typing import Any, Callable, Generic, Tuple, TypeVar, Union
+from typing import Any, Callable, Generic, overload, Tuple, TypeVar, Union
 
 T = TypeVar("T")
 
@@ -70,3 +70,31 @@ reveal_type(
 
 # This should generate an error because "hi" is not a descriptor instance.
 um2 = UserModel2(name="hi")
+
+
+class OverloadedDescriptor(Generic[T]):
+    def __get__(self, instance: object, owner: Any) -> T:
+        ...
+
+    @overload
+    def __set__(self, instance: Any, value: T) -> None:
+        ...
+
+    @overload
+    def __set__(self, instance: Any, value: float) -> None:
+        ...
+
+    def __set__(self, instance, value: T | float):
+        ...
+
+
+class UserModel3(ModelBaseDescriptorTransform):
+    name: OverloadedDescriptor[str]
+
+
+reveal_type(
+    UserModel3.__init__,
+    expected_text="(self: UserModel3, name: str | float) -> None",
+)
+
+um3 = UserModel3(name="hi")


### PR DESCRIPTION
I tested your transform_descriptor_types prototype and it wasn't working for me because my __set__ method had overloads. To be honest, it's not clear to me why overloading `__set__` would be interesting, but [SQLAlchemy's `Mapped` class](https://github.com/sqlalchemy/sqlalchemy/blob/f24a34140f6007cada900a8ae5ed03fe40ce2631/lib/sqlalchemy/orm/base.py#L656) has overloads for `__set__`, so I think we should handle this more gracefully.

Currently I'm getting the value type from the implementation function. However SQLAlchemy's current `Mapped` class has no annotation on the `__set__` impl's value parameter. We could use a Union of the types found on the overloads, but perhaps we should require library authors to annotate the `__set__` impl's value parameter?

What do you think?