### PR TITLE
Fix typos discovered by codespell

### DIFF
--- a/build/checkLockIndent.js
+++ b/build/checkLockIndent.js
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
 //@ts-check
 
-// Lerna doesn't do a good job preserving the indention in lock files.
+// Lerna doesn't do a good job preserving the indentation in lock files.
 // Check that the lock files are still indented correctly, otherwise
 // the change will cause problems with merging and the updateDeps script.
 

--- a/build/skipBootstrap.js
+++ b/build/skipBootstrap.js
@@ -2,7 +2,7 @@
 // This can be used to write npm script like:
 //     node ./build/skipBootstrap.js || lerna bootstrap
 // Which means "skip lerna bootstrap if SKIP_LERNA_BOOTSTRAP is set".
-// This prevents suprious bootstraps in nested lerna repos.
+// This prevents spurious bootstraps in nested lerna repos.
 
 if (!process.env.SKIP_LERNA_BOOTSTRAP) {
     process.exit(1);

--- a/docs/mypy-comparison.md
+++ b/docs/mypy-comparison.md
@@ -153,7 +153,7 @@ The following expression forms are not currently supported by mypy as type guard
 * `len(x) == L` and `len(x) != L` (where x is tuple and L is a literal integer)
 * `x in y` or `x not in y` (where y is instance of list, set, frozenset, deque, tuple, dict, defaultdict, or OrderedDict)
 * `S in D` and `S not in D` (where S is a string literal and D is a final TypedDict)
-* `bool(x)` (where x is any expression that is statically verifiable to be truthy or falsy in all cases)
+* `bool(x)` (where x is any expression that is statically verifiable to be truthy or falsey in all cases)
 
 
 ## Aliased Conditional Expressions

--- a/docs/type-concepts.md
+++ b/docs/type-concepts.md
@@ -186,8 +186,8 @@ In addition to assignment-based type narrowing, Pyright supports the following t
 * `issubclass(x, T)` (where T is a type or a tuple of types)
 * `callable(x)`
 * `f(x)` (where f is a user-defined type guard as defined in [PEP 647](https://www.python.org/dev/peps/pep-0647/))
-* `bool(x)` (where x is any expression that is statically verifiable to be truthy or falsy in all cases)
-* `x` (where x is any expression that is statically verifiable to be truthy or falsy in all cases)
+* `bool(x)` (where x is any expression that is statically verifiable to be truthy or falsey in all cases)
+* `x` (where x is any expression that is statically verifiable to be truthy or falsey in all cases)
 
 Expressions supported for type guards include simple names, member access chains (e.g. `a.b.c.d`), the unary `not` operator, the binary `and` and `or` operators, subscripts that are integer literals (e.g. `a[2]` or `a[-1]`), and call expressions. Other operators (such as arithmetic operators or other subscripts) are not supported.
 
@@ -305,7 +305,7 @@ def func4(value: str | int) -> str:
 
 If you later added another color to the `Color` enumeration above (e.g. `YELLOW = 4`), Pyright would detect that `func3` no longer exhausts all members of the enumeration and possibly returns `None`, which violates the declared return type. Likewise, if you modify the type of the `value` parameter in `func4` to expand the union, a similar error will be produced.
 
-This “narrowing for implied else” technique works for all narrowing expressions listed above with the exception of simple falsy/truthy statements and type guards. These are excluded because they are not generally used for exhaustive checks, and their inclusion would have a significant impact on analysis performance.
+This “narrowing for implied else” technique works for all narrowing expressions listed above with the exception of simple falsey/truthy statements and type guards. These are excluded because they are not generally used for exhaustive checks, and their inclusion would have a significant impact on analysis performance.
 
 ### Narrowing Any
 

--- a/packages/pyright-internal/src/tests/samples/super7.py
+++ b/packages/pyright-internal/src/tests/samples/super7.py
@@ -33,7 +33,7 @@ class SubClass(BaseClass):
         self = cls()
         reveal_type(super(__class__, self), expected_text="BaseClass")
 
-        # This should generate an errorr.
+        # This should generate an error.
         return super(__class__, self).my_method(self, value)
 
     @staticmethod

--- a/packages/pyright-internal/src/tests/samples/tuples1.py
+++ b/packages/pyright-internal/src/tests/samples/tuples1.py
@@ -39,8 +39,8 @@ def func3() -> Tuple[str, ...]:
     a = "1", 2, 3
 
     # This should generate an error because the
-    # heterogenous tuple can't be assigned to
-    # the homogenous tuple type.
+    # heterogeneous tuple can't be assigned to
+    # the homogeneous tuple type.
     return a
 
 

--- a/packages/pyright-internal/src/tests/samples/tuples4.py
+++ b/packages/pyright-internal/src/tests/samples/tuples4.py
@@ -1,4 +1,4 @@
-# This sample tests the translation of a heterogenous tuple
+# This sample tests the translation of a heterogeneous tuple
 # into an Iterable.
 
 from typing import Iterable, TypeVar, Union

--- a/packages/pyright-internal/src/tests/samples/typeNarrowingFalsy1.py
+++ b/packages/pyright-internal/src/tests/samples/typeNarrowingFalsy1.py
@@ -1,4 +1,4 @@
-# This sample tests type narrowing for falsy and truthy values.
+# This sample tests type narrowing for falsey and truthy values.
 
 from typing import Iterable, List, Literal, NamedTuple, Optional, Union
 

--- a/packages/pyright-internal/src/tests/samples/typeNarrowingTypedDict1.py
+++ b/packages/pyright-internal/src/tests/samples/typeNarrowingTypedDict1.py
@@ -80,7 +80,7 @@ def f6(p: Union[TD1, TD2, TD3]):
         reveal_type(v5, expected_text="str")
 
     # This should generate three errors, two for TD1 and TD2 (because
-    # "d" is not a valid key) and one for TD3 (beacuse "d" is not required).
+    # "d" is not a valid key) and one for TD3 (because "d" is not required).
     v6 = p["d"]
 
 

--- a/packages/pyright-internal/src/tests/samples/typeVarDefault3.py
+++ b/packages/pyright-internal/src/tests/samples/typeVarDefault3.py
@@ -7,10 +7,10 @@ from typing import Generic, TypeVar
 T1 = TypeVar("T1")
 T2 = TypeVar("T2", default=str)
 
-# This should generate an error becuase T1 is after T2.
+# This should generate an error because T1 is after T2.
 class ClassA(Generic[T2, T1]): ...
 
-# This should generate an error becuase T1 is after T2.
+# This should generate an error because T1 is after T2.
 class ClassB(dict[T2, T1]): ...
 
 class ClassC(dict[T2, T1], Generic[T1, T2]): ...

--- a/packages/pyright-internal/src/tests/samples/typeVarDefault4.py
+++ b/packages/pyright-internal/src/tests/samples/typeVarDefault4.py
@@ -4,7 +4,7 @@
 
 from typing import TypeVar
 
-# This should generate an error becuase T1 is after T2.
+# This should generate an error because T1 is after T2.
 class ClassA[T2=str, T1]: ...
 
 # This should generate an error because T1 is after T2.


### PR DESCRIPTION
[`codespell --ignore-words-list=classe,te --skip="./.*,*.json,*.pyi,*.ts"`](https://pypi.org/project/codespell)