### PR TITLE
Fix exclusions/inclusions to work with '.' prefixed directories

### DIFF
--- a/packages/pyright-internal/src/common/pathUtils.ts
+++ b/packages/pyright-internal/src/common/pathUtils.ts
@@ -649,7 +649,7 @@ export function getWildcardRegexPattern(rootPath: string, fileSpec: string): str
     const pathComponents = getPathComponents(absolutePath);
 
     const escapedSeparator = getRegexEscapedSeparator();
-    const doubleAsteriskRegexFragment = `(${escapedSeparator}[^${escapedSeparator}][^${escapedSeparator}]*)*?`;
+    const doubleAsteriskRegexFragment = `(${escapedSeparator}[^${escapedSeparator}][^.][^${escapedSeparator}]*)*?`;
     const reservedCharacterPattern = new RegExp(`[^\\w\\s${escapedSeparator}]`, 'g');
 
     // Strip the directory separator from the root component.

--- a/packages/pyright-internal/src/common/pathUtils.ts
+++ b/packages/pyright-internal/src/common/pathUtils.ts
@@ -649,7 +649,7 @@ export function getWildcardRegexPattern(rootPath: string, fileSpec: string): str
     const pathComponents = getPathComponents(absolutePath);
 
     const escapedSeparator = getRegexEscapedSeparator();
-    const doubleAsteriskRegexFragment = `(${escapedSeparator}[^${escapedSeparator}.][^${escapedSeparator}]*)*?`;
+    const doubleAsteriskRegexFragment = `(${escapedSeparator}[^${escapedSeparator}][^${escapedSeparator}]*)*?`;
     const reservedCharacterPattern = new RegExp(`[^\\w\\s${escapedSeparator}]`, 'g');
 
     // Strip the directory separator from the root component.

--- a/packages/pyright-internal/src/tests/pathUtils.test.ts
+++ b/packages/pyright-internal/src/tests/pathUtils.test.ts
@@ -27,7 +27,6 @@ import {
     getFileExtension,
     getFileName,
     getPathComponents,
-    getRegexEscapedSeparator,
     getRelativePath,
     getRelativePathFromDirectory,
     getWildcardRegexPattern,
@@ -133,26 +132,33 @@ test('stripFileExtension2', () => {
     assert.equal(path2, 'blah.blah/hello.cpython-32m');
 });
 
+function fixSeparators(linuxPath: string) {
+    if (path.sep === '\\') {
+        return linuxPath.replace(/\//g, path.sep);
+    }
+    return linuxPath;
+}
+
 test('getWildcardRegexPattern1', () => {
     const pattern = getWildcardRegexPattern('/users/me', './blah/');
     const regex = new RegExp(pattern);
-    assert.ok(regex.test('/users/me/blah/d'));
-    assert.ok(!regex.test('/users/me/blad/d'));
+    assert.ok(regex.test(fixSeparators('/users/me/blah/d')));
+    assert.ok(!regex.test(fixSeparators('/users/me/blad/d')));
 });
 
 test('getWildcardRegexPattern2', () => {
     const pattern = getWildcardRegexPattern('/users/me', './**/*.py?');
     const regex = new RegExp(pattern);
-    assert.ok(regex.test('/users/me/.blah/foo.pyd'));
-    assert.ok(!regex.test('/users/me/./foo.py'));
-    assert.ok(!regex.test('/users/me/.blah/foo.py')); // No char after
+    assert.ok(regex.test(fixSeparators('/users/me/.blah/foo.pyd')));
+    assert.ok(!regex.test(fixSeparators('/users/me/./foo.py')));
+    assert.ok(!regex.test(fixSeparators('/users/me/.blah/foo.py'))); // No char after
 });
 
 test('getWildcardRegexPattern3', () => {
     const pattern = getWildcardRegexPattern('/users/me', './**/.*.py');
     const regex = new RegExp(pattern);
-    assert.ok(regex.test('/users/me/.blah/.foo.py'));
-    assert.ok(!regex.test('/users/me/.blah/foo.py'));
+    assert.ok(regex.test(fixSeparators('/users/me/.blah/.foo.py')));
+    assert.ok(!regex.test(fixSeparators('/users/me/.blah/foo.py')));
 });
 
 test('getWildcardRoot1', () => {

--- a/packages/pyright-internal/src/tests/pathUtils.test.ts
+++ b/packages/pyright-internal/src/tests/pathUtils.test.ts
@@ -135,14 +135,24 @@ test('stripFileExtension2', () => {
 
 test('getWildcardRegexPattern1', () => {
     const pattern = getWildcardRegexPattern('/users/me', './blah/');
-    const sep = getRegexEscapedSeparator();
-    assert.equal(pattern, `${sep}users${sep}me${sep}blah`);
+    const regex = new RegExp(pattern);
+    assert.ok(regex.test('/users/me/blah/d'));
+    assert.ok(!regex.test('/users/me/blad/d'));
 });
 
 test('getWildcardRegexPattern2', () => {
-    const pattern = getWildcardRegexPattern('/users/me', './**/*.py?/');
-    const sep = getRegexEscapedSeparator();
-    assert.equal(pattern, `${sep}users${sep}me(${sep}[^${sep}.][^${sep}]*)*?${sep}[^${sep}]*\\.py[^${sep}]`);
+    const pattern = getWildcardRegexPattern('/users/me', './**/*.py?');
+    const regex = new RegExp(pattern);
+    assert.ok(regex.test('/users/me/.blah/foo.pyd'));
+    assert.ok(!regex.test('/users/me/./foo.py'));
+    assert.ok(!regex.test('/users/me/.blah/foo.py')); // No char after
+});
+
+test('getWildcardRegexPattern3', () => {
+    const pattern = getWildcardRegexPattern('/users/me', './**/.*.py');
+    const regex = new RegExp(pattern);
+    assert.ok(regex.test('/users/me/.blah/.foo.py'));
+    assert.ok(!regex.test('/users/me/.blah/foo.py'));
 });
 
 test('getWildcardRoot1', () => {


### PR DESCRIPTION
Addresses https://github.com/microsoft/pyright/issues/4322

Generated regex wasn't handling '.foo' as a directory.