### PR TITLE
Split TreeWalker to Visitor and getChildNodes

### DIFF
--- a/packages/pyright-internal/src/analyzer/parseTreeUtils.ts
+++ b/packages/pyright-internal/src/analyzer/parseTreeUtils.ts
@@ -44,7 +44,7 @@ import {
 import { TokenizerOutput } from '../parser/tokenizer';
 import { KeywordType, OperatorType, StringToken, StringTokenFlags, Token, TokenType } from '../parser/tokenizerTypes';
 import { getScope } from './analyzerNodeInfo';
-import { ParseTreeWalker } from './parseTreeWalker';
+import { getChildNodes, ParseTreeWalker } from './parseTreeWalker';
 
 export const enum PrintExpressionFlags {
     None = 0,
@@ -91,11 +91,9 @@ export function findNodeByOffset(node: ParseNode, offset: number): ParseNode | u
         return undefined;
     }
 
-    const parseTreeWalker = new ParseTreeWalker();
-
     // The range is found within this node. See if we can localize it
     // further by checking its children.
-    const children = parseTreeWalker.visitNode(node);
+    const children = getChildNodes(node);
     for (const child of children) {
         if (child) {
             const containingChild = findNodeByOffset(child, offset);

--- a/packages/pyright-internal/src/analyzer/parseTreeWalker.ts
+++ b/packages/pyright-internal/src/analyzer/parseTreeWalker.ts
@@ -7,6 +7,7 @@
  * Class that traverses a parse tree.
  */
 
+import * as debug from '../common/debug';
 import {
     ArgumentNode,
     AssertNode,
@@ -91,9 +92,827 @@ import {
     YieldNode,
 } from '../parser/parseNodes';
 
+/// Get child nodes of the given node.
+/// We could make this one a visitor but then we will lose ability to check
+/// whether we added a case for the new kind at the compile time.
+export function getChildNodes(node: ParseNode) {
+    switch (node.nodeType) {
+        case ParseNodeType.Error:
+            return [node.child, ...(node.decorators ?? [])];
+
+        case ParseNodeType.Argument:
+            return [node.name, node.valueExpression];
+
+        case ParseNodeType.Assert:
+            return [node.testExpression, node.exceptionExpression];
+
+        case ParseNodeType.AssignmentExpression:
+            return [node.name, node.rightExpression];
+
+        case ParseNodeType.Assignment:
+            return [node.leftExpression, node.rightExpression, node.typeAnnotationComment];
+
+        case ParseNodeType.AugmentedAssignment:
+            return [node.leftExpression, node.rightExpression];
+
+        case ParseNodeType.Await:
+            return [node.expression];
+
+        case ParseNodeType.BinaryOperation:
+            return [node.leftExpression, node.rightExpression];
+
+        case ParseNodeType.Break:
+            return [];
+
+        case ParseNodeType.Call:
+            return [node.leftExpression, ...node.arguments];
+
+        case ParseNodeType.Case:
+            return [node.pattern, node.guardExpression, node.suite];
+
+        case ParseNodeType.Class:
+            return [...node.decorators, node.name, node.typeParameters, ...node.arguments, node.suite];
+
+        case ParseNodeType.Constant:
+            return [];
+
+        case ParseNodeType.Continue:
+            return [];
+
+        case ParseNodeType.Decorator:
+            return [node.expression];
+
+        case ParseNodeType.Del:
+            return node.expressions;
+
+        case ParseNodeType.Dictionary:
+            return node.entries;
+
+        case ParseNodeType.DictionaryExpandEntry:
+            return [node.expandExpression];
+
+        case ParseNodeType.DictionaryKeyEntry:
+            return [node.keyExpression, node.valueExpression];
+
+        case ParseNodeType.Ellipsis:
+            return [];
+
+        case ParseNodeType.If:
+            return [node.testExpression, node.ifSuite, node.elseSuite];
+
+        case ParseNodeType.Import:
+            return node.list;
+
+        case ParseNodeType.ImportAs:
+            return [node.module, node.alias];
+
+        case ParseNodeType.ImportFrom:
+            return [node.module, ...node.imports];
+
+        case ParseNodeType.ImportFromAs:
+            return [node.name, node.alias];
+
+        case ParseNodeType.Index:
+            return [node.baseExpression, ...node.items];
+
+        case ParseNodeType.Except:
+            return [node.typeExpression, node.name, node.exceptSuite];
+
+        case ParseNodeType.For:
+            return [node.targetExpression, node.iterableExpression, node.forSuite, node.elseSuite];
+
+        case ParseNodeType.FormatString:
+            return node.expressions;
+
+        case ParseNodeType.Function:
+            return [
+                ...node.decorators,
+                node.name,
+                node.typeParameters,
+                ...node.parameters,
+                node.returnTypeAnnotation,
+                node.functionAnnotationComment,
+                node.suite,
+            ];
+
+        case ParseNodeType.FunctionAnnotation:
+            return [...node.paramTypeAnnotations, node.returnTypeAnnotation];
+
+        case ParseNodeType.Global:
+            return node.nameList;
+
+        case ParseNodeType.Lambda:
+            return [...node.parameters, node.expression];
+
+        case ParseNodeType.List:
+            return node.entries;
+
+        case ParseNodeType.ListComprehension:
+            return [node.expression, ...node.forIfNodes];
+
+        case ParseNodeType.ListComprehensionFor:
+            return [node.targetExpression, node.iterableExpression];
+
+        case ParseNodeType.ListComprehensionIf:
+            return [node.testExpression];
+
+        case ParseNodeType.Match:
+            return [node.subjectExpression, ...node.cases];
+
+        case ParseNodeType.MemberAccess:
+            return [node.leftExpression, node.memberName];
+
+        case ParseNodeType.ModuleName:
+            return node.nameParts;
+
+        case ParseNodeType.Module:
+            return [...node.statements];
+
+        case ParseNodeType.Name:
+            return [];
+
+        case ParseNodeType.Nonlocal:
+            return node.nameList;
+
+        case ParseNodeType.Number:
+            return [];
+
+        case ParseNodeType.Parameter:
+            return [node.name, node.typeAnnotation, node.typeAnnotationComment, node.defaultValue];
+
+        case ParseNodeType.Pass:
+            return [];
+
+        case ParseNodeType.PatternAs:
+            return [...node.orPatterns, node.target];
+
+        case ParseNodeType.PatternClass:
+            return [node.className, ...node.arguments];
+
+        case ParseNodeType.PatternClassArgument:
+            return [node.name, node.pattern];
+
+        case ParseNodeType.PatternCapture:
+            return [node.target];
+
+        case ParseNodeType.PatternLiteral:
+            return [node.expression];
+
+        case ParseNodeType.PatternMappingExpandEntry:
+            return [node.target];
+
+        case ParseNodeType.PatternMappingKeyEntry:
+            return [node.keyPattern, node.valuePattern];
+
+        case ParseNodeType.PatternMapping:
+            return [...node.entries];
+
+        case ParseNodeType.PatternSequence:
+            return [...node.entries];
+
+        case ParseNodeType.PatternValue:
+            return [node.expression];
+
+        case ParseNodeType.Raise:
+            return [node.typeExpression, node.valueExpression, node.tracebackExpression];
+
+        case ParseNodeType.Return:
+            return [node.returnExpression];
+
+        case ParseNodeType.Set:
+            return node.entries;
+
+        case ParseNodeType.Slice:
+            return [node.startValue, node.endValue, node.stepValue];
+
+        case ParseNodeType.StatementList:
+            return node.statements;
+
+        case ParseNodeType.StringList:
+            return [node.typeAnnotation, ...node.strings];
+
+        case ParseNodeType.String:
+            return [];
+
+        case ParseNodeType.Suite:
+            return [...node.statements];
+
+        case ParseNodeType.Ternary:
+            return [node.ifExpression, node.testExpression, node.elseExpression];
+
+        case ParseNodeType.Tuple:
+            return node.expressions;
+
+        case ParseNodeType.Try:
+            return [node.trySuite, ...node.exceptClauses, node.elseSuite, node.finallySuite];
+
+        case ParseNodeType.TypeAlias:
+            return [node.name, node.typeParameters, node.expression];
+
+        case ParseNodeType.TypeAnnotation:
+            return [node.valueExpression, node.typeAnnotation];
+
+        case ParseNodeType.TypeParameter:
+            return [node.name, node.boundExpression];
+
+        case ParseNodeType.TypeParameterList:
+            return [...node.parameters];
+
+        case ParseNodeType.UnaryOperation:
+            return [node.expression];
+
+        case ParseNodeType.Unpack:
+            return [node.expression];
+
+        case ParseNodeType.While:
+            return [node.testExpression, node.whileSuite, node.elseSuite];
+
+        case ParseNodeType.With:
+            return [...node.withItems, node.suite];
+
+        case ParseNodeType.WithItem:
+            return [node.expression, node.target];
+
+        case ParseNodeType.Yield:
+            return [node.expression];
+
+        case ParseNodeType.YieldFrom:
+            return [node.expression];
+
+        default:
+            debug.assertNever(node, `Unknown node type ${node}`);
+    }
+}
+
 // To use this class, create a subclass and override the
 // visitXXX methods that you want to handle.
-export class ParseTreeWalker {
+export class ParseTreeVisitor<T> {
+    constructor(private readonly _default: T) {
+        // empty
+    }
+
+    visit(node: ParseNode): T {
+        switch (node.nodeType) {
+            case ParseNodeType.Error:
+                return this.visitError(node);
+
+            case ParseNodeType.Argument:
+                return this.visitArgument(node);
+
+            case ParseNodeType.Assert:
+                return this.visitAssert(node);
+
+            case ParseNodeType.AssignmentExpression:
+                return this.visitAssignmentExpression(node);
+
+            case ParseNodeType.Assignment:
+                return this.visitAssignment(node);
+
+            case ParseNodeType.AugmentedAssignment:
+                return this.visitAugmentedAssignment(node);
+
+            case ParseNodeType.Await:
+                return this.visitAwait(node);
+
+            case ParseNodeType.BinaryOperation:
+                return this.visitBinaryOperation(node);
+
+            case ParseNodeType.Break:
+                return this.visitBreak(node);
+
+            case ParseNodeType.Call:
+                return this.visitCall(node);
+
+            case ParseNodeType.Case:
+                return this.visitCase(node);
+
+            case ParseNodeType.Class:
+                return this.visitClass(node);
+
+            case ParseNodeType.Constant:
+                return this.visitConstant(node);
+
+            case ParseNodeType.Continue:
+                return this.visitContinue(node);
+
+            case ParseNodeType.Decorator:
+                return this.visitDecorator(node);
+
+            case ParseNodeType.Del:
+                return this.visitDel(node);
+
+            case ParseNodeType.Dictionary:
+                return this.visitDictionary(node);
+
+            case ParseNodeType.DictionaryExpandEntry:
+                return this.visitDictionaryExpandEntry(node);
+
+            case ParseNodeType.DictionaryKeyEntry:
+                return this.visitDictionaryKeyEntry(node);
+
+            case ParseNodeType.Ellipsis:
+                return this.visitEllipsis(node);
+
+            case ParseNodeType.If:
+                return this.visitIf(node);
+
+            case ParseNodeType.Import:
+                return this.visitImport(node);
+
+            case ParseNodeType.ImportAs:
+                return this.visitImportAs(node);
+
+            case ParseNodeType.ImportFrom:
+                return this.visitImportFrom(node);
+
+            case ParseNodeType.ImportFromAs:
+                return this.visitImportFromAs(node);
+
+            case ParseNodeType.Index:
+                return this.visitIndex(node);
+
+            case ParseNodeType.Except:
+                return this.visitExcept(node);
+
+            case ParseNodeType.For:
+                return this.visitFor(node);
+
+            case ParseNodeType.FormatString:
+                return this.visitFormatString(node);
+
+            case ParseNodeType.Function:
+                return this.visitFunction(node);
+
+            case ParseNodeType.FunctionAnnotation:
+                return this.visitFunctionAnnotation(node);
+
+            case ParseNodeType.Global:
+                return this.visitGlobal(node);
+
+            case ParseNodeType.Lambda:
+                return this.visitLambda(node);
+
+            case ParseNodeType.List:
+                return this.visitList(node);
+
+            case ParseNodeType.ListComprehension:
+                return this.visitListComprehension(node);
+
+            case ParseNodeType.ListComprehensionFor:
+                return this.visitListComprehensionFor(node);
+
+            case ParseNodeType.ListComprehensionIf:
+                return this.visitListComprehensionIf(node);
+
+            case ParseNodeType.Match:
+                return this.visitMatch(node);
+
+            case ParseNodeType.MemberAccess:
+                return this.visitMemberAccess(node);
+
+            case ParseNodeType.ModuleName:
+                return this.visitModuleName(node);
+
+            case ParseNodeType.Module:
+                return this.visitModule(node);
+
+            case ParseNodeType.Name:
+                return this.visitName(node);
+
+            case ParseNodeType.Nonlocal:
+                return this.visitNonlocal(node);
+
+            case ParseNodeType.Number:
+                return this.visitNumber(node);
+
+            case ParseNodeType.Parameter:
+                return this.visitParameter(node);
+
+            case ParseNodeType.Pass:
+                return this.visitPass(node);
+
+            case ParseNodeType.PatternAs:
+                return this.visitPatternAs(node);
+
+            case ParseNodeType.PatternClass:
+                return this.visitPatternClass(node);
+
+            case ParseNodeType.PatternClassArgument:
+                return this.visitPatternClassArgument(node);
+
+            case ParseNodeType.PatternCapture:
+                return this.visitPatternCapture(node);
+
+            case ParseNodeType.PatternLiteral:
+                return this.visitPatternLiteral(node);
+
+            case ParseNodeType.PatternMappingExpandEntry:
+                return this.visitPatternMappingExpandEntry(node);
+
+            case ParseNodeType.PatternMappingKeyEntry:
+                return this.visitPatternMappingKeyEntry(node);
+
+            case ParseNodeType.PatternMapping:
+                return this.visitPatternMapping(node);
+
+            case ParseNodeType.PatternSequence:
+                return this.visitPatternSequence(node);
+
+            case ParseNodeType.PatternValue:
+                return this.visitPatternValue(node);
+
+            case ParseNodeType.Raise:
+                return this.visitRaise(node);
+
+            case ParseNodeType.Return:
+                return this.visitReturn(node);
+
+            case ParseNodeType.Set:
+                return this.visitSet(node);
+
+            case ParseNodeType.Slice:
+                return this.visitSlice(node);
+
+            case ParseNodeType.StatementList:
+                return this.visitStatementList(node);
+
+            case ParseNodeType.StringList:
+                return this.visitStringList(node);
+
+            case ParseNodeType.String:
+                return this.visitString(node);
+
+            case ParseNodeType.Suite:
+                return this.visitSuite(node);
+
+            case ParseNodeType.Ternary:
+                return this.visitTernary(node);
+
+            case ParseNodeType.Tuple:
+                return this.visitTuple(node);
+
+            case ParseNodeType.Try:
+                return this.visitTry(node);
+
+            case ParseNodeType.TypeAlias:
+                return this.visitTypeAlias(node);
+
+            case ParseNodeType.TypeAnnotation:
+                return this.visitTypeAnnotation(node);
+
+            case ParseNodeType.TypeParameter:
+                return this.visitTypeParameter(node);
+
+            case ParseNodeType.TypeParameterList:
+                return this.visitTypeParameterList(node);
+
+            case ParseNodeType.UnaryOperation:
+                return this.visitUnaryOperation(node);
+
+            case ParseNodeType.Unpack:
+                return this.visitUnpack(node);
+
+            case ParseNodeType.While:
+                return this.visitWhile(node);
+
+            case ParseNodeType.With:
+                return this.visitWith(node);
+
+            case ParseNodeType.WithItem:
+                return this.visitWithItem(node);
+
+            case ParseNodeType.Yield:
+                return this.visitYield(node);
+
+            case ParseNodeType.YieldFrom:
+                return this.visitYieldFrom(node);
+
+            default:
+                debug.assertNever(node, `Unknown node type ${node}`);
+        }
+    }
+
+    // Override these methods as necessary.
+    visitArgument(node: ArgumentNode) {
+        return this._default;
+    }
+
+    visitAssert(node: AssertNode) {
+        return this._default;
+    }
+
+    visitAssignment(node: AssignmentNode) {
+        return this._default;
+    }
+
+    visitAssignmentExpression(node: AssignmentExpressionNode) {
+        return this._default;
+    }
+
+    visitAugmentedAssignment(node: AugmentedAssignmentNode) {
+        return this._default;
+    }
+
+    visitAwait(node: AwaitNode) {
+        return this._default;
+    }
+
+    visitBinaryOperation(node: BinaryOperationNode) {
+        return this._default;
+    }
+
+    visitBreak(node: BreakNode) {
+        return this._default;
+    }
+
+    visitCall(node: CallNode) {
+        return this._default;
+    }
+
+    visitCase(node: CaseNode) {
+        return this._default;
+    }
+
+    visitClass(node: ClassNode) {
+        return this._default;
+    }
+
+    visitTernary(node: TernaryNode) {
+        return this._default;
+    }
+
+    visitContinue(node: ContinueNode) {
+        return this._default;
+    }
+
+    visitConstant(node: ConstantNode) {
+        return this._default;
+    }
+
+    visitDecorator(node: DecoratorNode) {
+        return this._default;
+    }
+
+    visitDel(node: DelNode) {
+        return this._default;
+    }
+
+    visitDictionary(node: DictionaryNode) {
+        return this._default;
+    }
+
+    visitDictionaryKeyEntry(node: DictionaryKeyEntryNode) {
+        return this._default;
+    }
+
+    visitDictionaryExpandEntry(node: DictionaryExpandEntryNode) {
+        return this._default;
+    }
+
+    visitError(node: ErrorNode) {
+        return this._default;
+    }
+
+    visitEllipsis(node: EllipsisNode) {
+        return this._default;
+    }
+
+    visitIf(node: IfNode) {
+        return this._default;
+    }
+
+    visitImport(node: ImportNode) {
+        return this._default;
+    }
+
+    visitImportAs(node: ImportAsNode) {
+        return this._default;
+    }
+
+    visitImportFrom(node: ImportFromNode) {
+        return this._default;
+    }
+
+    visitImportFromAs(node: ImportFromAsNode) {
+        return this._default;
+    }
+
+    visitIndex(node: IndexNode) {
+        return this._default;
+    }
+
+    visitExcept(node: ExceptNode) {
+        return this._default;
+    }
+
+    visitFor(node: ForNode) {
+        return this._default;
+    }
+
+    visitFormatString(node: FormatStringNode) {
+        return this._default;
+    }
+
+    visitFunction(node: FunctionNode) {
+        return this._default;
+    }
+
+    visitFunctionAnnotation(node: FunctionAnnotationNode) {
+        return this._default;
+    }
+
+    visitGlobal(node: GlobalNode) {
+        return this._default;
+    }
+
+    visitLambda(node: LambdaNode) {
+        return this._default;
+    }
+
+    visitList(node: ListNode) {
+        return this._default;
+    }
+
+    visitListComprehension(node: ListComprehensionNode) {
+        return this._default;
+    }
+
+    visitListComprehensionFor(node: ListComprehensionForNode) {
+        return this._default;
+    }
+
+    visitListComprehensionIf(node: ListComprehensionIfNode) {
+        return this._default;
+    }
+
+    visitMatch(node: MatchNode) {
+        return this._default;
+    }
+
+    visitMemberAccess(node: MemberAccessNode) {
+        return this._default;
+    }
+
+    visitModule(node: ModuleNode) {
+        return this._default;
+    }
+
+    visitModuleName(node: ModuleNameNode) {
+        return this._default;
+    }
+
+    visitName(node: NameNode) {
+        return this._default;
+    }
+
+    visitNonlocal(node: NonlocalNode) {
+        return this._default;
+    }
+
+    visitNumber(node: NumberNode) {
+        return this._default;
+    }
+
+    visitParameter(node: ParameterNode) {
+        return this._default;
+    }
+
+    visitPass(node: PassNode) {
+        return this._default;
+    }
+
+    visitPatternCapture(node: PatternCaptureNode) {
+        return this._default;
+    }
+
+    visitPatternClass(node: PatternClassNode) {
+        return this._default;
+    }
+
+    visitPatternClassArgument(node: PatternClassArgumentNode) {
+        return this._default;
+    }
+
+    visitPatternAs(node: PatternAsNode) {
+        return this._default;
+    }
+
+    visitPatternLiteral(node: PatternLiteralNode) {
+        return this._default;
+    }
+
+    visitPatternMappingExpandEntry(node: PatternMappingExpandEntryNode) {
+        return this._default;
+    }
+
+    visitPatternSequence(node: PatternSequenceNode) {
+        return this._default;
+    }
+
+    visitPatternValue(node: PatternValueNode) {
+        return this._default;
+    }
+
+    visitPatternMappingKeyEntry(node: PatternMappingKeyEntryNode) {
+        return this._default;
+    }
+
+    visitPatternMapping(node: PatternMappingNode) {
+        return this._default;
+    }
+
+    visitRaise(node: RaiseNode) {
+        return this._default;
+    }
+
+    visitReturn(node: ReturnNode) {
+        return this._default;
+    }
+
+    visitSet(node: SetNode) {
+        return this._default;
+    }
+
+    visitSlice(node: SliceNode) {
+        return this._default;
+    }
+
+    visitStatementList(node: StatementListNode) {
+        return this._default;
+    }
+
+    visitString(node: StringNode) {
+        return this._default;
+    }
+
+    visitStringList(node: StringListNode) {
+        return this._default;
+    }
+
+    visitSuite(node: SuiteNode) {
+        return this._default;
+    }
+
+    visitTuple(node: TupleNode) {
+        return this._default;
+    }
+
+    visitTry(node: TryNode) {
+        return this._default;
+    }
+
+    visitTypeAlias(node: TypeAliasNode) {
+        return this._default;
+    }
+
+    visitTypeAnnotation(node: TypeAnnotationNode) {
+        return this._default;
+    }
+
+    visitTypeParameter(node: TypeParameterNode) {
+        return this._default;
+    }
+
+    visitTypeParameterList(node: TypeParameterListNode) {
+        return this._default;
+    }
+
+    visitUnaryOperation(node: UnaryOperationNode) {
+        return this._default;
+    }
+
+    visitUnpack(node: UnpackNode) {
+        return this._default;
+    }
+
+    visitWhile(node: WhileNode) {
+        return this._default;
+    }
+
+    visitWith(node: WithNode) {
+        return this._default;
+    }
+
+    visitWithItem(node: WithItemNode) {
+        return this._default;
+    }
+
+    visitYield(node: YieldNode) {
+        return this._default;
+    }
+
+    visitYieldFrom(node: YieldFromNode) {
+        return this._default;
+    }
+}
+
+// To use this class, create a subclass and override the
+// visitXXX methods that you want to handle.
+export class ParseTreeWalker extends ParseTreeVisitor<boolean> {
+    constructor() {
+        super(/* default */ true);
+    }
+
     walk(node: ParseNode): void {
         const childrenToWalk = this.visitNode(node);
         if (childrenToWalk.length > 0) {
@@ -109,582 +928,10 @@ export class ParseTreeWalker {
         });
     }
 
-    // Calls the node-specific method (visitXXXX). If the method
-    // returns true, all child nodes for the node are returned.
-    // If the method returns false, we assume that the handler
-    // has already handled the child nodes, so an empty list is
-    // returned.
+    // If this.visit(node) returns true, all child nodes for the node are returned.
+    // If the method returns false, we assume that the handler has already handled the
+    // child nodes, so an empty list is returned.
     visitNode(node: ParseNode): ParseNodeArray {
-        switch (node.nodeType) {
-            case ParseNodeType.Error:
-                return this.visitError(node) ? [node.child, ...(node.decorators ?? [])] : [];
-
-            case ParseNodeType.Argument:
-                return this.visitArgument(node) ? [node.name, node.valueExpression] : [];
-
-            case ParseNodeType.Assert:
-                return this.visitAssert(node) ? [node.testExpression, node.exceptionExpression] : [];
-
-            case ParseNodeType.AssignmentExpression:
-                return this.visitAssignmentExpression(node) ? [node.name, node.rightExpression] : [];
-
-            case ParseNodeType.Assignment:
-                return this.visitAssignment(node)
-                    ? [node.leftExpression, node.rightExpression, node.typeAnnotationComment]
-                    : [];
-
-            case ParseNodeType.AugmentedAssignment:
-                return this.visitAugmentedAssignment(node) ? [node.leftExpression, node.rightExpression] : [];
-
-            case ParseNodeType.Await:
-                return this.visitAwait(node) ? [node.expression] : [];
-
-            case ParseNodeType.BinaryOperation:
-                return this.visitBinaryOperation(node) ? [node.leftExpression, node.rightExpression] : [];
-
-            case ParseNodeType.Break:
-                return this.visitBreak(node) ? [] : [];
-
-            case ParseNodeType.Call:
-                return this.visitCall(node) ? [node.leftExpression, ...node.arguments] : [];
-
-            case ParseNodeType.Case:
-                return this.visitCase(node) ? [node.pattern, node.guardExpression, node.suite] : [];
-
-            case ParseNodeType.Class:
-                return this.visitClass(node)
-                    ? [...node.decorators, node.name, node.typeParameters, ...node.arguments, node.suite]
-                    : [];
-
-            case ParseNodeType.Constant:
-                return this.visitConstant(node) ? [] : [];
-
-            case ParseNodeType.Continue:
-                return this.visitContinue(node) ? [] : [];
-
-            case ParseNodeType.Decorator:
-                return this.visitDecorator(node) ? [node.expression] : [];
-
-            case ParseNodeType.Del:
-                return this.visitDel(node) ? node.expressions : [];
-
-            case ParseNodeType.Dictionary:
-                return this.visitDictionary(node) ? node.entries : [];
-
-            case ParseNodeType.DictionaryExpandEntry:
-                return this.visitDictionaryExpandEntry(node) ? [node.expandExpression] : [];
-
-            case ParseNodeType.DictionaryKeyEntry:
-                return this.visitDictionaryKeyEntry(node) ? [node.keyExpression, node.valueExpression] : [];
-
-            case ParseNodeType.Ellipsis:
-                return this.visitEllipsis(node) ? [] : [];
-
-            case ParseNodeType.If:
-                return this.visitIf(node) ? [node.testExpression, node.ifSuite, node.elseSuite] : [];
-
-            case ParseNodeType.Import:
-                return this.visitImport(node) ? node.list : [];
-
-            case ParseNodeType.ImportAs:
-                return this.visitImportAs(node) ? [node.module, node.alias] : [];
-
-            case ParseNodeType.ImportFrom:
-                return this.visitImportFrom(node) ? [node.module, ...node.imports] : [];
-
-            case ParseNodeType.ImportFromAs:
-                return this.visitImportFromAs(node) ? [node.name, node.alias] : [];
-
-            case ParseNodeType.Index:
-                return this.visitIndex(node) ? [node.baseExpression, ...node.items] : [];
-
-            case ParseNodeType.Except:
-                return this.visitExcept(node) ? [node.typeExpression, node.name, node.exceptSuite] : [];
-
-            case ParseNodeType.For:
-                return this.visitFor(node)
-                    ? [node.targetExpression, node.iterableExpression, node.forSuite, node.elseSuite]
-                    : [];
-
-            case ParseNodeType.FormatString:
-                return this.visitFormatString(node) ? node.expressions : [];
-
-            case ParseNodeType.Function:
-                return this.visitFunction(node)
-                    ? [
-                          ...node.decorators,
-                          node.name,
-                          node.typeParameters,
-                          ...node.parameters,
-                          node.returnTypeAnnotation,
-                          node.functionAnnotationComment,
-                          node.suite,
-                      ]
-                    : [];
-
-            case ParseNodeType.FunctionAnnotation:
-                return this.visitFunctionAnnotation(node)
-                    ? [...node.paramTypeAnnotations, node.returnTypeAnnotation]
-                    : [];
-
-            case ParseNodeType.Global:
-                return this.visitGlobal(node) ? node.nameList : [];
-
-            case ParseNodeType.Lambda:
-                return this.visitLambda(node) ? [...node.parameters, node.expression] : [];
-
-            case ParseNodeType.List:
-                return this.visitList(node) ? node.entries : [];
-
-            case ParseNodeType.ListComprehension:
-                return this.visitListComprehension(node) ? [node.expression, ...node.forIfNodes] : [];
-
-            case ParseNodeType.ListComprehensionFor:
-                return this.visitListComprehensionFor(node) ? [node.targetExpression, node.iterableExpression] : [];
-
-            case ParseNodeType.ListComprehensionIf:
-                return this.visitListComprehensionIf(node) ? [node.testExpression] : [];
-
-            case ParseNodeType.Match:
-                return this.visitMatch(node) ? [node.subjectExpression, ...node.cases] : [];
-
-            case ParseNodeType.MemberAccess:
-                return this.visitMemberAccess(node) ? [node.leftExpression, node.memberName] : [];
-
-            case ParseNodeType.ModuleName:
-                return this.visitModuleName(node) ? node.nameParts : [];
-
-            case ParseNodeType.Module:
-                return this.visitModule(node) ? [...node.statements] : [];
-
-            case ParseNodeType.Name:
-                return this.visitName(node) ? [] : [];
-
-            case ParseNodeType.Nonlocal:
-                return this.visitNonlocal(node) ? node.nameList : [];
-
-            case ParseNodeType.Number:
-                return this.visitNumber(node) ? [] : [];
-
-            case ParseNodeType.Parameter:
-                return this.visitParameter(node)
-                    ? [node.name, node.typeAnnotation, node.typeAnnotationComment, node.defaultValue]
-                    : [];
-
-            case ParseNodeType.Pass:
-                return this.visitPass(node) ? [] : [];
-
-            case ParseNodeType.PatternAs:
-                return this.visitPatternAs(node) ? [...node.orPatterns, node.target] : [];
-
-            case ParseNodeType.PatternClass:
-                return this.visitPatternClass(node) ? [node.className, ...node.arguments] : [];
-
-            case ParseNodeType.PatternClassArgument:
-                return this.visitPatternClassArgument(node) ? [node.name, node.pattern] : [];
-
-            case ParseNodeType.PatternCapture:
-                return this.visitPatternCapture(node) ? [node.target] : [];
-
-            case ParseNodeType.PatternLiteral:
-                return this.visitPatternLiteral(node) ? [node.expression] : [];
-
-            case ParseNodeType.PatternMappingExpandEntry:
-                return this.visitPatternMappingExpandEntry(node) ? [node.target] : [];
-
-            case ParseNodeType.PatternMappingKeyEntry:
-                return this.visitPatternMappingKeyEntry(node) ? [node.keyPattern, node.valuePattern] : [];
-
-            case ParseNodeType.PatternMapping:
-                return this.visitPatternMapping(node) ? [...node.entries] : [];
-
-            case ParseNodeType.PatternSequence:
-                return this.visitPatternSequence(node) ? [...node.entries] : [];
-
-            case ParseNodeType.PatternValue:
-                return this.visitPatternValue(node) ? [node.expression] : [];
-            case ParseNodeType.Raise:
-                return this.visitRaise(node)
-                    ? [node.typeExpression, node.valueExpression, node.tracebackExpression]
-                    : [];
-
-            case ParseNodeType.Return:
-                return this.visitReturn(node) ? [node.returnExpression] : [];
-
-            case ParseNodeType.Set:
-                return this.visitSet(node) ? node.entries : [];
-
-            case ParseNodeType.Slice:
-                return this.visitSlice(node) ? [node.startValue, node.endValue, node.stepValue] : [];
-
-            case ParseNodeType.StatementList:
-                return this.visitStatementList(node) ? node.statements : [];
-
-            case ParseNodeType.StringList:
-                return this.visitStringList(node) ? [node.typeAnnotation, ...node.strings] : [];
-
-            case ParseNodeType.String:
-                return this.visitString(node) ? [] : [];
-
-            case ParseNodeType.Suite:
-                return this.visitSuite(node) ? [...node.statements] : [];
-
-            case ParseNodeType.Ternary:
-                return this.visitTernary(node) ? [node.ifExpression, node.testExpression, node.elseExpression] : [];
-
-            case ParseNodeType.Tuple:
-                return this.visitTuple(node) ? node.expressions : [];
-
-            case ParseNodeType.Try:
-                return this.visitTry(node)
-                    ? [node.trySuite, ...node.exceptClauses, node.elseSuite, node.finallySuite]
-                    : [];
-
-            case ParseNodeType.TypeAlias:
-                return this.visitTypeAlias(node) ? [node.name, node.typeParameters, node.expression] : [];
-
-            case ParseNodeType.TypeAnnotation:
-                return this.visitTypeAnnotation(node) ? [node.valueExpression, node.typeAnnotation] : [];
-
-            case ParseNodeType.TypeParameter:
-                return this.visitTypeParameter(node) ? [node.name, node.boundExpression] : [];
-
-            case ParseNodeType.TypeParameterList:
-                return this.visitTypeParameterList(node) ? [...node.parameters] : [];
-
-            case ParseNodeType.UnaryOperation:
-                return this.visitUnaryOperation(node) ? [node.expression] : [];
-
-            case ParseNodeType.Unpack:
-                return this.visitUnpack(node) ? [node.expression] : [];
-
-            case ParseNodeType.While:
-                return this.visitWhile(node) ? [node.testExpression, node.whileSuite, node.elseSuite] : [];
-
-            case ParseNodeType.With:
-                return this.visitWith(node) ? [...node.withItems, node.suite] : [];
-
-            case ParseNodeType.WithItem:
-                return this.visitWithItem(node) ? [node.expression, node.target] : [];
-
-            case ParseNodeType.Yield:
-                return this.visitYield(node) ? [node.expression] : [];
-
-            case ParseNodeType.YieldFrom:
-                return this.visitYieldFrom(node) ? [node.expression] : [];
-        }
-    }
-
-    // Override these methods as necessary.
-    visitArgument(node: ArgumentNode) {
-        return true;
-    }
-
-    visitAssert(node: AssertNode) {
-        return true;
-    }
-
-    visitAssignment(node: AssignmentNode) {
-        return true;
-    }
-
-    visitAssignmentExpression(node: AssignmentExpressionNode) {
-        return true;
-    }
-
-    visitAugmentedAssignment(node: AugmentedAssignmentNode) {
-        return true;
-    }
-
-    visitAwait(node: AwaitNode) {
-        return true;
-    }
-
-    visitBinaryOperation(node: BinaryOperationNode) {
-        return true;
-    }
-
-    visitBreak(node: BreakNode) {
-        return true;
-    }
-
-    visitCall(node: CallNode) {
-        return true;
-    }
-
-    visitCase(node: CaseNode) {
-        return true;
-    }
-
-    visitClass(node: ClassNode) {
-        return true;
-    }
-
-    visitTernary(node: TernaryNode) {
-        return true;
-    }
-
-    visitContinue(node: ContinueNode) {
-        return true;
-    }
-
-    visitConstant(node: ConstantNode) {
-        return true;
-    }
-
-    visitDecorator(node: DecoratorNode) {
-        return true;
-    }
-
-    visitDel(node: DelNode) {
-        return true;
-    }
-
-    visitDictionary(node: DictionaryNode) {
-        return true;
-    }
-
-    visitDictionaryKeyEntry(node: DictionaryKeyEntryNode) {
-        return true;
-    }
-
-    visitDictionaryExpandEntry(node: DictionaryExpandEntryNode) {
-        return true;
-    }
-
-    visitError(node: ErrorNode) {
-        return true;
-    }
-
-    visitEllipsis(node: EllipsisNode) {
-        return true;
-    }
-
-    visitIf(node: IfNode) {
-        return true;
-    }
-
-    visitImport(node: ImportNode) {
-        return true;
-    }
-
-    visitImportAs(node: ImportAsNode) {
-        return true;
-    }
-
-    visitImportFrom(node: ImportFromNode) {
-        return true;
-    }
-
-    visitImportFromAs(node: ImportFromAsNode) {
-        return true;
-    }
-
-    visitIndex(node: IndexNode) {
-        return true;
-    }
-
-    visitExcept(node: ExceptNode) {
-        return true;
-    }
-
-    visitFor(node: ForNode) {
-        return true;
-    }
-
-    visitFormatString(node: FormatStringNode) {
-        return true;
-    }
-
-    visitFunction(node: FunctionNode) {
-        return true;
-    }
-
-    visitFunctionAnnotation(node: FunctionAnnotationNode) {
-        return true;
-    }
-
-    visitGlobal(node: GlobalNode) {
-        return true;
-    }
-
-    visitLambda(node: LambdaNode) {
-        return true;
-    }
-
-    visitList(node: ListNode) {
-        return true;
-    }
-
-    visitListComprehension(node: ListComprehensionNode) {
-        return true;
-    }
-
-    visitListComprehensionFor(node: ListComprehensionForNode) {
-        return true;
-    }
-
-    visitListComprehensionIf(node: ListComprehensionIfNode) {
-        return true;
-    }
-
-    visitMatch(node: MatchNode) {
-        return true;
-    }
-
-    visitMemberAccess(node: MemberAccessNode) {
-        return true;
-    }
-
-    visitModule(node: ModuleNode) {
-        return true;
-    }
-
-    visitModuleName(node: ModuleNameNode) {
-        return true;
-    }
-
-    visitName(node: NameNode) {
-        return true;
-    }
-
-    visitNonlocal(node: NonlocalNode) {
-        return true;
-    }
-
-    visitNumber(node: NumberNode) {
-        return true;
-    }
-
-    visitParameter(node: ParameterNode) {
-        return true;
-    }
-
-    visitPass(node: PassNode) {
-        return true;
-    }
-
-    visitPatternCapture(node: PatternCaptureNode) {
-        return true;
-    }
-
-    visitPatternClass(node: PatternClassNode) {
-        return true;
-    }
-
-    visitPatternClassArgument(node: PatternClassArgumentNode) {
-        return true;
-    }
-
-    visitPatternAs(node: PatternAsNode) {
-        return true;
-    }
-
-    visitPatternLiteral(node: PatternLiteralNode) {
-        return true;
-    }
-
-    visitPatternMappingExpandEntry(node: PatternMappingExpandEntryNode) {
-        return true;
-    }
-
-    visitPatternSequence(node: PatternSequenceNode) {
-        return true;
-    }
-
-    visitPatternValue(node: PatternValueNode) {
-        return true;
-    }
-
-    visitPatternMappingKeyEntry(node: PatternMappingKeyEntryNode) {
-        return true;
-    }
-
-    visitPatternMapping(node: PatternMappingNode) {
-        return true;
-    }
-
-    visitRaise(node: RaiseNode) {
-        return true;
-    }
-
-    visitReturn(node: ReturnNode) {
-        return true;
-    }
-
-    visitSet(node: SetNode) {
-        return true;
-    }
-
-    visitSlice(node: SliceNode) {
-        return true;
-    }
-
-    visitStatementList(node: StatementListNode) {
-        return true;
-    }
-
-    visitString(node: StringNode) {
-        return true;
-    }
-
-    visitStringList(node: StringListNode) {
-        return true;
-    }
-
-    visitSuite(node: SuiteNode) {
-        return true;
-    }
-
-    visitTuple(node: TupleNode) {
-        return true;
-    }
-
-    visitTry(node: TryNode) {
-        return true;
-    }
-
-    visitTypeAlias(node: TypeAliasNode) {
-        return true;
-    }
-
-    visitTypeAnnotation(node: TypeAnnotationNode) {
-        return true;
-    }
-
-    visitTypeParameter(node: TypeParameterNode) {
-        return true;
-    }
-
-    visitTypeParameterList(node: TypeParameterListNode) {
-        return true;
-    }
-
-    visitUnaryOperation(node: UnaryOperationNode) {
-        return true;
-    }
-
-    visitUnpack(node: UnpackNode) {
-        return true;
-    }
-
-    visitWhile(node: WhileNode) {
-        return true;
-    }
-
-    visitWith(node: WithNode) {
-        return true;
-    }
-
-    visitWithItem(node: WithItemNode) {
-        return true;
-    }
-
-    visitYield(node: YieldNode) {
-        return true;
-    }
-
-    visitYieldFrom(node: YieldFromNode) {
-        return true;
+        return this.visit(node) ? getChildNodes(node) : [];
     }
 }


### PR DESCRIPTION
This is the first step to refactor checker to use 1 walker but multiple visitors which do its own checking inside of the checker.

PR with perf test (https://github.com/microsoft/pyrx/pull/2895)

and the result is pasted below.

`original walker` is what we have now 
`heap based walker (with 1 switch)` is a heap based (no recursion) [walker](https://github.com/microsoft/pyrx/blob/09287d8d55320e9b33215ba280696480b3e3130f/packages/pyright/packages/pyright-internal/src/analyzer/parseTreeWalker4.ts#L100) of the `original walker`
 `refactored walker (with 2 switch)`  is what I have in this PR
`heap based walker (with 2 switch)` is a heap based [walker](https://github.com/microsoft/pyrx/pull/2895/files#diff-a438e8c98f3ef4ee1f33c7a54814400af89b6bf6a60e26d4abe95358c7be8044) for `refactored walker (with 2 switch)`

I believe all perf difference comes from the fact that `original walker` had only 1 big switch to dispatch node based on node kind, but  `refactored walker (with 2 switch)`  has 2 of those (visit and getChildNodes)

converting recursion based to heap base didn't improve perf probably because it now has a real stack in heap to hold nodes to visit.

and as you said, the `original walker` is the fastest one, about 10% to 20% faster than other ones.

but that being said, it is like avg 0.02-0.04ms differences in elapsed time per tree or 0.00001-0.00002ms difference per node. which won't be noticeable. especially if walker does actual work rather than just purely iterating through all nodes.

```
  ~#@❯  npm run perftest                                                            

> pylance-internal@9999.0.0-dev perftest
> ts-node --project ./tsconfig.withBaseUrl.json -r tsconfig-paths/register ./src/walkerPerf.ts

scan files in D:\pytest\requestTest\.env\Lib\site-packages
found 4998 files


run 1 *******
run gc to clean memory

total file size 69548977bytes, total parse time 15.14sec for 4998 trees (3.03ms per tree)
original walker
total walking time 1.21sec for 4998 trees and 8770308 nodes. (0.24ms per tree) (0.000138ms per node)
heap based walker (with 1 switch)
total walking time 1.09sec for 4998 trees and 8770308 nodes. (0.22ms per tree) (0.000124ms per node)
refactored walker (with 2 switch)
total walking time 1.19sec for 4998 trees and 8770308 nodes. (0.24ms per tree) (0.000135ms per node)
heap based walker (with 2 switch)
total walking time 1.11sec for 4998 trees and 8770308 nodes. (0.22ms per tree) (0.000126ms per node)



run 2 *******
run gc to clean memory

total file size 69548977bytes, total parse time 15.63sec for 4998 trees (3.13ms per tree)
original walker
total walking time 0.93sec for 4998 trees and 8770308 nodes. (0.19ms per tree) (0.000105ms per node)
heap based walker (with 1 switch)
total walking time 1sec for 4998 trees and 8770308 nodes. (0.20ms per tree) (0.000114ms per node)
refactored walker (with 2 switch)
total walking time 1.13sec for 4998 trees and 8770308 nodes. (0.23ms per tree) (0.000129ms per node)
heap based walker (with 2 switch)
total walking time 1.12sec for 4998 trees and 8770308 nodes. (0.22ms per tree) (0.000127ms per node)



run 3 *******
run gc to clean memory

total file size 69548977bytes, total parse time 15.65sec for 4998 trees (3.13ms per tree)
original walker
total walking time 0.96sec for 4998 trees and 8770308 nodes. (0.19ms per tree) (0.000110ms per node)
heap based walker (with 1 switch)
total walking time 0.99sec for 4998 trees and 8770308 nodes. (0.20ms per tree) (0.000113ms per node)
refactored walker (with 2 switch)
total walking time 1.13sec for 4998 trees and 8770308 nodes. (0.23ms per tree) (0.000129ms per node)
heap based walker (with 2 switch)
total walking time 1.1sec for 4998 trees and 8770308 nodes. (0.22ms per tree) (0.000125ms per node)



run 4 *******
run gc to clean memory

total file size 69548977bytes, total parse time 15.29sec for 4998 trees (3.06ms per tree)
original walker
total walking time 0.97sec for 4998 trees and 8770308 nodes. (0.19ms per tree) (0.000111ms per node)
heap based walker (with 1 switch)
total walking time 0.99sec for 4998 trees and 8770308 nodes. (0.20ms per tree) (0.000113ms per node)
refactored walker (with 2 switch)
total walking time 1.14sec for 4998 trees and 8770308 nodes. (0.23ms per tree) (0.000130ms per node)
heap based walker (with 2 switch)
total walking time 1.08sec for 4998 trees and 8770308 nodes. (0.22ms per tree) (0.000123ms per node)



run 5 *******
run gc to clean memory

total file size 69548977bytes, total parse time 15.62sec for 4998 trees (3.13ms per tree)
original walker
total walking time 0.97sec for 4998 trees and 8770308 nodes. (0.19ms per tree) (0.000111ms per node)
heap based walker (with 1 switch)
total walking time 0.98sec for 4998 trees and 8770308 nodes. (0.20ms per tree) (0.000112ms per node)
refactored walker (with 2 switch)
total walking time 1.12sec for 4998 trees and 8770308 nodes. (0.22ms per tree) (0.000128ms per node)
heap based walker (with 2 switch)
total walking time 1.1sec for 4998 trees and 8770308 nodes. (0.22ms per tree) (0.000125ms per node)
```

one idea to remove second switch is putting childnodes to each parse node itself rather than having extra function to get those. only problem is since parse node is interface, we need to put it as field which consume memory.