### PR TITLE
[PylanceBot] Pull Pylance with Pyright 1.1.283

### DIFF
--- a/packages/pyright-internal/src/analyzer/backgroundAnalysisProgram.ts
+++ b/packages/pyright-internal/src/analyzer/backgroundAnalysisProgram.ts
@@ -158,6 +158,10 @@ export class BackgroundAnalysisProgram {
         );
     }
 
+    analyzeFile(filePath: string, token: CancellationToken): boolean {
+        return this._program.analyzeFile(filePath, token);
+    }
+
     startIndexing(indexOptions: IndexOptions) {
         this._backgroundAnalysis?.startIndexing(indexOptions, this._configOptions, this.importResolver, this.host.kind);
     }

--- a/packages/pyright-internal/src/analyzer/program.ts
+++ b/packages/pyright-internal/src/analyzer/program.ts
@@ -576,6 +576,18 @@ export class Program {
         });
     }
 
+    // Performs parsing and analysis of a single file in the program. If the file is not part of
+    // the program returns false to indicate analysis was not performed.
+    analyzeFile(filePath: string, token: CancellationToken = CancellationToken.None): boolean {
+        return this._runEvaluatorWithCancellationToken(token, () => {
+            const sourceFileInfo = this.getSourceFileInfo(filePath);
+            if (sourceFileInfo && this._checkTypes(sourceFileInfo, token)) {
+                return true;
+            }
+            return false;
+        });
+    }
+
     indexWorkspace(callback: (path: string, results: IndexResults) => void, token: CancellationToken): number {
         if (!this._configOptions.indexing) {
             return 0;
@@ -1604,7 +1616,7 @@ export class Program {
             const content = sourceFileInfo.sourceFile.getFileContent() ?? '';
             if (
                 options.indexingForAutoImportMode &&
-                !options.forceIndexing &&
+                !options.includeAllSymbols &&
                 !sourceFileInfo.sourceFile.isStubFile() &&
                 !sourceFileInfo.sourceFile.isThirdPartyPyTypedPresent()
             ) {

--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -21632,7 +21632,6 @@ export function createTypeEvaluator(importLookup: ImportLookup, evaluatorOptions
         if (isClassInstance(expandedSrcType) && ClassType.isBuiltIn(expandedSrcType, 'type')) {
             const srcTypeArgs = expandedSrcType.typeArguments;
             let typeTypeArg: Type;
-            let instantiableType: Type;
             if (srcTypeArgs && srcTypeArgs.length >= 1) {
                 typeTypeArg = srcTypeArgs[0];
                 if (isAnyOrUnknown(typeTypeArg)) {
@@ -21641,17 +21640,15 @@ export function createTypeEvaluator(importLookup: ImportLookup, evaluatorOptions
                     }
                     return TypeBase.isInstantiable(destType);
                 }
-                instantiableType = convertToInstantiable(typeTypeArg);
             } else {
                 typeTypeArg = objectType ?? AnyType.create();
-                instantiableType = expandedSrcType;
             }
 
             if (isClassInstance(typeTypeArg) || isTypeVar(typeTypeArg)) {
                 if (
                     assignType(
                         destType,
-                        instantiableType,
+                        convertToInstantiable(typeTypeArg),
                         diag?.createAddendum(),
                         destTypeVarContext,
                         srcTypeVarContext,

--- a/packages/pyright-internal/src/backgroundAnalysisBase.ts
+++ b/packages/pyright-internal/src/backgroundAnalysisBase.ts
@@ -635,6 +635,6 @@ export interface AnalysisResponse {
 }
 
 export interface IndexOptions {
-    // forceIndexing means it will include symbols not shown in __all__ for py file.
-    packageDepths: [moduleName: string, maxDepth: number, forceIndexing: boolean][];
+    // includeAllSymbols means it will include symbols not shown in __all__ for py file.
+    packageDepths: [moduleName: string, maxDepth: number, includeAllSymbols: boolean][];
 }

--- a/packages/pyright-internal/src/common/positionUtils.ts
+++ b/packages/pyright-internal/src/common/positionUtils.ts
@@ -22,20 +22,13 @@ export function convertOffsetToPosition(offset: number, lines: TextRangeCollecti
         };
     }
 
-    // Handle the case where we're pointing to the last line of the file.
-    let offsetAdjustment = 0;
-    if (offset >= lines.end) {
-        offset = lines.end - 1;
-        offsetAdjustment = 1;
-    }
-
-    const itemIndex = lines.getItemContaining(offset);
-    assert(itemIndex >= 0 && itemIndex <= lines.length);
+    const itemIndex = offset >= lines.end ? lines.count - 1 : lines.getItemContaining(offset);
+    assert(itemIndex >= 0 && itemIndex <= lines.count);
     const lineRange = lines.getItemAt(itemIndex);
     assert(lineRange !== undefined);
     return {
         line: itemIndex,
-        character: offset - lineRange.start + offsetAdjustment,
+        character: Math.max(0, Math.min(lineRange.length, offset - lineRange.start)),
     };
 }
 

--- a/packages/pyright-internal/src/languageServerBase.ts
+++ b/packages/pyright-internal/src/languageServerBase.ts
@@ -1400,6 +1400,7 @@ export abstract class LanguageServerBase implements LanguageServerInterface {
             includeUserSymbolsInAutoImport: false,
             extraCommitChars: false,
             importFormat: ImportFormat.Absolute,
+            triggerCharacter: params?.context?.triggerCharacter,
         };
     }
 

--- a/packages/pyright-internal/src/languageService/completionProvider.ts
+++ b/packages/pyright-internal/src/languageService/completionProvider.ts
@@ -276,6 +276,7 @@ export interface CompletionOptions {
     includeUserSymbolsInAutoImport: boolean;
     extraCommitChars: boolean;
     importFormat: ImportFormat;
+    triggerCharacter?: string;
 }
 
 export type AbbreviationMap = Map<string, AbbreviationInfo>;
@@ -509,6 +510,11 @@ export class CompletionProvider {
                 if (result || result === undefined) {
                     return result;
                 }
+            }
+
+            if (curNode.nodeType === ParseNodeType.List && this._options.triggerCharacter === '[') {
+                // If this is an empty list, don't start putting completions up yet.
+                return undefined;
             }
 
             if (curNode.nodeType === ParseNodeType.ImportFrom) {

--- a/packages/pyright-internal/src/languageService/documentSymbolProvider.ts
+++ b/packages/pyright-internal/src/languageService/documentSymbolProvider.ts
@@ -58,7 +58,7 @@ export interface IndexResults {
 
 export interface IndexOptions {
     indexingForAutoImportMode: boolean;
-    forceIndexing?: boolean;
+    includeAllSymbols?: boolean;
 }
 
 export type WorkspaceSymbolCallback = (symbols: SymbolInformation[]) => void;
@@ -332,7 +332,7 @@ function collectSymbolIndexData(
         // If we are not py.typed package, symbol must exist in __all__ for auto import mode.
         if (
             options.indexingForAutoImportMode &&
-            !options.forceIndexing &&
+            !options.includeAllSymbols &&
             !fileInfo.isStubFile &&
             !fileInfo.isInPyTypedPackage &&
             !symbol.isInDunderAll()

--- a/packages/pyright-internal/src/parser/parser.ts
+++ b/packages/pyright-internal/src/parser/parser.ts
@@ -1410,15 +1410,15 @@ export class Parser {
                 postColonCallback();
             }
 
+            let bodyIndentToken: IndentToken | undefined;
             const possibleIndent = this._peekToken();
             if (!this._consumeTokenIfType(TokenType.Indent)) {
                 this._addError(Localizer.Diagnostic.expectedIndentedBlock(), this._peekToken());
-                return suite;
-            }
-
-            const bodyIndentToken = possibleIndent as IndentToken;
-            if (bodyIndentToken.isIndentAmbiguous) {
-                this._addError(Localizer.Diagnostic.inconsistentTabs(), bodyIndentToken);
+            } else {
+                bodyIndentToken = possibleIndent as IndentToken;
+                if (bodyIndentToken.isIndentAmbiguous) {
+                    this._addError(Localizer.Diagnostic.inconsistentTabs(), bodyIndentToken);
+                }
             }
 
             while (true) {
@@ -1456,15 +1456,6 @@ export class Parser {
                     // initial indent of the suite body?
                     if (!bodyIndentToken || dedentToken.indentAmount < bodyIndentToken.indentAmount) {
                         break;
-                    } else if (dedentToken.indentAmount === bodyIndentToken.indentAmount) {
-                        // If the next token is also a dedent that reduces the indent
-                        // level to a less than the initial indent of the suite body, swallow
-                        // the extra dedent to help recover the parse.
-                        const nextToken = this._peekToken();
-                        if (this._consumeTokenIfType(TokenType.Dedent)) {
-                            extendRange(suite, nextToken);
-                            break;
-                        }
                     }
                 }
 

--- a/packages/pyright-internal/src/tests/checker.test.ts
+++ b/packages/pyright-internal/src/tests/checker.test.ts
@@ -388,7 +388,7 @@ test('Python2', () => {
 test('InconsistentSpaceTab1', () => {
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['inconsistentSpaceTab1.py']);
 
-    TestUtils.validateResults(analysisResults, 1);
+    TestUtils.validateResults(analysisResults, 4);
 });
 
 test('InconsistentSpaceTab2', () => {

--- a/packages/pyright-internal/src/tests/indentationUtils.ptvs.test.ts
+++ b/packages/pyright-internal/src/tests/indentationUtils.ptvs.test.ts
@@ -26,7 +26,7 @@ test('top level statement - function', () => {
 ////  [|/*marker*/|]
     `;
 
-    testIndentation(code, 0);
+    testIndentation(code, 4);
 });
 
 test('function with open paren at end of file', () => {
@@ -34,10 +34,7 @@ test('function with open paren at end of file', () => {
 //// def f(
 //// [|/*marker*/|]
     `;
-
-    // This is due to how our tokenizer associate new line at
-    // end of stream.
-    testIndentation(code, 0);
+    testIndentation(code, 4);
 });
 
 test('function with open paren between top level statement', () => {
@@ -76,10 +73,7 @@ test('call with open paren at end of file', () => {
 //// f(
 //// [|/*marker*/|]
     `;
-
-    // This is due to how our tokenizer associate new line at
-    // end of stream.
-    testIndentation(code, 0);
+    testIndentation(code, 4);
 });
 
 test('call with open paren between top level statement', () => {

--- a/packages/pyright-internal/src/tests/indentationUtils.test.ts
+++ b/packages/pyright-internal/src/tests/indentationUtils.test.ts
@@ -45,7 +45,7 @@ test('first child indentation', () => {
 ////     [|/*marker*/|]
     `;
 
-    testIndentation(code, 0);
+    testIndentation(code, 4);
 });
 
 test('nested first child indentation', () => {
@@ -55,7 +55,7 @@ test('nested first child indentation', () => {
 ////         [|/*marker*/|]
     `;
 
-    testIndentation(code, 4);
+    testIndentation(code, 8);
 });
 
 test('nested sibling indentation', () => {
@@ -272,7 +272,7 @@ test('single line comment', () => {
 
     `;
 
-    testIndentation(code, 0);
+    testIndentation(code, 4);
 });
 
 test('multiline string literals top', () => {
@@ -442,7 +442,7 @@ test('unfinished block', () => {
 ////     return 1
     `;
 
-    testIndentation(code, 4);
+    testIndentation(code, 8);
 });
 
 function testIndentation(code: string, indentation: number, preferDedent?: boolean) {

--- a/packages/pyright-internal/src/tests/parser.test.ts
+++ b/packages/pyright-internal/src/tests/parser.test.ts
@@ -103,7 +103,7 @@ test('ParserRecovery1', () => {
     const diagSink = new DiagnosticSink();
     const parseResults = TestUtils.parseSampleFile('parserRecovery1.py', diagSink).parseResults;
 
-    const node = findNodeByOffset(parseResults.parseTree, parseResults.text.length - 2);
+    const node = findNodeByOffset(parseResults.parseTree, parseResults.text.length - 1);
     const functionNode = getFirstAncestorOrSelfOfKind(node, ParseNodeType.Function);
     assert.equal(functionNode!.parent!.nodeType, ParseNodeType.Module);
 });
@@ -112,7 +112,7 @@ test('ParserRecovery2', () => {
     const diagSink = new DiagnosticSink();
     const parseResults = TestUtils.parseSampleFile('parserRecovery2.py', diagSink).parseResults;
 
-    const node = findNodeByOffset(parseResults.parseTree, parseResults.text.length - 2);
+    const node = findNodeByOffset(parseResults.parseTree, parseResults.text.length - 1);
     const functionNode = getFirstAncestorOrSelfOfKind(node, ParseNodeType.Function);
     assert.equal(functionNode!.parent!.nodeType, ParseNodeType.Suite);
 });
@@ -121,7 +121,7 @@ test('ParserRecovery3', () => {
     const diagSink = new DiagnosticSink();
     const parseResults = TestUtils.parseSampleFile('parserRecovery3.py', diagSink).parseResults;
 
-    const node = findNodeByOffset(parseResults.parseTree, parseResults.text.length - 2);
+    const node = findNodeByOffset(parseResults.parseTree, parseResults.text.length - 1);
     const functionNode = getFirstAncestorOrSelfOfKind(node, ParseNodeType.Function);
     assert.equal(functionNode!.parent!.nodeType, ParseNodeType.Module);
 });

--- a/packages/pyright-internal/src/tests/samples/genericTypes28.py
+++ b/packages/pyright-internal/src/tests/samples/genericTypes28.py
@@ -1,7 +1,7 @@
 # This sample tests that Optional types can be matched
 # to Type[T] expressions.
 
-from typing import Callable, Generic, Optional, Type, TypeVar
+from typing import Generic, Optional, Type, TypeVar
 
 _T1 = TypeVar("_T1")
 _T2 = TypeVar("_T2", bound=None)
@@ -49,7 +49,3 @@ def bar(value: _T1) -> Type[Foo[_T1]]:
 d = Bar.get()
 reveal_type(d, expected_text="Type[Bar]")
 reveal_type(Bar.get(), expected_text="Type[Bar]")
-
-
-def class_constructor(cls: type[_T1]) -> Callable[..., _T1]:
-    return cls

--- a/packages/pyright-internal/src/tests/samples/pyrightIgnore2.py
+++ b/packages/pyright-internal/src/tests/samples/pyrightIgnore2.py
@@ -1,4 +1,4 @@
-# This sample tests the use of a pyright ignore comment in conjunction
+# This sample tests the use of a # pyright: ignore comment in conjunction
 # with the reportUnnecessaryTypeIgnoreComment mechanism.
 
 from typing import Optional
@@ -19,6 +19,6 @@ def foo(self, x: Optional[int]) -> str:
     v4 = x + x  # pyright: ignore []
 
     # One of these is unnecessary
-    v5 = x + "hi"  # test # pyright: ignore [reportGeneralTypeIssues, foo]
+    v5 = x + "hi"  # pyright: ignore [reportGeneralTypeIssues, foo]
 
     return 3  # pyright: ignore [reportGeneralTypeIssues]

--- a/packages/pyright-internal/src/tests/tokenizer.test.ts
+++ b/packages/pyright-internal/src/tests/tokenizer.test.ts
@@ -1391,12 +1391,12 @@ test('Lines1', () => {
     // the replacement here.
     const sampleTextLfOnly = sampleText.replace(/\r\n/g, '\n');
     const resultsLf = t.tokenize(sampleTextLfOnly);
-    assert.equal(resultsLf.lines.count, 14);
+    assert.equal(resultsLf.lines.count, 15);
 
     // Now replace the LF with CR/LF sequences.
     const sampleTextCrLf = sampleTextLfOnly.replace(/\n/g, '\r\n');
     const resultsCrLf = t.tokenize(sampleTextCrLf);
-    assert.equal(resultsCrLf.lines.count, 14);
+    assert.equal(resultsCrLf.lines.count, 15);
 });
 
 test('Comments1', () => {


### PR DESCRIPTION
-   Bug fix: `source.unusedImports` is very slow and adds unnecessary whitespace [pylance-release#3715](https://github.com/microsoft/pylance-release/issues/3715)
-   Bug fix: Bad autocomplete when typing an open square bracket [pylance-release#3651](https://github.com/microsoft/pylance-release/issues/3651)
-   Enhancement: Apply includeAllSymbols flag to the default option

Co-authored-by: Bill Schnurr <bschnurr@microsoft.com>
Co-authored-by: HeeJae Chang <hechang@microsoft.com>
Co-authored-by: Erik De Bonte <erikd@microsoft.com>
Co-authored-by: Rich Chiodo <rchiodo@microsoft.com>
