### PR TITLE
[PylanceBot] Pull Pylance with Pyright 1.1.270

### DIFF
--- a/packages/pyright-internal/package-lock.json
+++ b/packages/pyright-internal/package-lock.json
@@ -20,10 +20,10 @@
                 "source-map-support": "^0.5.21",
                 "tmp": "^0.2.1",
                 "typescript-char": "^0.0.0",
-                "vscode-jsonrpc": "8.0.2-next.1",
-                "vscode-languageserver": "8.0.2-next.4",
-                "vscode-languageserver-textdocument": "^1.0.5",
-                "vscode-languageserver-types": "3.17.2-next.2",
+                "vscode-jsonrpc": "8.1.0-next.1",
+                "vscode-languageserver": "8.1.0-next.1",
+                "vscode-languageserver-textdocument": "^1.0.7",
+                "vscode-languageserver-types": "3.17.2",
                 "vscode-uri": "^3.0.3"
             },
             "devDependencies": {
@@ -4188,42 +4188,42 @@
             }
         },
         "node_modules/vscode-jsonrpc": {
-            "version": "8.0.2-next.1",
-            "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.0.2-next.1.tgz",
-            "integrity": "sha512-sbbvGSWja7NVBLHPGawtgezc8DHYJaP4qfr/AaJiyDapWcSFtHyPtm18+LnYMLTmB7bhOUW/lf5PeeuLpP6bKA==",
+            "version": "8.1.0-next.1",
+            "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.1.0-next.1.tgz",
+            "integrity": "sha512-FiPG+9TuMIga3t+kkalQytwqMtJu1djI+Pq+Ut2tvAJpcNHDJ0PYdjFv5mgEvTEJLujrYwjWHVkNe+XfHPBD/w==",
             "engines": {
                 "node": ">=14.0.0"
             }
         },
         "node_modules/vscode-languageserver": {
-            "version": "8.0.2-next.4",
-            "resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-8.0.2-next.4.tgz",
-            "integrity": "sha512-B3roWH4TmJiB6Zh5+r7zu0QdlLqJsPdGo0LeEi6OiLfrHYCDlcI7DNcQ7F17vWmxC3C82SrxMt/EuLBMpKQM0A==",
+            "version": "8.1.0-next.1",
+            "resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-8.1.0-next.1.tgz",
+            "integrity": "sha512-u14Rk4JgXI+7iS6AEXI2pNc1dWh/5JEXtaqa4TeBECKJlN+5242mbGBBPaHMOE7sSI1Kh66XhEMZJhPYjUfjHw==",
             "dependencies": {
-                "vscode-languageserver-protocol": "3.17.2-next.5"
+                "vscode-languageserver-protocol": "3.17.3-next.1"
             },
             "bin": {
                 "installServerIntoExtension": "bin/installServerIntoExtension"
             }
         },
         "node_modules/vscode-languageserver-protocol": {
-            "version": "3.17.2-next.5",
-            "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.2-next.5.tgz",
-            "integrity": "sha512-UlH+QL4Q4lX94of/UPDDwwWIkd8w7dtMW4khzvEDUoykiG9tba0iG6V0bAiv8XVpnBIUYjL2FNFiL3zl+TY1Sw==",
+            "version": "3.17.3-next.1",
+            "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.3-next.1.tgz",
+            "integrity": "sha512-vgjvPE0zox+1Fi4ljsSFJ+B3g8wGNbuAEEdulueVdv+R2VHtc06+dgxhWiG4LKPqXwjPDmiuxCnvd2xk3fzTTw==",
             "dependencies": {
-                "vscode-jsonrpc": "8.0.2-next.1",
-                "vscode-languageserver-types": "3.17.2-next.2"
+                "vscode-jsonrpc": "8.1.0-next.1",
+                "vscode-languageserver-types": "3.17.2"
             }
         },
         "node_modules/vscode-languageserver-textdocument": {
-            "version": "1.0.5",
-            "resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.5.tgz",
-            "integrity": "sha512-1ah7zyQjKBudnMiHbZmxz5bYNM9KKZYz+5VQLj+yr8l+9w3g+WAhCkUkWbhMEdC5u0ub4Ndiye/fDyS8ghIKQg=="
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.7.tgz",
+            "integrity": "sha512-bFJH7UQxlXT8kKeyiyu41r22jCZXG8kuuVVA33OEJn1diWOZK5n8zBSPZFHVBOu8kXZ6h0LIRhf5UnCo61J4Hg=="
         },
         "node_modules/vscode-languageserver-types": {
-            "version": "3.17.2-next.2",
-            "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.2-next.2.tgz",
-            "integrity": "sha512-TiAkLABgqkVWdAlC3XlOfdhdjIAdVU4YntPUm9kKGbXr+MGwpVnKz2KZMNBcvG0CFx8Hi8qliL0iq+ndPB720w=="
+            "version": "3.17.2",
+            "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.2.tgz",
+            "integrity": "sha512-zHhCWatviizPIq9B7Vh9uvrH6x3sK8itC84HkamnBWoDFJtzBf7SWlpLCZUit72b3os45h6RWQNC9xHRDF8dRA=="
         },
         "node_modules/vscode-uri": {
             "version": "3.0.3",
@@ -7603,36 +7603,36 @@
             }
         },
         "vscode-jsonrpc": {
-            "version": "8.0.2-next.1",
-            "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.0.2-next.1.tgz",
-            "integrity": "sha512-sbbvGSWja7NVBLHPGawtgezc8DHYJaP4qfr/AaJiyDapWcSFtHyPtm18+LnYMLTmB7bhOUW/lf5PeeuLpP6bKA=="
+            "version": "8.1.0-next.1",
+            "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.1.0-next.1.tgz",
+            "integrity": "sha512-FiPG+9TuMIga3t+kkalQytwqMtJu1djI+Pq+Ut2tvAJpcNHDJ0PYdjFv5mgEvTEJLujrYwjWHVkNe+XfHPBD/w=="
         },
         "vscode-languageserver": {
-            "version": "8.0.2-next.4",
-            "resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-8.0.2-next.4.tgz",
-            "integrity": "sha512-B3roWH4TmJiB6Zh5+r7zu0QdlLqJsPdGo0LeEi6OiLfrHYCDlcI7DNcQ7F17vWmxC3C82SrxMt/EuLBMpKQM0A==",
+            "version": "8.1.0-next.1",
+            "resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-8.1.0-next.1.tgz",
+            "integrity": "sha512-u14Rk4JgXI+7iS6AEXI2pNc1dWh/5JEXtaqa4TeBECKJlN+5242mbGBBPaHMOE7sSI1Kh66XhEMZJhPYjUfjHw==",
             "requires": {
-                "vscode-languageserver-protocol": "3.17.2-next.5"
+                "vscode-languageserver-protocol": "3.17.3-next.1"
             }
         },
         "vscode-languageserver-protocol": {
-            "version": "3.17.2-next.5",
-            "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.2-next.5.tgz",
-            "integrity": "sha512-UlH+QL4Q4lX94of/UPDDwwWIkd8w7dtMW4khzvEDUoykiG9tba0iG6V0bAiv8XVpnBIUYjL2FNFiL3zl+TY1Sw==",
+            "version": "3.17.3-next.1",
+            "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.3-next.1.tgz",
+            "integrity": "sha512-vgjvPE0zox+1Fi4ljsSFJ+B3g8wGNbuAEEdulueVdv+R2VHtc06+dgxhWiG4LKPqXwjPDmiuxCnvd2xk3fzTTw==",
             "requires": {
-                "vscode-jsonrpc": "8.0.2-next.1",
-                "vscode-languageserver-types": "3.17.2-next.2"
+                "vscode-jsonrpc": "8.1.0-next.1",
+                "vscode-languageserver-types": "3.17.2"
             }
         },
         "vscode-languageserver-textdocument": {
-            "version": "1.0.5",
-            "resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.5.tgz",
-            "integrity": "sha512-1ah7zyQjKBudnMiHbZmxz5bYNM9KKZYz+5VQLj+yr8l+9w3g+WAhCkUkWbhMEdC5u0ub4Ndiye/fDyS8ghIKQg=="
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.7.tgz",
+            "integrity": "sha512-bFJH7UQxlXT8kKeyiyu41r22jCZXG8kuuVVA33OEJn1diWOZK5n8zBSPZFHVBOu8kXZ6h0LIRhf5UnCo61J4Hg=="
         },
         "vscode-languageserver-types": {
-            "version": "3.17.2-next.2",
-            "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.2-next.2.tgz",
-            "integrity": "sha512-TiAkLABgqkVWdAlC3XlOfdhdjIAdVU4YntPUm9kKGbXr+MGwpVnKz2KZMNBcvG0CFx8Hi8qliL0iq+ndPB720w=="
+            "version": "3.17.2",
+            "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.2.tgz",
+            "integrity": "sha512-zHhCWatviizPIq9B7Vh9uvrH6x3sK8itC84HkamnBWoDFJtzBf7SWlpLCZUit72b3os45h6RWQNC9xHRDF8dRA=="
         },
         "vscode-uri": {
             "version": "3.0.3",

--- a/packages/pyright-internal/package.json
+++ b/packages/pyright-internal/package.json
@@ -26,10 +26,10 @@
         "source-map-support": "^0.5.21",
         "tmp": "^0.2.1",
         "typescript-char": "^0.0.0",
-        "vscode-jsonrpc": "8.0.2-next.1",
-        "vscode-languageserver": "8.0.2-next.4",
-        "vscode-languageserver-textdocument": "^1.0.5",
-        "vscode-languageserver-types": "3.17.2-next.2",
+        "vscode-jsonrpc": "8.1.0-next.1",
+        "vscode-languageserver": "8.1.0-next.1",
+        "vscode-languageserver-textdocument": "^1.0.7",
+        "vscode-languageserver-types": "3.17.2",
         "vscode-uri": "^3.0.3"
     },
     "devDependencies": {

--- a/packages/pyright-internal/src/analyzer/service.ts
+++ b/packages/pyright-internal/src/analyzer/service.ts
@@ -634,25 +634,41 @@ export class AnalyzerService {
             commandLineOptions.extraPaths
         );
 
+        this._configFilePath = configFilePath || pyprojectFilePath;
+
         if (commandLineOptions.fileSpecs.length > 0) {
             commandLineOptions.fileSpecs.forEach((fileSpec) => {
                 configOptions.include.push(getFileSpec(this.fs, projectRoot, fileSpec));
             });
-        } else if (!configFilePath) {
-            // If no config file was found and there are no explicit include
-            // paths specified, assume the caller wants to include all source
-            // files under the execution root path.
-            if (commandLineOptions.executionRoot) {
-                configOptions.include.push(getFileSpec(this.fs, commandLineOptions.executionRoot, '.'));
+        }
 
+        if (commandLineOptions.excludeFileSpecs.length > 0) {
+            commandLineOptions.excludeFileSpecs.forEach((fileSpec) => {
+                configOptions.exclude.push(getFileSpec(this.fs, projectRoot, fileSpec));
+            });
+        }
+
+        if (commandLineOptions.ignoreFileSpecs.length > 0) {
+            commandLineOptions.ignoreFileSpecs.forEach((fileSpec) => {
+                configOptions.ignore.push(getFileSpec(this.fs, projectRoot, fileSpec));
+            });
+        }
+
+        if (!this._configFilePath && commandLineOptions.executionRoot) {
+            if (commandLineOptions.fileSpecs.length === 0) {
+                // If no config file was found and there are no explicit include
+                // paths specified, assume the caller wants to include all source
+                // files under the execution root path.
+                configOptions.include.push(getFileSpec(this.fs, commandLineOptions.executionRoot, '.'));
+            }
+
+            if (commandLineOptions.excludeFileSpecs.length === 0) {
                 // Add a few common excludes to avoid long scan times.
                 defaultExcludes.forEach((exclude) => {
                     configOptions.exclude.push(getFileSpec(this.fs, commandLineOptions.executionRoot, exclude));
                 });
             }
         }
-
-        this._configFilePath = configFilePath || pyprojectFilePath;
 
         // If we found a config file, parse it to compute the effective options.
         let configJsonObj: object | undefined;

--- a/packages/pyright-internal/src/common/commandLineOptions.ts
+++ b/packages/pyright-internal/src/common/commandLineOptions.ts
@@ -44,6 +44,15 @@ export class CommandLineOptions {
     // are included.
     fileSpecs: string[] = [];
 
+    // A list of file specs to exclude in the analysis. Can contain
+    // directories, in which case all "*.py" files within those directories
+    // are excluded.
+    excludeFileSpecs: string[] = [];
+
+    // A list of file specs whose errors and warnings should be ignored even
+    // if they are included in the transitive closure of included files.
+    ignoreFileSpecs: string[] = [];
+
     // Watch for changes in workspace source files.
     watchForSourceChanges?: boolean | undefined;
 

--- a/packages/pyright-internal/src/common/envVarUtils.ts
+++ b/packages/pyright-internal/src/common/envVarUtils.ts
@@ -1,0 +1,30 @@
+/*
+ * envVarUtils.ts
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT license.
+ *
+ * Utils functions that handles environment variables.
+ */
+
+// Expands certain predefined variables supported within VS Code settings.
+// Ideally, VS Code would provide an API for doing this expansion, but
+// it doesn't. We'll handle the most common variables here as a convenience.
+export function expandPathVariables(rootPath: string, value: string): string {
+    const regexp = /\$\{(.*?)\}/g;
+    return value.replace(regexp, (match: string, name: string) => {
+        const trimmedName = name.trim();
+        if (trimmedName === 'workspaceFolder') {
+            return rootPath;
+        }
+        if (trimmedName === 'env:HOME' && process.env.HOME !== undefined) {
+            return process.env.HOME;
+        }
+        if (trimmedName === 'env:USERNAME' && process.env.USERNAME !== undefined) {
+            return process.env.USERNAME;
+        }
+        if (trimmedName === 'env:VIRTUAL_ENV' && process.env.VIRTUAL_ENV !== undefined) {
+            return process.env.VIRTUAL_ENV;
+        }
+        return match;
+    });
+}

--- a/packages/pyright-internal/src/common/realFileSystem.ts
+++ b/packages/pyright-internal/src/common/realFileSystem.ts
@@ -364,7 +364,7 @@ class RealFileSystem implements FileSystem {
             return realPath.substr(0, rootLength).toLowerCase() + realPath.substr(rootLength);
         } catch (e: any) {
             // Return as it is, if anything failed.
-            this._console.error(`Failed to get real file system casing for ${path}: ${e}`);
+            this._console.log(`Failed to get real file system casing for ${path}: ${e}`);
 
             return path;
         }

--- a/packages/pyright-internal/src/languageService/analyzerServiceExecutor.ts
+++ b/packages/pyright-internal/src/languageService/analyzerServiceExecutor.ts
@@ -149,5 +149,9 @@ function getEffectiveCommandLineOptions(
     commandLineOptions.extraPaths = serverSettings.extraPaths;
     commandLineOptions.diagnosticSeverityOverrides = serverSettings.diagnosticSeverityOverrides;
 
+    commandLineOptions.fileSpecs = serverSettings.fileSpecs ?? [];
+    commandLineOptions.excludeFileSpecs = serverSettings.excludeFileSpecs ?? [];
+    commandLineOptions.ignoreFileSpecs = serverSettings.ignoreFileSpecs ?? [];
+
     return commandLineOptions;
 }

--- a/packages/pyright-internal/src/parser/tokenizer.ts
+++ b/packages/pyright-internal/src/parser/tokenizer.ts
@@ -12,6 +12,7 @@
 
 import Char from 'typescript-char';
 
+import { isWhitespace } from '../analyzer/parseTreeUtils';
 import { IPythonMode } from '../analyzer/sourceFile';
 import { TextRange } from '../common/textRange';
 import { TextRangeCollection } from '../common/textRangeCollection';
@@ -1051,7 +1052,7 @@ export class Tokenizer {
     private _isIPythonMagics() {
         const prevToken = this._tokens.length > 0 ? this._tokens[this._tokens.length - 1] : undefined;
         return (
-            (prevToken === undefined || prevToken.type === TokenType.NewLine || prevToken.type === TokenType.Indent) &&
+            (prevToken === undefined || isWhitespace(prevToken)) &&
             (this._cs.currentChar === Char.Percent || this._cs.currentChar === Char.ExclamationMark)
         );
     }

--- a/packages/pyright-internal/src/server.ts
+++ b/packages/pyright-internal/src/server.ts
@@ -25,6 +25,7 @@ import { getCancellationFolderName } from './common/cancellationUtils';
 import { ConfigOptions } from './common/configOptions';
 import { ConsoleWithLogLevel, LogLevel } from './common/console';
 import { isDebugMode, isString } from './common/core';
+import { expandPathVariables } from './common/envVarUtils';
 import { FileBasedCancellationProvider } from './common/fileBasedCancellationUtils';
 import { FileSystem } from './common/fileSystem';
 import { FullAccessHost } from './common/fullAccessHost';
@@ -96,7 +97,7 @@ export class PyrightServer extends LanguageServerBase {
                 if (pythonPath && isString(pythonPath) && !isPythonBinary(pythonPath)) {
                     serverSettings.pythonPath = resolvePaths(
                         workspace.rootPath,
-                        this.expandPathVariables(workspace.rootPath, pythonPath)
+                        expandPathVariables(workspace.rootPath, pythonPath)
                     );
                 }
 
@@ -105,7 +106,7 @@ export class PyrightServer extends LanguageServerBase {
                 if (venvPath && isString(venvPath)) {
                     serverSettings.venvPath = resolvePaths(
                         workspace.rootPath,
-                        this.expandPathVariables(workspace.rootPath, venvPath)
+                        expandPathVariables(workspace.rootPath, venvPath)
                     );
                 }
             }
@@ -118,7 +119,7 @@ export class PyrightServer extends LanguageServerBase {
                     if (typeshedPath && isString(typeshedPath)) {
                         serverSettings.typeshedPath = resolvePaths(
                             workspace.rootPath,
-                            this.expandPathVariables(workspace.rootPath, typeshedPath)
+                            expandPathVariables(workspace.rootPath, typeshedPath)
                         );
                     }
                 }
@@ -127,7 +128,7 @@ export class PyrightServer extends LanguageServerBase {
                 if (stubPath && isString(stubPath)) {
                     serverSettings.stubPath = resolvePaths(
                         workspace.rootPath,
-                        this.expandPathVariables(workspace.rootPath, stubPath)
+                        expandPathVariables(workspace.rootPath, stubPath)
                     );
                 }
 
@@ -159,7 +160,7 @@ export class PyrightServer extends LanguageServerBase {
                 if (extraPaths && Array.isArray(extraPaths) && extraPaths.length > 0) {
                     serverSettings.extraPaths = extraPaths
                         .filter((p) => p && isString(p))
-                        .map((p) => resolvePaths(workspace.rootPath, this.expandPathVariables(workspace.rootPath, p)));
+                        .map((p) => resolvePaths(workspace.rootPath, expandPathVariables(workspace.rootPath, p)));
                 }
 
                 if (pythonAnalysisSection.typeCheckingMode !== undefined) {

--- a/packages/pyright-internal/src/tests/ipythonMode.test.ts
+++ b/packages/pyright-internal/src/tests/ipythonMode.test.ts
@@ -439,6 +439,35 @@ test('implicitly load ipython display module', async () => {
     });
 });
 
+test('magics at the end', async () => {
+    const code = `
+// @filename: test.py
+// @ipythonMode: true
+//// from random import random
+//// def estimate_pi(n=1e7) -> "area":
+////     """Estimate pi with monte carlo simulation.
+////     
+////     Arguments:
+////         n: number of simulations
+////     """
+////     in_circle = 0
+////     total = n
+////     
+////     while n != 0:
+////         prec_x = random()
+////         prec_y = random()
+////         if pow(prec_x, 2) + pow(prec_y, 2) <= 1:
+////             in_circle += 1 # inside the circle
+////         n -= 1
+////         
+////     return 4 * in_circle / total
+//// 
+//// [|/*marker*/%time estimate_pi()|]
+    `;
+
+    testIPython(code);
+});
+
 function testIPython(code: string, expectMagic = true) {
     const state = parseAndGetTestState(code).state;
     const range = state.getRangeByMarkerName('marker')!;

--- a/packages/pyright-internal/src/tests/parseTreeUtils.test.ts
+++ b/packages/pyright-internal/src/tests/parseTreeUtils.test.ts
@@ -256,7 +256,12 @@ test('getFullStatementRange', () => {
     const code = `
 //// [|/*marker1*/import a
 //// |][|/*marker2*/a = 1; |][|/*marker3*/b = 2
-//// |][|/*marker4*/if True:
+//// |]
+//// try:
+//// [|    /*marker4*/a = 1
+//// |]except Exception:
+////     pass
+//// [|/*marker5*/if True:
 ////     pass|]
     `;
 
@@ -265,7 +270,8 @@ test('getFullStatementRange', () => {
     testRange(state, 'marker1', ParseNodeType.Import);
     testRange(state, 'marker2', ParseNodeType.Assignment);
     testRange(state, 'marker3', ParseNodeType.Assignment);
-    testRange(state, 'marker4', ParseNodeType.If);
+    testRange(state, 'marker4', ParseNodeType.Assignment);
+    testRange(state, 'marker5', ParseNodeType.If);
 
     function testRange(state: TestState, markerName: string, type: ParseNodeType) {
         const range = state.getRangeByMarkerName(markerName)!;

--- a/packages/vscode-pyright/package-lock.json
+++ b/packages/vscode-pyright/package-lock.json
@@ -9,10 +9,10 @@
             "version": "1.1.270",
             "license": "MIT",
             "dependencies": {
-                "vscode-jsonrpc": "8.0.2-next.1",
-                "vscode-languageclient": "8.0.2-next.4",
-                "vscode-languageserver": "8.0.2-next.4",
-                "vscode-languageserver-protocol": "3.17.2-next.5"
+                "vscode-jsonrpc": "8.1.0-next.1",
+                "vscode-languageclient": "8.1.0-next.1",
+                "vscode-languageserver": "8.1.0-next.1",
+                "vscode-languageserver-protocol": "3.17.3-next.1"
             },
             "devDependencies": {
                 "@types/copy-webpack-plugin": "^10.1.0",
@@ -575,6 +575,7 @@
             "version": "1.1.11",
             "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
             "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+            "dev": true,
             "dependencies": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -804,7 +805,8 @@
         "node_modules/concat-map": {
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-            "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+            "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+            "dev": true
         },
         "node_modules/console-control-strings": {
             "version": "1.1.0",
@@ -1795,6 +1797,7 @@
             "version": "3.0.4",
             "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
             "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+            "dev": true,
             "dependencies": {
                 "brace-expansion": "^1.1.7"
             },
@@ -2369,9 +2372,9 @@
             }
         },
         "node_modules/semver": {
-            "version": "7.3.5",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-            "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+            "version": "7.3.7",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
+            "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
             "dependencies": {
                 "lru-cache": "^6.0.0"
             },
@@ -3024,50 +3027,69 @@
             }
         },
         "node_modules/vscode-jsonrpc": {
-            "version": "8.0.2-next.1",
-            "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.0.2-next.1.tgz",
-            "integrity": "sha512-sbbvGSWja7NVBLHPGawtgezc8DHYJaP4qfr/AaJiyDapWcSFtHyPtm18+LnYMLTmB7bhOUW/lf5PeeuLpP6bKA==",
+            "version": "8.1.0-next.1",
+            "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.1.0-next.1.tgz",
+            "integrity": "sha512-FiPG+9TuMIga3t+kkalQytwqMtJu1djI+Pq+Ut2tvAJpcNHDJ0PYdjFv5mgEvTEJLujrYwjWHVkNe+XfHPBD/w==",
             "engines": {
                 "node": ">=14.0.0"
             }
         },
         "node_modules/vscode-languageclient": {
-            "version": "8.0.2-next.4",
-            "resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-8.0.2-next.4.tgz",
-            "integrity": "sha512-j9BEiCYMN9IoKwYdk9iickV6WNPVGPoVO11SMdoxFnWPIT3y5UAe3qf/WsfA9OdklAIaxxYasfgyKCpBjSPNuw==",
+            "version": "8.1.0-next.1",
+            "resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-8.1.0-next.1.tgz",
+            "integrity": "sha512-lJraJ8IrqXr83ZciAs4dN32f9kEPuOb/FqAeUTgnW5cAxo0Qux0/EMgKyU33Qf9LdEI0I9iwRVxQWtawbyUUfg==",
             "dependencies": {
-                "minimatch": "^3.0.4",
-                "semver": "^7.3.5",
-                "vscode-languageserver-protocol": "3.17.2-next.5"
+                "minimatch": "^5.1.0",
+                "semver": "^7.3.7",
+                "vscode-languageserver-protocol": "3.17.3-next.1"
             },
             "engines": {
                 "vscode": "^1.67.0"
             }
         },
-        "node_modules/vscode-languageserver": {
-            "version": "8.0.2-next.4",
-            "resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-8.0.2-next.4.tgz",
-            "integrity": "sha512-B3roWH4TmJiB6Zh5+r7zu0QdlLqJsPdGo0LeEi6OiLfrHYCDlcI7DNcQ7F17vWmxC3C82SrxMt/EuLBMpKQM0A==",
+        "node_modules/vscode-languageclient/node_modules/brace-expansion": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+            "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
             "dependencies": {
-                "vscode-languageserver-protocol": "3.17.2-next.5"
+                "balanced-match": "^1.0.0"
+            }
+        },
+        "node_modules/vscode-languageclient/node_modules/minimatch": {
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.0.tgz",
+            "integrity": "sha512-9TPBGGak4nHfGZsPBohm9AWg6NoT7QTCehS3BIJABslyZbzxfV78QM2Y6+i741OPZIafFAaiiEMh5OyIrJPgtg==",
+            "dependencies": {
+                "brace-expansion": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/vscode-languageserver": {
+            "version": "8.1.0-next.1",
+            "resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-8.1.0-next.1.tgz",
+            "integrity": "sha512-u14Rk4JgXI+7iS6AEXI2pNc1dWh/5JEXtaqa4TeBECKJlN+5242mbGBBPaHMOE7sSI1Kh66XhEMZJhPYjUfjHw==",
+            "dependencies": {
+                "vscode-languageserver-protocol": "3.17.3-next.1"
             },
             "bin": {
                 "installServerIntoExtension": "bin/installServerIntoExtension"
             }
         },
         "node_modules/vscode-languageserver-protocol": {
-            "version": "3.17.2-next.5",
-            "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.2-next.5.tgz",
-            "integrity": "sha512-UlH+QL4Q4lX94of/UPDDwwWIkd8w7dtMW4khzvEDUoykiG9tba0iG6V0bAiv8XVpnBIUYjL2FNFiL3zl+TY1Sw==",
+            "version": "3.17.3-next.1",
+            "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.3-next.1.tgz",
+            "integrity": "sha512-vgjvPE0zox+1Fi4ljsSFJ+B3g8wGNbuAEEdulueVdv+R2VHtc06+dgxhWiG4LKPqXwjPDmiuxCnvd2xk3fzTTw==",
             "dependencies": {
-                "vscode-jsonrpc": "8.0.2-next.1",
-                "vscode-languageserver-types": "3.17.2-next.2"
+                "vscode-jsonrpc": "8.1.0-next.1",
+                "vscode-languageserver-types": "3.17.2"
             }
         },
         "node_modules/vscode-languageserver-types": {
-            "version": "3.17.2-next.2",
-            "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.2-next.2.tgz",
-            "integrity": "sha512-TiAkLABgqkVWdAlC3XlOfdhdjIAdVU4YntPUm9kKGbXr+MGwpVnKz2KZMNBcvG0CFx8Hi8qliL0iq+ndPB720w=="
+            "version": "3.17.2",
+            "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.2.tgz",
+            "integrity": "sha512-zHhCWatviizPIq9B7Vh9uvrH6x3sK8itC84HkamnBWoDFJtzBf7SWlpLCZUit72b3os45h6RWQNC9xHRDF8dRA=="
         },
         "node_modules/watchpack": {
             "version": "2.4.0",
@@ -3817,6 +3839,7 @@
             "version": "1.1.11",
             "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
             "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+            "dev": true,
             "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -3979,7 +4002,8 @@
         "concat-map": {
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-            "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+            "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+            "dev": true
         },
         "console-control-strings": {
             "version": "1.1.0",
@@ -4727,6 +4751,7 @@
             "version": "3.0.4",
             "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
             "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+            "dev": true,
             "requires": {
                 "brace-expansion": "^1.1.7"
             }
@@ -5150,9 +5175,9 @@
             }
         },
         "semver": {
-            "version": "7.3.5",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-            "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+            "version": "7.3.7",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
+            "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
             "requires": {
                 "lru-cache": "^6.0.0"
             }
@@ -5634,41 +5659,59 @@
             }
         },
         "vscode-jsonrpc": {
-            "version": "8.0.2-next.1",
-            "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.0.2-next.1.tgz",
-            "integrity": "sha512-sbbvGSWja7NVBLHPGawtgezc8DHYJaP4qfr/AaJiyDapWcSFtHyPtm18+LnYMLTmB7bhOUW/lf5PeeuLpP6bKA=="
+            "version": "8.1.0-next.1",
+            "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.1.0-next.1.tgz",
+            "integrity": "sha512-FiPG+9TuMIga3t+kkalQytwqMtJu1djI+Pq+Ut2tvAJpcNHDJ0PYdjFv5mgEvTEJLujrYwjWHVkNe+XfHPBD/w=="
         },
         "vscode-languageclient": {
-            "version": "8.0.2-next.4",
-            "resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-8.0.2-next.4.tgz",
-            "integrity": "sha512-j9BEiCYMN9IoKwYdk9iickV6WNPVGPoVO11SMdoxFnWPIT3y5UAe3qf/WsfA9OdklAIaxxYasfgyKCpBjSPNuw==",
+            "version": "8.1.0-next.1",
+            "resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-8.1.0-next.1.tgz",
+            "integrity": "sha512-lJraJ8IrqXr83ZciAs4dN32f9kEPuOb/FqAeUTgnW5cAxo0Qux0/EMgKyU33Qf9LdEI0I9iwRVxQWtawbyUUfg==",
             "requires": {
-                "minimatch": "^3.0.4",
-                "semver": "^7.3.5",
-                "vscode-languageserver-protocol": "3.17.2-next.5"
+                "minimatch": "^5.1.0",
+                "semver": "^7.3.7",
+                "vscode-languageserver-protocol": "3.17.3-next.1"
+            },
+            "dependencies": {
+                "brace-expansion": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+                    "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+                    "requires": {
+                        "balanced-match": "^1.0.0"
+                    }
+                },
+                "minimatch": {
+                    "version": "5.1.0",
+                    "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.0.tgz",
+                    "integrity": "sha512-9TPBGGak4nHfGZsPBohm9AWg6NoT7QTCehS3BIJABslyZbzxfV78QM2Y6+i741OPZIafFAaiiEMh5OyIrJPgtg==",
+                    "requires": {
+                        "brace-expansion": "^2.0.1"
+                    }
+                }
             }
         },
         "vscode-languageserver": {
-            "version": "8.0.2-next.4",
-            "resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-8.0.2-next.4.tgz",
-            "integrity": "sha512-B3roWH4TmJiB6Zh5+r7zu0QdlLqJsPdGo0LeEi6OiLfrHYCDlcI7DNcQ7F17vWmxC3C82SrxMt/EuLBMpKQM0A==",
+            "version": "8.1.0-next.1",
+            "resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-8.1.0-next.1.tgz",
+            "integrity": "sha512-u14Rk4JgXI+7iS6AEXI2pNc1dWh/5JEXtaqa4TeBECKJlN+5242mbGBBPaHMOE7sSI1Kh66XhEMZJhPYjUfjHw==",
             "requires": {
-                "vscode-languageserver-protocol": "3.17.2-next.5"
+                "vscode-languageserver-protocol": "3.17.3-next.1"
             }
         },
         "vscode-languageserver-protocol": {
-            "version": "3.17.2-next.5",
-            "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.2-next.5.tgz",
-            "integrity": "sha512-UlH+QL4Q4lX94of/UPDDwwWIkd8w7dtMW4khzvEDUoykiG9tba0iG6V0bAiv8XVpnBIUYjL2FNFiL3zl+TY1Sw==",
+            "version": "3.17.3-next.1",
+            "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.3-next.1.tgz",
+            "integrity": "sha512-vgjvPE0zox+1Fi4ljsSFJ+B3g8wGNbuAEEdulueVdv+R2VHtc06+dgxhWiG4LKPqXwjPDmiuxCnvd2xk3fzTTw==",
             "requires": {
-                "vscode-jsonrpc": "8.0.2-next.1",
-                "vscode-languageserver-types": "3.17.2-next.2"
+                "vscode-jsonrpc": "8.1.0-next.1",
+                "vscode-languageserver-types": "3.17.2"
             }
         },
         "vscode-languageserver-types": {
-            "version": "3.17.2-next.2",
-            "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.2-next.2.tgz",
-            "integrity": "sha512-TiAkLABgqkVWdAlC3XlOfdhdjIAdVU4YntPUm9kKGbXr+MGwpVnKz2KZMNBcvG0CFx8Hi8qliL0iq+ndPB720w=="
+            "version": "3.17.2",
+            "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.2.tgz",
+            "integrity": "sha512-zHhCWatviizPIq9B7Vh9uvrH6x3sK8itC84HkamnBWoDFJtzBf7SWlpLCZUit72b3os45h6RWQNC9xHRDF8dRA=="
         },
         "watchpack": {
             "version": "2.4.0",

--- a/packages/vscode-pyright/package.json
+++ b/packages/vscode-pyright/package.json
@@ -866,10 +866,10 @@
         "webpack-dev": "npm run clean && webpack --mode development --watch --progress"
     },
     "dependencies": {
-        "vscode-jsonrpc": "8.0.2-next.1",
-        "vscode-languageclient": "8.0.2-next.4",
-        "vscode-languageserver": "8.0.2-next.4",
-        "vscode-languageserver-protocol": "3.17.2-next.5"
+        "vscode-jsonrpc": "8.1.0-next.1",
+        "vscode-languageclient": "8.1.0-next.1",
+        "vscode-languageserver": "8.1.0-next.1",
+        "vscode-languageserver-protocol": "3.17.3-next.1"
     },
     "devDependencies": {
         "@types/copy-webpack-plugin": "^10.1.0",


### PR DESCRIPTION
- Update LSP to latest versions
- Added VS Code settings for include, exclude, and ignore paths: `python.analysis.include`, `python.analysis.exclude`, `python.analysis.ignore`.
- Made "remove all unused imports" only remove top level imports, and made individual "remove unused import" command remove leading whitespace
- Fixed bug with handling ipython magics that appear after a dedent.