### PR TITLE
fix: empty range for submodule fallback

### DIFF
--- a/packages/pyright-internal/src/analyzer/binder.ts
+++ b/packages/pyright-internal/src/analyzer/binder.ts
@@ -1883,7 +1883,7 @@ export class Binder extends ParseTreeWalker {
                             node: importSymbolNode,
                             path: implicitImport.path,
                             loadSymbolsFromPath: true,
-                            range: convertTextRangeToRange(importSymbolNode, this._fileInfo.lines),
+                            range: getEmptyRange(),
                             usesLocalName: false,
                             moduleName: this._fileInfo.moduleName,
                             isInExceptSuite: this._isInExceptSuite,

--- a/packages/pyright-internal/src/tests/fourslash/findDefinitions.namespaceImport.fourslash.ts
+++ b/packages/pyright-internal/src/tests/fourslash/findDefinitions.namespaceImport.fourslash.ts
@@ -22,7 +22,7 @@
                 definitions: [
                     {
                         path: helper.getMarkerByName('def1').fileName,
-                        range: { start: { line: 0, character: 16 }, end: { line: 0, character: 20 } },
+                        range: { start: { line: 0, character: 0 }, end: { line: 0, character: 0 } },
                     },
                 ],
             },
@@ -30,7 +30,7 @@
                 definitions: [
                     {
                         path: helper.getMarkerByName('def2').fileName,
-                        range: { start: { line: 1, character: 16 }, end: { line: 1, character: 20 } },
+                        range: { start: { line: 0, character: 0 }, end: { line: 0, character: 0 } },
                     },
                 ],
             },


### PR DESCRIPTION
When adding declaration to symbols, there's at least one case where the resolved declaration (which is obtained via the submodule fallback) is of type `Alias` and it refers to a module (not a node), hence the empty range should be used.

Without this fix, LSP clients can fail to jump to the location because although the file exists the ranges might not.

Fixes #4521 