### PR TITLE
[PylanceBot] Pull Pylance with Pyright 1.1.249

### DIFF
--- a/packages/pyright-internal/src/analyzer/backgroundAnalysisProgram.ts
+++ b/packages/pyright-internal/src/analyzer/backgroundAnalysisProgram.ts
@@ -96,6 +96,11 @@ export class BackgroundAnalysisProgram {
         this._program.setFileOpened(filePath, version, [{ text: contents }], options);
     }
 
+    updateChainedFilePath(filePath: string, chainedFilePath: string | undefined) {
+        this._backgroundAnalysis?.updateChainedFilePath(filePath, chainedFilePath);
+        this._program.updateChainedFilePath(filePath, chainedFilePath);
+    }
+
     updateOpenFileContents(
         path: string,
         version: number | null,

--- a/packages/pyright-internal/src/analyzer/program.ts
+++ b/packages/pyright-internal/src/analyzer/program.ts
@@ -313,9 +313,6 @@ export class Program {
                 options?.ipythonMode ?? false
             );
 
-            // ChainedSourceFile can only be set by open file. And once it is set,
-            // it can't be changed. It can only be removed (deleted). File from fs
-            // can't set chained source file.
             const chainedFilePath = options?.chainedFilePath;
             sourceFileInfo = {
                 sourceFile,
@@ -343,6 +340,18 @@ export class Program {
         }
 
         sourceFileInfo.sourceFile.setClientVersion(version, contents);
+    }
+
+    updateChainedFilePath(filePath: string, chainedFilePath: string | undefined) {
+        const sourceFileInfo = this._getSourceFileInfoFromPath(filePath);
+        if (sourceFileInfo) {
+            sourceFileInfo.chainedSourceFile = chainedFilePath
+                ? this._getSourceFileInfoFromPath(chainedFilePath)
+                : undefined;
+
+            sourceFileInfo.sourceFile.markDirty();
+            this._markFileDirtyRecursive(sourceFileInfo, new Map<string, boolean>());
+        }
     }
 
     setFileClosed(filePath: string): FileDiagnostics[] {

--- a/packages/pyright-internal/src/analyzer/service.ts
+++ b/packages/pyright-internal/src/analyzer/service.ts
@@ -259,6 +259,11 @@ export class AnalyzerService {
         this._scheduleReanalysis(/* requireTrackedFileUpdate */ false);
     }
 
+    updateChainedFilePath(path: string, chainedFilePath: string | undefined) {
+        this._backgroundAnalysisProgram.updateChainedFilePath(path, chainedFilePath);
+        this._scheduleReanalysis(/*requireTrackedFileUpdate*/ false);
+    }
+
     updateOpenFileContents(
         path: string,
         version: number | null,

--- a/packages/pyright-internal/src/backgroundAnalysisBase.ts
+++ b/packages/pyright-internal/src/backgroundAnalysisBase.ts
@@ -116,6 +116,13 @@ export class BackgroundAnalysisBase {
         });
     }
 
+    updateChainedFilePath(filePath: string, chainedFilePath: string | undefined) {
+        this.enqueueRequest({
+            requestType: 'updateChainedFilePath',
+            data: { filePath, chainedFilePath },
+        });
+    }
+
     setFileClosed(filePath: string) {
         this.enqueueRequest({ requestType: 'setFileClosed', data: filePath });
     }
@@ -417,6 +424,12 @@ export abstract class BackgroundAnalysisRunnerBase extends BackgroundThreadBase 
                 break;
             }
 
+            case 'updateChainedFilePath': {
+                const { filePath, chainedFilePath } = msg.data;
+                this.program.updateChainedFilePath(filePath, chainedFilePath);
+                break;
+            }
+
             case 'setFileClosed': {
                 const diagnostics = this.program.setFileClosed(msg.data);
                 this._reportDiagnostics(diagnostics, this.program.getFilesToAnalyzeCount(), 0);
@@ -566,6 +579,7 @@ export interface AnalysisRequest {
         | 'setAllowedThirdPartyImports'
         | 'ensurePartialStubPackages'
         | 'setFileOpened'
+        | 'updateChainedFilePath'
         | 'setFileClosed'
         | 'markAllFilesDirty'
         | 'markFilesDirty'

--- a/packages/pyright-internal/src/common/uriParser.ts
+++ b/packages/pyright-internal/src/common/uriParser.ts
@@ -13,10 +13,10 @@ import { FileSystem } from './fileSystem';
 import { convertUriToPath } from './pathUtils';
 
 export class UriParser {
-    constructor(private _fs: FileSystem) {}
+    constructor(protected readonly _fs: FileSystem) {}
 
     public decodeTextDocumentPosition(textDocument: TextDocumentIdentifier, position: Position) {
-        const filePath = convertUriToPath(this._fs, textDocument.uri);
+        const filePath = this.decodeTextDocumentUri(textDocument.uri);
         return { filePath, position };
     }
 

--- a/packages/pyright-internal/src/languageServerBase.ts
+++ b/packages/pyright-internal/src/languageServerBase.ts
@@ -270,7 +270,8 @@ export abstract class LanguageServerBase implements LanguageServerInterface {
     constructor(
         protected _serverOptions: ServerOptions,
         protected _connection: Connection,
-        readonly console: ConsoleInterface
+        readonly console: ConsoleInterface,
+        uriParserFactory = (fs: FileSystem) => new UriParser(fs)
     ) {
         // Stash the base directory into a global variable.
         // This must happen before fs.getModulePath().
@@ -288,7 +289,7 @@ export abstract class LanguageServerBase implements LanguageServerInterface {
         this._fileWatcherProvider = this._serverOptions.fileWatcherProvider;
 
         this.fs = new PyrightFileSystem(this._serverOptions.fileSystem);
-        this._uriParser = new UriParser(this.fs);
+        this._uriParser = uriParserFactory(this.fs);
 
         // Set the working directory to a known location within
         // the extension directory. Otherwise the execution of

--- a/packages/vscode-pyright/package-lock.json
+++ b/packages/vscode-pyright/package-lock.json
@@ -84,9 +84,9 @@
             "dev": true
         },
         "@types/vscode": {
-            "version": "1.66.0",
-            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.66.0.tgz",
-            "integrity": "sha512-ZfJck4M7nrGasfs4A4YbUoxis3Vu24cETw3DERsNYtDZmYSYtk6ljKexKFKhImO/ZmY6ZMsmegu2FPkXoUFImA==",
+            "version": "1.67.0",
+            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.67.0.tgz",
+            "integrity": "sha512-GH8BDf8cw9AC9080uneJfulhSa7KHSMI2s/CyKePXoGNos9J486w2V4YKoeNUqIEkW4hKoEAWp6/cXTwyGj47g==",
             "dev": true
         },
         "@webassemblyjs/ast": {

--- a/packages/vscode-pyright/package.json
+++ b/packages/vscode-pyright/package.json
@@ -852,7 +852,7 @@
     "devDependencies": {
         "@types/copy-webpack-plugin": "^10.1.0",
         "@types/node": "^17.0.14",
-        "@types/vscode": "~1.66.0",
+        "@types/vscode": "~1.67.0",
         "copy-webpack-plugin": "^10.2.4",
         "detect-indent": "^6.1.0",
         "shx": "^0.3.4",


### PR DESCRIPTION
Changes to support LSP notebooks in Pylance:

- Allow chained file path to be changed
- Allow derived servers to provide alternate UriParser implementations
- Upgrade to @types/vscode 1.67.0