### PR TITLE
Fix tsc type generation error

### DIFF
--- a/packages/pyright-internal/src/analyzer/dataClasses.ts
+++ b/packages/pyright-internal/src/analyzer/dataClasses.ts
@@ -116,8 +116,8 @@ export function synthesizeDataClassMethods(
     }
 
     // Maintain a list of "type evaluators".
-    type TypeEvaluator = () => Type;
-    const localEntryTypeEvaluator: { entry: DataClassEntry; evaluator: TypeEvaluator }[] = [];
+    type GetTypeFunction = () => Type;
+    const localEntryTypeEvaluator: { entry: DataClassEntry; evaluator: GetTypeFunction }[] = [];
     let sawKeywordOnlySeparator = false;
 
     node.suite.statements.forEach((statementList) => {
@@ -125,7 +125,7 @@ export function synthesizeDataClassMethods(
             statementList.statements.forEach((statement) => {
                 let variableNameNode: NameNode | undefined;
                 let aliasName: string | undefined;
-                let variableTypeEvaluator: TypeEvaluator | undefined;
+                let variableTypeEvaluator: GetTypeFunction | undefined;
                 let hasDefaultValue = false;
                 let isKeywordOnly = ClassType.isDataClassKeywordOnlyParams(classType) || sawKeywordOnlySeparator;
                 let defaultValueExpression: ExpressionNode | undefined;


### PR DESCRIPTION
When building pyright-internal with `tsc --emitDeclarationOnly --declaration`, it gives an error:

```
src/analyzer/dataClasses.ts:68:16 - error TS4078: Parameter 'evaluator' of exported function has or is using private name 'TypeEvaluator'.

68     evaluator: TypeEvaluator,
                  ~~~~~~~~~~~~~
```

This is caused by a duplicate definition of `TypeEvaluator`. The definition on L119 is not exported and tsc seems to confuse it with the exported parameter on line 68, which is exported and references `TypeEvalulator` defined in typeEvaluatorTypes.ts L279.