### PR TITLE
Treat the type of anonymous classes and functions as not declared

### DIFF
--- a/packages/pyright-internal/src/analyzer/declarationUtils.ts
+++ b/packages/pyright-internal/src/analyzer/declarationUtils.ts
@@ -20,7 +20,7 @@ export function hasTypeForDeclaration(declaration: Declaration): boolean {
 
         case DeclarationType.Class:
         case DeclarationType.Function:
-            if (declaration.node.name.value == '_') {
+            if (declaration.node.name.value === '_') {
                 return false;
             }
             return true;

--- a/packages/pyright-internal/src/analyzer/declarationUtils.ts
+++ b/packages/pyright-internal/src/analyzer/declarationUtils.ts
@@ -15,9 +15,14 @@ import { getFileInfoFromNode } from './parseTreeUtils';
 export function hasTypeForDeclaration(declaration: Declaration): boolean {
     switch (declaration.type) {
         case DeclarationType.Intrinsic:
-        case DeclarationType.Class:
         case DeclarationType.SpecialBuiltInClass:
+            return true;
+
+        case DeclarationType.Class:
         case DeclarationType.Function:
+            if (declaration.node.name.value == '_') {
+                return false;
+            }
             return true;
 
         case DeclarationType.Parameter: {

--- a/packages/pyright-internal/src/tests/samples/assignment11.py
+++ b/packages/pyright-internal/src/tests/samples/assignment11.py
@@ -1,0 +1,66 @@
+# This sample tests that `_` in any scope can be re-assigned with any
+# type including functions/methods and classes.
+
+from typing import cast
+
+# Global scope.
+if True:
+    _ = cast("int", ...)
+    reveal_type(_, expected_text="int")
+
+    _ = cast("float", ...)
+    reveal_type(_, expected_text="float")
+
+    _ = cast("str", ...)
+    reveal_type(_, expected_text="str")
+
+    def _() -> None: ...
+    reveal_type(_, expected_text="() -> None")
+
+    class _:
+        ...
+    reveal_type(_, expected_text="Type[_]")
+
+# Function scope.
+def f() -> None:
+    _ = cast("int", ...)
+    reveal_type(_, expected_text="int")
+
+    _ = cast("float", ...)
+    reveal_type(_, expected_text="float")
+
+    _ = cast("str", ...)
+    reveal_type(_, expected_text="str")
+
+    def _() -> None: ...
+    reveal_type(_, expected_text="() -> None")
+
+    class _:
+        ...
+    reveal_type(_, expected_text="Type[_]")
+
+# Class scope.
+class C:
+    _ = cast("int", ...)
+    reveal_type(_, expected_text="int")
+
+    _ = cast("float", ...)
+    reveal_type(_, expected_text="float")
+
+    _ = cast("str", ...)
+    reveal_type(_, expected_text="str")
+
+    def _(self) -> None: ...
+    reveal_type(_, expected_text="(self: Self@C) -> None")
+
+    @staticmethod
+    def _() -> None: ...
+    reveal_type(_, expected_text="() -> None")
+
+    @classmethod
+    def _(cls) -> None: ...
+    reveal_type(_, expected_text="(cls: Type[Self@C]) -> None")
+
+    class _:
+        ...
+    reveal_type(_, expected_text="Type[_]")

--- a/packages/pyright-internal/src/tests/typeEvaluator2.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator2.test.ts
@@ -120,6 +120,12 @@ test('Assignment10', () => {
     TestUtils.validateResults(analysisResults, 0);
 });
 
+test('Assignment11', () => {
+    const analysisResults = TestUtils.typeAnalyzeSampleFiles(['assignment11.py']);
+
+    TestUtils.validateResults(analysisResults, 0);
+});
+
 test('AugmentedAssignment1', () => {
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['augmentedAssignment1.py']);
 


### PR DESCRIPTION
... so that the anonymous variable can still be re-assigned with any values even if it's declared as a class or function in the same scope.