### PR TITLE
Make pyright command fail if option value is missing

### DIFF
--- a/packages/pyright-internal/src/pyright.ts
+++ b/packages/pyright-internal/src/pyright.ts
@@ -167,6 +167,13 @@ async function processArgs(): Promise<ExitStatus> {
         return ExitStatus.NoErrors;
     }
 
+    for (const [arg, value] of Object.entries(args)) {
+        if (value === null) {
+            console.error(`'${arg}' option requires a value`);
+            return ExitStatus.ParameterError;
+        }
+    }
+
     if (args.outputjson) {
         const incompatibleArgs = ['stats', 'verbose', 'createstub', 'dependencies'];
         for (const arg of incompatibleArgs) {


### PR DESCRIPTION
For options like -v,--venv-path <DIRECTORY> omitting the <DIRECTORY>
should result in the command failing. command-line-args apparently
doesn't take care of that and just sets venvpath to null.

This is especially unfortunate because users might assume that -v
enables verbose output, so running `pyright -v` should really fail
instead of happily running as if no option was passed.