### PR TITLE
[PylanceBot] Pull Pylance with Pyright 1.1.260

### DIFF
--- a/packages/pyright-internal/src/analyzer/importResolver.ts
+++ b/packages/pyright-internal/src/analyzer/importResolver.ts
@@ -782,15 +782,16 @@ export class ImportResolver {
         const fs = this.fileSystem;
         const ignored: string[] = [];
         const paths: string[] = [];
+        const typeshedPathEx = this.getTypeshedPathEx(execEnv, ignored);
 
         // Add paths to search stub packages.
         addPaths(this._configOptions.stubPath);
         addPaths(execEnv.root);
         execEnv.extraPaths.forEach((p) => addPaths(p));
-        addPaths(this.getTypeshedPathEx(execEnv, ignored));
+        addPaths(typeshedPathEx);
         this.getPythonSearchPaths(ignored).forEach((p) => addPaths(p));
 
-        this.fileSystem.processPartialStubPackages(paths, this.getImportRoots(execEnv));
+        this.fileSystem.processPartialStubPackages(paths, this.getImportRoots(execEnv), typeshedPathEx);
         this._invalidateFileSystemCache();
         return true;
 

--- a/packages/pyright-internal/src/analyzer/parseTreeUtils.ts
+++ b/packages/pyright-internal/src/analyzer/parseTreeUtils.ts
@@ -1538,13 +1538,63 @@ export function getCallNodeAndActiveParameterIndex(
     }
 }
 
-export function getTokenAt(tokens: TextRangeCollection<Token>, position: number) {
+export function getTokenIndexAtLeft(
+    tokens: TextRangeCollection<Token>,
+    position: number,
+    includeWhitespace = false,
+    includeZeroLengthToken = false
+) {
     const index = tokens.getItemAtPosition(position);
+    if (index < 0) {
+        return -1;
+    }
+
+    for (let i = index; i >= 0; i--) {
+        const token = tokens.getItemAt(i);
+        if (!includeZeroLengthToken && token.length === 0) {
+            continue;
+        }
+
+        if (!includeWhitespace && isWhitespace(token)) {
+            continue;
+        }
+
+        if (TextRange.getEnd(token) <= position) {
+            return i;
+        }
+    }
+
+    return -1;
+}
+
+export function getTokenAtLeft(
+    tokens: TextRangeCollection<Token>,
+    position: number,
+    includeWhitespace = false,
+    includeZeroLengthToken = false
+) {
+    const index = getTokenIndexAtLeft(tokens, position, includeWhitespace, includeZeroLengthToken);
     if (index < 0) {
         return undefined;
     }
 
     return tokens.getItemAt(index);
+}
+
+function isWhitespace(token: Token) {
+    return token.type === TokenType.NewLine || token.type === TokenType.Indent || token.type === TokenType.Dedent;
+}
+
+export function getTokenAtIndex(tokens: TextRangeCollection<Token>, index: number) {
+    if (index < 0) {
+        return undefined;
+    }
+
+    return tokens.getItemAt(index);
+}
+
+export function getTokenAt(tokens: TextRangeCollection<Token>, position: number) {
+    return getTokenAtIndex(tokens, tokens.getItemAtPosition(position));
 }
 
 export function getTokenOverlapping(tokens: TextRangeCollection<Token>, position: number) {

--- a/packages/pyright-internal/src/analyzer/service.ts
+++ b/packages/pyright-internal/src/analyzer/service.ts
@@ -1416,6 +1416,7 @@ export class AnalyzerService {
         this._removeLibraryFileWatcher();
 
         if (!this._watchForLibraryChanges) {
+            this._librarySearchPathsToWatch = undefined;
             return;
         }
 

--- a/packages/pyright-internal/src/languageService/completionProvider.ts
+++ b/packages/pyright-internal/src/languageService/completionProvider.ts
@@ -229,16 +229,16 @@ export interface CompletionItemData {
     filePath: string;
     workspacePath: string;
     position: Position;
-    autoImportText?: string | undefined;
-    symbolLabel?: string | undefined;
-    funcParensDisabled?: boolean | undefined;
+    autoImportText?: string;
+    symbolLabel?: string;
+    funcParensDisabled?: boolean;
 }
 
 // MemberAccessInfo attempts to gather info for unknown types
 export interface MemberAccessInfo {
-    lastKnownModule?: string | undefined;
-    lastKnownMemberName?: string | undefined;
-    unknownMemberName?: string | undefined;
+    lastKnownModule?: string;
+    lastKnownMemberName?: string;
+    unknownMemberName?: string;
 }
 
 export interface AutoImportInfo {
@@ -265,9 +265,9 @@ export interface ExtensionInfo {
 }
 
 interface CompletionResultsBase {
-    memberAccessInfo?: MemberAccessInfo | undefined;
-    autoImportInfo?: AutoImportInfo | undefined;
-    extensionInfo?: ExtensionInfo | undefined;
+    memberAccessInfo?: MemberAccessInfo;
+    autoImportInfo?: AutoImportInfo;
+    extensionInfo?: ExtensionInfo;
 }
 export interface CompletionResultsList extends CompletionResultsBase {
     completionList: CompletionList;
@@ -281,13 +281,14 @@ export interface CompletionOptions {
     snippet: boolean;
     lazyEdit: boolean;
     autoImport: boolean;
+    extraCommitChars: boolean;
 }
 
 export type AbbreviationMap = Map<string, AbbreviationInfo>;
 
 export interface AutoImportMaps {
-    nameMap?: AbbreviationMap | undefined;
-    libraryMap?: Map<string, IndexResults> | undefined;
+    nameMap?: AbbreviationMap;
+    libraryMap?: Map<string, IndexResults>;
     getModuleSymbolsMap: () => ModuleSymbolMap;
 }
 
@@ -297,30 +298,32 @@ interface RecentCompletionInfo {
 }
 
 interface Edits {
-    format?: InsertTextFormat | undefined;
-    textEdit?: TextEdit | undefined;
-    additionalTextEdits?: TextEditAction[] | undefined;
+    format?: InsertTextFormat;
+    textEdit?: TextEdit;
+    additionalTextEdits?: TextEditAction[];
 }
 
-interface SymbolDetail {
-    funcParensDisabled?: boolean | undefined;
-    autoImportSource?: string | undefined;
-    autoImportAlias?: string | undefined;
-    boundObjectOrClass?: ClassType | undefined;
-    edits?: Edits | undefined;
+interface CommonDetail {
+    funcParensDisabled?: boolean;
+    edits?: Edits;
+    extraCommitChars?: boolean;
 }
 
-interface CompletionDetail {
-    funcParensDisabled?: boolean | undefined;
-    typeDetail?: string | undefined;
-    documentation?: string | undefined;
+interface SymbolDetail extends CommonDetail {
+    autoImportSource?: string;
+    autoImportAlias?: string;
+    boundObjectOrClass?: ClassType;
+}
+
+interface CompletionDetail extends CommonDetail {
+    typeDetail?: string;
+    documentation?: string;
     autoImportText?: {
         source: string;
         importText: string;
     };
-    edits?: Edits | undefined;
-    sortText?: string | undefined;
-    itemDetail?: string | undefined;
+    sortText?: string;
+    itemDetail?: string;
 }
 
 export const autoImportDetail = 'Auto-import';
@@ -833,7 +836,46 @@ export class CompletionProvider {
                 return this._createSingleKeywordCompletion('else');
             }
 
-            case ErrorExpressionCategory.MissingExpression:
+            case ErrorExpressionCategory.MissingExpression: {
+                // Don't show completion after random dots.
+                const tokenizerOutput = this._parseResults.tokenizerOutput;
+                const offset = convertPositionToOffset(this._position, tokenizerOutput.lines);
+                const index = ParseTreeUtils.getTokenIndexAtLeft(tokenizerOutput.tokens, offset!);
+                const token = ParseTreeUtils.getTokenAtIndex(tokenizerOutput.tokens, index);
+                if (token?.type === TokenType.Dot || token?.type === TokenType.Ellipsis) {
+                    break;
+                }
+
+                // ex) class MyType:
+                //         def is_str(self): ...
+                //     myType = MyType()
+                //
+                // In incomplete code such as "myType.is" <= "is" will be tokenized as keyword not identifier,
+                // so even if user's intention is writing "is_str", completion after "is" won't include "is_str"
+                // since parser won't see "is" as partially written member name instead it will see it as
+                // expression statement with missing expression after "is" keyword.
+                // In such case, use "MyType." to get completion.
+                if (token?.type !== TokenType.Keyword || TextRange.getEnd(token) !== offset) {
+                    return this._getExpressionCompletions(node, priorWord, priorText, postText);
+                }
+
+                const previousToken = ParseTreeUtils.getTokenAtIndex(tokenizerOutput.tokens, index - 1);
+                if (previousToken?.type !== TokenType.Dot) {
+                    return this._getExpressionCompletions(node, priorWord, priorText, postText);
+                }
+
+                const previousOffset = TextRange.getEnd(previousToken);
+                const previousNode = ParseTreeUtils.findNodeByOffset(this._parseResults.parseTree, previousOffset);
+                if (
+                    previousNode?.nodeType !== ParseNodeType.Error ||
+                    previousNode.category !== ErrorExpressionCategory.MissingMemberAccessName
+                ) {
+                    return this._getExpressionCompletions(node, priorWord, priorText, postText);
+                }
+
+                return this._getMissingMemberAccessNameCompletions(previousNode, previousOffset, priorWord);
+            }
+
             case ErrorExpressionCategory.MissingDecoratorCallName: {
                 return this._getExpressionCompletions(node, priorWord, priorText, postText);
             }
@@ -849,10 +891,8 @@ export class CompletionProvider {
             }
 
             case ErrorExpressionCategory.MissingMemberAccessName: {
-                if (node.child && isExpressionNode(node.child)) {
-                    return this._getMemberAccessCompletions(node.child, priorWord);
-                }
-                break;
+                const offset = convertPositionToOffset(this._position, this._parseResults.tokenizerOutput.lines);
+                return this._getMissingMemberAccessNameCompletions(node, offset!, priorWord);
             }
 
             case ErrorExpressionCategory.MissingFunctionParameterList: {
@@ -870,6 +910,21 @@ export class CompletionProvider {
         }
 
         return undefined;
+    }
+
+    private _getMissingMemberAccessNameCompletions(node: ErrorNode, offset: number, priorWord: string) {
+        const index = ParseTreeUtils.getTokenIndexAtLeft(this._parseResults.tokenizerOutput.tokens, offset) - 1;
+        const previousToken = ParseTreeUtils.getTokenAtIndex(this._parseResults.tokenizerOutput.tokens, index);
+        if (previousToken?.type === TokenType.Dot || previousToken?.type === TokenType.Ellipsis) {
+            // Don't allow multiple dot bring up completions.
+            return undefined;
+        }
+
+        if (!node.child || !isExpressionNode(node.child)) {
+            return undefined;
+        }
+
+        return this._getMemberAccessCompletions(node.child, priorWord);
     }
 
     private _isOverload(node: DecoratorNode): boolean {
@@ -2210,6 +2265,7 @@ export class CompletionProvider {
         for (const result of results) {
             if (result.symbol) {
                 this._addSymbol(result.name, result.symbol, priorWord, completionResults.completionMap, {
+                    extraCommitChars: true,
                     autoImportSource: result.source,
                     autoImportAlias: result.alias,
                     edits: {
@@ -2224,6 +2280,7 @@ export class CompletionProvider {
                     priorWord,
                     completionResults.completionMap,
                     {
+                        extraCommitChars: true,
                         autoImportText: this._getAutoImportText(result.name, result.source, result.alias),
                         edits: {
                             textEdit: this._createReplaceEdits(priorWord, /* node */ undefined, result.insertionText),
@@ -2436,6 +2493,7 @@ export class CompletionProvider {
                     this._addSymbol(name, symbol, priorWord, completionMap, {
                         boundObjectOrClass,
                         funcParensDisabled: isInImport,
+                        extraCommitChars: !isInImport,
                     });
                 }
             }
@@ -2667,6 +2725,7 @@ export class CompletionProvider {
 
             this._addNameToCompletions(detail.autoImportAlias ?? name, itemKind, priorWord, completionMap, {
                 autoImportText,
+                extraCommitChars: detail.extraCommitChars,
                 funcParensDisabled: detail.funcParensDisabled,
                 edits: detail.edits,
             });
@@ -2676,6 +2735,7 @@ export class CompletionProvider {
             if (synthesizedType) {
                 const itemKind: CompletionItemKind = CompletionItemKind.Variable;
                 this._addNameToCompletions(name, itemKind, priorWord, completionMap, {
+                    extraCommitChars: detail.extraCommitChars,
                     funcParensDisabled: detail.funcParensDisabled,
                     edits: detail.edits,
                 });
@@ -2722,6 +2782,10 @@ export class CompletionProvider {
 
         const completionItem = CompletionItem.create(name);
         completionItem.kind = itemKind;
+
+        if (detail?.extraCommitChars) {
+            this._addExtraCommitChar(completionItem, ...this._getExtraCommitCharsForKind(itemKind));
+        }
 
         const completionItemData: CompletionItemData = {
             workspacePath: this._workspacePath,
@@ -2992,10 +3056,34 @@ export class CompletionProvider {
             const completionItem = CompletionItem.create(completionName);
             completionItem.kind = CompletionItemKind.Module;
             completionItem.sortText = this._makeSortText(SortCategory.ImportModuleName, completionName);
+            this._addExtraCommitChar(completionItem, '.');
             completionMap.set(completionItem);
         });
 
         return { completionMap };
+    }
+
+    private _getExtraCommitCharsForKind(kind: CompletionItemKind) {
+        switch (kind) {
+            case CompletionItemKind.Class:
+                return ['.', '('];
+            case CompletionItemKind.Function:
+            case CompletionItemKind.Method:
+                return ['('];
+            case CompletionItemKind.Module:
+            case CompletionItemKind.Enum:
+                return ['.'];
+            default:
+                return [];
+        }
+    }
+
+    private _addExtraCommitChar(item: CompletionItem, ...commitChars: string[]) {
+        if (!this._options.extraCommitChars || commitChars.length === 0) {
+            return;
+        }
+
+        item.commitCharacters = commitChars;
     }
 
     private _isPossiblePropertyDeclaration(decl: FunctionDeclaration) {

--- a/packages/pyright-internal/src/tests/chainedSourceFiles.test.ts
+++ b/packages/pyright-internal/src/tests/chainedSourceFiles.test.ts
@@ -53,6 +53,7 @@ test('check chained files', async () => {
             lazyEdit: false,
             snippet: false,
             autoImport: false,
+            extraCommitChars: false,
         },
         undefined,
         CancellationToken.None
@@ -98,6 +99,7 @@ test('modify chained files', async () => {
             lazyEdit: false,
             snippet: false,
             autoImport: false,
+            extraCommitChars: false,
         },
         undefined,
         CancellationToken.None

--- a/packages/pyright-internal/src/tests/fourslash/completions.commitChars.fourslash.ts
+++ b/packages/pyright-internal/src/tests/fourslash/completions.commitChars.fourslash.ts
@@ -1,0 +1,49 @@
+/// <reference path="fourslash.ts" />
+
+// @filename: test.py
+//// from samples import *
+//// foo[|/*marker1*/|]
+//// fooClass().foo[|/*marker2*/|]
+
+// @filename: samples.py
+//// import fooLib as fooLib
+//// def fooFunc(): ...
+//// class fooClass():
+////     def fooMethod(self): ...
+
+// @filename: fooLib.py
+//// # empty
+
+{
+    // @ts-ignore
+    await helper.verifyCompletion('included', 'markdown', {
+        marker1: {
+            completions: [
+                {
+                    label: 'fooLib',
+                    kind: Consts.CompletionItemKind.Module,
+                    commitCharacters: ['.'],
+                },
+                {
+                    label: 'fooFunc',
+                    kind: Consts.CompletionItemKind.Function,
+                    commitCharacters: ['('],
+                },
+                {
+                    label: 'fooClass',
+                    kind: Consts.CompletionItemKind.Class,
+                    commitCharacters: ['.', '('],
+                },
+            ],
+        },
+        marker2: {
+            completions: [
+                {
+                    label: 'fooMethod',
+                    kind: Consts.CompletionItemKind.Method,
+                    commitCharacters: ['('],
+                },
+            ],
+        },
+    });
+}

--- a/packages/pyright-internal/src/tests/fourslash/completions.triggers.fourslash.ts
+++ b/packages/pyright-internal/src/tests/fourslash/completions.triggers.fourslash.ts
@@ -1,0 +1,35 @@
+/// <reference path="fourslash.ts" />
+
+// @filename: test1.py
+//// .[|/*marker1*/|]
+
+// @filename: test2.py
+//// ..[|/*marker2*/|]
+
+// @filename: test3.py
+//// ...[|/*marker3*/|]
+
+// @filename: test4.py
+//// ....[|/*marker4*/|]
+
+// @filename: test5.py
+//// dict = { "test" : "value" }
+//// dict[.[|/*marker5*/|]]
+
+// @filename: test6.py
+//// a = 1
+//// a..[|/*marker6*/|]
+
+{
+    helper.openFiles(helper.getMarkers().map((m) => m.fileName));
+
+    // @ts-ignore
+    await helper.verifyCompletion('exact', 'markdown', {
+        marker1: { completions: [] },
+        marker2: { completions: [] },
+        marker3: { completions: [] },
+        marker4: { completions: [] },
+        marker5: { completions: [] },
+        marker6: { completions: [] },
+    });
+}

--- a/packages/pyright-internal/src/tests/fourslash/fourslash.ts
+++ b/packages/pyright-internal/src/tests/fourslash/fourslash.ts
@@ -60,6 +60,7 @@ declare namespace _ {
         textEdit?: TextEdit;
         additionalTextEdits?: TextEdit[];
         detailDescription?: string;
+        commitCharacters?: string[];
     }
 
     interface TextRange {

--- a/packages/pyright-internal/src/tests/harness/fourslash/testState.ts
+++ b/packages/pyright-internal/src/tests/harness/fourslash/testState.ts
@@ -65,6 +65,7 @@ import {
     WorkspaceServiceInstance,
 } from '../../../languageServerBase';
 import { AbbreviationInfo } from '../../../languageService/autoImporter';
+import { CompletionOptions } from '../../../languageService/completionProvider';
 import { DefinitionFilter } from '../../../languageService/definitionProvider';
 import { convertHoverResults } from '../../../languageService/hoverProvider';
 import { ParseNode } from '../../../parser/parseNodes';
@@ -1089,7 +1090,13 @@ export class TestState {
             const expectedCompletions = map[markerName].completions;
             const completionPosition = this.convertOffsetToPosition(filePath, marker.position);
 
-            const options = { format: docFormat, snippet: true, lazyEdit: true, autoImport: true };
+            const options: CompletionOptions = {
+                format: docFormat,
+                snippet: true,
+                lazyEdit: true,
+                autoImport: true,
+                extraCommitChars: true,
+            };
             const nameMap = abbrMap ? new Map<string, AbbreviationInfo>(Object.entries(abbrMap)) : undefined;
             const result = await this.workspace.serviceInstance.getCompletionsForPosition(
                 filePath,
@@ -1958,6 +1965,10 @@ export class TestState {
 
         if (expected.detailDescription !== undefined) {
             assert.strictEqual(actual.labelDetails?.description, expected.detailDescription);
+        }
+
+        if (expected.commitCharacters !== undefined) {
+            expect(expected.commitCharacters.sort()).toEqual(actual.commitCharacters?.sort());
         }
     }
 }

--- a/packages/pyright-internal/src/tests/pyrightFileSystem.test.ts
+++ b/packages/pyright-internal/src/tests/pyrightFileSystem.test.ts
@@ -168,6 +168,39 @@ test('uri tests', () => {
     assert(!fs.removeUriMap('file://test.pyi', file));
 });
 
+test('bundled partial stubs', () => {
+    const bundledPath = combinePaths(normalizeSlashes('/'), 'bundled');
+
+    const files = [
+        {
+            path: combinePaths(bundledPath, 'myLib-stubs', 'partialStub.pyi'),
+            content: 'def test(): ...',
+        },
+        {
+            path: combinePaths(bundledPath, 'myLib-stubs', 'py.typed'),
+            content: 'partial\n',
+        },
+        {
+            path: combinePaths(libraryRoot, 'myLib', 'partialStub.py'),
+            content: 'def test(): pass',
+        },
+        {
+            path: combinePaths(libraryRoot, 'myLib', 'py.typed'),
+            content: '',
+        },
+    ];
+
+    const fs = createFileSystem(files);
+    fs.processPartialStubPackages([bundledPath], [libraryRoot], bundledPath);
+
+    const stubFile = combinePaths(libraryRoot, 'myLib', 'partialStub.pyi');
+    assert(!fs.existsSync(stubFile));
+
+    const myLib = combinePaths(libraryRoot, 'myLib');
+    const entries = fs.readdirEntriesSync(myLib);
+    assert.strictEqual(2, entries.length);
+});
+
 function createFileSystem(files: { path: string; content: string }[]): PyrightFileSystem {
     const fs = new TestFileSystem(/* ignoreCase */ false, { cwd: normalizeSlashes('/') });
 


### PR DESCRIPTION
This PR includes

1. fixed a bug in parser where it creates error node with overlapped spans with another node.
2. fixed a bug in completion where it sometimes loses completion with certain member name 
ex) symbol.is <= "is" is keyword, so user can't write something like is_valid since we lose completion at "is" since we think it is keyword.
3. make sure py.typed library shadow bundled partial stubs (only bundled one, user installed partial stubs work as expected)
4. added support for extra commit char when enabled.
5. added support for disabling library file watching to workaround inotify limit issue on linux (hidden option)