### PR TITLE
Fix argsRemainingCount calculation

### DIFF
--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -9290,7 +9290,7 @@ export function createTypeEvaluator(importLookup: ImportLookup, evaluatorOptions
                 (paramInfo) =>
                     paramInfo.param.category === ParameterCategory.VarArgList && !isParamSpec(paramInfo.param.type)
             );
-            if (firstArgsParam >= paramIndex) {
+            if (firstArgsParam >= paramIndex && firstArgsParam < positionalOnlyLimitIndex) {
                 // If there is another args parameter beyond the current param index,
                 // reduce the count by one because it's permitted to pass zero arguments
                 // to *args.

--- a/packages/pyright-internal/src/tests/samples/call3.py
+++ b/packages/pyright-internal/src/tests/samples/call3.py
@@ -153,7 +153,19 @@ def f10(x, *args, /, y):
 def f11(x, *args, *, y):
     pass
 
+def f15(x, /, *args):
+    pass
 
+# This should generate an error because x
+# is a position-only parameter.
+f15(x=1)
+
+def f16(x, /, *args, **kw):
+    pass
+
+# This should generate an error because x
+# is a position-only parameter.
+f16(x=1)
 
 def f12(a: int, b: str, /):
     ...

--- a/packages/pyright-internal/src/tests/typeEvaluator1.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator1.test.ts
@@ -624,12 +624,12 @@ test('Call3', () => {
     // Analyze with Python 3.7 settings. This will generate more errors.
     configOptions.defaultPythonVersion = PythonVersion.V3_7;
     const analysisResults37 = TestUtils.typeAnalyzeSampleFiles(['call3.py'], configOptions);
-    TestUtils.validateResults(analysisResults37, 32);
+    TestUtils.validateResults(analysisResults37, 36);
 
     // Analyze with Python 3.8 settings.
     configOptions.defaultPythonVersion = PythonVersion.V3_8;
     const analysisResults38 = TestUtils.typeAnalyzeSampleFiles(['call3.py'], configOptions);
-    TestUtils.validateResults(analysisResults38, 18);
+    TestUtils.validateResults(analysisResults38, 20);
 });
 
 test('Call4', () => {


### PR DESCRIPTION
Possible fix for #3974. When calculating the number of remaining positional args (`argsRemainingCount`) I think we shouldn't subtract one for a `VarArgList` that is after `positionalOnlyLimitIndex`.

There's a problem with verifying the new tests. Each of the two scenarios should produce one error, but the bug caused them to produce zero and two errors respectively. So both with and without my fix, the total number of errors is 2. Since the validation logic checks the total number of errors in the sample file, it can't tell if the bug has occurred. Should I remove one of the test cases?