### PR TITLE
Show doc strings on module part hover

### DIFF
--- a/packages/pyright-internal/src/analyzer/typeDocStringUtils.ts
+++ b/packages/pyright-internal/src/analyzer/typeDocStringUtils.ts
@@ -188,7 +188,7 @@ export function getModuleDocString(
     if (!docString) {
         if (resolvedDecl && isStubFile(resolvedDecl.path)) {
             const modules = sourceMapper.findModules(resolvedDecl.path);
-            docString = _getModuleNodeDocString(modules);
+            docString = getModuleNodeDocString(modules);
         }
     }
 
@@ -366,7 +366,7 @@ function _getFunctionOrClassDeclsDocString(decls: FunctionDeclaration[] | ClassD
     return undefined;
 }
 
-function _getModuleNodeDocString(modules: ModuleNode[]): string | undefined {
+export function getModuleNodeDocString(modules: ModuleNode[]): string | undefined {
     for (const module of modules) {
         if (module.statements) {
             const docString = ParseTreeUtils.getDocString(module.statements);

--- a/packages/pyright-internal/src/analyzer/typeDocStringUtils.ts
+++ b/packages/pyright-internal/src/analyzer/typeDocStringUtils.ts
@@ -179,6 +179,19 @@ export function getVariableInStubFileDocStrings(decl: VariableDeclaration, sourc
     return docStrings;
 }
 
+export function getModuleNodeDocString(modules: ModuleNode[]): string | undefined {
+    for (const module of modules) {
+        if (module.statements) {
+            const docString = ParseTreeUtils.getDocString(module.statements);
+            if (docString) {
+                return docString;
+            }
+        }
+    }
+
+    return undefined;
+}
+
 export function getModuleDocString(
     type: ModuleType,
     resolvedDecl: DeclarationBase | undefined,
@@ -360,19 +373,6 @@ function _getFunctionOrClassDeclsDocString(decls: FunctionDeclaration[] | ClassD
         const docString = getFunctionOrClassDeclDocString(decl);
         if (docString) {
             return docString;
-        }
-    }
-
-    return undefined;
-}
-
-export function getModuleNodeDocString(modules: ModuleNode[]): string | undefined {
-    for (const module of modules) {
-        if (module.statements) {
-            const docString = ParseTreeUtils.getDocString(module.statements);
-            if (docString) {
-                return docString;
-            }
         }
     }
 

--- a/packages/pyright-internal/src/languageService/hoverProvider.ts
+++ b/packages/pyright-internal/src/languageService/hoverProvider.ts
@@ -147,8 +147,13 @@ export class HoverProvider {
         } else if (node.nodeType === ParseNodeType.ModuleName || node.nodeType === ParseNodeType.Module) {
             const importInfo = getImportInfo(node);
             if (importInfo) {
-                this._addResultsPart(results.parts, '(module) ' + importInfo.importName, /* python */ true);
-                this._addModuleDocString(format, sourceMapper, results.parts, importInfo.resolvedPaths);
+                this._addModuleParts(
+                    format,
+                    sourceMapper,
+                    results.parts,
+                    importInfo.importName,
+                    importInfo.resolvedPaths
+                );
             }
         }
 
@@ -301,8 +306,7 @@ export class HoverProvider {
             }
 
             case DeclarationType.Alias: {
-                this._addResultsPart(parts, '(module) ' + node.value, /* python */ true);
-                this._addModuleDocString(format, sourceMapper, parts, [resolvedDecl.path]);
+                this._addModuleParts(format, sourceMapper, parts, node.value, [resolvedDecl.path]);
                 break;
             }
 
@@ -501,12 +505,16 @@ export class HoverProvider {
         }
     }
 
-    private static _addModuleDocString(
+    private static _addModuleParts(
         format: MarkupKind,
         sourceMapper: SourceMapper,
         parts: HoverTextPart[],
+        name: string,
         resolvedPaths: string[]
     ) {
+        // First the 'module' header.
+        this._addResultsPart(parts, '(module) ' + name, /* python */ true);
+
         // Parse the modules files and try to find the doc string.
         const modules = resolvedPaths.map((p) => sourceMapper.findModules(p)).flat();
         const docString = getModuleNodeDocString(modules);

--- a/packages/pyright-internal/src/languageService/hoverProvider.ts
+++ b/packages/pyright-internal/src/languageService/hoverProvider.ts
@@ -491,11 +491,6 @@ export class HoverProvider {
         const type = evaluator.getType(node);
         if (type) {
             this._addDocumentationPartForType(format, sourceMapper, parts, type, resolvedDecl, evaluator);
-        } else if (node.parent?.nodeType === ParseNodeType.ModuleName) {
-            const importInfo = getImportInfo(node.parent);
-            if (importInfo) {
-                this._addModuleParts(format, sourceMapper, parts, importInfo.importName, importInfo.resolvedPaths);
-            }
         }
     }
 

--- a/packages/pyright-internal/src/languageService/hoverProvider.ts
+++ b/packages/pyright-internal/src/languageService/hoverProvider.ts
@@ -144,17 +144,6 @@ export class HoverProvider {
             if (type !== undefined) {
                 this._tryAddPartsForTypedDictKey(format, sourceMapper, evaluator, node, type, results.parts);
             }
-        } else if (node.nodeType === ParseNodeType.ModuleName || node.nodeType === ParseNodeType.Module) {
-            const importInfo = getImportInfo(node);
-            if (importInfo) {
-                this._addModuleParts(
-                    format,
-                    sourceMapper,
-                    results.parts,
-                    importInfo.importName,
-                    importInfo.resolvedPaths
-                );
-            }
         }
 
         return results.parts.length > 0 ? results : undefined;
@@ -502,6 +491,11 @@ export class HoverProvider {
         const type = evaluator.getType(node);
         if (type) {
             this._addDocumentationPartForType(format, sourceMapper, parts, type, resolvedDecl, evaluator);
+        } else if (node.parent?.nodeType === ParseNodeType.ModuleName) {
+            const importInfo = getImportInfo(node.parent);
+            if (importInfo) {
+                this._addModuleParts(format, sourceMapper, parts, importInfo.importName, importInfo.resolvedPaths);
+            }
         }
     }
 

--- a/packages/pyright-internal/src/languageService/hoverProvider.ts
+++ b/packages/pyright-internal/src/languageService/hoverProvider.ts
@@ -11,7 +11,6 @@
 
 import { CancellationToken, Hover, MarkupKind } from 'vscode-languageserver';
 
-import { getImportInfo } from '../analyzer/analyzerNodeInfo';
 import { Declaration, DeclarationType } from '../analyzer/declaration';
 import { convertDocStringToMarkdown, convertDocStringToPlainText } from '../analyzer/docStringConversion';
 import * as ParseTreeUtils from '../analyzer/parseTreeUtils';

--- a/packages/pyright-internal/src/tests/fourslash/hover.docFromSrc.fourslash.ts
+++ b/packages/pyright-internal/src/tests/fourslash/hover.docFromSrc.fourslash.ts
@@ -55,19 +55,19 @@
 //// def func2() -> bool: ...
 
 // @filename: test.py
-//// import module1
-//// import module2
+//// import [|/*module1_docs*/module1|] as m1
+//// import [|/*module2_docs*/module2|] as m2
 ////
-//// print([|/*module1_docs*/module1|].[|/*func1_docs*/func1|]())
+//// print([|/*m1_docs*/m1|].[|/*func1_docs*/func1|]())
 ////
-//// a = module1.[|/*a_docs*/A|]()
+//// a = m1.[|/*a_docs*/A|]()
 //// print(a.[|/*method1_docs*/method1|]())
 ////
-//// b = module1.[|/*b_docs*/B|]()
+//// b = m1.[|/*b_docs*/B|]()
 ////
-//// print([|/*module2_docs*/module2|].[|/*func2_docs*/func2|]())
+//// print([|/*m2_docs*/m2|].[|/*func2_docs*/func2|]())
 ////
-//// inner = module1.A.[|/*a_inner_docs*/Inner|]()
+//// inner = m1.A.[|/*a_inner_docs*/Inner|]()
 //// print(inner.[|/*inner_method1_docs*/method1|]())
 
 helper.verifyHover('markdown', {
@@ -80,4 +80,6 @@ helper.verifyHover('markdown', {
     method1_docs: '```python\n(method) method1() -> bool\n```\n---\nA.method1 docs',
     module1_docs: '```python\n(module) module1\n```\n---\nmodule1 docs',
     module2_docs: '```python\n(module) module2\n```\n---\nmodule2 docs',
+    m1_docs: '```python\n(module) m1\n```\n---\nmodule1 docs',
+    m2_docs: '```python\n(module) m2\n```\n---\nmodule2 docs',
 });

--- a/packages/pyright-internal/src/tests/fourslash/hover.docFromSrc.pkg-vs-module2.fourslash.ts
+++ b/packages/pyright-internal/src/tests/fourslash/hover.docFromSrc.pkg-vs-module2.fourslash.ts
@@ -2,10 +2,12 @@
 
 // @filename: package1/__init__.py
 // @library: true
+//// '''package1 docs'''
 //// from .subpackage import func1
 
 // @filename: package1/subpackage/__init__.py
 // @library: true
+//// '''subpackage docs'''
 //// def func1():
 ////     '''func1 docs'''
 ////     return True
@@ -17,10 +19,11 @@
 //// def func1() -> bool: ...
 
 // @filename: test.py
-//// from package1 import func1
+//// from [|/*package_docs*/package1|] import func1
 ////
 //// print([|/*func1_docs*/func1|]())
 
 helper.verifyHover('markdown', {
     func1_docs: '```python\n(function) func1() -> bool\n```\n---\nfunc1 docs',
+    package_docs: '```python\n(module) package1\n```\n---\npackage1 docs',
 });

--- a/packages/pyright-internal/src/tests/fourslash/hover.docFromSrc.relativeImport2.fourslash.ts
+++ b/packages/pyright-internal/src/tests/fourslash/hover.docFromSrc.relativeImport2.fourslash.ts
@@ -13,10 +13,11 @@
 ////
 
 // @filename: test.py
-//// from .module1 import func1
+//// from [|/*module_docs*/.module1|] import func1
 ////
 //// print([|/*func1_docs*/func1|]())
 
 helper.verifyHover('markdown', {
     func1_docs: '```python\n(function) func1() -> bool\n```\n---\nfunc1 docs',
+    module_docs: '```python\n(module) .module1\n```\n---\nmodule1 docs',
 });

--- a/packages/pyright-internal/src/tests/fourslash/hover.docFromSrc.relativeImport2.fourslash.ts
+++ b/packages/pyright-internal/src/tests/fourslash/hover.docFromSrc.relativeImport2.fourslash.ts
@@ -13,11 +13,11 @@
 ////
 
 // @filename: test.py
-//// from [|/*module_docs*/.module1|] import func1
+//// from .[|/*module_docs*/module1|] import func1
 ////
 //// print([|/*func1_docs*/func1|]())
 
 helper.verifyHover('markdown', {
     func1_docs: '```python\n(function) func1() -> bool\n```\n---\nfunc1 docs',
-    module_docs: '```python\n(module) .module1\n```\n---\nmodule1 docs',
+    module_docs: '```python\n(module) module1\n```\n---\nmodule1 docs',
 });

--- a/packages/pyright-internal/src/tests/fourslash/hover.docFromSrc.relativeImport3.fourslash.ts
+++ b/packages/pyright-internal/src/tests/fourslash/hover.docFromSrc.relativeImport3.fourslash.ts
@@ -29,6 +29,7 @@
 //// # empty
 
 // @filename: typings/dj/db/models/__init__.pyi
+//// '''models doc string'''
 //// from .base import Model as Model
 
 // @filename: typings/dj/db/models/base.pyi
@@ -36,7 +37,7 @@
 ////     def clean_fields(self) -> None: ...
 
 // @filename: test.py
-//// from [|/*djmarker*/dj|].[|/*dbmarker*/db|] import models
+//// from [|/*djmarker*/dj|].[|/*dbmarker*/db|] import [|/*modelsmarker*/models|]
 ////
 //// class Person(models.Model):
 ////     pass
@@ -48,4 +49,5 @@ helper.verifyHover('markdown', {
     marker: '```python\n(method) clean_fields() -> None\n```\n---\nclean\\_fields docs',
     djmarker: '```python\n(module) dj\n```\n---\ndj doc string',
     dbmarker: '```python\n(module) db\n```\n---\ndb doc string',
+    modelsmarker: '```python\n(module) models\n```\n---\nmodels doc string',
 });

--- a/packages/pyright-internal/src/tests/fourslash/hover.docFromSrc.relativeImport3.fourslash.ts
+++ b/packages/pyright-internal/src/tests/fourslash/hover.docFromSrc.relativeImport3.fourslash.ts
@@ -2,14 +2,17 @@
 
 // @filename: dj/__init__.py
 // @library: true
+//// '''dj doc string'''
 //// # empty
 
 // @filename: dj/db/__init__.py
 // @library: true
+//// '''db doc string'''
 //// # empty
 
 // @filename: dj/db/models/__init__.py
 // @library: true
+//// '''models doc string'''
 //// from dj.db.models.base import Model
 
 // @filename: dj/db/models/base.py
@@ -33,7 +36,7 @@
 ////     def clean_fields(self) -> None: ...
 
 // @filename: test.py
-//// from dj.db import models
+//// from [|/*djmarker*/dj|].[|/*dbmarker*/db|] import models
 ////
 //// class Person(models.Model):
 ////     pass
@@ -43,4 +46,6 @@
 
 helper.verifyHover('markdown', {
     marker: '```python\n(method) clean_fields() -> None\n```\n---\nclean\\_fields docs',
+    djmarker: '```python\n(module) dj\n```\n---\ndj doc string',
+    dbmarker: '```python\n(module) db\n```\n---\ndb doc string',
 });


### PR DESCRIPTION
Addresses https://github.com/microsoft/pylance-release/issues/3636

Use parsed source file to determine module doc strings on hover even when the module is not used.