### PR TITLE
Expand enums in negative narrowing of `x in y`

### DIFF
--- a/packages/pyright-internal/src/analyzer/typeGuards.ts
+++ b/packages/pyright-internal/src/analyzer/typeGuards.ts
@@ -1482,7 +1482,7 @@ function narrowTypeForContainerType(
             if (allLiteralTypes && allLiteralTypes.length > 0) {
                 return combineTypes(
                     allLiteralTypes.filter((type) => !typesToEliminate.some((t) => isTypeSame(t, type)))
-                ); //!ClassType.isLiteralValueSame(type, literalType)
+                );
             }
         }
 

--- a/packages/pyright-internal/src/analyzer/typeGuards.ts
+++ b/packages/pyright-internal/src/analyzer/typeGuards.ts
@@ -1474,6 +1474,18 @@ function narrowTypeForContainerType(
     }
 
     return mapSubtypes(referenceType, (referenceSubtype) => {
+        referenceSubtype = evaluator.makeTopLevelTypeVarsConcrete(referenceSubtype);
+        if (isClassInstance(referenceSubtype) && referenceSubtype.literalValue === undefined) {
+            // If we're able to enumerate all possible literal values
+            // (for bool or enum), we can eliminate all others in a negative test.
+            const allLiteralTypes = enumerateLiteralsForType(evaluator, referenceSubtype);
+            if (allLiteralTypes && allLiteralTypes.length > 0) {
+                return combineTypes(
+                    allLiteralTypes.filter((type) => !typesToEliminate.some((t) => isTypeSame(t, type)))
+                ); //!ClassType.isLiteralValueSame(type, literalType)
+            }
+        }
+
         if (typesToEliminate.some((t) => isTypeSame(t, referenceSubtype))) {
             return undefined;
         }

--- a/packages/pyright-internal/src/tests/samples/typeNarrowingIn2.py
+++ b/packages/pyright-internal/src/tests/samples/typeNarrowingIn2.py
@@ -1,0 +1,25 @@
+# This sample tests type narrowing for Enums using the "in" operator.
+
+import enum
+
+
+class MyEnum(enum.Enum):
+    A = enum.auto()
+    B = enum.auto()
+    C = enum.auto()
+
+
+def func0(x: MyEnum):
+    if x is MyEnum.C:
+        return
+    elif x in (MyEnum.A, MyEnum.B):
+        reveal_type(x, expected_text="Literal[MyEnum.A, MyEnum.B]")
+    else:
+        reveal_type(x, expected_text="Never")
+
+
+def func1(x: MyEnum):
+    if x in (MyEnum.A, MyEnum.B):
+        reveal_type(x, expected_text="Literal[MyEnum.A, MyEnum.B]")
+    else:
+        reveal_type(x, expected_text="Literal[MyEnum.C]")

--- a/packages/pyright-internal/src/tests/typeEvaluator1.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator1.test.ts
@@ -403,6 +403,12 @@ test('TypeNarrowingIn1', () => {
     TestUtils.validateResults(analysisResults, 2);
 });
 
+test('TypeNarrowingIn2', () => {
+    const analysisResults = TestUtils.typeAnalyzeSampleFiles(['typeNarrowingIn2.py']);
+
+    TestUtils.validateResults(analysisResults, 0);
+});
+
 test('TypeNarrowingLiteralMember1', () => {
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['typeNarrowingLiteralMember1.py']);
 


### PR DESCRIPTION
Address #4102

Enhanced `narrowTypeForContainerType` to expand enums into their constituent literals in the negative ("else") narrowing case of `enumInstance in tupleOfEnums`. Previously it would return the enum type.