### PR TITLE
[PylanceBot] Pull Pylance with Pyright 1.1.280

### DIFF
--- a/packages/pyright-internal/src/analyzer/binder.ts
+++ b/packages/pyright-internal/src/analyzer/binder.ts
@@ -23,7 +23,7 @@ import { assert, assertNever, fail } from '../common/debug';
 import { CreateTypeStubFileAction, Diagnostic } from '../common/diagnostic';
 import { DiagnosticRule } from '../common/diagnosticRules';
 import { getFileName, stripFileExtension } from '../common/pathUtils';
-import { convertOffsetsToRange } from '../common/positionUtils';
+import { convertTextRangeToRange } from '../common/positionUtils';
 import { getEmptyRange } from '../common/textRange';
 import { TextRange } from '../common/textRange';
 import { Localizer } from '../localization/localize';
@@ -397,7 +397,7 @@ export class Binder extends ParseTreeWalker {
             type: DeclarationType.Class,
             node,
             path: this._fileInfo.filePath,
-            range: convertOffsetsToRange(node.name.start, TextRange.getEnd(node.name), this._fileInfo.lines),
+            range: convertTextRangeToRange(node.name, this._fileInfo.lines),
             moduleName: this._fileInfo.moduleName,
             isInExceptSuite: this._isInExceptSuite,
         };
@@ -455,7 +455,7 @@ export class Binder extends ParseTreeWalker {
             isMethod: !!containingClassNode,
             isGenerator: false,
             path: this._fileInfo.filePath,
-            range: convertOffsetsToRange(node.name.start, TextRange.getEnd(node.name), this._fileInfo.lines),
+            range: convertTextRangeToRange(node.name, this._fileInfo.lines),
             moduleName: this._fileInfo.moduleName,
             isInExceptSuite: this._isInExceptSuite,
         };
@@ -522,11 +522,7 @@ export class Binder extends ParseTreeWalker {
                                 type: DeclarationType.Parameter,
                                 node: paramNode,
                                 path: this._fileInfo.filePath,
-                                range: convertOffsetsToRange(
-                                    paramNode.start,
-                                    TextRange.getEnd(paramNode),
-                                    this._fileInfo.lines
-                                ),
+                                range: convertTextRangeToRange(paramNode, this._fileInfo.lines),
                                 moduleName: this._fileInfo.moduleName,
                                 isInExceptSuite: this._isInExceptSuite,
                             };
@@ -599,11 +595,7 @@ export class Binder extends ParseTreeWalker {
                                 type: DeclarationType.Parameter,
                                 node: paramNode,
                                 path: this._fileInfo.filePath,
-                                range: convertOffsetsToRange(
-                                    paramNode.start,
-                                    TextRange.getEnd(paramNode),
-                                    this._fileInfo.lines
-                                ),
+                                range: convertTextRangeToRange(paramNode, this._fileInfo.lines),
                                 moduleName: this._fileInfo.moduleName,
                                 isInExceptSuite: this._isInExceptSuite,
                             };
@@ -751,7 +743,7 @@ export class Binder extends ParseTreeWalker {
                 type: DeclarationType.TypeParameter,
                 node: param,
                 path: this._fileInfo.filePath,
-                range: convertOffsetsToRange(node.start, TextRange.getEnd(node), this._fileInfo.lines),
+                range: convertTextRangeToRange(node, this._fileInfo.lines),
                 moduleName: this._fileInfo.moduleName,
                 isInExceptSuite: this._isInExceptSuite,
             };
@@ -786,7 +778,7 @@ export class Binder extends ParseTreeWalker {
             type: DeclarationType.TypeAlias,
             node,
             path: this._fileInfo.filePath,
-            range: convertOffsetsToRange(node.name.start, TextRange.getEnd(node.name), this._fileInfo.lines),
+            range: convertTextRangeToRange(node.name, this._fileInfo.lines),
             moduleName: this._fileInfo.moduleName,
             isInExceptSuite: this._isInExceptSuite,
         };
@@ -1369,7 +1361,7 @@ export class Binder extends ParseTreeWalker {
                     isConstant: isConstantName(node.name.value),
                     inferredTypeSource: node,
                     path: this._fileInfo.filePath,
-                    range: convertOffsetsToRange(node.name.start, TextRange.getEnd(node.name), this._fileInfo.lines),
+                    range: convertTextRangeToRange(node.name, this._fileInfo.lines),
                     moduleName: this._fileInfo.moduleName,
                     isInExceptSuite: this._isInExceptSuite,
                 };
@@ -1764,7 +1756,7 @@ export class Binder extends ParseTreeWalker {
                                     node,
                                     path: resolvedPath,
                                     loadSymbolsFromPath: true,
-                                    range: getEmptyRange(),
+                                    range: getEmptyRange(), // Range is unknown for wildcarded name import.
                                     usesLocalName: false,
                                     symbolName: name,
                                     moduleName: this._fileInfo.moduleName,
@@ -1836,6 +1828,7 @@ export class Binder extends ParseTreeWalker {
             node.imports.forEach((importSymbolNode) => {
                 const importedName = importSymbolNode.name.value;
                 const nameNode = importSymbolNode.alias || importSymbolNode.name;
+
                 const symbol = this._bindNameToScope(this._currentScope, nameNode);
 
                 if (symbol) {
@@ -1875,7 +1868,7 @@ export class Binder extends ParseTreeWalker {
                             node: importSymbolNode,
                             path: implicitImport.path,
                             loadSymbolsFromPath: true,
-                            range: getEmptyRange(),
+                            range: convertTextRangeToRange(importSymbolNode, this._fileInfo.lines),
                             usesLocalName: false,
                             moduleName: this._fileInfo.moduleName,
                             isInExceptSuite: this._isInExceptSuite,
@@ -1901,7 +1894,7 @@ export class Binder extends ParseTreeWalker {
                         usesLocalName: !!importSymbolNode.alias,
                         symbolName: importedName,
                         submoduleFallback,
-                        range: getEmptyRange(),
+                        range: convertTextRangeToRange(nameNode, this._fileInfo.lines),
                         moduleName: this._fileInfo.moduleName,
                         isInExceptSuite: this._isInExceptSuite,
                         isNativeLib: importInfo?.isNativeLib,
@@ -2243,11 +2236,7 @@ export class Binder extends ParseTreeWalker {
                     isConstant: isConstantName(node.target.value),
                     inferredTypeSource: node,
                     path: this._fileInfo.filePath,
-                    range: convertOffsetsToRange(
-                        node.target.start,
-                        TextRange.getEnd(node.target),
-                        this._fileInfo.lines
-                    ),
+                    range: convertTextRangeToRange(node.target, this._fileInfo.lines),
                     moduleName: this._fileInfo.moduleName,
                     isInExceptSuite: this._isInExceptSuite,
                 };
@@ -2327,11 +2316,7 @@ export class Binder extends ParseTreeWalker {
                 isConstant: isConstantName(slotName),
                 isDefinedBySlots: true,
                 path: this._fileInfo.filePath,
-                range: convertOffsetsToRange(
-                    slotNameNode.start,
-                    slotNameNode.start + slotNameNode.length,
-                    this._fileInfo.lines
-                ),
+                range: convertTextRangeToRange(slotNameNode, this._fileInfo.lines),
                 moduleName: this._fileInfo.moduleName,
                 isInExceptSuite: this._isInExceptSuite,
             };
@@ -2380,7 +2365,7 @@ export class Binder extends ParseTreeWalker {
                 isConstant: isConstantName(target.value),
                 inferredTypeSource: target.parent,
                 path: this._fileInfo.filePath,
-                range: convertOffsetsToRange(target.start, TextRange.getEnd(target), this._fileInfo.lines),
+                range: convertTextRangeToRange(target, this._fileInfo.lines),
                 moduleName: this._fileInfo.moduleName,
                 isInExceptSuite: this._isInExceptSuite,
             };
@@ -2477,7 +2462,7 @@ export class Binder extends ParseTreeWalker {
                 node,
                 path: pathOfLastSubmodule,
                 loadSymbolsFromPath: false,
-                range: getEmptyRange(),
+                range: importAlias ? convertTextRangeToRange(importAlias, this._fileInfo.lines) : getEmptyRange(),
                 usesLocalName: !!importAlias,
                 moduleName: importInfo.importName,
                 firstNamePart: firstNamePartValue,
@@ -2492,7 +2477,7 @@ export class Binder extends ParseTreeWalker {
                 node,
                 path: pathOfLastSubmodule,
                 loadSymbolsFromPath: true,
-                range: getEmptyRange(),
+                range: importAlias ? convertTextRangeToRange(importAlias, this._fileInfo.lines) : getEmptyRange(),
                 usesLocalName: !!importAlias,
                 moduleName: importInfo?.importName ?? '',
                 firstNamePart: firstNamePartValue,
@@ -3471,7 +3456,7 @@ export class Binder extends ParseTreeWalker {
                         isInferenceAllowedInPyTyped: this._isInferenceAllowedInPyTyped(name.value),
                         typeAliasName: isPossibleTypeAlias ? target : undefined,
                         path: this._fileInfo.filePath,
-                        range: convertOffsetsToRange(name.start, TextRange.getEnd(name), this._fileInfo.lines),
+                        range: convertTextRangeToRange(name, this._fileInfo.lines),
                         moduleName: this._fileInfo.moduleName,
                         isInExceptSuite: this._isInExceptSuite,
                         docString: this._getVariableDocString(target),
@@ -3519,11 +3504,7 @@ export class Binder extends ParseTreeWalker {
                         inferredTypeSource: source,
                         isDefinedByMemberAccess: true,
                         path: this._fileInfo.filePath,
-                        range: convertOffsetsToRange(
-                            target.memberName.start,
-                            target.memberName.start + target.memberName.length,
-                            this._fileInfo.lines
-                        ),
+                        range: convertTextRangeToRange(target.memberName, this._fileInfo.lines),
                         moduleName: this._fileInfo.moduleName,
                         isInExceptSuite: this._isInExceptSuite,
                         docString: this._getVariableDocString(target),
@@ -3637,7 +3618,7 @@ export class Binder extends ParseTreeWalker {
                         typeAliasName: isExplicitTypeAlias ? target : undefined,
                         path: this._fileInfo.filePath,
                         typeAnnotationNode,
-                        range: convertOffsetsToRange(name.start, TextRange.getEnd(name), this._fileInfo.lines),
+                        range: convertTextRangeToRange(name, this._fileInfo.lines),
                         moduleName: this._fileInfo.moduleName,
                         isInExceptSuite: this._isInExceptSuite,
                         docString: this._getVariableDocString(target),
@@ -3710,11 +3691,7 @@ export class Binder extends ParseTreeWalker {
                         isFinal: finalInfo.isFinal,
                         path: this._fileInfo.filePath,
                         typeAnnotationNode: finalInfo.isFinal && !finalInfo.finalTypeNode ? undefined : typeAnnotation,
-                        range: convertOffsetsToRange(
-                            target.memberName.start,
-                            target.memberName.start + target.memberName.length,
-                            this._fileInfo.lines
-                        ),
+                        range: convertTextRangeToRange(target.memberName, this._fileInfo.lines),
                         moduleName: this._fileInfo.moduleName,
                         isInExceptSuite: this._isInExceptSuite,
                         docString: this._getVariableDocString(target),
@@ -4139,11 +4116,7 @@ export class Binder extends ParseTreeWalker {
                 type: DeclarationType.SpecialBuiltInClass,
                 node: annotationNode,
                 path: this._fileInfo.filePath,
-                range: convertOffsetsToRange(
-                    annotationNode.start,
-                    TextRange.getEnd(annotationNode),
-                    this._fileInfo.lines
-                ),
+                range: convertTextRangeToRange(annotationNode, this._fileInfo.lines),
                 moduleName: this._fileInfo.moduleName,
                 isInExceptSuite: this._isInExceptSuite,
             });

--- a/packages/pyright-internal/src/analyzer/declaration.ts
+++ b/packages/pyright-internal/src/analyzer/declaration.ts
@@ -50,11 +50,13 @@ export interface DeclarationBase {
     // Used by hover provider to display helpful text.
     type: DeclarationType;
 
-    // Parse node associated with the declaration.
+    // Parse node associated with the declaration. Does not necessarily match
+    // the path and range.
     node: ParseNode;
 
     // The file and range within that file that
-    // contains the declaration.
+    // contains the declaration. Unless this is an alias, then path refers to the
+    // file the alias is referring to.
     path: string;
     range: Range;
 

--- a/packages/pyright-internal/src/analyzer/declarationUtils.ts
+++ b/packages/pyright-internal/src/analyzer/declarationUtils.ts
@@ -58,7 +58,8 @@ export function hasTypeForDeclaration(declaration: Declaration): boolean {
 export function areDeclarationsSame(
     decl1: Declaration,
     decl2: Declaration,
-    treatModuleInImportAndFromImportSame = false
+    treatModuleInImportAndFromImportSame = false,
+    skipRangeForAliases = false
 ): boolean {
     if (decl1.type !== decl2.type) {
         return false;
@@ -68,11 +69,13 @@ export function areDeclarationsSame(
         return false;
     }
 
-    if (
-        decl1.range.start.line !== decl2.range.start.line ||
-        decl1.range.start.character !== decl2.range.start.character
-    ) {
-        return false;
+    if (!skipRangeForAliases || decl1.type !== DeclarationType.Alias) {
+        if (
+            decl1.range.start.line !== decl2.range.start.line ||
+            decl1.range.start.character !== decl2.range.start.character
+        ) {
+            return false;
+        }
     }
 
     // Alias declarations refer to the entire import statement.

--- a/packages/pyright-internal/src/analyzer/sourceFile.ts
+++ b/packages/pyright-internal/src/analyzer/sourceFile.ts
@@ -168,7 +168,9 @@ export class SourceFile {
     private _typeIgnoreAll: IgnoreComment | undefined;
     private _pyrightIgnoreLines = new Map<number, IgnoreComment>();
 
-    // Settings that control which diagnostics should be output.
+    // Settings that control which diagnostics should be output. The rules
+    // are initialized to the basic set. They should be updated after the
+    // the file is parsed.
     private _diagnosticRuleSet = getBasicDiagnosticRuleSet();
 
     // Circular dependencies that have been reported in this file.
@@ -327,11 +329,7 @@ export class SourceFile {
         // Filter the diagnostics based on "pyright: ignore" lines.
         if (this._pyrightIgnoreLines.size > 0) {
             diagList = diagList.filter((d) => {
-                if (
-                    d.category !== DiagnosticCategory.UnusedCode &&
-                    d.category !== DiagnosticCategory.UnreachableCode &&
-                    d.category !== DiagnosticCategory.Deprecated
-                ) {
+                if (d.category !== DiagnosticCategory.UnreachableCode && d.category !== DiagnosticCategory.Deprecated) {
                     for (let line = d.range.start.line; line <= d.range.end.line; line++) {
                         const pyrightIgnoreComment = this._pyrightIgnoreLines.get(line);
                         if (pyrightIgnoreComment) {

--- a/packages/pyright-internal/src/commands/createTypeStub.ts
+++ b/packages/pyright-internal/src/commands/createTypeStub.ts
@@ -25,7 +25,9 @@ export class CreateTypeStubCommand implements ServerCommand {
             const service = await AnalyzerServiceExecutor.cloneService(
                 this._ls,
                 await this._ls.getWorkspaceForFile(callingFile ?? workspaceRoot),
-                importName
+                {
+                    typeStubTargetImportName: importName,
+                }
             );
 
             try {

--- a/packages/pyright-internal/src/common/workspaceEditUtils.ts
+++ b/packages/pyright-internal/src/common/workspaceEditUtils.ts
@@ -12,14 +12,18 @@ import {
     DeleteFile,
     RenameFile,
     TextDocumentEdit,
+    TextEdit,
     WorkspaceEdit,
 } from 'vscode-languageserver';
 
+import { SourceFileInfo } from '../analyzer/program';
+import { AnalyzerService } from '../analyzer/service';
 import { FileEditAction, FileEditActions } from '../common/editAction';
-import { convertPathToUri } from '../common/pathUtils';
+import { convertPathToUri, convertUriToPath } from '../common/pathUtils';
 import { createMapFromItems } from './collectionUtils';
 import { assertNever } from './debug';
 import { FileSystem } from './fileSystem';
+import { convertTextRangeToRange } from './positionUtils';
 
 export function convertWorkspaceEdits(fs: FileSystem, edits: FileEditAction[]) {
     const workspaceEdit: WorkspaceEdit = {
@@ -101,4 +105,93 @@ export function convertWorkspaceDocumentEdits(
     }
 
     return workspaceEdit;
+}
+
+export function applyWorkspaceEdits(service: AnalyzerService, edits: WorkspaceEdit, filesChanged: Set<string>) {
+    if (edits.changes) {
+        for (const kv of Object.entries(edits.changes)) {
+            const filePath = convertUriToPath(service.fs, kv[0]);
+            const fileInfo = service.backgroundAnalysisProgram.program.getSourceFileInfo(filePath);
+            if (!fileInfo || !fileInfo.isTracked) {
+                // We don't allow non user file being modified.
+                continue;
+            }
+
+            applyDocumentChanges(service, fileInfo, kv[1]);
+            filesChanged.add(filePath);
+        }
+    }
+
+    // For now, we don't support annotations.
+    if (edits.documentChanges) {
+        for (const change of edits.documentChanges) {
+            if (TextDocumentEdit.is(change)) {
+                const filePath = convertUriToPath(service.fs, change.textDocument.uri);
+                const fileInfo = service.backgroundAnalysisProgram.program.getSourceFileInfo(filePath);
+                if (!fileInfo || !fileInfo.isTracked) {
+                    // We don't allow non user file being modified.
+                    continue;
+                }
+
+                applyDocumentChanges(service, fileInfo, change.edits);
+                filesChanged.add(filePath);
+            }
+
+            // For now, we don't support other kinds of text changes.
+            // But if we want to add support for those in future, we should add them here.
+        }
+    }
+}
+
+export function applyDocumentChanges(service: AnalyzerService, fileInfo: SourceFileInfo, edits: TextEdit[]) {
+    if (!fileInfo.isOpenByClient) {
+        const fileContent = fileInfo.sourceFile.getFileContent();
+        service.setFileOpened(
+            fileInfo.sourceFile.getFilePath(),
+            0,
+            fileContent ?? '',
+            fileInfo.sourceFile.getIPythonMode(),
+            fileInfo.sourceFile.getRealFilePath()
+        );
+    }
+
+    const version = (fileInfo.sourceFile.getClientVersion() ?? 0) + 1;
+    service.updateOpenFileContents(
+        fileInfo.sourceFile.getFilePath(),
+        version,
+        edits.map((t) => ({ range: t.range, text: t.newText })),
+        fileInfo.sourceFile.getIPythonMode(),
+        fileInfo.sourceFile.getRealFilePath()
+    );
+}
+
+export function generateWorkspaceEdits(base: AnalyzerService, target: AnalyzerService, filesChanged: Set<string>) {
+    // For now, we won't do text diff to find out minimal text changes. instead, we will
+    // consider whole text of the files are changed. In future, we could consider
+    // doing minimal changes using vscode's differ (https://github.com/microsoft/vscode/blob/main/src/vs/base/common/diff/diff.ts)
+    // to support annotation.
+    const edits: WorkspaceEdit = { changes: {} };
+
+    for (const filePath of filesChanged) {
+        const original = base.backgroundAnalysisProgram.program.getBoundSourceFile(filePath);
+        const final = target.backgroundAnalysisProgram.program.getBoundSourceFile(filePath);
+        if (!original || !final) {
+            // Both must exist.
+            continue;
+        }
+
+        const parseResults = original.getParseResults();
+        if (!parseResults) {
+            continue;
+        }
+
+        edits.changes![convertPathToUri(base.fs, filePath)] = [
+            {
+                range: convertTextRangeToRange(parseResults.parseTree, parseResults.tokenizerOutput.lines),
+                newText: final.getFileContent() ?? '',
+            },
+        ];
+    }
+
+    return edits;
 }

--- a/packages/pyright-internal/src/languageService/analyzerServiceExecutor.ts
+++ b/packages/pyright-internal/src/languageService/analyzerServiceExecutor.ts
@@ -21,6 +21,12 @@ import {
     WorkspaceServiceInstance,
 } from '../languageServerBase';
 
+export interface CloneOptions {
+    useBackgroundAnalysis?: boolean;
+    typeStubTargetImportName?: string;
+    fileSystem?: FileSystem;
+}
+
 export class AnalyzerServiceExecutor {
     static runWithOptions(
         languageServiceRootPath: string,
@@ -44,12 +50,13 @@ export class AnalyzerServiceExecutor {
     static async cloneService(
         ls: LanguageServerInterface,
         workspace: WorkspaceServiceInstance,
-        typeStubTargetImportName?: string,
-        fileSystem?: FileSystem
+        options?: CloneOptions
     ): Promise<AnalyzerService> {
         // Allocate a temporary pseudo-workspace to perform this job.
         const instanceName = 'cloned service';
         const serviceId = getNextServiceId(instanceName);
+
+        options = options ?? {};
 
         const tempWorkspace: WorkspaceServiceInstance = {
             workspaceName: `temp workspace for cloned service`,
@@ -60,8 +67,8 @@ export class AnalyzerServiceExecutor {
             serviceInstance: workspace.serviceInstance.clone(
                 instanceName,
                 serviceId,
-                ls.createBackgroundAnalysis(serviceId),
-                fileSystem
+                options.useBackgroundAnalysis ? ls.createBackgroundAnalysis(serviceId) : undefined,
+                options.fileSystem
             ),
             disableLanguageServices: true,
             disableOrganizeImports: true,
@@ -75,7 +82,7 @@ export class AnalyzerServiceExecutor {
             ls.rootPath,
             tempWorkspace,
             serverSettings,
-            typeStubTargetImportName,
+            options.typeStubTargetImportName,
             /* trackFiles */ false
         );
 

--- a/packages/pyright-internal/src/languageService/documentSymbolCollector.ts
+++ b/packages/pyright-internal/src/languageService/documentSymbolCollector.ts
@@ -196,7 +196,12 @@ export class DocumentSymbolCollector extends ParseTreeWalker {
         // need to call resolveAliasDeclaration on them.
         if (
             this._declarations.some((decl) =>
-                areDeclarationsSame(decl, resolvedDecl, this._treatModuleInImportAndFromImportSame)
+                areDeclarationsSame(
+                    decl,
+                    resolvedDecl!,
+                    this._treatModuleInImportAndFromImportSame,
+                    /* skipRangeForAliases */ true
+                )
             )
         ) {
             return true;
@@ -210,7 +215,12 @@ export class DocumentSymbolCollector extends ParseTreeWalker {
         }
 
         return this._declarations.some((decl) =>
-            areDeclarationsSame(decl, resolvedDeclNonlocal, this._treatModuleInImportAndFromImportSame)
+            areDeclarationsSame(
+                decl,
+                resolvedDeclNonlocal,
+                this._treatModuleInImportAndFromImportSame,
+                /* skipRangeForAliases */ true
+            )
         );
     }
 
@@ -273,7 +283,14 @@ export class DocumentSymbolCollector extends ParseTreeWalker {
 
     private static _addIfUnique(declarations: Declaration[], itemToAdd: Declaration) {
         for (const def of declarations) {
-            if (areDeclarationsSame(def, itemToAdd)) {
+            if (
+                areDeclarationsSame(
+                    def,
+                    itemToAdd,
+                    /* treatModuleInImportAndFromImportSame */ false,
+                    /* skipRangeForAliases */ true
+                )
+            ) {
                 return;
             }
         }

--- a/packages/pyright-internal/src/tests/diagnostics.test.ts
+++ b/packages/pyright-internal/src/tests/diagnostics.test.ts
@@ -1,0 +1,41 @@
+/*
+ * diagnostics.test.ts
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT license.
+ *
+ * Unit tests for diagnostics
+ */
+
+import { parseAndGetTestState } from './harness/fourslash/testState';
+
+test('unused import', async () => {
+    const code = `
+// @filename: test1.py
+//// from test2 import [|/*marker*/foo|]
+
+// @filename: test2.py
+//// def foo(): pass
+    `;
+
+    const state = parseAndGetTestState(code).state;
+
+    state.verifyDiagnostics({
+        marker: { category: 'unused', message: '"foo" is not accessed' },
+    });
+});
+
+test('pyright ignore unused import', async () => {
+    const code = `
+// @filename: test1.py
+//// from test2 import [|/*marker*/foo|] # pyright: ignore
+
+// @filename: test2.py
+//// def foo(): pass
+    `;
+
+    const state = parseAndGetTestState(code).state;
+
+    state.verifyDiagnostics({
+        marker: { category: 'none', message: '' },
+    });
+});

--- a/packages/pyright-internal/src/tests/fourslash/findDefinitions.namespaceImport.fourslash.ts
+++ b/packages/pyright-internal/src/tests/fourslash/findDefinitions.namespaceImport.fourslash.ts
@@ -22,7 +22,7 @@
                 definitions: [
                     {
                         path: helper.getMarkerByName('def1').fileName,
-                        range: { start: { line: 0, character: 0 }, end: { line: 0, character: 0 } },
+                        range: { start: { line: 0, character: 16 }, end: { line: 0, character: 20 } },
                     },
                 ],
             },
@@ -30,7 +30,7 @@
                 definitions: [
                     {
                         path: helper.getMarkerByName('def2').fileName,
-                        range: { start: { line: 0, character: 0 }, end: { line: 0, character: 0 } },
+                        range: { start: { line: 1, character: 16 }, end: { line: 1, character: 20 } },
                     },
                 ],
             },

--- a/packages/pyright-internal/src/tests/harness/fourslash/testState.ts
+++ b/packages/pyright-internal/src/tests/harness/fourslash/testState.ts
@@ -566,6 +566,8 @@ export class TestState {
                         ? result.warnings
                         : category === 'information'
                         ? result.information
+                        : category === 'unused'
+                        ? result.unused
                         : category === 'none'
                         ? []
                         : this.raiseError(`unexpected category ${category}`);
@@ -1645,6 +1647,7 @@ export class TestState {
                     errors: diagnostics.filter((diag) => diag.category === DiagnosticCategory.Error),
                     warnings: diagnostics.filter((diag) => diag.category === DiagnosticCategory.Warning),
                     information: diagnostics.filter((diag) => diag.category === DiagnosticCategory.Information),
+                    unused: diagnostics.filter((diag) => diag.category === DiagnosticCategory.UnusedCode),
                 };
                 return [filePath, value] as [string, typeof value];
             } else {

--- a/packages/pyright-internal/src/tests/workspaceEditUtils.test.ts
+++ b/packages/pyright-internal/src/tests/workspaceEditUtils.test.ts
@@ -1,0 +1,202 @@
+/*
+ * workspaceEditUtils.test.ts
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT license.
+ *
+ * test workspaceEditUtils
+ */
+
+import * as assert from 'assert';
+import { TextDocumentEdit } from 'vscode-languageserver-types';
+
+import { convertPathToUri } from '../common/pathUtils';
+import { applyWorkspaceEdits, generateWorkspaceEdits } from '../common/workspaceEditUtils';
+import { AnalyzerServiceExecutor } from '../languageService/analyzerServiceExecutor';
+import { TestLanguageService } from './harness/fourslash/testLanguageService';
+import { parseAndGetTestState, TestState } from './harness/fourslash/testState';
+import { verifyWorkspaceEdit } from './harness/fourslash/workspaceEditTestUtils';
+
+test('test applyWorkspaceEdits changes', async () => {
+    const code = `
+// @filename: test.py
+//// [|/*marker*/|]
+        `;
+
+    const state = parseAndGetTestState(code).state;
+    const cloned = await getClonedService(state);
+    const range = state.getRangeByMarkerName('marker')!;
+
+    const fileChanged = new Set<string>();
+    applyWorkspaceEdits(
+        cloned,
+        {
+            changes: {
+                [convertPathToUri(cloned.fs, range.fileName)]: [
+                    {
+                        range: state.convertPositionRange(range),
+                        newText: 'Text Changed',
+                    },
+                ],
+            },
+        },
+        fileChanged
+    );
+
+    assert.strictEqual(fileChanged.size, 1);
+    assert.strictEqual(cloned.test_program.getSourceFile(range.fileName)?.getFileContent(), 'Text Changed');
+});
+
+test('test applyWorkspaceEdits documentChanges', async () => {
+    const code = `
+// @filename: test.py
+//// [|/*marker*/|]
+        `;
+
+    const state = parseAndGetTestState(code).state;
+    const cloned = await getClonedService(state);
+    const range = state.getRangeByMarkerName('marker')!;
+
+    const fileChanged = new Set<string>();
+    applyWorkspaceEdits(
+        cloned,
+        {
+            documentChanges: [
+                TextDocumentEdit.create(
+                    {
+                        uri: convertPathToUri(cloned.fs, range.fileName),
+                        version: null,
+                    },
+                    [
+                        {
+                            range: state.convertPositionRange(range),
+                            newText: 'Text Changed',
+                        },
+                    ]
+                ),
+            ],
+        },
+        fileChanged
+    );
+
+    assert.strictEqual(fileChanged.size, 1);
+    assert.strictEqual(cloned.test_program.getSourceFile(range.fileName)?.getFileContent(), 'Text Changed');
+});
+
+test('test generateWorkspaceEdits', async () => {
+    const code = `
+// @filename: test1.py
+//// [|/*marker1*/|]
+
+// @filename: test2.py
+//// [|/*marker2*/|]
+        `;
+
+    const state = parseAndGetTestState(code).state;
+    const cloned = await getClonedService(state);
+    const range1 = state.getRangeByMarkerName('marker1')!;
+
+    const fileChanged = new Set<string>();
+    applyWorkspaceEdits(
+        cloned,
+        {
+            changes: {
+                [convertPathToUri(cloned.fs, range1.fileName)]: [
+                    {
+                        range: state.convertPositionRange(range1),
+                        newText: 'Test1 Changed',
+                    },
+                ],
+            },
+        },
+        fileChanged
+    );
+
+    applyWorkspaceEdits(
+        cloned,
+        {
+            documentChanges: [
+                TextDocumentEdit.create(
+                    {
+                        uri: convertPathToUri(cloned.fs, range1.fileName),
+                        version: null,
+                    },
+                    [
+                        {
+                            range: { start: { line: 0, character: 0 }, end: { line: 0, character: 5 } },
+                            newText: 'NewTest1',
+                        },
+                    ]
+                ),
+            ],
+        },
+        fileChanged
+    );
+
+    const range2 = state.getRangeByMarkerName('marker2')!;
+    applyWorkspaceEdits(
+        cloned,
+        {
+            documentChanges: [
+                TextDocumentEdit.create(
+                    {
+                        uri: convertPathToUri(cloned.fs, range2.fileName),
+                        version: null,
+                    },
+                    [
+                        {
+                            range: state.convertPositionRange(range2),
+                            newText: 'Test2 Changed',
+                        },
+                    ]
+                ),
+            ],
+        },
+        fileChanged
+    );
+
+    applyWorkspaceEdits(
+        cloned,
+        {
+            changes: {
+                [convertPathToUri(cloned.fs, range2.fileName)]: [
+                    {
+                        range: { start: { line: 0, character: 0 }, end: { line: 0, character: 5 } },
+                        newText: 'NewTest2',
+                    },
+                ],
+            },
+        },
+        fileChanged
+    );
+
+    assert.strictEqual(fileChanged.size, 2);
+
+    const actualEdits = generateWorkspaceEdits(state.workspace.serviceInstance, cloned, fileChanged);
+    verifyWorkspaceEdit(
+        {
+            changes: {
+                [convertPathToUri(cloned.fs, range1.fileName)]: [
+                    {
+                        range: state.convertPositionRange(range1),
+                        newText: 'NewTest1 Changed',
+                    },
+                ],
+                [convertPathToUri(cloned.fs, range2.fileName)]: [
+                    {
+                        range: state.convertPositionRange(range1),
+                        newText: 'NewTest2 Changed',
+                    },
+                ],
+            },
+        },
+        actualEdits
+    );
+});
+
+async function getClonedService(state: TestState) {
+    return await AnalyzerServiceExecutor.cloneService(
+        new TestLanguageService(state.workspace, state.console, state.workspace.serviceInstance.fs),
+        state.workspace,
+        { useBackgroundAnalysis: false }
+    );
+}


### PR DESCRIPTION
Rollup of the following changes:
- Alias declarations have a range so they are deduped correctly
- source.fixall support in pylance
- allow # pyright : ignore  in unused code
- support 'reportShadowedImports' being overridden in pylance

Co-authored-by: Bill Schnurr <bschnurr@microsoft.com>
Co-authored-by: HeeJae Chang <hechang@microsoft.com>
Co-authored-by: Erik De Bonte <erikd@microsoft.com>
Co-authored-by: Rich Chiodo <rchiodo@microsoft.com>