### PR TITLE
Changed the handling of partial stub packages to conform with PEP 561

### DIFF
--- a/packages/pyright-internal/src/analyzer/sourceFile.ts
+++ b/packages/pyright-internal/src/analyzer/sourceFile.ts
@@ -1392,10 +1392,10 @@ export class SourceFile {
     }
 
     private _getPathForLogging(filepath: string) {
-        if (!this.fileSystem.isMappedFilePath(filepath)) {
-            return filepath;
+        if (this.fileSystem.isMappedFilePath(filepath)) {
+            return this.fileSystem.getOriginalFilePath(filepath);
         }
 
-        return '[virtual] ' + filepath;
+        return filepath;
     }
 }

--- a/packages/pyright-internal/src/readonlyAugmentedFileSystem.ts
+++ b/packages/pyright-internal/src/readonlyAugmentedFileSystem.ts
@@ -58,8 +58,13 @@ export class ReadOnlyAugmentedFileSystem implements FileSystem {
         if (!movedEntries || this._realFS.existsSync(path)) {
             entries.push(
                 ...this._realFS.readdirEntriesSync(path).filter((item) => {
-                    // Filter out the stub package directory.
-                    return !this._isMovedEntry(combinePaths(path, item.name));
+                    // Filter out the stub package directory and any
+                    // entries that will be overwritten by stub package
+                    // virtual items.
+                    return (
+                        !this._isMovedEntry(combinePaths(path, item.name)) &&
+                        !movedEntries?.some((movedEntry) => movedEntry.name === item.name)
+                    );
                 })
             );
         }

--- a/packages/pyright-internal/src/tests/importResolver.test.ts
+++ b/packages/pyright-internal/src/tests/importResolver.test.ts
@@ -103,7 +103,7 @@ test('side by side files', () => {
     const configOptions = new ConfigOptions(normalizeSlashes('/'));
     const importResolver = new ImportResolver(fs, configOptions, new TestAccessHost(fs.getModulePath(), [libraryRoot]));
 
-    // Real side by side stub file win over virtual one.
+    // Stub package wins over original package (per PEP 561 rules).
     const sideBySideResult = importResolver.resolveImport(myFile, configOptions.findExecEnvironment(myFile), {
         leadingDots: 0,
         nameParts: ['myLib', 'partialStub'],
@@ -115,7 +115,7 @@ test('side by side files', () => {
 
     const sideBySideStubFile = combinePaths(libraryRoot, 'myLib', 'partialStub.pyi');
     assert.strictEqual(1, sideBySideResult.resolvedPaths.filter((f) => f === sideBySideStubFile).length);
-    assert.strictEqual('# empty', fs.readFileSync(sideBySideStubFile, 'utf8'));
+    assert.strictEqual('def test(): ...', fs.readFileSync(sideBySideStubFile, 'utf8'));
 
     // Side by side stub doesn't completely disable partial stub.
     const partialStubResult = importResolver.resolveImport(myFile, configOptions.findExecEnvironment(myFile), {
@@ -312,10 +312,10 @@ test('py.typed file', () => {
         },
     ];
 
-    // If py.typed file exists, then partial stub is disabled for this library.
+    // Partial stub package always overrides original package.
     const importResult = getImportResult(files, ['myLib']);
     assert(importResult.isImportFound);
-    assert(!importResult.isStubFile);
+    assert(importResult.isStubFile);
 });
 
 test('py.typed library', () => {

--- a/packages/pyright-internal/src/tests/pyrightFileSystem.test.ts
+++ b/packages/pyright-internal/src/tests/pyrightFileSystem.test.ts
@@ -102,7 +102,7 @@ test('existing stub file', () => {
     const entries = fs.readdirEntriesSync(myLib);
     assert.strictEqual(2, entries.length);
 
-    assert.strictEqual('def test(): pass', fs.readFileSync(stubFile, 'utf8'));
+    assert.strictEqual('def test(): ...', fs.readFileSync(stubFile, 'utf8'));
 
     assert(!fs.existsSync(combinePaths(libraryRoot, 'myLib-stubs')));
 });


### PR DESCRIPTION
Partial stubs should always overlay the original package even if that package is marked "py.typed".