### PR TITLE
"Expression value is unused" should not be reported for last expression in notebook cell

### DIFF
--- a/packages/pyright-internal/src/analyzer/checker.ts
+++ b/packages/pyright-internal/src/analyzer/checker.ts
@@ -1538,8 +1538,9 @@ export class Checker extends ParseTreeWalker {
             reportAsUnused &&
             this._fileInfo.ipythonMode === IPythonMode.CellDocs &&
             node.parent?.nodeType === ParseNodeType.StatementList &&
+            node.parent.statements[node.parent.statements.length - 1] === node &&
             node.parent.parent?.nodeType === ParseNodeType.Module &&
-            node.parent.statements[node.parent.statements.length - 1] === node
+            node.parent.parent.statements[node.parent.parent.statements.length - 1] === node.parent
         ) {
             // Exclude an expression at the end of a notebook cell, as that is treated as
             // the cell's value.

--- a/packages/pyright-internal/src/analyzer/checker.ts
+++ b/packages/pyright-internal/src/analyzer/checker.ts
@@ -1534,6 +1534,18 @@ export class Checker extends ParseTreeWalker {
             }
         }
 
+        if (
+            reportAsUnused &&
+            this._fileInfo.ipythonMode === IPythonMode.CellDocs &&
+            node.parent?.nodeType === ParseNodeType.StatementList &&
+            node.parent.parent?.nodeType === ParseNodeType.Module &&
+            node.parent.statements[node.parent.statements.length - 1] === node
+        ) {
+            // Exclude an expression at the end of a notebook cell, as that is treated as
+            // the cell's value.
+            reportAsUnused = false;
+        }
+
         if (reportAsUnused) {
             this._evaluator.addDiagnostic(
                 this._fileInfo.diagnosticRuleSet.reportUnusedExpression,

--- a/packages/pyright-internal/src/analyzer/dataClasses.ts
+++ b/packages/pyright-internal/src/analyzer/dataClasses.ts
@@ -600,7 +600,10 @@ export function synthesizeDataClassMethods(
             )
         );
     }
-    symbolTable.set('__dataclass_fields__', Symbol.createWithType(SymbolFlags.ClassMember, dictType));
+    symbolTable.set(
+        '__dataclass_fields__',
+        Symbol.createWithType(SymbolFlags.ClassMember | SymbolFlags.ClassVar, dictType)
+    );
 
     if (ClassType.isGeneratedDataClassSlots(classType) && classType.details.localSlotsNames === undefined) {
         classType.details.localSlotsNames = localDataClassEntries.map((entry) => entry.name);

--- a/packages/pyright-internal/src/analyzer/sourceFile.ts
+++ b/packages/pyright-internal/src/analyzer/sourceFile.ts
@@ -1357,7 +1357,7 @@ export class SourceFile {
     }
 
     test_enableIPythonMode(enable: boolean) {
-        this._ipythonMode = enable ? IPythonMode.ConcatDoc : IPythonMode.None;
+        this._ipythonMode = enable ? IPythonMode.CellDocs : IPythonMode.None;
     }
 
     private _buildFileInfo(

--- a/packages/pyright-internal/src/tests/harness/fourslash/testState.ts
+++ b/packages/pyright-internal/src/tests/harness/fourslash/testState.ts
@@ -545,7 +545,7 @@ export class TestState {
     }
 
     verifyDiagnostics(map?: { [marker: string]: { category: string; message: string } }): void {
-        this._analyze();
+        this.analyze();
 
         // organize things per file
         const resultPerFile = this._getDiagnosticsPerFile();
@@ -671,7 +671,7 @@ export class TestState {
     ): Promise<any> {
         // make sure we don't use cache built from other tests
         this.workspace.serviceInstance.invalidateAndForceReanalysis();
-        this._analyze();
+        this.analyze();
 
         for (const range of this.getRanges()) {
             const name = this.getMarkerName(range.marker!);
@@ -737,7 +737,7 @@ export class TestState {
     }
 
     async verifyCommand(command: Command, files: { [filePath: string]: string }): Promise<any> {
-        this._analyze();
+        this.analyze();
 
         const commandResult = await this._hostSpecificFeatures.execute(
             new TestLanguageService(this.workspace, this.console, this.fs),
@@ -923,7 +923,7 @@ export class TestState {
         },
         verifyCodeActionCount?: boolean
     ): Promise<any> {
-        this._analyze();
+        this.analyze();
 
         for (const range of this.getRanges()) {
             const name = this.getMarkerName(range.marker!);
@@ -1076,7 +1076,7 @@ export class TestState {
         },
         abbrMap?: { [abbr: string]: AbbreviationInfo }
     ): Promise<void> {
-        this._analyze();
+        this.analyze();
 
         for (const marker of this.getMarkers()) {
             const markerName = this.getMarkerName(marker);
@@ -1246,7 +1246,7 @@ export class TestState {
             };
         }
     ): void {
-        this._analyze();
+        this.analyze();
 
         for (const marker of this.getMarkers()) {
             const fileName = marker.fileName;
@@ -1315,7 +1315,7 @@ export class TestState {
             references: DocumentRange[];
         };
     }) {
-        this._analyze();
+        this.analyze();
 
         for (const marker of this.getMarkers()) {
             const fileName = marker.fileName;
@@ -1365,7 +1365,7 @@ export class TestState {
             references: DocumentHighlight[];
         };
     }) {
-        this._analyze();
+        this.analyze();
 
         for (const name of Object.keys(map)) {
             const marker = this.getMarkerByName(name);
@@ -1397,7 +1397,7 @@ export class TestState {
         },
         filter: DefinitionFilter = DefinitionFilter.All
     ) {
-        this._analyze();
+        this.analyze();
 
         for (const marker of this.getMarkers()) {
             const fileName = marker.fileName;
@@ -1425,7 +1425,7 @@ export class TestState {
             definitions: DocumentRange[];
         };
     }) {
-        this._analyze();
+        this.analyze();
 
         for (const marker of this.getMarkers()) {
             const fileName = marker.fileName;
@@ -1454,7 +1454,7 @@ export class TestState {
             changes: FileEditAction[];
         };
     }) {
-        this._analyze();
+        this.analyze();
 
         for (const marker of this.getMarkers()) {
             const fileName = marker.fileName;
@@ -1798,7 +1798,7 @@ export class TestState {
         return position <= editStart ? position : position < editEnd ? -1 : position + length - +(editEnd - editStart);
     }
 
-    private _analyze() {
+    public analyze() {
         while (this.program.analyze()) {
             // Continue to call analyze until it completes. Since we're not
             // specifying a timeout, it should complete the first time.

--- a/packages/pyright-internal/src/tests/ipythonMode.test.ts
+++ b/packages/pyright-internal/src/tests/ipythonMode.test.ts
@@ -584,10 +584,11 @@ test('unused expression is error if within another statement', async () => {
 
 function verifyAnalysisDiagnosticCount(code: string, expectedCount: number) {
     const state = parseAndGetTestState(code).state;
-    const range = state.getRangeByMarkerName('marker')!;
 
-    const source = state.program.getBoundSourceFile(range.fileName)!;
     state.analyze();
+
+    const range = state.getRangeByMarkerName('marker')!;
+    const source = state.program.getBoundSourceFile(range.fileName)!;
     const diagnostics = source.getDiagnostics(state.configOptions);
 
     assert.strictEqual(diagnostics?.length, expectedCount);

--- a/packages/pyright-internal/src/tests/ipythonMode.test.ts
+++ b/packages/pyright-internal/src/tests/ipythonMode.test.ts
@@ -571,6 +571,18 @@ test('unused expression at end is not error', async () => {
     verifyAnalysisDiagnosticCount(code, 0);
 });
 
+test('unused expression is error if not at end of cell', async () => {
+    const code = `
+// @filename: test.py
+// @ipythonMode: true
+//// 4[|/*marker*/|]
+////
+//// x = 1
+    `;
+
+    verifyAnalysisDiagnosticCount(code, 1);
+});
+
 test('unused expression is error if within another statement', async () => {
     const code = `
 // @filename: test.py

--- a/packages/pyright-internal/src/tests/ipythonMode.test.ts
+++ b/packages/pyright-internal/src/tests/ipythonMode.test.ts
@@ -9,6 +9,7 @@
 import assert from 'assert';
 import { CompletionItemKind, MarkupKind } from 'vscode-languageserver-types';
 
+import { DiagnosticRule } from '../common/diagnosticRules';
 import { TextRange } from '../common/textRange';
 import { TextRangeCollection } from '../common/textRangeCollection';
 import { Localizer } from '../localization/localize';
@@ -580,7 +581,7 @@ test('unused expression is error if not at end of cell', async () => {
 //// x = 1
     `;
 
-    verifyAnalysisDiagnosticCount(code, 1);
+    verifyAnalysisDiagnosticCount(code, 1, DiagnosticRule.reportUnusedExpression);
 });
 
 test('unused expression is error if within another statement', async () => {
@@ -591,10 +592,10 @@ test('unused expression is error if within another statement', async () => {
 ////     4[|/*marker*/|]
     `;
 
-    verifyAnalysisDiagnosticCount(code, 1);
+    verifyAnalysisDiagnosticCount(code, 1, DiagnosticRule.reportUnusedExpression);
 });
 
-function verifyAnalysisDiagnosticCount(code: string, expectedCount: number) {
+function verifyAnalysisDiagnosticCount(code: string, expectedCount: number, expectedRule?: string) {
     const state = parseAndGetTestState(code).state;
 
     state.analyze();
@@ -604,4 +605,7 @@ function verifyAnalysisDiagnosticCount(code: string, expectedCount: number) {
     const diagnostics = source.getDiagnostics(state.configOptions);
 
     assert.strictEqual(diagnostics?.length, expectedCount);
+    if (expectedRule) {
+        diagnostics.forEach((diagnostic) => assert.strictEqual(diagnostic.getRule(), expectedRule));
+    }
 }


### PR DESCRIPTION
Address https://github.com/microsoft/pylance-release/issues/3282

Don't report an error for an unused expression at the end of a notebook cell, as it is treated as the cell's value.

The tests are checking the diagnostic count which we would normally do by testing a sample `.py` file, but I don't believe we have a way to enable `ipythonMode` with that approach. If you'd prefer the tests to work that way, I can look into making that work.