### PR TITLE
Addressed a type evaluation performance issue. This change disables t…

### DIFF
--- a/packages/pyright-internal/src/analyzer/typeGuards.ts
+++ b/packages/pyright-internal/src/analyzer/typeGuards.ts
@@ -307,27 +307,6 @@ export function getTypeNarrowingCallback(
                     }
                 }
 
-                // Look for <literal> == X or <literal> != X
-                if (ParseTreeUtils.isMatchingExpression(reference, testExpression.rightExpression)) {
-                    const leftTypeResult = evaluator.getTypeOfExpression(testExpression.leftExpression);
-                    const leftType = leftTypeResult.type;
-
-                    if (isClassInstance(leftType) && leftType.literalValue !== undefined) {
-                        return (type: Type) => {
-                            return {
-                                type: narrowTypeForLiteralComparison(
-                                    evaluator,
-                                    type,
-                                    leftType,
-                                    adjIsPositiveTest,
-                                    /* isIsOperator */ false
-                                ),
-                                isIncomplete: !!leftTypeResult.isIncomplete,
-                            };
-                        };
-                    }
-                }
-
                 // Look for X[<literal>] == <literal> or X[<literal>] != <literal>
                 if (
                     testExpression.leftExpression.nodeType === ParseNodeType.Index &&

--- a/packages/pyright-internal/src/tests/samples/codeFlow4.py
+++ b/packages/pyright-internal/src/tests/samples/codeFlow4.py
@@ -44,10 +44,10 @@ def func4(x: Color):
     if x == Color.RED:
         return
 
-    if x == Color.GREEN or (Color.PERIWINKLE == x and True):
+    if x == Color.GREEN or (x == Color.PERIWINKLE and True):
         y = 2
     else:
-        if Color.BLUE == x:
+        if x == Color.BLUE:
             y = 3
 
     print(y)

--- a/packages/pyright-internal/src/tests/samples/typeNarrowingLiteral1.py
+++ b/packages/pyright-internal/src/tests/samples/typeNarrowingLiteral1.py
@@ -17,14 +17,9 @@ def func_1(p1: Literal["a", "b", "c"]):
     else:
         reveal_type(p1, expected_text="Literal['a']")
 
-    if "a" != p1:
-        reveal_type(p1, expected_text="Literal['c', 'b']")
-    else:
-        reveal_type(p1, expected_text="Literal['a']")
-
 
 def func2(p1: Literal[1, 4, 7]):
-    if 4 == p1 or 1 == p1:
+    if p1 == 4 or p1 == 1:
         reveal_type(p1, expected_text="Literal[4, 1]")
     else:
         reveal_type(p1, expected_text="Literal[7]")


### PR DESCRIPTION
…ype guard expressions of the form `L == X` and `L != X` where `L` is a literal and `X` is a narrowable expression. The more common forms `X == L` and `X != L` are still supported. The less-common expression forms were never documented to work. This addresses issue https://github.com/microsoft/pyright/issues/4519.