### PR TITLE
[PylanceBot] Pull Pylance with Pyright 1.1.290

### DIFF
--- a/packages/pyright-internal/src/languageService/completionProvider.ts
+++ b/packages/pyright-internal/src/languageService/completionProvider.ts
@@ -2614,7 +2614,7 @@ export class CompletionProvider {
                     this._addSymbol(name, symbol, priorWord, completionMap, {
                         boundObjectOrClass,
                         funcParensDisabled: isInImport,
-                        extraCommitChars: !isInImport,
+                        extraCommitChars: !isInImport && !!priorWord,
                     });
                 }
             }

--- a/packages/pyright-internal/src/tests/fourslash/completions.commitChars.fourslash.ts
+++ b/packages/pyright-internal/src/tests/fourslash/completions.commitChars.fourslash.ts
@@ -8,6 +8,10 @@
 // @filename: test1.py
 //// from .samp[|/*marker3*/|]
 
+// @filename: test2.py
+//// from samples import *
+//// [|/*marker4*/|]
+
 // @filename: samples.py
 //// import fooLib as fooLib
 //// def fooFunc(): ...
@@ -55,7 +59,26 @@
                 {
                     label: 'samples',
                     kind: Consts.CompletionItemKind.Module,
-                    commitCharacters: undefined,
+                    commitCharacters: [],
+                },
+            ],
+        },
+        marker4: {
+            completions: [
+                {
+                    label: 'fooLib',
+                    kind: Consts.CompletionItemKind.Module,
+                    commitCharacters: [],
+                },
+                {
+                    label: 'fooFunc',
+                    kind: Consts.CompletionItemKind.Function,
+                    commitCharacters: [],
+                },
+                {
+                    label: 'fooClass',
+                    kind: Consts.CompletionItemKind.Class,
+                    commitCharacters: [],
                 },
             ],
         },

--- a/packages/pyright-internal/src/tests/harness/fourslash/testStateUtils.ts
+++ b/packages/pyright-internal/src/tests/harness/fourslash/testStateUtils.ts
@@ -1,0 +1,80 @@
+/*
+ * testStateUtils.ts
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT license.
+ *
+ * Various test utility functions for TestState.
+ */
+
+import assert from 'assert';
+import * as JSONC from 'jsonc-parser';
+
+import { configFileNames } from '../../../analyzer/service';
+import { Comparison, toBoolean } from '../../../common/core';
+import { combinePaths, getBaseFileName } from '../../../common/pathUtils';
+import { getStringComparer } from '../../../common/stringUtils';
+import * as vfs from '../vfs/filesystem';
+import { FourSlashData, FourSlashFile, GlobalMetadataOptionNames, Marker, MetadataOptionNames } from './fourSlashTypes';
+
+export function createVfsInfoFromFourSlashData(projectRoot: string, testData: FourSlashData) {
+    const metaProjectRoot = testData.globalOptions[GlobalMetadataOptionNames.projectRoot];
+    projectRoot = metaProjectRoot ? combinePaths(projectRoot, metaProjectRoot) : projectRoot;
+
+    const ignoreCase = toBoolean(testData.globalOptions[GlobalMetadataOptionNames.ignoreCase]);
+
+    let rawConfigJson = '';
+    const sourceFileNames: string[] = [];
+    const files: vfs.FileSet = {};
+
+    for (const file of testData.files) {
+        // if one of file is configuration file, set config options from the given json
+        if (isConfig(file, ignoreCase)) {
+            try {
+                rawConfigJson = JSONC.parse(file.content);
+            } catch (e: any) {
+                throw new Error(`Failed to parse test ${file.fileName}: ${e.message}`);
+            }
+        } else {
+            files[file.fileName] = new vfs.File(file.content, { meta: file.fileOptions, encoding: 'utf8' });
+
+            if (!toBoolean(file.fileOptions[MetadataOptionNames.library])) {
+                sourceFileNames.push(file.fileName);
+            }
+        }
+    }
+    return { files, sourceFileNames, projectRoot, ignoreCase, rawConfigJson };
+}
+
+export function getMarkerName(testData: FourSlashData, markerToFind: Marker) {
+    let found: string | undefined;
+    testData.markerPositions.forEach((marker, name) => {
+        if (marker === markerToFind) {
+            found = name;
+        }
+    });
+
+    assert.ok(found);
+    return found!;
+}
+
+export function getMarkerByName(testData: FourSlashData, markerName: string) {
+    const markerPos = testData.markerPositions.get(markerName);
+    if (markerPos === undefined) {
+        throw new Error(
+            `Unknown marker "${markerName}" Available markers: ${getMarkerNames(testData)
+                .map((m) => '"' + m + '"')
+                .join(', ')}`
+        );
+    } else {
+        return markerPos;
+    }
+}
+
+export function getMarkerNames(testData: FourSlashData): string[] {
+    return [...testData.markerPositions.keys()];
+}
+
+function isConfig(file: FourSlashFile, ignoreCase: boolean): boolean {
+    const comparer = getStringComparer(ignoreCase);
+    return configFileNames.some((f) => comparer(getBaseFileName(file.fileName), f) === Comparison.EqualTo);
+}

--- a/packages/pyright-internal/src/tests/signatureHelp.test.ts
+++ b/packages/pyright-internal/src/tests/signatureHelp.test.ts
@@ -1,0 +1,90 @@
+/*
+ * signatureHelp.test.ts
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT license.
+ *
+ * Unit tests for signature help.
+ */
+
+import assert from 'assert';
+import { CancellationToken, MarkupKind } from 'vscode-languageserver';
+
+import { convertOffsetToPosition } from '../common/positionUtils';
+import { parseAndGetTestState } from './harness/fourslash/testState';
+
+test('invalid position in format string segment', () => {
+    const code = `
+// @filename: test.py
+//// f'{"(".capit[|/*marker*/|]alize()}'
+    `;
+
+    checkSignatureHelp(code, false);
+});
+
+test('valid position in format string segment', () => {
+    const code = `
+// @filename: test.py
+//// f'{"(".capitalize([|/*marker*/|])}'
+    `;
+
+    checkSignatureHelp(code, true);
+});
+
+test('valid position in the second format string segment', () => {
+    const code = `
+// @filename: test.py
+//// f'{print("hello")} {"(".capitalize([|/*marker*/|])}'
+    `;
+
+    checkSignatureHelp(code, true);
+});
+
+test('invalid position in the second format string segment', () => {
+    const code = `
+// @filename: test.py
+//// f'{print("hello")} {"(".capitalize [|/*marker*/|]  ()}'
+    `;
+
+    checkSignatureHelp(code, false);
+});
+
+test('nested call in format string segment', () => {
+    const code = `
+// @filename: test.py
+//// def foo():
+////     pass
+////
+//// f'{"(".capitalize(foo([|/*marker*/|]))}'
+    `;
+
+    checkSignatureHelp(code, true);
+});
+
+test('within arguments in format string segment', () => {
+    const code = `
+// @filename: test.py
+//// def foo():
+////     pass
+////
+//// f'{"(".capitalize(fo[|/*marker*/|]o())}'
+    `;
+
+    checkSignatureHelp(code, true);
+});
+
+function checkSignatureHelp(code: string, expects: boolean) {
+    const state = parseAndGetTestState(code).state;
+    const marker = state.getMarkerByName('marker');
+
+    const parseResults = state.workspace.serviceInstance.getParseResult(marker.fileName)!;
+    const position = convertOffsetToPosition(marker.position, parseResults.tokenizerOutput.lines);
+
+    const actual = state.workspace.serviceInstance.getSignatureHelpForPosition(
+        marker.fileName,
+        position,
+        MarkupKind.Markdown,
+        CancellationToken.None
+    );
+
+    assert.strictEqual(!!actual, expects);
+}


### PR DESCRIPTION
rollup of the following changes:
    1. Officepy (#3039)
    2. improve when to show signature help inside of format string (#3088)
    3. now, we add extra commit chars to completion item only if there is matching pretext exists. (#3084)