### PR TITLE
Increase vscode engine on vscode-pyright to ^1.66.0

### DIFF
--- a/packages/vscode-pyright/package.json
+++ b/packages/vscode-pyright/package.json
@@ -14,7 +14,7 @@
         "url": "https://github.com/Microsoft/pyright"
     },
     "engines": {
-        "vscode": "^1.63.1"
+        "vscode": "^1.66.0"
     },
     "keywords": [
         "python"


### PR DESCRIPTION
The new version of vscode-languageclient (8.0.0-next.14) depends on VS Code 1.66+, so to be safe we're matching that dependency on vscode-pyright since it depends on vscode-languageclient.