### PR TITLE
Actions to publish to VS Code Marketplace

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,7 +50,7 @@ jobs:
           path: packages/vscode-pyright/${{ env.VSIX_NAME }}
 
   create_release:
-    if: github.repository == 'microsoft/pyright' && startsWith(github.ref, 'refs/tags/')
+    if: github.repository == 'microsoft/pyright'
     runs-on: ubuntu-latest
     name: Create release
     needs: [build]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,19 +17,20 @@ jobs:
     name: Build
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-node@v2-beta
+      - uses: actions/setup-node@v3
         with:
           node-version: ${{ env.NODE_VERSION }}
 
       - name: Get npm cache directory
         id: npm-cache
         run: |
-          echo "::set-output name=dir::$(npm config get cache)"
-      - uses: actions/cache@v2
+          echo "dir=$(npm config get cache)" >> $GITHUB_OUTPUT
+
+      - uses: actions/cache@v3
         with:
           path: ${{ steps.npm-cache.outputs.dir }}
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
@@ -44,7 +45,7 @@ jobs:
           npm run package
           mv pyright-*.vsix ${{ env.VSIX_NAME }}
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: ${{ env.ARTIFACT_NAME_VSIX }}
           path: packages/vscode-pyright/${{ env.VSIX_NAME }}
@@ -57,27 +58,18 @@ jobs:
 
     steps:
       - name: Download artifacts
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           path: artifacts
 
       # TODO: If the release already exists (tag created via the GUI), reuse it.
       - name: Create release
         id: create_release
-        uses: actions/create-release@v1
+        uses: ncipollo/release-action@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tag_name: ${{ github.ref }}
-          release_name: Published ${{ github.ref }}
+          name: Published ${{ github.ref_name }}
           draft: true
-
-      - name: Upload VSIX
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./artifacts/${{ env.ARTIFACT_NAME_VSIX }}/${{ env.VSIX_NAME }}
-          asset_name: ${{ env.VSIX_NAME }}
-          asset_content_type: application/zip
+          artifacts: ./artifacts/${{ env.ARTIFACT_NAME_VSIX }}/${{ env.VSIX_NAME }}
+          artifactContentType: application/zip

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,7 +42,7 @@ jobs:
         working-directory: packages/vscode-pyright
         run: |
           npm run package
-          mv pyright-${{ github.event.release.tag_name }}.vsix ${{ env.VSIX_NAME }}
+          mv pyright-*.vsix ${{ env.VSIX_NAME }}
 
       - uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   build:
-    if: github.repository == 'microsoft/pyright'
+    # if: github.repository == 'microsoft/pyright'
     runs-on: ubuntu-latest
     name: Build
 
@@ -51,7 +51,8 @@ jobs:
           path: ${{ env.VSIX_NAME }}
 
   create_release:
-    if: github.repository == 'microsoft/pyright' && startsWith(github.ref, 'refs/tags/')
+    # if: github.repository == 'microsoft/pyright' && startsWith(github.ref, 'refs/tags/')
+    if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
     name: Create release
     needs: [build]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,7 +71,6 @@ jobs:
           tag_name: ${{ github.ref }}
           release_name: ${{ github.ref }}
           draft: true
-          prerelease: ${{ contains(github.ref, '-') || !endswith(github.ref, '0')  }}
 
       - name: Upload VSIX
         uses: actions/upload-release-asset@v1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,7 +47,7 @@ jobs:
       - uses: actions/upload-artifact@v2
         with:
           name: ${{ env.ARTIFACT_NAME_VSIX }}
-          path: ${{ env.VSIX_NAME }}
+          path: packages/vscode-pyright/${{ env.VSIX_NAME }}
 
   create_release:
     # if: github.repository == 'microsoft/pyright' && startsWith(github.ref, 'refs/tags/')

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -69,7 +69,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tag_name: ${{ github.ref }}
-          release_name: ${{ github.ref }}
+          release_name: Published ${{ github.ref }}
           draft: true
 
       - name: Upload VSIX

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,7 +45,6 @@ jobs:
           mv pyright-${{ github.event.release.tag_name }}.vsix ${{ env.VSIX_NAME }}
 
       - uses: actions/upload-artifact@v2
-        working-directory: packages/vscode-pyright
         with:
           name: ${{ env.ARTIFACT_NAME_VSIX }}
           path: ${{ env.VSIX_NAME }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,85 @@
+name: 'Build'
+
+env:
+  NODE_VERSION: '16' # Shipped with VS Code.
+  ARTIFACT_NAME_VSIX: vsix
+  VSIX_NAME: vscode-pyright.vsix
+
+on:
+  push:
+    tags:
+      - '1.1.[0-9][0-9][0-9]'
+
+jobs:
+  build:
+    if: github.repository == 'microsoft/pyright'
+    runs-on: ubuntu-latest
+    name: Build
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v2-beta
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: Get npm cache directory
+        id: npm-cache
+        run: |
+          echo "::set-output name=dir::$(npm config get cache)"
+      - uses: actions/cache@v2
+        with:
+          path: ${{ steps.npm-cache.outputs.dir }}
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+
+      - run: npm run install:all
+
+      - name: Build VSIX
+        working-directory: packages/vscode-pyright
+        run: |
+          npm run package
+          mv pyright-${{ github.event.release.tag_name }}.vsix ${{ env.VSIX_NAME }}
+
+      - uses: actions/upload-artifact@v2
+        working-directory: packages/vscode-pyright
+        with:
+          name: ${{ env.ARTIFACT_NAME_VSIX }}
+          path: ${{ env.VSIX_NAME }}
+
+  create_release:
+    if: github.repository == 'microsoft/pyright' && startsWith(github.ref, 'refs/tags/')
+    runs-on: ubuntu-latest
+    name: Create release
+    needs: [build]
+
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v2
+        with:
+          path: artifacts
+
+      # TODO: If the release already exists (tag created via the GUI), reuse it.
+      - name: Create release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: ${{ github.ref }}
+          draft: true
+          prerelease: ${{ contains(github.ref, '-') || !endswith(github.ref, '0')  }}
+
+      - name: Upload VSIX
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./artifacts/${{ env.ARTIFACT_NAME_VSIX }}/${{ env.VSIX_NAME }}
+          asset_name: ${{ env.VSIX_NAME }}
+          asset_content_type: application/zip

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   build:
-    # if: github.repository == 'microsoft/pyright'
+    if: github.repository == 'microsoft/pyright'
     runs-on: ubuntu-latest
     name: Build
 
@@ -50,8 +50,7 @@ jobs:
           path: packages/vscode-pyright/${{ env.VSIX_NAME }}
 
   create_release:
-    # if: github.repository == 'microsoft/pyright' && startsWith(github.ref, 'refs/tags/')
-    if: startsWith(github.ref, 'refs/tags/')
+    if: github.repository == 'microsoft/pyright' && startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
     name: Create release
     needs: [build]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,9 +15,9 @@ jobs:
     name: Publish extension to marketplace
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
-      - uses: actions/setup-node@v2-beta
+      - uses: actions/setup-node@v3
         with:
           node-version: ${{ env.NODE_VERSION }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,44 @@
+name: Publish Release
+
+on:
+  release:
+    types: [published]
+
+env:
+  VSIX_NAME: vscode-pyright.vsix
+  NODE_VERSION: '16' # Shipped with VS Code.
+
+jobs:
+  publish_extension:
+    if: ${{ github.repository == 'microsoft/pyright' }}
+    runs-on: ubuntu-latest
+    name: Publish extension to marketplace
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions/setup-node@v2-beta
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      - run: npm install
+
+      - name: Download VSIX
+        uses: i3h/download-release-asset@v1
+        with:
+          owner: microsoft
+          repo: pyrx
+          tag: ${{ github.event.release.tag_name }}
+          file: ${{ env.VSIX_NAME }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      # https://code.visualstudio.com/api/working-with-extensions/publishing-extension
+      - name: Install VSCE
+        run: |
+          npm install -g "vsce@$(jq -r '.dependencies.vsce.version' < packages/vscode-pyright/package-lock.json)"
+          npx vsce --version
+
+      # https://code.visualstudio.com/api/working-with-extensions/publishing-extension#get-a-personal-access-token
+      - name: Publish VSIX
+        if: ${{ !github.event.release.prerelease }}
+        run: npx vsce publish --packagePath ${{ env.VSIX_NAME }} --pat ${{ secrets.VSCE_TOKEN }} --noVerify

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,8 +26,8 @@ jobs:
       - name: Download VSIX
         uses: i3h/download-release-asset@v1
         with:
-          owner: microsoft
-          repo: pyrx
+          owner: debonte
+          repo: pyright
           tag: ${{ github.event.release.tag_name }}
           file: ${{ env.VSIX_NAME }}
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ env:
 
 jobs:
   publish_extension:
-    # if: ${{ github.repository == 'microsoft/pyright' }}
+    if: ${{ github.repository == 'microsoft/pyright' }}
     runs-on: ubuntu-latest
     name: Publish extension to marketplace
 
@@ -26,7 +26,7 @@ jobs:
       - name: Download VSIX
         uses: i3h/download-release-asset@v1
         with:
-          owner: debonte
+          owner: microsoft
           repo: pyright
           tag: ${{ github.event.release.tag_name }}
           file: ${{ env.VSIX_NAME }}
@@ -39,6 +39,6 @@ jobs:
           npx vsce --version
 
       # https://code.visualstudio.com/api/working-with-extensions/publishing-extension#get-a-personal-access-token
-      # - name: Publish VSIX
-      #   if: ${{ !github.event.release.prerelease }}
-      #   run: npx vsce publish --packagePath ${{ env.VSIX_NAME }} --pat ${{ secrets.VSCE_TOKEN }} --noVerify
+      - name: Publish VSIX
+        if: ${{ !github.event.release.prerelease }}
+        run: npx vsce publish --packagePath ${{ env.VSIX_NAME }} --pat ${{ secrets.VSCE_TOKEN }} --noVerify

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,5 +40,4 @@ jobs:
 
       # https://code.visualstudio.com/api/working-with-extensions/publishing-extension#get-a-personal-access-token
       - name: Publish VSIX
-        if: ${{ !github.event.release.prerelease }}
         run: npx vsce publish --packagePath ${{ env.VSIX_NAME }} --pat ${{ secrets.VSCE_TOKEN }} --noVerify

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ env:
 
 jobs:
   publish_extension:
-    if: ${{ github.repository == 'microsoft/pyright' }}
+    # if: ${{ github.repository == 'microsoft/pyright' }}
     runs-on: ubuntu-latest
     name: Publish extension to marketplace
 
@@ -39,6 +39,6 @@ jobs:
           npx vsce --version
 
       # https://code.visualstudio.com/api/working-with-extensions/publishing-extension#get-a-personal-access-token
-      - name: Publish VSIX
-        if: ${{ !github.event.release.prerelease }}
-        run: npx vsce publish --packagePath ${{ env.VSIX_NAME }} --pat ${{ secrets.VSCE_TOKEN }} --noVerify
+      # - name: Publish VSIX
+      #   if: ${{ !github.event.release.prerelease }}
+      #   run: npx vsce publish --packagePath ${{ env.VSIX_NAME }} --pat ${{ secrets.VSCE_TOKEN }} --noVerify


### PR DESCRIPTION
Fixes #4680 

Adds two new GitHub actions based on Pylance's build and release actions.

I've tested both of them in my fork except for the final step of actually publishing. We can try that with the next release. The publishing PAT is already [in place](https://github.com/microsoft/pyright/settings/secrets/actions).

### build.yml
Triggered when a new `1.1.###` tag is pushed. Does the following:
1. Checks out that tag.
2. Installs node and runs `npm run install:all`
3. Builds a new VSIX with `npm run package`.
4. Saves that VSIX as a build artifact.
5. Creates a new release named "Published `<tag name>`". That naming matches the [existing releases](https://github.com/microsoft/pyright/releases).
6. Saves the VSIX as a release asset.

### release.yml
Triggered when someone edits the release and pushes the "Publish Release" button. Does the following:
1. Downloads the VSIX asset from the release.
2. Publishes it to the VS Code Marketplace via `vsce`.