### PR TITLE
Show TypedDict key type and docstring on hover

### DIFF
--- a/packages/pyright-internal/src/tests/fourslash/fourslash.ts
+++ b/packages/pyright-internal/src/tests/fourslash/fourslash.ts
@@ -264,7 +264,7 @@ declare namespace _ {
             },
             verifyCodeActionCount?: boolean
         ): Promise<any>;
-        verifyHover(kind: string, map: { [marker: string]: string }): void;
+        verifyHover(kind: string, map: { [marker: string]: string | null }): void;
         verifyCompletion(
             verifyMode: FourSlashCompletionVerificationMode,
             docFormat: MarkupKind,

--- a/packages/pyright-internal/src/tests/fourslash/hover.typedDict.key.fourslash.ts
+++ b/packages/pyright-internal/src/tests/fourslash/hover.typedDict.key.fourslash.ts
@@ -1,0 +1,37 @@
+/// <reference path="fourslash.ts" />
+
+// @filename: test.py
+//// from typing import TypedDict
+////
+//// class User(TypedDict):
+////     name: str
+////     """The fullname of the User"""
+////
+////     age: int
+////     """The age of the User, will not be over 200"""
+////
+////     views: float
+////
+//// user: User = {[|/*marker1*/'name'|]: 'Robert'}
+////
+//// def foo(user: User) -> None:
+////     ...
+////
+//// foo({[|/*marker2*/'name'|]})
+//// foo({[|/*marker3*/'views'|]})
+//// foo({[|/*marker4*/'points'|]})
+//// foo({'name': 'Robert', [|/*marker5*/'age'|]})
+//// foo({'name': 'Robert', [|/*marker6*/'age'|]: 100})
+//// foo({'name': [|/*marker7*/'Robert'|], 'age': 100})
+//// foo({'name': [|/*marker8*/'name'|]})
+
+helper.verifyHover('markdown', {
+    marker1: '```python\n(key) name: str\n```\n---\nThe fullname of the User',
+    marker2: '```python\n(key) name: str\n```\n---\nThe fullname of the User',
+    marker3: '```python\n(key) views: float\n```',
+    marker4: null,
+    marker5: '```python\n(key) age: int\n```\n---\nThe age of the User, will not be over 200',
+    marker6: '```python\n(key) age: int\n```\n---\nThe age of the User, will not be over 200',
+    marker7: null,
+    marker8: null,
+});

--- a/packages/pyright-internal/src/tests/harness/fourslash/testState.ts
+++ b/packages/pyright-internal/src/tests/harness/fourslash/testState.ts
@@ -962,7 +962,7 @@ export class TestState {
         }
     }
 
-    verifyHover(kind: MarkupKind, map: { [marker: string]: string }): void {
+    verifyHover(kind: MarkupKind, map: { [marker: string]: string | null }): void {
         // Do not force analyze, it can lead to test passing while it doesn't work in product
         for (const range of this.getRanges()) {
             const name = this.getMarkerName(range.marker!);
@@ -977,6 +977,13 @@ export class TestState {
                 kind,
                 this.program.getHoverForPosition(range.fileName, rangePos.start, kind, CancellationToken.None)
             );
+
+            // if expected is null then there should be nothing shown on hover
+            if (expected === null) {
+                assert.equal(actual, undefined);
+                continue;
+            }
+
             assert.ok(actual);
 
             assert.deepEqual(actual!.range, rangePos);


### PR DESCRIPTION
closes https://github.com/microsoft/pylance-release/issues/2508

Screenshots:

Without docstring:
![2bc604757abb4e39a1c5e91dd48c6900](https://user-images.githubusercontent.com/23125036/161211840-ce3bbaef-f16c-46b7-a80f-93dce3e5ba02.jpg)

With docstring:
![94bcde8ffcd34cb78c5dfb9213996106](https://user-images.githubusercontent.com/23125036/161211725-7fd2ea0e-08bc-468f-9424-c538c1bc334f.jpg)