### PR TITLE
improve hover readability by moving multiple parameters and return ty…

### DIFF
--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -24539,8 +24539,16 @@ export function createTypeEvaluator(importLookup: ImportLookup, evaluatorOptions
         if (options?.useTypingUnpack) {
             flags |= TypePrinter.PrintTypeFlags.UseTypingUnpack;
         }
+        const parameterIndention = options?.parameterIndention ?? 0;
 
-        return TypePrinter.printType(type, flags, getFunctionEffectiveReturnType);
+        return TypePrinter.printType(
+            type,
+            flags,
+            getFunctionEffectiveReturnType,
+            /* recursionTypes */ [],
+            /* recursionCount */ 0,
+            parameterIndention
+        );
     }
 
     // Calls back into the parser to parse the contents of a string literal.

--- a/packages/pyright-internal/src/analyzer/typeEvaluatorTypes.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluatorTypes.ts
@@ -321,6 +321,7 @@ export interface PrintTypeOptions {
     expandTypeAlias?: boolean;
     enforcePythonSyntax?: boolean;
     useTypingUnpack?: boolean;
+    parameterIndention?: number;
 }
 
 export interface TypeEvaluator {

--- a/packages/pyright-internal/src/analyzer/typePrinter.ts
+++ b/packages/pyright-internal/src/analyzer/typePrinter.ts
@@ -368,12 +368,12 @@ export function printType(
                         return `((${parts[0].join(', ')}) -> ${parts[1]})`;
                     }
 
-                    // no indentation when only one parameter or when printing functions as parameters
+                    // Use single line form when printing functions as parameters.
                     if (parameterIndention === 0 || recursionCount > 1 || parts[0].length <= 1) {
                         return `(${parts[0].join(', ')}) -> ${parts[1]}`;
                     }
 
-                    // format with indentation
+                    // Separate parameters into addition lines with indentation.
                     const indentString = '\n' + ' '.repeat(parameterIndention);
                     return `(${parts[0].join(',' + indentString)}${indentString}) -> ${parts[1]}`;
                 }
@@ -382,7 +382,7 @@ export function printType(
             case TypeCategory.OverloadedFunction: {
                 const overloadedType = type;
                 const overloads = overloadedType.overloads.map((overload) =>
-                    // Reduce the recursion count by one to allow parameter indention to work
+                    // Reduce the recursion count by one to allow parameter indention to work.
                     printType(
                         overload,
                         printTypeFlags,

--- a/packages/pyright-internal/src/languageService/hoverProvider.ts
+++ b/packages/pyright-internal/src/languageService/hoverProvider.ts
@@ -281,9 +281,12 @@ export class HoverProvider {
                             /* python */ true
                         );
                     } else {
+                        const functionName = node.value + sep;
                         this._addResultsPart(
                             parts,
-                            `(${label}) ` + node.value + sep + evaluator.printType(type),
+                            `(${label}) ` +
+                                functionName +
+                                evaluator.printType(type, { parameterIndention: functionName.length }),
                             /* python */ true
                         );
                     }
@@ -445,18 +448,19 @@ export class HoverProvider {
         }
 
         if (methodType && (isFunction(methodType) || isOverloadedFunction(methodType))) {
-            let classText = '';
+            let classText = '(class)\n';
+            const indention = node.value.length;
             if (isOverloadedFunction(methodType)) {
                 const overloads = methodType.overloads.map((overload) => evaluator.printFunctionParts(overload));
                 overloads.forEach((overload, index) => {
-                    classText = classText + `${node.value}(${overload[0].join(', ')})\n\n`;
+                    classText += `${node.value}(${overload[0].join(',\n' + ' '.repeat(indention))})\n\n`;
                 });
             } else if (isFunction(methodType)) {
                 const functionParts = evaluator.printFunctionParts(methodType);
-                classText = `${node.value}(${functionParts[0].join(', ')})`;
+                classText += `${node.value}(${functionParts[0].join(',\n' + ' '.repeat(indention))})`;
             }
 
-            this._addResultsPart(parts, '(class) ' + classText, /* python */ true);
+            this._addResultsPart(parts, classText, /* python */ true);
             const addedDoc = this._addDocumentationPartForType(
                 format,
                 sourceMapper,
@@ -476,7 +480,7 @@ export class HoverProvider {
 
     private static _getTypeText(node: NameNode, evaluator: TypeEvaluator, expandTypeAlias = false): string {
         const type = evaluator.getType(node) || UnknownType.create();
-        return ': ' + evaluator.printType(type, { expandTypeAlias });
+        return ': ' + evaluator.printType(type, { expandTypeAlias, parameterIndention: node.value.length + 2 });
     }
 
     private static _addDocumentationPart(

--- a/packages/pyright-internal/src/languageService/hoverProvider.ts
+++ b/packages/pyright-internal/src/languageService/hoverProvider.ts
@@ -217,7 +217,7 @@ export class HoverProvider {
                 }
 
                 const typeText = typeVarName || node.value + this._getTypeText(typeNode, evaluator, expandTypeAlias);
-                this._addResultsPart(parts, `(${label}) ${typeText}`, /* python */ true);
+                this._addResultsPart(parts, `(${label})\n${typeText}`, /* python */ true);
                 this._addDocumentationPart(format, sourceMapper, parts, node, evaluator, resolvedDecl);
                 break;
             }
@@ -284,7 +284,7 @@ export class HoverProvider {
                         const functionName = node.value + sep;
                         this._addResultsPart(
                             parts,
-                            `(${label}) ` +
+                            `(${label})\n` +
                                 functionName +
                                 evaluator.printType(type, { parameterIndention: functionName.length }),
                             /* python */ true

--- a/packages/pyright-internal/src/languageService/tooltipUtils.ts
+++ b/packages/pyright-internal/src/languageService/tooltipUtils.ts
@@ -40,7 +40,9 @@ export function getOverloadedFunctionTooltip(
     columnThreshold = 70
 ) {
     let content = '';
-    const overloads = OverloadedFunctionType.getOverloads(type).map((o) => o.details.name + evaluator.printType(o));
+    const overloads = OverloadedFunctionType.getOverloads(type).map(
+        (o) => o.details.name + evaluator.printType(o, { parameterIndention: o.details.name.length })
+    );
 
     for (let i = 0; i < overloads.length; i++) {
         if (i !== 0 && overloads[i].length > columnThreshold && overloads[i - 1].length <= columnThreshold) {

--- a/packages/pyright-internal/src/tests/fourslash/completions.inherited.overload.docFromScrWithStub.fourslash.ts
+++ b/packages/pyright-internal/src/tests/fourslash/completions.inherited.overload.docFromScrWithStub.fourslash.ts
@@ -45,7 +45,7 @@ await helper.verifyCompletion('included', 'markdown', {
                 label: 'func',
                 kind: Consts.CompletionItemKind.Method,
                 documentation:
-                    '```python\nfunc(self: ChildA, x: str) -> str\nfunc(self: ChildA, x: int) -> int\n```\n---\nfunc docs',
+                    '```python\nfunc(self: ChildA,\n    x: str\n    ) -> str\n\nfunc(self: ChildA,\n    x: int\n    ) -> int\n```\n---\nfunc docs',
             },
         ],
     },

--- a/packages/pyright-internal/src/tests/fourslash/completions.inherited.overload.docFromStub.fourslash.ts
+++ b/packages/pyright-internal/src/tests/fourslash/completions.inherited.overload.docFromStub.fourslash.ts
@@ -46,7 +46,7 @@ await helper.verifyCompletion('included', 'markdown', {
                 label: 'func',
                 kind: Consts.CompletionItemKind.Method,
                 documentation:
-                    '```python\nfunc(self: ChildA, x: str) -> str\nfunc(self: ChildA, x: int) -> int\n```\n---\nfunc docs',
+                    '```python\nfunc(self: ChildA,\n    x: str\n    ) -> str\n\nfunc(self: ChildA,\n    x: int\n    ) -> int\n```\n---\nfunc docs',
             },
         ],
     },

--- a/packages/pyright-internal/src/tests/fourslash/hover.builtinDocstrings.fourslash.ts
+++ b/packages/pyright-internal/src/tests/fourslash/hover.builtinDocstrings.fourslash.ts
@@ -49,16 +49,16 @@
 {
     helper.verifyHover('plaintext', {
         object: '(class) object\n\nThis is the class doc for object.',
-        objectInit: '(class) object()\n\nThis is the __init__ doc for object.',
+        objectInit: '(class)\nobject()\n\nThis is the __init__ doc for object.',
         objectDir: '(method) __dir__() -> Iterable[str]\n\nThis is the __dir__ doc for object.',
         a: '(class) A',
-        aInit: '(class) A()',
+        aInit: '(class)\nA()',
         aDir: '(method) __dir__() -> Iterable[str]',
         b: '(class) B\n\nThis is the class doc for B.',
-        bInit: '(class) B()\n\nThis is the __init__ doc for B.',
+        bInit: '(class)\nB()\n\nThis is the __init__ doc for B.',
         c: '(class) C\n\nThis is the class doc for C.',
-        cInit: '(class) C()\n\nThis is the class doc for C.',
+        cInit: '(class)\nC()\n\nThis is the class doc for C.',
         d: '(class) D',
-        dInit: '(class) D()\n\nThis is the __init__ doc for D.',
+        dInit: '(class)\nD()\n\nThis is the __init__ doc for D.',
     });
 }

--- a/packages/pyright-internal/src/tests/fourslash/hover.class.docString.fourslash.ts
+++ b/packages/pyright-internal/src/tests/fourslash/hover.class.docString.fourslash.ts
@@ -24,5 +24,5 @@
 //// class A(): pass
 
 helper.verifyHover('markdown', {
-    marker1: '```python\n(class) A()\n```\n---\ndoc string for A',
+    marker1: '```python\n(class)\nA()\n```\n---\ndoc string for A',
 });

--- a/packages/pyright-internal/src/tests/fourslash/hover.classNoInit.fourslash.ts
+++ b/packages/pyright-internal/src/tests/fourslash/hover.classNoInit.fourslash.ts
@@ -10,5 +10,5 @@
 //// [|/*marker1*/Something|]()
 
 helper.verifyHover('markdown', {
-    marker1: '```python\n(class) Something(text: str)\n```\n---\nThis is a test.',
+    marker1: '```python\n(class)\nSomething(text: str)\n```\n---\nThis is a test.',
 });

--- a/packages/pyright-internal/src/tests/fourslash/hover.docFromSrc.fourslash.ts
+++ b/packages/pyright-internal/src/tests/fourslash/hover.docFromSrc.fourslash.ts
@@ -71,9 +71,9 @@
 //// print(inner.[|/*inner_method1_docs*/method1|]())
 
 helper.verifyHover('markdown', {
-    a_docs: '```python\n(class) A()\n```\n---\nA docs',
-    b_docs: '```python\n(class) B()\n```\n---\nB init docs',
-    a_inner_docs: '```python\n(class) Inner()\n```\n---\nA.Inner docs',
+    a_docs: '```python\n(class)\nA()\n```\n---\nA docs',
+    b_docs: '```python\n(class)\nB()\n```\n---\nB init docs',
+    a_inner_docs: '```python\n(class)\nInner()\n```\n---\nA.Inner docs',
     func1_docs: '```python\n(function) func1() -> bool\n```\n---\nfunc1 docs',
     func2_docs: '```python\n(function) func2() -> bool\n```\n---\nfunc2 docs',
     inner_method1_docs: '```python\n(method) method1() -> bool\n```\n---\nA.Inner.method1 docs',

--- a/packages/pyright-internal/src/tests/fourslash/hover.docFromSrc.typeshed.fourslash.ts
+++ b/packages/pyright-internal/src/tests/fourslash/hover.docFromSrc.typeshed.fourslash.ts
@@ -16,5 +16,5 @@
 //// print(requests.[|/*marker*/head|](''))
 
 helper.verifyHover('markdown', {
-    marker: '```python\n(function) head(url: Unknown, **kwargs: Unknown) -> None\n```\n---\nSends a &lt;HEAD&gt; request.',
+    marker: '```python\n(function) head(url: Unknown,\n    **kwargs: Unknown\n    ) -> None\n```\n---\nSends a &lt;HEAD&gt; request.',
 });

--- a/packages/pyright-internal/src/tests/fourslash/hover.docstring.overloads.fourslash.ts
+++ b/packages/pyright-internal/src/tests/fourslash/hover.docstring.overloads.fourslash.ts
@@ -36,6 +36,6 @@
 
 helper.verifyHover('markdown', {
     marker1:
-        '```python\n(variable) dontwork: Overload[(self: _rand, x: int) -> None, (self: _rand, x: float) -> None]\n```\n---\ndontwork docstring',
+        '```python\n(variable) dontwork: Overload[(self: _rand,\n          x: int\n          ) -> None,\n\n          (self: _rand,\n          x: float\n          ) -> None]\n```\n---\ndontwork docstring',
     marker2: '```python\n(variable) works: (self: _rand) -> None\n```\n---\nworks docstring',
 });

--- a/packages/pyright-internal/src/tests/fourslash/hover.dunderNew.basic.fourslash.ts
+++ b/packages/pyright-internal/src/tests/fourslash/hover.dunderNew.basic.fourslash.ts
@@ -9,5 +9,5 @@
 //// x = [|/*marker1*/Foo|]()
 
 helper.verifyHover('markdown', {
-    marker1: '```python\n(class) Foo(name: str)\n```\n---\ndoc for \\_\\_new\\_\\_.',
+    marker1: '```python\n(class)\nFoo(name: str)\n```\n---\ndoc for \\_\\_new\\_\\_.',
 });

--- a/packages/pyright-internal/src/tests/fourslash/hover.dunderNew.inheritance.fourslash.ts
+++ b/packages/pyright-internal/src/tests/fourslash/hover.dunderNew.inheritance.fourslash.ts
@@ -12,5 +12,5 @@
 //// x = [|/*marker1*/Child|]()
 
 helper.verifyHover('markdown', {
-    marker1: '```python\n(class) Child(name: str)\n```',
+    marker1: '```python\n(class)\nChild(name: str)\n```',
 });

--- a/packages/pyright-internal/src/tests/fourslash/hover.dunderNew.inheritance2.fourslash.ts
+++ b/packages/pyright-internal/src/tests/fourslash/hover.dunderNew.inheritance2.fourslash.ts
@@ -18,5 +18,5 @@
 //// x = [|/*marker1*/GrandChild|]()
 
 helper.verifyHover('markdown', {
-    marker1: '```python\n(class) GrandChild(name: str)\n```',
+    marker1: '```python\n(class)\nGrandChild(name: str)\n```',
 });

--- a/packages/pyright-internal/src/tests/fourslash/hover.dunderNew.overloads.fourslash.ts
+++ b/packages/pyright-internal/src/tests/fourslash/hover.dunderNew.overloads.fourslash.ts
@@ -13,5 +13,5 @@
 //// x = [|/*marker1*/Foo|]()
 
 helper.verifyHover('markdown', {
-    marker1: '```python\n(class) Foo(name: str, last: str)\n\nFoo(age: int, height: float)\n\n\n```',
+    marker1: '```python\n(class)\nFoo(name: str,\n   last: str)\n\nFoo(age: int,\n   height: float)\n\n\n```',
 });

--- a/packages/pyright-internal/src/tests/fourslash/hover.dunderNew.withInit.fourslash.ts
+++ b/packages/pyright-internal/src/tests/fourslash/hover.dunderNew.withInit.fourslash.ts
@@ -11,5 +11,5 @@
 //// x = [|/*marker1*/Foo|]()
 
 helper.verifyHover('markdown', {
-    marker1: '```python\n(class) Foo(name: str)\n```\n---\ndoc for \\_\\_new\\_\\_.',
+    marker1: '```python\n(class)\nFoo(name: str)\n```\n---\ndoc for \\_\\_new\\_\\_.',
 });

--- a/packages/pyright-internal/src/tests/fourslash/hover.inherited.docFromSrc.fourslash.ts
+++ b/packages/pyright-internal/src/tests/fourslash/hover.inherited.docFromSrc.fourslash.ts
@@ -55,9 +55,9 @@
 
 helper.verifyHover('markdown', {
     child_a_method1_docs: '```python\n(method) method1() -> bool\n```\n---\nA.method1 docs',
-    child_a_docs: '```python\n(class) ChildA()\n```',
-    child_b_docs: '```python\n(class) ChildB()\n```\n---\nB init docs',
+    child_a_docs: '```python\n(class)\nChildA()\n```',
+    child_b_docs: '```python\n(class)\nChildB()\n```\n---\nB init docs',
     child_b_init_docs: '```python\n(method) __init__() -> None\n```\n---\nB init docs',
-    secondDerived_docs: '```python\n(class) Derived2()\n```',
+    secondDerived_docs: '```python\n(class)\nDerived2()\n```',
     secondDerived_method_docs: '```python\n(method) method() -> None\n```\n---\nBase.method docs',
 });

--- a/packages/pyright-internal/src/tests/fourslash/hover.inherited.docFromSrcWithStub.fourslash.ts
+++ b/packages/pyright-internal/src/tests/fourslash/hover.inherited.docFromSrcWithStub.fourslash.ts
@@ -47,8 +47,8 @@
 
 helper.verifyHover('markdown', {
     child_a_method1_docs: '```python\n(method) method1() -> bool\n```\n---\nA.method1 docs',
-    child_a_docs: '```python\n(class) ChildA()\n```',
-    child_a_inner_docs: '```python\n(class) ChildInner()\n```',
+    child_a_docs: '```python\n(class)\nChildA()\n```',
+    child_a_inner_docs: '```python\n(class)\nChildInner()\n```',
     child_a_inner_method1_docs: '```python\n(method) method1() -> bool\n```\n---\nA.Inner.method1 docs',
-    child_b_docs: '```python\n(class) ChildB()\n```',
+    child_b_docs: '```python\n(class)\nChildB()\n```',
 });

--- a/packages/pyright-internal/src/tests/fourslash/hover.inherited.docFromStub.fourslash.ts
+++ b/packages/pyright-internal/src/tests/fourslash/hover.inherited.docFromStub.fourslash.ts
@@ -36,7 +36,7 @@
 
 helper.verifyHover('markdown', {
     child_a_method1_docs: '```python\n(method) method1() -> bool\n```\n---\nA.method1 docs',
-    child_a_docs: '```python\n(class) ChildA()\n```',
-    child_a_inner_docs: '```python\n(class) ChildInner()\n```',
+    child_a_docs: '```python\n(class)\nChildA()\n```',
+    child_a_inner_docs: '```python\n(class)\nChildInner()\n```',
     child_a_inner_method1_docs: '```python\n(method) method1() -> bool\n```\n---\nA.Inner.method1 docs',
 });

--- a/packages/pyright-internal/src/tests/fourslash/hover.inherited.overload.docFromSrcWithStub.fourslash.ts
+++ b/packages/pyright-internal/src/tests/fourslash/hover.inherited.overload.docFromSrcWithStub.fourslash.ts
@@ -41,6 +41,6 @@
 
 helper.verifyHover('markdown', {
     child_a_func_doc:
-        '```python\n(method)\nfunc(self: ChildA, x: str) -> str\nfunc(self: ChildA, x: int) -> int\n```\n---\nfunc docs',
+        '```python\n(method)\nfunc(self: ChildA,\n    x: str\n    ) -> str\nfunc(self: ChildA,\n    x: int\n    ) -> int\n```\n---\nfunc docs',
     child_a_instance_func_doc: '```python\n(method)\nfunc(x: str) -> str\nfunc(x: int) -> int\n```\n---\nfunc docs',
 });

--- a/packages/pyright-internal/src/tests/fourslash/hover.inherited.overload.docFromStub.fourslash.ts
+++ b/packages/pyright-internal/src/tests/fourslash/hover.inherited.overload.docFromStub.fourslash.ts
@@ -42,6 +42,6 @@
 
 helper.verifyHover('markdown', {
     child_a_func_doc:
-        '```python\n(method)\nfunc(self: ChildA, x: str) -> str\nfunc(self: ChildA, x: int) -> int\n```\n---\nfunc docs',
+        '```python\n(method)\nfunc(self: ChildA,\n    x: str\n    ) -> str\nfunc(self: ChildA,\n    x: int\n    ) -> int\n```\n---\nfunc docs',
     child_a_instance_func_doc: '```python\n(method)\nfunc(x: str) -> str\nfunc(x: int) -> int\n```\n---\nfunc docs',
 });

--- a/packages/pyright-internal/src/tests/fourslash/hover.init.fourslash.ts
+++ b/packages/pyright-internal/src/tests/fourslash/hover.init.fourslash.ts
@@ -31,9 +31,9 @@
 //// c = test.[|/*marker5*/C1|]()
 
 helper.verifyHover('markdown', {
-    marker1: '```python\n(class) C1(name: str = "hello")\n```\n---\n\\_\\_init\\_\\_ docs',
+    marker1: '```python\n(class)\nC1(name: str = "hello")\n```\n---\n\\_\\_init\\_\\_ docs',
     marker2: '```python\n(type alias) unionType: Type[C1] | Type[C2]\n```',
-    marker3: '```python\n(class) G(value: int)\n```',
-    marker4: '```python\n(class) G(value: int)\n```',
-    marker5: '```python\n(class) C1(name: str = "hello")\n```\n---\n\\_\\_init\\_\\_ docs',
+    marker3: '```python\n(class)\nG(value: int)\n```',
+    marker4: '```python\n(class)\nG(value: int)\n```',
+    marker5: '```python\n(class)\nC1(name: str = "hello")\n```\n---\n\\_\\_init\\_\\_ docs',
 });

--- a/packages/pyright-internal/src/tests/fourslash/hover.libCodeAndStub.fourslash.ts
+++ b/packages/pyright-internal/src/tests/fourslash/hover.libCodeAndStub.fourslash.ts
@@ -44,7 +44,7 @@
 //// obj.[|/*marker5*/read_write_prop|] = r
 
 helper.verifyHover('markdown', {
-    marker1: '```python\n(class) Validator()\n```\n---\nThe validator class',
+    marker1: '```python\n(class)\nValidator()\n```\n---\nThe validator class',
     marker2: '```python\n(method) is_valid(text: str) -> bool\n```\n---\nChecks if the input string is valid.',
     marker3: '```python\n(property) read_only_prop: bool\n```\n---\nThe read-only property.',
     marker4: '```python\n(property) read_write_prop: bool\n```\n---\nThe read-write property.',

--- a/packages/pyright-internal/src/tests/fourslash/hover.libCodeNoStub.fourslash.ts
+++ b/packages/pyright-internal/src/tests/fourslash/hover.libCodeNoStub.fourslash.ts
@@ -33,7 +33,7 @@
 //// obj.[|/*marker5*/read_write_prop|] = r
 
 helper.verifyHover('markdown', {
-    marker1: '```python\n(class) Validator()\n```\n---\nThe validator class',
+    marker1: '```python\n(class)\nValidator()\n```\n---\nThe validator class',
     marker2: '```python\n(method) is_valid(text: str) -> bool\n```\n---\nChecks if the input string is valid.',
     marker3: '```python\n(property) read_only_prop: bool\n```\n---\nThe read-only property.',
     marker4: '```python\n(property) read_write_prop: bool\n```\n---\nThe read-write property.',

--- a/packages/pyright-internal/src/tests/fourslash/hover.libStub.fourslash.ts
+++ b/packages/pyright-internal/src/tests/fourslash/hover.libStub.fourslash.ts
@@ -33,7 +33,7 @@
 //// obj.[|/*marker5*/read_write_prop|] = r
 
 helper.verifyHover('markdown', {
-    marker1: '```python\n(class) Validator()\n```\n---\nThe validator class',
+    marker1: '```python\n(class)\nValidator()\n```\n---\nThe validator class',
     marker2: '```python\n(method) is_valid(text: str) -> bool\n```\n---\nChecks if the input string is valid.',
     marker3: '```python\n(property) read_only_prop: bool\n```\n---\nThe read-only property.',
     marker4: '```python\n(property) read_write_prop: bool\n```\n---\nThe read-write property.',

--- a/packages/pyright-internal/src/tests/fourslash/import.multipart.fourslash.ts
+++ b/packages/pyright-internal/src/tests/fourslash/import.multipart.fourslash.ts
@@ -17,5 +17,5 @@
 
 // @ts-ignore
 helper.verifyHover('markdown', {
-    marker: '```python\n(class) Foo()\n```',
+    marker: '```python\n(class)\nFoo()\n```',
 });


### PR DESCRIPTION
…pe annotations to separate lines

- moving `(method)/(function)/(class)` labels to a separate line 
- moving return type annotation to a separate line to give its types more horizontal visual spacing
![image](https://user-images.githubusercontent.com/1946977/204718920-835744ef-8d91-44d3-8ad4-8da58c5e3cc7.png)


- methods with overloads
![image](https://user-images.githubusercontent.com/1946977/204718002-8896e4d0-6db6-4a57-a137-4402873fdd9f.png)

- adding an additional lines between overloads when an overloaded function is assigned to a variable. 
- 'choice:' isn't appearing blue due to ":" 
![image](https://user-images.githubusercontent.com/1946977/204719895-467ecd95-5194-4060-8ad1-7e7d3795ce16.png)

