### PR TITLE
Changed hover provider to limit its display of overloaded functions w…

### DIFF
--- a/packages/pyright-internal/src/languageService/hoverProvider.ts
+++ b/packages/pyright-internal/src/languageService/hoverProvider.ts
@@ -499,7 +499,11 @@ export class HoverProvider {
                 const callTypeResult = evaluator.getTypeResult(callNode);
 
                 if (callTypeResult?.overloadsUsedForCall && callTypeResult.overloadsUsedForCall.length > 0) {
-                    type = OverloadedFunctionType.create(callTypeResult.overloadsUsedForCall);
+                    if (callTypeResult.overloadsUsedForCall.length === 1) {
+                        type = callTypeResult.overloadsUsedForCall[0];
+                    } else {
+                        type = OverloadedFunctionType.create(callTypeResult.overloadsUsedForCall);
+                    }
                 }
             }
         }

--- a/packages/pyright-internal/src/tests/fourslash/hover.overloadedFunction.fourslash.ts
+++ b/packages/pyright-internal/src/tests/fourslash/hover.overloadedFunction.fourslash.ts
@@ -1,0 +1,23 @@
+/// <reference path="fourslash.ts" />
+
+// @filename: test.py
+//// from typing import overload
+////
+//// @overload
+//// def func(a: int) -> int:
+////     ...
+////
+//// @overload
+//// def func(a: str) -> str:
+////     ...
+////
+//// def func(a: int | str) -> int | str:
+////     return a
+////
+//// [|/*marker1*/func|](1)
+//// [|/*marker2*/func|]("hi")
+
+helper.verifyHover('markdown', {
+    marker1: '```python\n(function) func(a: int) -> int\n```',
+    marker2: '```python\n(function) func(a: str) -> str\n```',
+});


### PR DESCRIPTION
…hen hovering over a name that is part of a call expression. In such cases, the context of the call's arguments often provides sufficient context to select one (or in some cases, several) overloads.