### PR TITLE
Changed the `dataclass_transform` mechanism to assume that a class-based classes are frozen

### DIFF
--- a/packages/pyright-internal/src/analyzer/dataClasses.ts
+++ b/packages/pyright-internal/src/analyzer/dataClasses.ts
@@ -707,12 +707,14 @@ function isDataclassFieldConstructor(type: Type, fieldDescriptorNames: string[])
 
 export function validateDataClassTransformDecorator(
     evaluator: TypeEvaluator,
-    node: CallNode
+    node: CallNode,
+    defaultToFrozen = false
 ): DataClassBehaviors | undefined {
     const behaviors: DataClassBehaviors = {
         keywordOnlyParams: false,
         generateEq: true,
         generateOrder: false,
+        isFrozen: defaultToFrozen,
         fieldDescriptorNames: [],
     };
 
@@ -858,6 +860,7 @@ export function getDataclassDecoratorBehaviors(type: Type): DataClassBehaviors |
             keywordOnlyParams: false,
             generateEq: true,
             generateOrder: false,
+            isFrozen: false,
             fieldDescriptorNames: ['dataclasses.field', 'dataclasses.Field'],
         };
     }
@@ -984,15 +987,6 @@ export function applyDataClassClassBehaviorOverrides(
             applyDataClassBehaviorOverride(evaluator, arg.name, classType, arg.name.value, arg.valueExpression);
         }
     });
-
-    // For class-based dataclass_transform, there's no standard way
-    // to specify whether the class is frozen or not. We will conservatively
-    // assume that the class is frozen so a `__hash__` function is always
-    // synthesized. Without this, users may see false positive errors when
-    // an instance is used in a set or the key of a dictionary. This assumption
-    // may result in a false negative if the class isn't actually frozen, but
-    // that's better than a false positive.
-    classType.details.flags |= ClassTypeFlags.FrozenDataClass;
 }
 
 export function applyDataClassDefaultBehaviors(classType: ClassType, defaultBehaviors: DataClassBehaviors) {
@@ -1009,6 +1003,10 @@ export function applyDataClassDefaultBehaviors(classType: ClassType, defaultBeha
 
     if (defaultBehaviors.generateOrder) {
         classType.details.flags |= ClassTypeFlags.SynthesizedDataClassOrder;
+    }
+
+    if (defaultBehaviors.isFrozen) {
+        classType.details.flags |= ClassTypeFlags.FrozenDataClass;
     }
 }
 

--- a/packages/pyright-internal/src/analyzer/dataClasses.ts
+++ b/packages/pyright-internal/src/analyzer/dataClasses.ts
@@ -984,6 +984,15 @@ export function applyDataClassClassBehaviorOverrides(
             applyDataClassBehaviorOverride(evaluator, arg.name, classType, arg.name.value, arg.valueExpression);
         }
     });
+
+    // For class-based dataclass_transform, there's no standard way
+    // to specify whether the class is frozen or not. We will conservatively
+    // assume that the class is frozen so a `__hash__` function is always
+    // synthesized. Without this, users may see false positive errors when
+    // an instance is used in a set or the key of a dictionary. This assumption
+    // may result in a false negative if the class isn't actually frozen, but
+    // that's better than a false positive.
+    classType.details.flags |= ClassTypeFlags.FrozenDataClass;
 }
 
 export function applyDataClassDefaultBehaviors(classType: ClassType, defaultBehaviors: DataClassBehaviors) {

--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -15828,9 +15828,17 @@ export function createTypeEvaluator(importLookup: ImportLookup, evaluatorOptions
                     decoratorCallType.details.name === '__dataclass_transform__' ||
                     decoratorCallType.details.builtInName === 'dataclass_transform'
                 ) {
+                    // For class-based dataclass_transform, there's no standard way
+                    // to specify whether the class is frozen or not. We will conservatively
+                    // assume that the class is frozen so a `__hash__` function is always
+                    // synthesized. Without this, users may see false positive errors when
+                    // an instance is used in a set or the key of a dictionary. This assumption
+                    // may result in a false negative if the class isn't actually frozen, but
+                    // that's better than a false positive.
                     originalClassType.details.classDataClassTransform = validateDataClassTransformDecorator(
                         evaluatorInterface,
-                        decoratorNode.expression
+                        decoratorNode.expression,
+                        /* defaultToFrozen */ true
                     );
                 }
             }

--- a/packages/pyright-internal/src/analyzer/types.ts
+++ b/packages/pyright-internal/src/analyzer/types.ts
@@ -461,6 +461,7 @@ export interface DataClassBehaviors {
     keywordOnlyParams: boolean;
     generateEq: boolean;
     generateOrder: boolean;
+    isFrozen: boolean;
     fieldDescriptorNames: string[];
 }
 

--- a/packages/pyright-internal/src/tests/samples/dataclassTransform2.py
+++ b/packages/pyright-internal/src/tests/samples/dataclassTransform2.py
@@ -78,3 +78,6 @@ v2 = c2_1 < c2_2
 # This should generate an error because Customer2 supports
 # keyword-only parameters for its constructor.
 c2_3 = Customer2(0, "John")
+
+hashable1 = {Customer2(id=1): 1}
+hashable2 = {Customer2(id=1), Customer2(id=2)}


### PR DESCRIPTION
Changed the `dataclass_transform` mechanism to assume that a class-based dataclass-like classes (like that used by pydantic) area frozen so a `__hash__` method is synthesized. This addresses https://github.com/microsoft/pyright/issues/4168.