### PR TITLE
Handle case where last positional param is an unpacked unbounded tuple

### DIFF
--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -9251,6 +9251,17 @@ export function createTypeEvaluator(importLookup: ImportLookup, evaluatorOptions
             }
         }
 
+        // If there weren't enough positional arguments to populate all of the
+        // positional-only parameters and the next positional-only parameter is
+        // an unbounded tuple, skip past it.
+        if (
+            positionalOnlyLimitIndex >= 0 &&
+            paramIndex < positionalOnlyLimitIndex &&
+            paramDetails.params[paramIndex].param.category === ParameterCategory.VarArgList
+        ) {
+            paramIndex++;
+        }
+
         // Check if there weren't enough positional arguments to populate all of
         // the positional-only parameters.
         if (

--- a/packages/pyright-internal/src/tests/samples/callable6.py
+++ b/packages/pyright-internal/src/tests/samples/callable6.py
@@ -13,6 +13,7 @@ TA2 = Callable[[int, Unpack[Tuple[int, ...]], Unpack[Tuple[int, int, str]], str]
 
 TA3 = Callable[[int, Unpack[Tuple[int, int]], str], int]
 
+TA4 = Callable[[Unpack[Tuple[int, ...]]], _T]
 
 def func1(x: TA1):
     r1 = x(3, 4, 5, (1, 2, "hi"), "hi")
@@ -35,6 +36,10 @@ def func2(x: TA3):
 
     # This should generate an error.
     x(3, 4, "hi", "hi")
+
+
+def func6(x: TA4):
+    x()
 
 
 Ts = TypeVarTuple("Ts")


### PR DESCRIPTION
Address #3971

If the last positional parameter of a function is an unbounded unpacked tuple and no argument is supplied, we currently report an error ("Expected 1 more positional argument"), even though it's legal to pass 0 arguments for that tuple.

```python
def func(x: Callable[[Unpack[tuple[int, ...]]], None]):
    x() # Expected 1 more positional argument
```

If there's another parameter after the tuple, `matchFunctionArgumentsToParameters` works properly. But if the tuple is the last parameter, we exit the loop that processes positional arguments without running the `ParameterCategory.VarArgList` related logic for the tuple. This means that `paramIndex` doesn't get incremented and thus we report the positional argument count error.

Fixed by checking for this case after the loop and incrementing `paramIndex`.

I considered trying to go around the loop again for this case, but doing that safely required a lot of additional array length checks. This seemed cleaner.

I noticed that in the following scenario we say, "Expected 2 more positional arguments". Would you agree that it should say "Expected 1 more..."? Wanted to get feedback on my approach here before looking into that.

```python
def func(x: Callable[[Unpack[tuple[int, ...]], int], None]):
    x() # Expected 2 more positional arguments
```