### PR TITLE
Allow non-identifier characters immediately after #region

### DIFF
--- a/packages/pyright-internal/src/analyzer/regions.ts
+++ b/packages/pyright-internal/src/analyzer/regions.ts
@@ -39,14 +39,8 @@ export function getRegionComments(parseResults: ParseResults): RegionComment[] {
     return comments;
 }
 
-// A comment starting with "region" is only treated as a region if it is not followed by an identifier character.
-// So these are regions:
-// #region
-// # region
-// #region: foo
-//
-// And these are not:
-// #region_name
+// A comment starting with "region" or "endregion" is only treated as a region/endregion
+// if it is not followed by an identifier character.
 const StartRegionRegx = /^\s*region\b/;
 const EndRegionRegex = /^\s*endregion\b/;
 

--- a/packages/pyright-internal/src/analyzer/regions.ts
+++ b/packages/pyright-internal/src/analyzer/regions.ts
@@ -39,8 +39,16 @@ export function getRegionComments(parseResults: ParseResults): RegionComment[] {
     return comments;
 }
 
-const StartRegionRegx = /^\s*region(\s*)(.*)$/;
-const EndRegionRegex = /^\s*endregion(\s*)(.*)$/;
+// A comment starting with "region" is only treated as a region if it is not followed by an identifier character.
+// So these are regions:
+// #region
+// # region
+// #region: foo
+//
+// And these are not:
+// #region_name
+const StartRegionRegx = /^\s*region[^\w]/;
+const EndRegionRegex = /^\s*endregion[^\w]/;
 
 function getRegionCommentType(comment: Comment, parseResults: ParseResults): RegionCommentType | undefined {
     const hashOffset = comment.start - 1;
@@ -59,16 +67,10 @@ function getRegionCommentType(comment: Comment, parseResults: ParseResults): Reg
     const startRegionMatch = StartRegionRegx.exec(comment.value);
     const endRegionMatch = EndRegionRegex.exec(comment.value);
 
-    // If the # region is followed by a space or has nothing after it, it's treated as a region.
-    // Whereas, # regionfoo should not be a region.
-    if (startRegionMatch && startRegionMatch.length > 2) {
-        return startRegionMatch[1].length > 0 || (startRegionMatch[1].length === 0 && startRegionMatch[2].length === 0)
-            ? RegionCommentType.Region
-            : undefined;
-    } else if (endRegionMatch && endRegionMatch.length > 2) {
-        return endRegionMatch[1].length > 0 || (endRegionMatch[1].length === 0 && endRegionMatch[2].length === 0)
-            ? RegionCommentType.EndRegion
-            : undefined;
+    if (startRegionMatch) {
+        return RegionCommentType.Region;
+    } else if (endRegionMatch) {
+        return RegionCommentType.EndRegion;
     } else {
         return undefined;
     }

--- a/packages/pyright-internal/src/analyzer/regions.ts
+++ b/packages/pyright-internal/src/analyzer/regions.ts
@@ -47,8 +47,8 @@ export function getRegionComments(parseResults: ParseResults): RegionComment[] {
 //
 // And these are not:
 // #region_name
-const StartRegionRegx = /^\s*region[^\w]/;
-const EndRegionRegex = /^\s*endregion[^\w]/;
+const StartRegionRegx = /^\s*region\b/;
+const EndRegionRegex = /^\s*endregion\b/;
 
 function getRegionCommentType(comment: Comment, parseResults: ParseResults): RegionCommentType | undefined {
     const hashOffset = comment.start - 1;

--- a/packages/pyright-internal/src/tests/samples/regionComments1.py
+++ b/packages/pyright-internal/src/tests/samples/regionComments1.py
@@ -5,6 +5,10 @@
 #  endregion
 #endregion
 
+#region_not a region
+#region: foo
+#endregion
+
 #region Extra endregion
 #endregion
 #endregion


### PR DESCRIPTION
Addresses https://github.com/microsoft/pyright/issues/4496

The detection logic for `#region` and `#endregion` was recently [changed](https://[github.com](https://github.com/microsoft/pyrx/pull/3024)/microsoft/pyrx/pull/3024) to require whitespace after the word "region" or "endregion". This was too strict.

Change the logic to allow any non-identifier character (i.e. anything other than `a-zA-Z0-9_`) after the word "region" or "endregion".

So these are good:
- `#region`
- `#region foo`
- `#region: foo`

And these are not:
- `#regionfoo`
- `#region_name`