### PR TITLE
docs: fix wrong description of reportUndefinedVariable

### DIFF
--- a/packages/vscode-pyright/package.json
+++ b/packages/vscode-pyright/package.json
@@ -698,7 +698,7 @@
                         },
                         "reportUndefinedVariable": {
                             "type": "string",
-                            "description": "Diagnostics for a missing or misnamed “self” parameter in instance methods and “cls” parameter in class methods. Instance methods in metaclasses (classes that derive from “type”) are allowed to use “cls” for instance methods.",
+                            "description": "Diagnostics for undefined variables.",
                             "default": "error",
                             "enum": [
                                 "none",


### PR DESCRIPTION
This description is modified from docs/configuration.md
https://github.com/microsoft/pyright/blob/bab8e4e0123c2793adc85df4c263c89e8b436b0c/docs/configuration.md#L159
The original one seems to be copied from reportSelfClsParameterName
https://github.com/microsoft/pyright/blob/e077a8a1d01e8bff884124e202015db23258ade7/packages/vscode-pyright/package.json#L655-L665