### PR TITLE
Fix `__init__` method of dataclass with unknown ancestor

### DIFF
--- a/packages/pyright-internal/src/tests/samples/dataclass24.py
+++ b/packages/pyright-internal/src/tests/samples/dataclass24.py
@@ -1,0 +1,20 @@
+# This sample tests the generation of __init__ when some ancestor
+# classes are unknown.
+
+from dataclasses import dataclass
+import abc
+from random import random
+
+C = abc.ABC if random() else object
+
+class B(C):
+    def __init__(self, x: int):
+        pass
+
+
+@dataclass
+class A(B):
+    color: str
+
+
+reveal_type(A.__init__, expected_text="(self: A, *args: Any, **kwargs: Any) -> None")

--- a/packages/pyright-internal/src/tests/typeEvaluator4.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator4.test.ts
@@ -615,6 +615,12 @@ test('DataClass23', () => {
     TestUtils.validateResults(analysisResults, 0);
 });
 
+test('DataClass24', () => {
+    const analysisResults = TestUtils.typeAnalyzeSampleFiles(['dataclass24.py']);
+
+    TestUtils.validateResults(analysisResults, 1);
+});
+
 test('DataClassPostInit1', () => {
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['dataclassPostInit1.py']);
 


### PR DESCRIPTION
Address https://github.com/microsoft/pylance-release/issues/3512

When a dataclass has unknown ancestor types, we call `FunctionType.addDefaultParameters(initType)` to configure the `__init__` method with args and kwargs. But then we don't actually use the `__init__` method that we've set up.

Fixed to call `symbolTable.set` for `__init__` in this scenario.