### PR TITLE
[PylanceBot] Pull Pylance with Pyright 1.1.253

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -73,7 +73,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-latest, windows-2019, ubuntu-latest]
+        os: [macos-latest, windows-latest, ubuntu-latest]
 
     name: Test ${{ matrix.os }}
     runs-on: ${{ matrix.os }}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -34,10 +34,10 @@
                 "background": {
                     "activeOnStart": true,
                     "beginsPattern": {
-                        "regexp": "Compiling.*?|Compilation .*?starting"
+                        "regexp": "PublicPath: .*?"
                     },
                     "endsPattern": {
-                        "regexp": "Compiled .*?successfully|Compilation .*?finished"
+                        "regexp": "webpack compiled in .*? ms"
                     }
                 }
             }

--- a/package-lock.json
+++ b/package-lock.json
@@ -2320,7 +2320,7 @@
         "cint": {
             "version": "8.2.1",
             "resolved": "https://registry.npmjs.org/cint/-/cint-8.2.1.tgz",
-            "integrity": "sha1-cDhrG0jidz0NYxZqVa/5TvRFahI=",
+            "integrity": "sha512-gyWqJHXgDFPNx7PEyFJotutav+al92TTC3dWlMFyTETlOyKBQMZb7Cetqmj3GlrnSILHwSJRwf4mIGzc7C5lXw==",
             "dev": true
         },
         "clean-stack": {
@@ -2409,7 +2409,7 @@
         "clone-response": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.2.tgz",
-            "integrity": "sha1-0dyXOSAxTfZ/vrlCI7TuNQI56Ws=",
+            "integrity": "sha512-yjLXh88P599UOyPTFX0POsd7WxnbsVsGohcwzHOLspIhhpalPw1BcqED8NblyZLKcGrL8dTgMlcaZxV2jAD41Q==",
             "dev": true,
             "requires": {
                 "mimic-response": "^1.0.0"
@@ -2454,7 +2454,7 @@
         "colors": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
-            "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs=",
+            "integrity": "sha512-pFGrxThWcWQ2MsAz6RtgeWe4NK2kUE1WfsrvvlctdII745EW9I0yflqhe7++M5LEc7bV2c/9/5zc8sFcpL0Drw==",
             "dev": true
         },
         "columnify": {
@@ -2841,7 +2841,7 @@
         "decompress-response": {
             "version": "3.3.0",
             "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
-            "integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
+            "integrity": "sha512-BzRPQuY1ip+qDonAOz42gRm/pg9F768C+npV/4JOsxRC2sq+Rlk+Q4ZCAsOhnIaMrgarILY+RMUIvMmmX1qAEA==",
             "dev": true,
             "requires": {
                 "mimic-response": "^1.0.0"
@@ -2965,7 +2965,7 @@
         "duplexer3": {
             "version": "0.1.4",
             "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
-            "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=",
+            "integrity": "sha512-CEj8FwwNA4cVH2uFCoHUrmojhYh1vmCdOaneKJXwkeY1i9jnlslVo9dx+hQ5Hl9GnH/Bwy/IjxAyOePyPKYnzA==",
             "dev": true
         },
         "ecc-jsbn": {
@@ -3368,7 +3368,7 @@
         "fast-levenshtein": {
             "version": "2.0.6",
             "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-            "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+            "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
             "dev": true
         },
         "fast-memoize": {
@@ -3518,7 +3518,7 @@
         "functional-red-black-tree": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
-            "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
+            "integrity": "sha512-dsKNQNdj6xA3T+QlADDA7mOSlX0qiMINjn0cgr+eGHGsbSHzTabcIogz2+p/iqP1Xs6EP/sS2SbqH+brGTbq0g==",
             "dev": true
         },
         "gauge": {
@@ -3991,7 +3991,7 @@
         "import-lazy": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-2.1.0.tgz",
-            "integrity": "sha1-BWmOPUXIjo1+nZLLBYTnfwlvPkM=",
+            "integrity": "sha512-m7ZEHgtw69qOGw+jwxXkHlrlIPdTGkyh66zXZ1ajZbxkDBNjSY/LGbmjc7h0s2ELsUDTAhFr55TrPSSqJGPG0A==",
             "dev": true
         },
         "import-local": {
@@ -4400,7 +4400,7 @@
         "jju": {
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/jju/-/jju-1.4.0.tgz",
-            "integrity": "sha1-o6vicYryQaKykE+EpiWXDzia4yo=",
+            "integrity": "sha512-8wb9Yw966OSxApiCt0K3yNJL8pnNeIv+OEq2YMidz4FKP6nonSRoOXc80iXY4JaN2FC11B9qsNmDsm+ZOfMROA==",
             "dev": true
         },
         "js-tokens": {
@@ -4427,7 +4427,7 @@
         "json-buffer": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.0.tgz",
-            "integrity": "sha1-Wx85evx11ne96Lz8Dkfh+aPZqJg=",
+            "integrity": "sha512-CuUqjv0FUZIdXkHPI8MezCnFCdaTAacej1TZYulLoAg1h/PhwkdXFN4V/gzY4g+fMBCOV2xF+rp7t2XD2ns/NQ==",
             "dev": true
         },
         "json-parse-better-errors": {
@@ -4445,7 +4445,7 @@
         "json-parse-helpfulerror": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/json-parse-helpfulerror/-/json-parse-helpfulerror-1.0.3.tgz",
-            "integrity": "sha1-E/FM4C7tTpgSl7ZOueO5MuLdE9w=",
+            "integrity": "sha512-XgP0FGR77+QhUxjXkwOMkC94k3WtqEBfcnjWqhRd82qTat4SWKRE+9kUnynz/shm3I4ea2+qISvTIeGTNU7kJg==",
             "dev": true,
             "requires": {
                 "jju": "^1.1.0"
@@ -4466,7 +4466,7 @@
         "json-stable-stringify-without-jsonify": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
-            "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
+            "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
             "dev": true
         },
         "json-stringify-safe": {
@@ -4503,7 +4503,7 @@
         "jsonlines": {
             "version": "0.1.1",
             "resolved": "https://registry.npmjs.org/jsonlines/-/jsonlines-0.1.1.tgz",
-            "integrity": "sha1-T80kbcXQ44aRkHxEqwAveC0dlMw=",
+            "integrity": "sha512-ekDrAGso79Cvf+dtm+mL8OBI2bmAOt3gssYs833De/C9NmIpWDWyUO4zPgB5x2/OhY366dkhgfPMYfwZF7yOZA==",
             "dev": true
         },
         "jsonparse": {
@@ -4661,7 +4661,7 @@
                 "path-exists": {
                     "version": "3.0.0",
                     "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-                    "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+                    "integrity": "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==",
                     "dev": true
                 }
             }
@@ -5265,7 +5265,7 @@
         "natural-compare": {
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
-            "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
+            "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
             "dev": true
         },
         "negotiator": {
@@ -6254,7 +6254,7 @@
         "prepend-http": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-2.0.0.tgz",
-            "integrity": "sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc=",
+            "integrity": "sha512-ravE6m9Atw9Z/jjttRUZ+clIXogdghyZAuWJ3qEzjT+jI/dL1ifAqhZeC5VHzQp1MSt1+jxKkFNemj/iO7tVUA==",
             "dev": true
         },
         "prettier": {
@@ -6740,7 +6740,7 @@
         "responselike": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/responselike/-/responselike-1.0.2.tgz",
-            "integrity": "sha1-kYcg7ztjHFZCvgaPFa3lpG9Loec=",
+            "integrity": "sha512-/Fpe5guzJk1gPqdJLJR5u7eG/gNY4nImjbRDaVWVMRhne55TCmj2i9Q+54PBRfatRC8v/rIiv9BN0pMd9OV5EQ==",
             "dev": true,
             "requires": {
                 "lowercase-keys": "^1.0.0"

--- a/packages/pyright-internal/package-lock.json
+++ b/packages/pyright-internal/package-lock.json
@@ -925,7 +925,7 @@
         "asynckit": {
             "version": "0.4.0",
             "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-            "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+            "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
             "dev": true
         },
         "babel-jest": {
@@ -1142,7 +1142,7 @@
         "co": {
             "version": "4.6.0",
             "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-            "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
+            "integrity": "sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ==",
             "dev": true
         },
         "collect-v8-coverage": {
@@ -1261,7 +1261,7 @@
         "dedent": {
             "version": "0.7.0",
             "resolved": "https://registry.npmjs.org/dedent/-/dedent-0.7.0.tgz",
-            "integrity": "sha1-JJXduvbrh0q7Dhvp3yLS5aVEMmw=",
+            "integrity": "sha512-Q6fKUPqnAHAyhiUgFU7BUzLiv0kd8saH9al7tnu5Q/okj6dnupxyTgFIBjVzJATdfIAm9NAsvXNzjaKa+bxVyA==",
             "dev": true
         },
         "deep-is": {
@@ -1279,7 +1279,7 @@
         "delayed-stream": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-            "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+            "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
             "dev": true
         },
         "detect-newline": {
@@ -1338,7 +1338,7 @@
         "escape-string-regexp": {
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-            "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+            "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
             "dev": true
         },
         "escodegen": {
@@ -1392,7 +1392,7 @@
         "exit": {
             "version": "0.1.2",
             "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
-            "integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=",
+            "integrity": "sha512-Zk/eNKV2zbjpKzrsQ+n1G6poVbErQxJ0LBOJXaKZ1EViLzH+hrLu9cdXI4zw9dBQJslwBEpbQ2P1oS7nDxs6jQ==",
             "dev": true
         },
         "expect": {
@@ -1416,7 +1416,7 @@
         "fast-levenshtein": {
             "version": "2.0.6",
             "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-            "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+            "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
             "dev": true
         },
         "fb-watchman": {
@@ -1617,7 +1617,7 @@
         "imurmurhash": {
             "version": "0.1.4",
             "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-            "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+            "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
             "dev": true
         },
         "inflight": {
@@ -1702,13 +1702,13 @@
         "is-typedarray": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-            "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+            "integrity": "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==",
             "dev": true
         },
         "isexe": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-            "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+            "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
             "dev": true
         },
         "istanbul-lib-coverage": {
@@ -2349,7 +2349,7 @@
         "levn": {
             "version": "0.3.0",
             "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
-            "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+            "integrity": "sha512-0OO4y2iOHix2W6ujICbKIaEQXvFQHue65vUG3pb5EUomzPI90z9hsA1VsO/dbIIpC53J8gxM9Q4Oho0jrCM/yA==",
             "dev": true,
             "requires": {
                 "prelude-ls": "~1.1.2",
@@ -2379,7 +2379,7 @@
         "lodash.memoize": {
             "version": "4.1.2",
             "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
-            "integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=",
+            "integrity": "sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==",
             "dev": true
         },
         "lru-cache": {
@@ -2481,13 +2481,13 @@
         "natural-compare": {
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
-            "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
+            "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
             "dev": true
         },
         "node-int64": {
             "version": "0.4.0",
             "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
-            "integrity": "sha1-h6kGXNs1XTGC2PlM4RGIuCXGijs=",
+            "integrity": "sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==",
             "dev": true
         },
         "node-releases": {
@@ -2629,7 +2629,7 @@
         "prelude-ls": {
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-            "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+            "integrity": "sha512-ESF23V4SKG6lVSGZgYNpbsiaAkdab6ZgOxe52p7+Kid3W3u3bxR4Vfd/o21dmN7jSt0IwgZ4v5MUd26FEtXE9w==",
             "dev": true
         },
         "pretty-format": {
@@ -2699,7 +2699,7 @@
         "require-directory": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-            "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+            "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
             "dev": true
         },
         "resolve": {
@@ -3123,36 +3123,36 @@
             }
         },
         "vscode-jsonrpc": {
-            "version": "8.0.1",
-            "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.0.1.tgz",
-            "integrity": "sha512-N/WKvghIajmEvXpatSzvTvOIz61ZSmOSa4BRA4pTLi+1+jozquQKP/MkaylP9iB68k73Oua1feLQvH3xQuigiQ=="
+            "version": "8.0.2-next.1",
+            "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.0.2-next.1.tgz",
+            "integrity": "sha512-sbbvGSWja7NVBLHPGawtgezc8DHYJaP4qfr/AaJiyDapWcSFtHyPtm18+LnYMLTmB7bhOUW/lf5PeeuLpP6bKA=="
         },
         "vscode-languageserver": {
-            "version": "8.0.1",
-            "resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-8.0.1.tgz",
-            "integrity": "sha512-sn7SjBwWm3OlmLtgg7jbM0wBULppyL60rj8K5HF0ny/MzN+GzPBX1kCvYdybhl7UW63V5V5tRVnyB8iwC73lSQ==",
+            "version": "8.0.2-next.4",
+            "resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-8.0.2-next.4.tgz",
+            "integrity": "sha512-B3roWH4TmJiB6Zh5+r7zu0QdlLqJsPdGo0LeEi6OiLfrHYCDlcI7DNcQ7F17vWmxC3C82SrxMt/EuLBMpKQM0A==",
             "requires": {
-                "vscode-languageserver-protocol": "3.17.1"
+                "vscode-languageserver-protocol": "3.17.2-next.5"
             }
         },
         "vscode-languageserver-protocol": {
-            "version": "3.17.1",
-            "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.1.tgz",
-            "integrity": "sha512-BNlAYgQoYwlSgDLJhSG+DeA8G1JyECqRzM2YO6tMmMji3Ad9Mw6AW7vnZMti90qlAKb0LqAlJfSVGEdqMMNzKg==",
+            "version": "3.17.2-next.5",
+            "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.2-next.5.tgz",
+            "integrity": "sha512-UlH+QL4Q4lX94of/UPDDwwWIkd8w7dtMW4khzvEDUoykiG9tba0iG6V0bAiv8XVpnBIUYjL2FNFiL3zl+TY1Sw==",
             "requires": {
-                "vscode-jsonrpc": "8.0.1",
-                "vscode-languageserver-types": "3.17.1"
+                "vscode-jsonrpc": "8.0.2-next.1",
+                "vscode-languageserver-types": "3.17.2-next.2"
             }
         },
         "vscode-languageserver-textdocument": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.4.tgz",
-            "integrity": "sha512-/xhqXP/2A2RSs+J8JNXpiiNVvvNM0oTosNVmQnunlKvq9o4mupHOBAnnzH0lwIPKazXKvAKsVp1kr+H/K4lgoQ=="
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.5.tgz",
+            "integrity": "sha512-1ah7zyQjKBudnMiHbZmxz5bYNM9KKZYz+5VQLj+yr8l+9w3g+WAhCkUkWbhMEdC5u0ub4Ndiye/fDyS8ghIKQg=="
         },
         "vscode-languageserver-types": {
-            "version": "3.17.1",
-            "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.1.tgz",
-            "integrity": "sha512-K3HqVRPElLZVVPtMeKlsyL9aK0GxGQpvtAUTfX4k7+iJ4mc1M+JM+zQwkgGy2LzY0f0IAafe8MKqIkJrxfGGjQ=="
+            "version": "3.17.2-next.2",
+            "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.2-next.2.tgz",
+            "integrity": "sha512-TiAkLABgqkVWdAlC3XlOfdhdjIAdVU4YntPUm9kKGbXr+MGwpVnKz2KZMNBcvG0CFx8Hi8qliL0iq+ndPB720w=="
         },
         "vscode-uri": {
             "version": "3.0.3",

--- a/packages/pyright-internal/package.json
+++ b/packages/pyright-internal/package.json
@@ -26,10 +26,10 @@
         "source-map-support": "^0.5.21",
         "tmp": "^0.2.1",
         "typescript-char": "^0.0.0",
-        "vscode-jsonrpc": "8.0.1",
-        "vscode-languageserver": "8.0.1",
-        "vscode-languageserver-textdocument": "^1.0.4",
-        "vscode-languageserver-types": "3.17.1",
+        "vscode-jsonrpc": "8.0.2-next.1",
+        "vscode-languageserver": "8.0.2-next.4",
+        "vscode-languageserver-textdocument": "^1.0.5",
+        "vscode-languageserver-types": "3.17.2-next.2",
         "vscode-uri": "^3.0.3"
     },
     "devDependencies": {

--- a/packages/pyright-internal/src/common/browserConnectionUtils.ts
+++ b/packages/pyright-internal/src/common/browserConnectionUtils.ts
@@ -1,0 +1,14 @@
+/*
+ * browserConnectionUtils.ts
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT license.
+ *
+ * Create LSP browser connection from the given reader and writer
+ */
+
+import { MessageReader, MessageWriter } from 'vscode-jsonrpc';
+import * as LSP from 'vscode-languageserver/browser';
+
+export function createConnection(reader: MessageReader, writer: MessageWriter) {
+    return LSP.createConnection(reader, writer);
+}

--- a/packages/pyright-internal/src/common/fileSystem.ts
+++ b/packages/pyright-internal/src/common/fileSystem.ts
@@ -33,6 +33,7 @@ export interface Stats {
     isSymbolicLink(): boolean;
     isFIFO(): boolean;
     isSocket(): boolean;
+    isZipDirectory?: () => boolean;
 }
 
 export interface MkDirOptions {

--- a/packages/pyright-internal/src/common/pathUtils.ts
+++ b/packages/pyright-internal/src/common/pathUtils.ts
@@ -547,8 +547,17 @@ export function isDirectory(fs: FileSystem, path: string): boolean {
     return tryStat(fs, path)?.isDirectory() ?? false;
 }
 
-export function isFile(fs: FileSystem, path: string): boolean {
-    return tryStat(fs, path)?.isFile() ?? false;
+export function isFile(fs: FileSystem, path: string, treatZipDirectoryAsFile = false): boolean {
+    const stats = tryStat(fs, path);
+    if (stats?.isFile()) {
+        return true;
+    }
+
+    if (!treatZipDirectoryAsFile) {
+        return false;
+    }
+
+    return stats?.isZipDirectory?.() ?? false;
 }
 
 export function tryStat(fs: FileSystem, path: string): Stats | undefined {

--- a/packages/pyright-internal/src/common/realFileSystem.ts
+++ b/packages/pyright-internal/src/common/realFileSystem.ts
@@ -275,6 +275,7 @@ class RealFileSystem implements FileSystem {
                     ...stat,
                     isFile: () => false,
                     isDirectory: () => true,
+                    isZipDirectory: () => true,
                 };
             }
         }

--- a/packages/pyright-internal/src/tests/fourslash/fourslash.ts
+++ b/packages/pyright-internal/src/tests/fourslash/fourslash.ts
@@ -59,6 +59,7 @@ declare namespace _ {
         detail?: string;
         textEdit?: TextEdit;
         additionalTextEdits?: TextEdit[];
+        detailDescription?: string;
     }
 
     interface TextRange {

--- a/packages/pyright-internal/src/tests/harness/fourslash/testState.ts
+++ b/packages/pyright-internal/src/tests/harness/fourslash/testState.ts
@@ -1942,6 +1942,10 @@ export class TestState {
         assert.strictEqual(actual.insertText, expected.insertionText);
         this._verifyEdit(actual.textEdit as TextEdit, expected.textEdit);
         this._verifyEdits(actual.additionalTextEdits, expected.additionalTextEdits);
+
+        if (expected.detailDescription !== undefined) {
+            assert.strictEqual(actual.labelDetails?.description, expected.detailDescription);
+        }
     }
 }
 

--- a/packages/pyright/webpack.config.js
+++ b/packages/pyright/webpack.config.js
@@ -32,6 +32,8 @@ module.exports = (_, { mode }) => {
             all: false,
             errors: true,
             warnings: true,
+            publicPath: true,
+            timings: true,
         },
         resolve: {
             extensions: ['.ts', '.js'],

--- a/packages/vscode-pyright/package-lock.json
+++ b/packages/vscode-pyright/package-lock.json
@@ -2294,41 +2294,41 @@
             }
         },
         "vscode-jsonrpc": {
-            "version": "8.0.1",
-            "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.0.1.tgz",
-            "integrity": "sha512-N/WKvghIajmEvXpatSzvTvOIz61ZSmOSa4BRA4pTLi+1+jozquQKP/MkaylP9iB68k73Oua1feLQvH3xQuigiQ=="
+            "version": "8.0.2-next.1",
+            "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.0.2-next.1.tgz",
+            "integrity": "sha512-sbbvGSWja7NVBLHPGawtgezc8DHYJaP4qfr/AaJiyDapWcSFtHyPtm18+LnYMLTmB7bhOUW/lf5PeeuLpP6bKA=="
         },
         "vscode-languageclient": {
-            "version": "8.0.1",
-            "resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-8.0.1.tgz",
-            "integrity": "sha512-9XoE+HJfaWvu7Y75H3VmLo5WLCtsbxEgEhrLPqwt7eyoR49lUIyyrjb98Yfa50JCMqF2cePJAEVI6oe2o1sIhw==",
+            "version": "8.0.2-next.4",
+            "resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-8.0.2-next.4.tgz",
+            "integrity": "sha512-j9BEiCYMN9IoKwYdk9iickV6WNPVGPoVO11SMdoxFnWPIT3y5UAe3qf/WsfA9OdklAIaxxYasfgyKCpBjSPNuw==",
             "requires": {
                 "minimatch": "^3.0.4",
                 "semver": "^7.3.5",
-                "vscode-languageserver-protocol": "3.17.1"
+                "vscode-languageserver-protocol": "3.17.2-next.5"
             }
         },
         "vscode-languageserver": {
-            "version": "8.0.1",
-            "resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-8.0.1.tgz",
-            "integrity": "sha512-sn7SjBwWm3OlmLtgg7jbM0wBULppyL60rj8K5HF0ny/MzN+GzPBX1kCvYdybhl7UW63V5V5tRVnyB8iwC73lSQ==",
+            "version": "8.0.2-next.4",
+            "resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-8.0.2-next.4.tgz",
+            "integrity": "sha512-B3roWH4TmJiB6Zh5+r7zu0QdlLqJsPdGo0LeEi6OiLfrHYCDlcI7DNcQ7F17vWmxC3C82SrxMt/EuLBMpKQM0A==",
             "requires": {
-                "vscode-languageserver-protocol": "3.17.1"
+                "vscode-languageserver-protocol": "3.17.2-next.5"
             }
         },
         "vscode-languageserver-protocol": {
-            "version": "3.17.1",
-            "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.1.tgz",
-            "integrity": "sha512-BNlAYgQoYwlSgDLJhSG+DeA8G1JyECqRzM2YO6tMmMji3Ad9Mw6AW7vnZMti90qlAKb0LqAlJfSVGEdqMMNzKg==",
+            "version": "3.17.2-next.5",
+            "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.2-next.5.tgz",
+            "integrity": "sha512-UlH+QL4Q4lX94of/UPDDwwWIkd8w7dtMW4khzvEDUoykiG9tba0iG6V0bAiv8XVpnBIUYjL2FNFiL3zl+TY1Sw==",
             "requires": {
-                "vscode-jsonrpc": "8.0.1",
-                "vscode-languageserver-types": "3.17.1"
+                "vscode-jsonrpc": "8.0.2-next.1",
+                "vscode-languageserver-types": "3.17.2-next.2"
             }
         },
         "vscode-languageserver-types": {
-            "version": "3.17.1",
-            "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.1.tgz",
-            "integrity": "sha512-K3HqVRPElLZVVPtMeKlsyL9aK0GxGQpvtAUTfX4k7+iJ4mc1M+JM+zQwkgGy2LzY0f0IAafe8MKqIkJrxfGGjQ=="
+            "version": "3.17.2-next.2",
+            "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.2-next.2.tgz",
+            "integrity": "sha512-TiAkLABgqkVWdAlC3XlOfdhdjIAdVU4YntPUm9kKGbXr+MGwpVnKz2KZMNBcvG0CFx8Hi8qliL0iq+ndPB720w=="
         },
         "watchpack": {
             "version": "2.3.1",

--- a/packages/vscode-pyright/package.json
+++ b/packages/vscode-pyright/package.json
@@ -844,10 +844,10 @@
         "webpack-dev": "npm run clean && webpack --mode development --watch --progress"
     },
     "dependencies": {
-        "vscode-jsonrpc": "8.0.1",
-        "vscode-languageclient": "8.0.1",
-        "vscode-languageserver": "8.0.1",
-        "vscode-languageserver-protocol": "3.17.1"
+        "vscode-jsonrpc": "8.0.2-next.1",
+        "vscode-languageclient": "8.0.2-next.4",
+        "vscode-languageserver": "8.0.2-next.4",
+        "vscode-languageserver-protocol": "3.17.2-next.5"
     },
     "devDependencies": {
         "@types/copy-webpack-plugin": "^10.1.0",

--- a/packages/vscode-pyright/webpack.config.js
+++ b/packages/vscode-pyright/webpack.config.js
@@ -33,6 +33,8 @@ module.exports = (_, { mode }) => {
             all: false,
             errors: true,
             warnings: true,
+            publicPath: true,
+            timings: true,
         },
         resolve: {
             extensions: ['.ts', '.js'],


### PR DESCRIPTION
- Show module paths in auto import dialog
- Upgrade LSP to latest
- Fix file watcher to treat ZIPs as files instead of directories
- Fix cancellation errors in vscode.dev scenarios
- Use windows-latest for Windows-based test runs to maximize machine availability
- Fix webpack watch mode (i.e. fast incremental builds)