### PR TITLE
Change `dataClassFieldWithDefault` from error to diagnostic

### DIFF
--- a/packages/pyright-internal/src/analyzer/dataClasses.ts
+++ b/packages/pyright-internal/src/analyzer/dataClasses.ts
@@ -407,7 +407,12 @@ export function synthesizeDataClassMethods(
                                 (p) => p.hasDefault && p.includeInInit && !p.isKeywordOnly
                             );
                             if (firstDefaultValueIndex >= 0 && firstDefaultValueIndex < insertIndex) {
-                                evaluator.addError(Localizer.Diagnostic.dataClassFieldWithDefault(), variableNameNode);
+                                evaluator.addDiagnostic(
+                                    AnalyzerNodeInfo.getFileInfo(node).diagnosticRuleSet.reportGeneralTypeIssues,
+                                    DiagnosticRule.reportGeneralTypeIssues,
+                                    Localizer.Diagnostic.dataClassFieldWithDefault(),
+                                    variableNameNode
+                                );
                             }
                         }
                     }


### PR DESCRIPTION
Address https://github.com/microsoft/pylance-release/issues/3939

Move `"Fields without default values cannot appear after fields with default values"` to the `reportGeneralTypeIssues` diagnostic so the error is not reported for users with `typeCheckingMode` set to `off`.