### PR TITLE
don't use "." as one of commit char

### DIFF
--- a/packages/pyright-internal/src/languageServerBase.ts
+++ b/packages/pyright-internal/src/languageServerBase.ts
@@ -580,7 +580,7 @@ export abstract class LanguageServerBase implements LanguageServerInterface {
                 renameProvider: { prepareProvider: true, workDoneProgress: true },
                 completionProvider: {
                     triggerCharacters: this.client.hasVisualStudioExtensionsCapability ? ['.', '[', '@'] : ['.', '['],
-                    allCommitCharacters: ['.', ';', '(', '['],
+                    allCommitCharacters: [';', '(', '['],
                     resolveProvider: true,
                     workDoneProgress: true,
                     completionItem: {


### PR DESCRIPTION
we should put it back once we make sure we only auto show completion after "." when it is for member access or relative module

otherwise, typing dot shouldn't bring up completion. 