### PR TITLE
[PylanceBot] Pull Pylance with Pyright 1.1.269

### DIFF
--- a/packages/pyright-internal/src/analyzer/binder.ts
+++ b/packages/pyright-internal/src/analyzer/binder.ts
@@ -1159,7 +1159,9 @@ export class Binder extends ParseTreeWalker {
 
         this._currentFlowNode = this._finishFlowLabel(postForLabel);
 
-        if (node.asyncToken) {
+        // Async for is not allowed outside of an async function
+        // unless we're in ipython mode.
+        if (node.asyncToken && !this._fileInfo.ipythonMode) {
             const enclosingFunction = ParseTreeUtils.getEnclosingFunction(node);
             if (!enclosingFunction || !enclosingFunction.isAsync) {
                 this._addError(Localizer.Diagnostic.asyncNotInAsyncFunction(), node.asyncToken);
@@ -1988,7 +1990,8 @@ export class Binder extends ParseTreeWalker {
                 this._addExceptTargets(this._currentFlowNode!);
             }
 
-            if (node.asyncToken) {
+            if (node.asyncToken && !this._fileInfo.ipythonMode) {
+                // Top level async with is allowed in ipython mode.
                 const enclosingFunction = ParseTreeUtils.getEnclosingFunction(node);
                 if (!enclosingFunction || !enclosingFunction.isAsync) {
                     this._addError(Localizer.Diagnostic.asyncNotInAsyncFunction(), node.asyncToken);
@@ -2095,8 +2098,9 @@ export class Binder extends ParseTreeWalker {
                     this._bindPossibleTupleNamedTarget(compr.targetExpression, addedSymbols);
                     this._addInferredTypeAssignmentForVariable(compr.targetExpression, compr);
 
-                    // Async for is not allowed outside of an async function.
-                    if (compr.asyncToken) {
+                    // Async for is not allowed outside of an async function
+                    // unless we're in ipython mode.
+                    if (compr.asyncToken && !this._fileInfo.ipythonMode) {
                         if (!enclosingFunction || !enclosingFunction.isAsync) {
                             // Allow if it's within a generator expression. Execution of
                             // generator expressions is deferred and therefore can be

--- a/packages/pyright-internal/src/analyzer/program.ts
+++ b/packages/pyright-internal/src/analyzer/program.ts
@@ -159,6 +159,7 @@ export interface OpenFileOptions {
     isTracked: boolean;
     ipythonMode: IPythonMode;
     chainedFilePath: string | undefined;
+    realFilePath: string | undefined;
 }
 
 // Container for all of the files that are being analyzed. Files
@@ -316,6 +317,7 @@ export class Program {
                 /* isInPyTypedPackage */ false,
                 this._console,
                 this._logTracker,
+                options?.realFilePath,
                 options?.ipythonMode ?? IPythonMode.None
             );
 

--- a/packages/pyright-internal/src/analyzer/service.ts
+++ b/packages/pyright-internal/src/analyzer/service.ts
@@ -250,12 +250,14 @@ export class AnalyzerService {
         version: number | null,
         contents: string,
         ipythonMode = IPythonMode.None,
-        chainedFilePath?: string
+        chainedFilePath?: string,
+        realFilePath?: string
     ) {
         this._backgroundAnalysisProgram.setFileOpened(path, version, contents, {
             isTracked: this.isTracked(path),
             ipythonMode,
             chainedFilePath,
+            realFilePath,
         });
         this._scheduleReanalysis(/* requireTrackedFileUpdate */ false);
     }
@@ -280,6 +282,7 @@ export class AnalyzerService {
             isTracked: this.isTracked(path),
             ipythonMode,
             chainedFilePath,
+            realFilePath: undefined,
         });
         this._scheduleReanalysis(/* requireTrackedFileUpdate */ false);
     }

--- a/packages/pyright-internal/src/analyzer/sourceFile.ts
+++ b/packages/pyright-internal/src/analyzer/sourceFile.ts
@@ -93,8 +93,12 @@ export class SourceFile {
     // Console interface to use for debugging.
     private _console: ConsoleInterface;
 
-    // File path on disk.
+    // File path unique to this file within the workspace. May not represent
+    // a real file on disk.
     private readonly _filePath: string;
+
+    // File path on disk. May not be unique.
+    private readonly _realFilePath: string;
 
     // Period-delimited import path for the module.
     private _moduleName: string;
@@ -205,11 +209,13 @@ export class SourceFile {
         isThirdPartyPyTypedPresent: boolean,
         console?: ConsoleInterface,
         logTracker?: LogTracker,
+        realFilePath?: string,
         ipythonMode = IPythonMode.None
     ) {
         this.fileSystem = fs;
         this._console = console || new StandardConsole();
         this._filePath = filePath;
+        this._realFilePath = realFilePath ?? filePath;
         this._moduleName = moduleName;
         this._isStubFile = filePath.endsWith('.pyi');
         this._isThirdPartyImport = isThirdPartyImport;
@@ -487,7 +493,7 @@ export class SourceFile {
         }
 
         // If the file is in the ignore list, clear the diagnostic list.
-        if (options.ignore.find((ignoreFileSpec) => ignoreFileSpec.regExp.test(this._filePath))) {
+        if (options.ignore.find((ignoreFileSpec) => ignoreFileSpec.regExp.test(this._realFilePath))) {
             diagList = [];
         }
 
@@ -829,7 +835,7 @@ export class SourceFile {
 
                 // Is this file in a "strict" path?
                 const useStrict =
-                    configOptions.strict.find((strictFileSpec) => strictFileSpec.regExp.test(this._filePath)) !==
+                    configOptions.strict.find((strictFileSpec) => strictFileSpec.regExp.test(this._realFilePath)) !==
                     undefined;
 
                 this._diagnosticRuleSet = CommentUtils.getFileLevelDirectives(

--- a/packages/pyright-internal/src/tests/ipythonMode.test.ts
+++ b/packages/pyright-internal/src/tests/ipythonMode.test.ts
@@ -270,6 +270,121 @@ test('await still raises errors when used in wrong context in ipython mode', () 
     assert(diagnostics?.some((d) => d.message === Localizer.Diagnostic.awaitNotInAsync()));
 });
 
+test('top level async for raises errors in regular mode', () => {
+    const code = `
+//// async def b():
+////     for i in range(5):
+////         yield i
+////
+//// [|/*marker*/async for x in b():|]
+////     print("")
+    `;
+
+    const state = parseAndGetTestState(code).state;
+    const range = state.getRangeByMarkerName('marker')!;
+
+    const source = state.program.getBoundSourceFile(range.fileName)!;
+    const diagnostics = source.getDiagnostics(state.configOptions);
+
+    assert(diagnostics?.some((d) => d.message === Localizer.Diagnostic.asyncNotInAsyncFunction()));
+});
+
+test('top level async for raises no errors in ipython mode', () => {
+    const code = `
+// @ipythonMode: true
+//// async def b():
+////     for i in range(5):
+////         yield i
+////
+//// [|/*marker*/async for x in b():|]
+////     print("")
+    `;
+
+    const state = parseAndGetTestState(code).state;
+    const range = state.getRangeByMarkerName('marker')!;
+
+    const source = state.program.getBoundSourceFile(range.fileName)!;
+    const diagnostics = source.getDiagnostics(state.configOptions);
+
+    assert(!diagnostics?.some((d) => d.message === Localizer.Diagnostic.asyncNotInAsyncFunction()));
+});
+
+test('top level async for in list comprehension raises errors in regular mode', () => {
+    const code = `
+//// async def b():
+////     for i in range(5):
+////         yield i
+////
+//// y = [|/*marker*/[x async for x in b()]|]
+    `;
+
+    const state = parseAndGetTestState(code).state;
+    const range = state.getRangeByMarkerName('marker')!;
+
+    const source = state.program.getBoundSourceFile(range.fileName)!;
+    const diagnostics = source.getDiagnostics(state.configOptions);
+
+    assert(diagnostics?.some((d) => d.message === Localizer.Diagnostic.asyncNotInAsyncFunction()));
+});
+
+test('top level async for in list comprehension raises no errors in ipython mode', () => {
+    const code = `
+// @ipythonMode: true
+//// async def b():
+////     for i in range(5):
+////         yield i
+////
+//// y = [|/*marker*/[x async for x in b()]|]
+    `;
+
+    const state = parseAndGetTestState(code).state;
+    const range = state.getRangeByMarkerName('marker')!;
+
+    const source = state.program.getBoundSourceFile(range.fileName)!;
+    const diagnostics = source.getDiagnostics(state.configOptions);
+
+    assert(!diagnostics?.some((d) => d.message === Localizer.Diagnostic.asyncNotInAsyncFunction()));
+});
+
+test('top level async with raises errors in regular mode', () => {
+    const code = `
+//// from contextlib import AsyncExitStack
+////
+//// cm = AsyncExitStack()
+////
+//// [|/*marker*/async with cm:|]
+////     pass
+    `;
+
+    const state = parseAndGetTestState(code).state;
+    const range = state.getRangeByMarkerName('marker')!;
+
+    const source = state.program.getBoundSourceFile(range.fileName)!;
+    const diagnostics = source.getDiagnostics(state.configOptions);
+
+    assert(diagnostics?.some((d) => d.message === Localizer.Diagnostic.asyncNotInAsyncFunction()));
+});
+
+test('top level async with raises no errors in ipython mode', () => {
+    const code = `
+// @ipythonMode: true
+//// from contextlib import AsyncExitStack
+////
+//// cm = AsyncExitStack()
+////
+//// [|/*marker*/async with cm:|]
+////     pass
+    `;
+
+    const state = parseAndGetTestState(code).state;
+    const range = state.getRangeByMarkerName('marker')!;
+
+    const source = state.program.getBoundSourceFile(range.fileName)!;
+    const diagnostics = source.getDiagnostics(state.configOptions);
+
+    assert(!diagnostics?.some((d) => d.message === Localizer.Diagnostic.asyncNotInAsyncFunction()));
+});
+
 test('try implicitly load ipython display module but fail', async () => {
     const code = `
 // @ipythonMode: true


### PR DESCRIPTION
rollup of the following changes:
- Use workspace.isInitialized to block other LSP requests for cells
- Allow top-level async for and async with in notebooks
- make sure we initialize default root folders even when workspaceFolder capability is not supported by client.
- Fix ignore of LSP notebook files