### PR TITLE
Fixed file watcher regression.

### DIFF
--- a/packages/pyright-internal/src/analyzer/service.ts
+++ b/packages/pyright-internal/src/analyzer/service.ts
@@ -621,18 +621,18 @@ export class AnalyzerService {
 
         if (commandLineOptions.fileSpecs.length > 0) {
             commandLineOptions.fileSpecs.forEach((fileSpec) => {
-                configOptions.include.push(getFileSpec(projectRoot, fileSpec));
+                configOptions.include.push(getFileSpec(this._fs, projectRoot, fileSpec));
             });
         } else if (!configFilePath) {
             // If no config file was found and there are no explicit include
             // paths specified, assume the caller wants to include all source
             // files under the execution root path.
             if (commandLineOptions.executionRoot) {
-                configOptions.include.push(getFileSpec(commandLineOptions.executionRoot, '.'));
+                configOptions.include.push(getFileSpec(this._fs, commandLineOptions.executionRoot, '.'));
 
                 // Add a few common excludes to avoid long scan times.
                 defaultExcludes.forEach((exclude) => {
-                    configOptions.exclude.push(getFileSpec(commandLineOptions.executionRoot, exclude));
+                    configOptions.exclude.push(getFileSpec(this._fs, commandLineOptions.executionRoot, exclude));
                 });
             }
         }
@@ -654,6 +654,7 @@ export class AnalyzerService {
                 configJsonObj,
                 this._typeCheckingMode,
                 this._console,
+                this._fs,
                 host,
                 commandLineOptions.diagnosticSeverityOverrides,
                 commandLineOptions.fileSpecs.length > 0
@@ -665,14 +666,14 @@ export class AnalyzerService {
             // the project should be included.
             if (configOptions.include.length === 0) {
                 this._console.info(`No include entries specified; assuming ${configFileDir}`);
-                configOptions.include.push(getFileSpec(configFileDir, '.'));
+                configOptions.include.push(getFileSpec(this._fs, configFileDir, '.'));
             }
 
             // If there was no explicit set of excludes, add a few common ones to avoid long scan times.
             if (configOptions.exclude.length === 0) {
                 defaultExcludes.forEach((exclude) => {
                     this._console.info(`Auto-excluding ${exclude}`);
-                    configOptions.exclude.push(getFileSpec(configFileDir, exclude));
+                    configOptions.exclude.push(getFileSpec(this._fs, configFileDir, exclude));
                 });
 
                 if (configOptions.autoExcludeVenv === undefined) {

--- a/packages/pyright-internal/src/common/configOptions.ts
+++ b/packages/pyright-internal/src/common/configOptions.ts
@@ -787,6 +787,7 @@ export class ConfigOptions {
         configObj: any,
         typeCheckingMode: string | undefined,
         console: ConsoleInterface,
+        fs: FileSystem,
         host: Host,
         diagnosticOverrides?: DiagnosticSeverityOverridesMap,
         skipIncludeSection = false
@@ -807,7 +808,7 @@ export class ConfigOptions {
                         } else if (isAbsolute(fileSpec)) {
                             console.error(`Ignoring path "${fileSpec}" in "include" array because it is not relative.`);
                         } else {
-                            this.include.push(getFileSpec(this.projectRoot, fileSpec));
+                            this.include.push(getFileSpec(fs, this.projectRoot, fileSpec));
                         }
                     });
                 }
@@ -827,7 +828,7 @@ export class ConfigOptions {
                     } else if (isAbsolute(fileSpec)) {
                         console.error(`Ignoring path "${fileSpec}" in "exclude" array because it is not relative.`);
                     } else {
-                        this.exclude.push(getFileSpec(this.projectRoot, fileSpec));
+                        this.exclude.push(getFileSpec(fs, this.projectRoot, fileSpec));
                     }
                 });
             }
@@ -846,7 +847,7 @@ export class ConfigOptions {
                     } else if (isAbsolute(fileSpec)) {
                         console.error(`Ignoring path "${fileSpec}" in "ignore" array because it is not relative.`);
                     } else {
-                        this.ignore.push(getFileSpec(this.projectRoot, fileSpec));
+                        this.ignore.push(getFileSpec(fs, this.projectRoot, fileSpec));
                     }
                 });
             }
@@ -865,7 +866,7 @@ export class ConfigOptions {
                     } else if (isAbsolute(fileSpec)) {
                         console.error(`Ignoring path "${fileSpec}" in "strict" array because it is not relative.`);
                     } else {
-                        this.strict.push(getFileSpec(this.projectRoot, fileSpec));
+                        this.strict.push(getFileSpec(fs, this.projectRoot, fileSpec));
                     }
                 });
             }

--- a/packages/pyright-internal/src/common/pathUtils.ts
+++ b/packages/pyright-internal/src/common/pathUtils.ts
@@ -710,12 +710,12 @@ export function hasPythonExtension(path: string) {
     return path.endsWith('.py') || path.endsWith('.pyi');
 }
 
-export function getFileSpec(rootPath: string, fileSpec: string): FileSpec {
+export function getFileSpec(fs: FileSystem, rootPath: string, fileSpec: string): FileSpec {
     let regExPattern = getWildcardRegexPattern(rootPath, fileSpec);
     const escapedSeparator = getRegexEscapedSeparator();
     regExPattern = `^(${regExPattern})($|${escapedSeparator})`;
 
-    const regExp = new RegExp(regExPattern);
+    const regExp = new RegExp(regExPattern, isFileSystemCaseSensitive(fs) ? undefined : 'i');
     const wildcardRoot = getWildcardRoot(rootPath, fileSpec);
 
     return {

--- a/packages/pyright-internal/src/tests/config.test.ts
+++ b/packages/pyright-internal/src/tests/config.test.ts
@@ -17,6 +17,7 @@ import { NoAccessHost } from '../common/host';
 import { combinePaths, getBaseFileName, normalizePath, normalizeSlashes } from '../common/pathUtils';
 import { PythonVersion } from '../common/pythonVersion';
 import { createFromRealFileSystem } from '../common/realFileSystem';
+import { TestFileSystem } from './harness/vfs/filesystem';
 
 test('FindFilesWithConfigFile', () => {
     const cwd = normalizePath(process.cwd());
@@ -192,7 +193,8 @@ test('PythonPlatform', () => {
             "extraPaths" : []
     }]}`);
 
-    configOptions.initializeFromJson(json, undefined, nullConsole, new NoAccessHost());
+    const fs = new TestFileSystem(/* ignoreCase */ false);
+    configOptions.initializeFromJson(json, undefined, nullConsole, fs, new NoAccessHost());
 
     const env = configOptions.executionEnvironments[0];
     assert.strictEqual(env.pythonPlatform, 'platform');


### PR DESCRIPTION
Previous change around file watcher added isTracked check so that we don't refresh service just because py file under project root is changed. isTracked will make sure the py file changed is actually part of the source files.

But the fix found a bug where some of the paths that are used under file watcher are not normalized. because of that, isTracked returned some files as not part of the source files breaking file watcher in some cases.

Now, we make sure all paths involved in the file watcher are all normalized.