### PR TITLE
[PylanceBot] Pull Pylance with Pyright 1.1.235

### DIFF
--- a/packages/pyright-internal/src/analyzer/importResolver.ts
+++ b/packages/pyright-internal/src/analyzer/importResolver.ts
@@ -1565,9 +1565,8 @@ export class ImportResolver {
             });
         }
 
-        this._cachedTypeshedThirdPartyPackageRoots = [
-            ...new Set(...this._cachedTypeshedThirdPartyPackagePaths.values()),
-        ].sort();
+        const flattenPaths = [...this._cachedTypeshedThirdPartyPackagePaths.values()].flatMap((v) => v);
+        this._cachedTypeshedThirdPartyPackageRoots = [...new Set(flattenPaths)].sort();
     }
 
     private _getCompletionSuggestionsTypeshedPath(

--- a/packages/pyright-internal/src/common/pathUtils.ts
+++ b/packages/pyright-internal/src/common/pathUtils.ts
@@ -197,11 +197,11 @@ export function directoryExists(fs: FileSystem, path: string): boolean {
     return fileSystemEntryExists(fs, path, FileSystemEntryKind.Directory);
 }
 
-const invalidSeparator = path.sep === '/' ? '\\' : '/';
-export function normalizeSlashes(pathString: string): string {
-    if (pathString.includes(invalidSeparator)) {
+const getInvalidSeparator = (sep: string) => (sep === '/' ? '\\' : '/');
+export function normalizeSlashes(pathString: string, sep = path.sep): string {
+    if (pathString.includes(getInvalidSeparator(sep))) {
         const separatorRegExp = /[\\/]/g;
-        return pathString.replace(separatorRegExp, path.sep);
+        return pathString.replace(separatorRegExp, sep);
     }
 
     return pathString;

--- a/packages/pyright-internal/src/languageService/analyzerServiceExecutor.ts
+++ b/packages/pyright-internal/src/languageService/analyzerServiceExecutor.ts
@@ -53,6 +53,7 @@ export class AnalyzerServiceExecutor {
             disableLanguageServices: true,
             disableOrganizeImports: true,
             isInitialized: createDeferred<boolean>(),
+            searchPathsToWatch: [],
         };
 
         const serverSettings = await ls.getSettings(workspace);

--- a/packages/pyright-internal/src/server.ts
+++ b/packages/pyright-internal/src/server.ts
@@ -52,7 +52,7 @@ export class PyrightServer extends LanguageServerBase {
 
         const console = new ConsoleWithLogLevel(connection.console);
         const workspaceMap = new WorkspaceMap();
-        const fileWatcherProvider = new WorkspaceFileWatcherProvider(workspaceMap, console);
+        const fileWatcherProvider = new WorkspaceFileWatcherProvider();
         const fileSystem = createFromRealFileSystem(console, fileWatcherProvider);
 
         super(

--- a/packages/pyright-internal/src/tests/harness/fourslash/testLanguageService.ts
+++ b/packages/pyright-internal/src/tests/harness/fourslash/testLanguageService.ts
@@ -73,6 +73,7 @@ export class TestLanguageService implements LanguageServerInterface {
             disableLanguageServices: false,
             disableOrganizeImports: false,
             isInitialized: createDeferred<boolean>(),
+            searchPathsToWatch: [],
         };
     }
     decodeTextDocumentUri(uriString: string): string {

--- a/packages/pyright-internal/src/tests/harness/fourslash/testState.ts
+++ b/packages/pyright-internal/src/tests/harness/fourslash/testState.ts
@@ -189,6 +189,7 @@ export class TestState {
             disableLanguageServices: false,
             disableOrganizeImports: false,
             isInitialized: createDeferred<boolean>(),
+            searchPathsToWatch: [],
         };
 
         const indexer = toBoolean(testData.globalOptions[GlobalMetadataOptionNames.indexer]);

--- a/packages/pyright-internal/src/tests/importResolver.test.ts
+++ b/packages/pyright-internal/src/tests/importResolver.test.ts
@@ -363,6 +363,27 @@ test('no empty import roots', () => {
     importResolver.getImportRoots(configOptions.getDefaultExecEnvironment()).forEach((path) => assert(path));
 });
 
+test('multiple typeshedFallback', () => {
+    const files = [
+        {
+            path: combinePaths('/', typeshedFallback, 'stubs', 'aLib', 'aLib', '__init__.pyi'),
+            content: '# empty',
+        },
+        {
+            path: combinePaths('/', typeshedFallback, 'stubs', 'bLib', 'bLib', '__init__.pyi'),
+            content: '# empty',
+        },
+    ];
+
+    const fs = createFileSystem(files);
+    const configOptions = new ConfigOptions(''); // Empty, like open-file mode.
+    const importResolver = new ImportResolver(fs, configOptions, new TestAccessHost(fs.getModulePath(), [libraryRoot]));
+    const importRoots = importResolver.getImportRoots(configOptions.getDefaultExecEnvironment());
+
+    assert.strictEqual(1, importRoots.filter((f) => f === combinePaths('/', typeshedFallback, 'stubs', 'aLib')).length);
+    assert.strictEqual(1, importRoots.filter((f) => f === combinePaths('/', typeshedFallback, 'stubs', 'bLib')).length);
+});
+
 test('import side by side file root', () => {
     const files = [
         {

--- a/packages/pyright-internal/src/workspaceMap.ts
+++ b/packages/pyright-internal/src/workspaceMap.ts
@@ -62,6 +62,7 @@ export class WorkspaceMap extends Map<string, WorkspaceServiceInstance> {
                     disableLanguageServices: false,
                     disableOrganizeImports: false,
                     isInitialized: createDeferred<boolean>(),
+                    searchPathsToWatch: [],
                 };
                 this.set(this._defaultWorkspacePath, defaultWorkspace);
                 ls.updateSettingsForWorkspace(defaultWorkspace).ignoreErrors();


### PR DESCRIPTION
rollup of:

- rely on vscode's file watcher for all folders. remove non-workspace paths node file watcher
- fix normalize path and slash for LSP
- fix missing docstrings in Pillow due to improper typeshed typeshedFallback stub folder path parsing