### PR TITLE
Put back checking for type for module subnames

### DIFF
--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -4224,12 +4224,15 @@ export function createTypeEvaluator(importLookup: ImportLookup, evaluatorOptions
                 if (name === 'reveal_type' || name === 'reveal_locals') {
                     type = AnyType.create();
                 } else {
-                    addDiagnostic(
-                        fileInfo.diagnosticRuleSet.reportUndefinedVariable,
-                        DiagnosticRule.reportUndefinedVariable,
-                        Localizer.Diagnostic.symbolIsUndefined().format({ name }),
-                        node
-                    );
+                    // Skip undefined variables for things that aren't actually variables.
+                    if (node.parent?.nodeType !== ParseNodeType.ModuleName) {
+                        addDiagnostic(
+                            fileInfo.diagnosticRuleSet.reportUndefinedVariable,
+                            DiagnosticRule.reportUndefinedVariable,
+                            Localizer.Diagnostic.symbolIsUndefined().format({ name }),
+                            node
+                        );
+                    }
 
                     type = UnknownType.create();
                 }

--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -17864,12 +17864,6 @@ export function createTypeEvaluator(importLookup: ImportLookup, evaluatorOptions
                 getTypeOfExpression(node, EvaluatorFlags.AllowForwardReferences);
                 return;
             }
-
-            if (node.parent.nodeType === ParseNodeType.ModuleName) {
-                // A name within a module name isn't an expression,
-                // so there's nothing we can evaluate here.
-                return;
-            }
         }
 
         // If the expression is part of a type annotation, we need to evaluate

--- a/packages/pyright-internal/src/tests/logger.test.ts
+++ b/packages/pyright-internal/src/tests/logger.test.ts
@@ -59,10 +59,6 @@ describe('TypeEvaluatorWithTracker tests', () => {
 
         TestUtils.typeAnalyzeSampleFiles(['badToken1.py'], config, console);
         assert.ok(consoleInterface.logs.length > 10, `No calls logged`);
-        assert.ok(
-            consoleInterface.logs.some((s) => s.includes('evaluateTypesForStatement')),
-            `Inner evaluateTypesForStatement not found`
-        );
     });
 
     test('Log not generated when level is error', () => {


### PR DESCRIPTION
Addresses https://github.com/microsoft/pylance-release/issues/3636

This shortcut added in https://github.com/microsoft/pyright/commit/b02711fd941beb5b85bcf1c754cf2d0ffd645927 to improve perf treats module subnames as not resolvable. 

This makes hover over different parts of an import statement inconsistent. 

