### PR TITLE
Pull Pylance 2022.7.11

### DIFF
--- a/packages/pyright-internal/src/languageServerBase.ts
+++ b/packages/pyright-internal/src/languageServerBase.ts
@@ -580,7 +580,6 @@ export abstract class LanguageServerBase implements LanguageServerInterface {
                 renameProvider: { prepareProvider: true, workDoneProgress: true },
                 completionProvider: {
                     triggerCharacters: this.client.hasVisualStudioExtensionsCapability ? ['.', '[', '@'] : ['.', '['],
-                    allCommitCharacters: ['.', ';', '(', '['],
                     resolveProvider: true,
                     workDoneProgress: true,
                     completionItem: {


### PR DESCRIPTION
Remove `allCommitCharacters` from `completionProvider`.