### PR TITLE
Don't treat classes decorated with `dataclass_transform` as dataclasses

### DIFF
--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -15094,7 +15094,7 @@ export function createTypeEvaluator(importLookup: ImportLookup, evaluatorOptions
                 return (
                     isClass(mroClass) &&
                     mroClass.details.classDataClassTransform !== undefined &&
-                    mroClass !== classType
+                    !ClassType.isSameGenericClass(mroClass, classType)
                 );
             });
 

--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -15091,7 +15091,11 @@ export function createTypeEvaluator(importLookup: ImportLookup, evaluatorOptions
             dataClassBehaviors = effectiveMetaclass.details.classDataClassTransform;
         } else {
             const baseClassDataTransform = classType.details.mro.find((mroClass) => {
-                return isClass(mroClass) && mroClass.details.classDataClassTransform !== undefined;
+                return (
+                    isClass(mroClass) &&
+                    mroClass.details.classDataClassTransform !== undefined &&
+                    mroClass !== classType
+                );
             });
 
             if (baseClassDataTransform) {

--- a/packages/pyright-internal/src/tests/samples/dataclassTransform2.py
+++ b/packages/pyright-internal/src/tests/samples/dataclassTransform2.py
@@ -23,6 +23,8 @@ def model_field(
     field_specifiers=(ModelField, model_field),
 )
 class ModelMeta(type):
+    not_a_field: str
+
     def __init_subclass__(
         cls,
         *,

--- a/packages/pyright-internal/src/tests/samples/dataclassTransform3.py
+++ b/packages/pyright-internal/src/tests/samples/dataclassTransform3.py
@@ -1,7 +1,7 @@
 # This sample tests the handling of the dataclass_transform mechanism
 # when applied to a class.
 
-from typing import Any, Callable, Optional, Tuple, TypeVar, Union
+from typing import Any, Callable, Generic, Optional, Tuple, TypeVar, Union
 
 _T = TypeVar("_T")
 
@@ -83,3 +83,27 @@ v2 = c2_1 < c2_2
 # This should generate an error because Customer2 supports
 # keyword-only parameters for its constructor.
 c2_3 = Customer2(0, "John")
+
+_T = TypeVar("_T")
+
+@__dataclass_transform__(
+    kw_only_default=True,
+    field_specifiers=(ModelField, model_field),
+)
+class GenericModelBase(Generic[_T]):
+    not_a_field: _T
+
+    def __init_subclass__(
+        cls,
+        *,
+        frozen: bool = False,
+        kw_only: bool = True,
+        order: bool = True,
+    ) -> None:
+        ...
+
+
+class GenericCustomer(GenericModelBase[int]):
+    id: int = model_field()
+
+gc_1 = GenericCustomer(id=3)

--- a/packages/pyright-internal/src/tests/samples/dataclassTransform3.py
+++ b/packages/pyright-internal/src/tests/samples/dataclassTransform3.py
@@ -32,6 +32,8 @@ def model_field(
     field_specifiers=(ModelField, model_field),
 )
 class ModelBase:
+    not_a_field: str
+
     def __init_subclass__(
         cls,
         *,


### PR DESCRIPTION
For https://github.com/microsoft/pylance-release/issues/3304

Attributes on classes decorated with `dataclass_transform` and their base classes should not be treated as dataclasses. That is, attributes on those classes are not fields.

Fixed by not calling `applyDataClassDefaultBehaviors` for these classes.