### PR TITLE
[PylanceBot] Pull Pylance with Pyright 1.1.296

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -32,7 +32,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL

--- a/packages/pyright-internal/src/analyzer/declaration.ts
+++ b/packages/pyright-internal/src/analyzer/declaration.ts
@@ -31,6 +31,8 @@ import {
     YieldNode,
 } from '../parser/parseNodes';
 
+export const UnresolvedModuleMarker = '*** unresolved ***';
+
 export const enum DeclarationType {
     Intrinsic,
     Variable,
@@ -289,4 +291,8 @@ export function isSpecialBuiltInClassDeclaration(decl: Declaration): decl is Spe
 
 export function isIntrinsicDeclaration(decl: Declaration): decl is IntrinsicDeclaration {
     return decl.type === DeclarationType.Intrinsic;
+}
+
+export function isUnresolvedAliasDeclaration(decl: Declaration): boolean {
+    return isAliasDeclaration(decl) && decl.path === UnresolvedModuleMarker;
 }

--- a/packages/pyright-internal/src/common/collectionUtils.ts
+++ b/packages/pyright-internal/src/common/collectionUtils.ts
@@ -386,3 +386,11 @@ export function addIfNotNull<T>(arr: T[], t: T): T[] {
     arr.push(t);
     return arr;
 }
+
+export function arrayEquals<T>(c1: T[], c2: T[], predicate: (e1: T, e2: T) => boolean) {
+    if (c1.length !== c2.length) {
+        return false;
+    }
+
+    return c1.every((v, i) => predicate(v, c2[i]));
+}

--- a/packages/pyright-internal/src/common/positionUtils.ts
+++ b/packages/pyright-internal/src/common/positionUtils.ts
@@ -8,6 +8,7 @@
  * line/column positions.
  */
 
+import { TokenizerOutput } from '../parser/tokenizer';
 import { assert } from './debug';
 import { Position, Range, TextRange } from './textRange';
 import { TextRangeCollection } from './textRangeCollection';
@@ -68,4 +69,19 @@ export function convertRangeToTextRange(range: Range, lines: TextRangeCollection
 
 export function convertTextRangeToRange(range: TextRange, lines: TextRangeCollection<TextRange>): Range {
     return convertOffsetsToRange(range.start, TextRange.getEnd(range), lines);
+}
+
+// Returns the position of the last character in a line (before the newline).
+export function getLineEndPosition(tokenizerOutput: TokenizerOutput, line: number): Position {
+    const lines = tokenizerOutput.lines;
+    const lineRange = lines.getItemAt(line);
+    // Character should be at the end of the line but before the newline.
+    const char =
+        line < lines.count - 1
+            ? lineRange.length - tokenizerOutput.predominantEndOfLineSequence.length
+            : lineRange.length;
+    return {
+        line,
+        character: char,
+    };
 }

--- a/packages/pyright-internal/src/languageService/hoverProvider.ts
+++ b/packages/pyright-internal/src/languageService/hoverProvider.ts
@@ -121,6 +121,13 @@ export class HoverProvider {
                 let primaryDeclaration = declarations[0];
                 if (primaryDeclaration.type === DeclarationType.Alias && declarations.length > 1) {
                     primaryDeclaration = declarations[1];
+                } else if (
+                    primaryDeclaration.type === DeclarationType.Variable &&
+                    declarations.length > 1 &&
+                    primaryDeclaration.isDefinedBySlots
+                ) {
+                    // Slots cannot have docstrings, so pick the secondary.
+                    primaryDeclaration = declarations[1];
                 }
 
                 this._addResultsForDeclaration(

--- a/packages/pyright-internal/src/languageService/importAdder.ts
+++ b/packages/pyright-internal/src/languageService/importAdder.ts
@@ -16,6 +16,7 @@ import {
     isClassDeclaration,
     isFunctionDeclaration,
     isParameterDeclaration,
+    isUnresolvedAliasDeclaration,
     isVariableDeclaration,
     ModuleLoaderActions,
 } from '../analyzer/declaration';
@@ -145,7 +146,7 @@ export class ImportAdder {
         const execEnv = this._configOptions.findExecEnvironment(filePath);
         for (const decl of result.declarations.keys() ?? []) {
             const importInfo = this._getImportInfo(decl, filePath);
-            if (!importInfo) {
+            if (!importInfo || isUnresolvedAliasDeclaration(decl)) {
                 continue;
             }
 
@@ -378,6 +379,10 @@ class NameCollector extends ParseTreeWalker {
     }
 
     override visitName(name: NameNode) {
+        if (!TextRange.containsRange(this._range, name)) {
+            return false;
+        }
+
         throwIfCancellationRequested(this._token);
 
         // We process dotted name as a whole rather than

--- a/packages/pyright-internal/src/tests/fourslash/completions.errorNodes.fourslash.ts
+++ b/packages/pyright-internal/src/tests/fourslash/completions.errorNodes.fourslash.ts
@@ -1,0 +1,27 @@
+/// <reference path="fourslash.ts" />
+
+// @filename: test.py
+//// import os
+
+//// class App():
+////     def __init(self):
+////         self.instance_path = "\\foo"
+
+//// app = App()
+//// try:
+////     os.makedirs(app.in[|/*marker*/|])
+
+//// except:
+////     pass
+
+// @ts-ignore
+await helper.verifyCompletion('included', 'markdown', {
+    marker: {
+        completions: [
+            {
+                label: 'instance_path',
+                kind: Consts.CompletionItemKind.Variable,
+            },
+        ],
+    },
+});

--- a/packages/pyright-internal/src/tests/fourslash/hover.slots.fourslash.ts
+++ b/packages/pyright-internal/src/tests/fourslash/hover.slots.fourslash.ts
@@ -1,0 +1,15 @@
+/// <reference path="fourslash.ts" />
+
+// @filename: test.py
+//// class Chat:
+////    __slots__ = ("id",)
+////
+////    def __init__(self):
+////        self.id = 1234
+////        """The ID of the channel."""
+////
+//// y = Chat()
+//// y.[|/*marker*/id|]
+helper.verifyHover('markdown', {
+    marker: '```python\n(variable) id: int\n```\n---\nThe ID of the channel.',
+});

--- a/packages/pyright-internal/src/tests/importAdder.test.ts
+++ b/packages/pyright-internal/src/tests/importAdder.test.ts
@@ -1355,6 +1355,20 @@ test('use relative import format - textEditTracker', () => {
     testImportMoveWithTracker(code, ImportFormat.Relative);
 });
 
+test('dont include token not contained in the span', () => {
+    const code = `
+// @filename: test1.py
+//// import random
+//// 
+//// [|/*src*/answer_word = random.choice(["a","b","c","d"])
+//// |]guess_word = "c"
+
+// @filename: nested/__init__.py
+//// [|{|"r":"import random!n!!n!!n!"|}|][|/*dest*/|]
+        `;
+    testImportMove(code, ImportFormat.Absolute);
+});
+
 function testImportMoveWithTracker(code: string, importFormat = ImportFormat.Absolute) {
     const state = parseAndGetTestState(code).state;
 

--- a/packages/pyright-internal/src/tests/indentationUtils.reindent.test.ts
+++ b/packages/pyright-internal/src/tests/indentationUtils.reindent.test.ts
@@ -387,6 +387,33 @@ test('re-indentation tab on multiline text', () => {
     testIndentation(code, 2, expected);
 });
 
+test('dont include token not contained in the span', () => {
+    const code = `
+//// import random
+////
+//// [|/*marker*/answer_word = random.choice(["a","b","c","d"])
+//// |]guess_word = "c"
+    `;
+
+    const expected = `answer_word = random.choice(["a","b","c","d"])`;
+
+    testIndentation(code, 0, expected);
+});
+
+test('handle comment before first token', () => {
+    const code = `
+//// [|/*marker*/# this function doesn't do much
+//// def myfunc(a, b):
+////     return a + b|]
+    `;
+
+    const expected = `# this function doesn't do much
+def myfunc(a, b):
+    return a + b`;
+
+    testIndentation(code, 0, expected);
+});
+
 function testIndentation(code: string, indentation: number, expected: string, indentFirstToken = true) {
     const state = parseAndGetTestState(code).state;
     const range = state.getRangeByMarkerName('marker')!;

--- a/packages/pyright-internal/src/tests/moveSymbol.importAdder.test.ts
+++ b/packages/pyright-internal/src/tests/moveSymbol.importAdder.test.ts
@@ -12,16 +12,16 @@ import { testMoveSymbolAtPosition } from './renameModuleTestUtils';
 test('move imports used in the symbol', () => {
     const code = `
 // @filename: test.py
-//// from typing import List, Mapping
+//// [|{|"r":"!n!class MyType:!n!    pass!n!!n!"|}from typing import List, Mapping
 //// 
 //// class MyType:
 ////     pass
 //// 
-//// [|{|"r":""|}def [|/*marker*/foo|](a: str, b: List[int]) -> None:
+//// def [|/*marker*/foo|](a: str, b: List[int]) -> None:
 ////     c: Mapping[str, MyType] = { 'hello', MyType() }|]
 
 // @filename: moved.py
-//// [|{|"r":"from typing import List, Mapping!n!!n!!n!"|}|][|{|"r":"from test import MyType!n!!n!!n!"|}|][|{|"r":"def foo(a: str, b: List[int]) -> None:!n!    c: Mapping[str, MyType] = { 'hello', MyType() }", "name": "dest"|}|]
+//// [|{|"r":"from test import MyType!n!!n!!n!from typing import List, Mapping!n!!n!!n!def foo(a: str, b: List[int]) -> None:!n!    c: Mapping[str, MyType] = { 'hello', MyType() }", "name": "dest"|}|]
         `;
 
     testFromCode(code);
@@ -30,16 +30,16 @@ test('move imports used in the symbol', () => {
 test('import with alias', () => {
     const code = `
 // @filename: test.py
-//// from typing import List as l, Mapping as m
+//// [|{|"r":"!n!class MyType:!n!    pass!n!!n!"|}from typing import List as l, Mapping as m
 //// 
 //// class MyType:
 ////     pass
 //// 
-//// [|{|"r":""|}def [|/*marker*/foo|](a: str, b: l[int]) -> None:
+//// def [|/*marker*/foo|](a: str, b: l[int]) -> None:
 ////     c: m[str, MyType] = { 'hello', MyType() }|]
 
 // @filename: moved.py
-//// [|{|"r":"from typing import List as l, Mapping as m!n!!n!!n!"|}|][|{|"r":"from test import MyType!n!!n!!n!"|}|][|{|"r":"def foo(a: str, b: l[int]) -> None:!n!    c: m[str, MyType] = { 'hello', MyType() }", "name": "dest"|}|]
+//// [|{|"r":"from test import MyType!n!!n!!n!from typing import List as l, Mapping as m!n!!n!!n!def foo(a: str, b: l[int]) -> None:!n!    c: m[str, MyType] = { 'hello', MyType() }", "name": "dest"|}|]
         `;
 
     testFromCode(code);
@@ -48,12 +48,12 @@ test('import with alias', () => {
 test('with existing imports', () => {
     const code = `
 // @filename: test.py
-//// from typing import List, Mapping
+//// [|{|"r":"!n!class MyType:!n!    pass!n!!n!"|}from typing import List, Mapping
 //// 
 //// class MyType:
 ////     pass
 //// 
-//// [|{|"r":""|}def [|/*marker*/foo|](a: str, b: List[int]) -> None:
+//// def [|/*marker*/foo|](a: str, b: List[int]) -> None:
 ////     c: Mapping[str, MyType] = { 'hello', MyType() }|]
 
 // @filename: moved.py
@@ -67,7 +67,7 @@ test('with existing imports', () => {
 test('merge with existing imports', () => {
     const code = `
 // @filename: test.py
-//// from typing import List, Mapping
+//// [|{|"r":"!n!class MyType:!n!    pass!n!!n!class MyType2(MyType):!n!    pass!n!!n!"|}from typing import List, Mapping
 //// 
 //// class MyType:
 ////     pass
@@ -75,13 +75,13 @@ test('merge with existing imports', () => {
 //// class MyType2(MyType):
 ////     pass
 //// 
-//// [|{|"r":""|}def [|/*marker*/foo|](a: str, b: List[int]) -> None:
+//// def [|/*marker*/foo|](a: str, b: List[int]) -> None:
 ////     c: Mapping[str, MyType] = { 'hello', MyType2() }|]
 
 // @filename: moved.py
-//// from typing import Mapping[|{|"r":"!n!from typing import List"|}|]
-//// from test import MyType[|{|"r":"!n!from test import MyType2"|}|]
-//// m = MyType()[|{|"r":"!n!!n!!n!def foo(a: str, b: List[int]) -> None:!n!    c: Mapping[str, MyType] = { 'hello', MyType2() }", "name": "dest"|}|]
+//// [|{|"r":"from typing import List, Mapping!n!from test import MyType, MyType2!n!m = MyType()!n!!n!!n!def foo(a: str, b: List[int]) -> None:!n!    c: Mapping[str, MyType] = { 'hello', MyType2() }", "name": "dest"|}from typing import Mapping
+//// from test import MyType
+//// m = MyType()|]
         `;
 
     testFromCode(code);
@@ -90,12 +90,12 @@ test('merge with existing imports', () => {
 test('merge with existing moving symbol imports', () => {
     const code = `
 // @filename: test.py
-//// from typing import List, Mapping
+//// [|{|"r":"!n!class MyType:!n!    pass!n!!n!"|}from typing import List, Mapping
 //// 
 //// class MyType:
 ////     pass
 //// 
-//// [|{|"r":""|}def [|/*marker*/foo|](a: str, b: List[int]) -> None:
+//// def [|/*marker*/foo|](a: str, b: List[int]) -> None:
 ////     c: Mapping[str, MyType] = { 'hello', MyType() }|]
 
 // @filename: moved.py
@@ -111,19 +111,19 @@ test('merge with existing moving symbol imports', () => {
 test('merge with existing moving symbol imports and add new one', () => {
     const code = `
 // @filename: test.py
-//// from typing import List, Mapping
+//// [|{|"r":"!n!class MyType:!n!    pass!n!!n!"|}from typing import List, Mapping
 //// 
 //// class MyType:
 ////     pass
 //// 
-//// [|{|"r":""|}def [|/*marker*/foo|](a: str, b: List[int]) -> None:
+//// def [|/*marker*/foo|](a: str, b: List[int]) -> None:
 ////     c: Mapping[str, MyType] = { 'hello', MyType() }|]
 
 // @filename: moved.py
-//// from typing import List, Mapping
-//// [|{|"r":""|}from test import foo[|{|"r":"!n!from test import MyType"|}|][|{|"r":"!n!!n!!n!def foo(a: str, b: List[int]) -> None:!n!    c: Mapping[str, MyType] = { 'hello', MyType() }", "name": "dest"|}|]
-//// |]
-//// foo()
+//// [|{|"r":"from typing import List, Mapping!n!!n!from test import MyType!n!!n!!n!def foo(a: str, b: List[int]) -> None:!n!    c: Mapping[str, MyType] = { 'hello', MyType() }!n!!n!foo()", "name": "dest"|}from typing import List, Mapping
+//// from test import foo
+//// 
+//// foo()|]
         `;
 
     testFromCode(code);
@@ -132,9 +132,9 @@ test('merge with existing moving symbol imports and add new one', () => {
 test('symbol from destination file used', () => {
     const code = `
 // @filename: test.py
-//// from moved import MyType
+//// [|{|"r":"!n!"|}from moved import MyType
 //// 
-//// [|{|"r":""|}def [|/*marker*/foo|](a: MyType) -> None:
+//// def [|/*marker*/foo|](a: MyType) -> None:
 ////     c: Mapping[str, MyType] = { 'hello', a }|]
 
 // @filename: moved.py
@@ -149,9 +149,9 @@ test('symbol from destination file used', () => {
 test('insert after all symbols references', () => {
     const code = `
 // @filename: test.py
-//// from moved import MyType
+//// [|{|"r":"!n!"|}from moved import MyType
 //// 
-//// [|{|"r":""|}def [|/*marker*/foo|](a: MyType) -> None:
+//// def [|/*marker*/foo|](a: MyType) -> None:
 ////     c: Mapping[str, MyType] = { 'hello', a }|]
 
 // @filename: moved.py
@@ -169,9 +169,9 @@ test('insert after all symbols references', () => {
 test('insert after all symbols references 2', () => {
     const code = `
 // @filename: test.py
-//// from moved import MyType
+//// [|{|"r":"!n!"|}from moved import MyType
 //// 
-//// [|{|"r":""|}def [|/*marker*/foo|](a: MyType) -> None:
+//// def [|/*marker*/foo|](a: MyType) -> None:
 ////     c: Mapping[str, MyType] = { 'hello', a }|]
 
 // @filename: moved.py
@@ -188,9 +188,9 @@ test('insert after all symbols references 2', () => {
 test('symbol used before all symbol references', () => {
     const code = `
 // @filename: test.py
-//// from moved import MyType
+//// [|{|"r":"!n!"|}from moved import MyType
 //// 
-//// [|{|"r":""|}def [|/*marker*/foo|](a: MyType) -> None:
+//// def [|/*marker*/foo|](a: MyType) -> None:
 ////     c: Mapping[str, MyType] = { 'hello', a }|]
 
 // @filename: moved.py
@@ -205,13 +205,136 @@ test('symbol used before all symbol references', () => {
     testFromCode(code);
 });
 
-function testFromCode(code: string) {
+test('symbol with import statements', () => {
+    const code = `
+// @filename: test.py
+//// [|{|"r": "import sys!n!!n!"|}import os, os.path, sys
+//// 
+//// def [|/*marker*/foo|]():
+////     p = os.path.curdir
+////     os.abort()|]
+
+// @filename: moved.py
+//// [|{|"r": "import os!n!import os.path!n!!n!!n!def foo():!n!    p = os.path.curdir!n!    os.abort()", "name": "dest"|}|]
+        `;
+
+    testFromCode(code);
+});
+
+test('symbol with import statements with alias', () => {
+    const code = `
+// @filename: test.py
+//// [|{|"r": "import sys!n!!n!"|}import os, os.path as path, sys
+//// 
+//// def [|/*marker*/foo|]():
+////     p = path.curdir
+////     os.abort()|]
+
+// @filename: moved.py
+//// [|{|"r": "import os!n!import os.path as path!n!!n!!n!def foo():!n!    p = path.curdir!n!    os.abort()", "name": "dest"|}|]
+        `;
+
+    testFromCode(code);
+});
+
+test('symbol with import statements with alias 2', () => {
+    const code = `
+// @filename: test.py
+//// [|{|"r": "import sys!n!!n!"|}import os, os.path as p1, sys
+//// 
+//// def [|/*marker*/foo|]():
+////     p = p1.curdir
+////     os.abort()|]
+
+// @filename: moved.py
+//// [|{|"r": "import os!n!import os.path as p1!n!!n!!n!def foo():!n!    p = p1.curdir!n!    os.abort()", "name": "dest"|}|]
+        `;
+
+    testFromCode(code);
+});
+
+test('symbol with import statements with multiple unused imports', () => {
+    const code = `
+// @filename: test.py
+//// [|{|"r": "import os.path, sys!n!!n!"|}import os, os.path, sys
+//// 
+//// def [|/*marker*/foo|]():
+////     os.abort()|]
+
+// @filename: moved.py
+//// [|{|"r": "import os!n!!n!!n!def foo():!n!    os.abort()", "name": "dest"|}|]
+        `;
+
+    testFromCode(code);
+});
+
+test('symbol with import statements with used imports', () => {
+    const code = `
+// @filename: test.py
+//// [|{|"r": "import os.path as path, sys!n!!n!p = path.curdir!n!!n!"|}import os, os.path as path, sys
+//// 
+//// p = path.curdir
+////
+//// def [|/*marker*/foo|]():
+////     p = path.curdir
+////     os.abort()|]
+
+// @filename: moved.py
+//// [|{|"r": "import os!n!import os.path as path!n!!n!!n!def foo():!n!    p = path.curdir!n!    os.abort()", "name": "dest"|}|]
+        `;
+
+    testFromCode(code);
+});
+
+test('symbol with invalid import', () => {
+    const code = `
+// @filename: test.py
+//// import notExist
+//// 
+//// p = notExist.fooStr
+////
+//// [|{|"r": ""|}def [|/*marker*/foo|]():
+////     p = notExist.fooStr|]
+
+// @filename: moved.py
+//// [|{|"r": "def foo():!n!    p = notExist.fooStr", "name": "dest"|}|]
+        `;
+
+    testFromCode(code, true);
+});
+
+test('symbol with import with error', () => {
+    const code = `
+// @filename: test.py
+//// #pyright: strict
+//// import lib # should have no stub diagnostic
+//// 
+//// lib.bar()
+////
+//// [|{|"r": ""|}def [|/*marker*/foo|]():
+////     p = lib.bar()|]
+
+// @filename: lib/__init__.py
+// @library: true
+//// def bar(): pass
+
+// @filename: moved.py
+//// [|{|"r": "import lib!n!!n!!n!def foo():!n!    p = lib.bar()", "name": "dest"|}|]
+        `;
+
+    testFromCode(code, true);
+});
+
+function testFromCode(code: string, expectsMissingImport = false) {
     const state = parseAndGetTestState(code).state;
 
     testMoveSymbolAtPosition(
         state,
         state.getMarkerByName('marker').fileName,
         state.getMarkerByName('dest').fileName,
-        state.getPositionRange('marker').start
+        state.getPositionRange('marker').start,
+        undefined,
+        undefined,
+        expectsMissingImport
     );
 }

--- a/packages/pyright-internal/src/tests/moveSymbol.insertion.test.ts
+++ b/packages/pyright-internal/src/tests/moveSymbol.insertion.test.ts
@@ -449,6 +449,120 @@ test('move variable with doc string', () => {
     testFromCode(code);
 });
 
+test('move a variable with another variable next line', () => {
+    const code = `
+// @filename: test.py
+//// [|{|"r":"!n!guess_word = 'c'"|}import random
+//// 
+//// [|/*marker*/answer_word|] = random.choice(['a','b','c','d'])
+//// guess_word = 'c'|]
+
+// @filename: moved.py
+//// [|{|"r":"import random!n!!n!!n!answer_word = random.choice(['a','b','c','d'])", "name": "dest"|}|]
+    `;
+
+    testFromCode(code);
+});
+
+test('Handle comments at the begining better 1', () => {
+    const code = `
+// @filename: test.py
+//// # this function doesn't do much
+//// [|{|"r":""|}def [|/*marker*/myfunc|](a, b):
+////     return a + b|]
+
+// @filename: moved.py
+//// [|{|"r":"def myfunc(a, b):!n!    return a + b", "name": "dest"|}|]
+    `;
+
+    testFromCode(code);
+});
+
+test('Handle comments at the begining better 2', () => {
+    const code = `
+// @filename: test.py
+//// import os
+////
+//// [|{|"r":""|}# this function doesn't do much
+//// def [|/*marker*/myfunc|](a, b):
+////     return a + b|]
+
+// @filename: moved.py
+//// [|{|"r":"# this function doesn't do much!n!def myfunc(a, b):!n!    return a + b", "name": "dest"|}|]
+    `;
+
+    testFromCode(code);
+});
+
+test('variable with multiline expression', () => {
+    const code = `
+// @filename: test.py
+//// [|{|"r":"!n!"|}from functools import partial
+//// 
+//// [|/*marker*/sum1_2|] = partial(sum, 
+//// [1, 
+//// 2]
+//// )|]
+
+// @filename: moved.py
+//// [|{|"r":"from functools import partial!n!!n!!n!sum1_2 = partial(sum,!n![1,!n!2]!n!)", "name": "dest"|}|]
+    `;
+
+    testFromCode(code);
+});
+
+test('multiple variables in a single line 1', () => {
+    const code = `
+// @filename: test.py
+//// [|{|"r":""|}[|/*marker*/a|] = 1; |]b = 1
+
+// @filename: moved.py
+//// [|{|"r":"a = 1;", "name": "dest"|}|]
+    `;
+
+    testFromCode(code);
+});
+
+test('multiple variables in a single line 2', () => {
+    const code = `
+// @filename: test.py
+//// a = 1;[|{|"r":""|}[|/*marker*/b|] = 2|]
+
+// @filename: moved.py
+//// [|{|"r":"b = 2", "name": "dest"|}|]
+    `;
+
+    testFromCode(code);
+});
+
+test('multiple variables in multiple lines 1', () => {
+    const code = `
+// @filename: test.py
+//// [|{|"r":""|}[|/*marker*/a|] = \\
+////     1 + 2; |]b = 3 + \\
+////                4 
+
+// @filename: moved.py
+//// [|{|"r":"a = \\\\!n!    1 + 2;", "name": "dest"|}|]
+    `;
+
+    testFromCode(code);
+});
+
+test('multiple variables in multiple lines 2', () => {
+    const code = `
+// @filename: test.py
+//// a = \\
+////     1 + 2; [|{|"r":""|}[|/*marker*/b|] = 3 + \\
+////                4|]
+
+// @filename: moved.py
+//// [|{|"r":"b = 3 + \\\\!n!    4", "name": "dest"|}|]
+    `;
+
+    testFromCode(code);
+});
+
 function testFromCode(code: string) {
     const state = parseAndGetTestState(code).state;
 

--- a/packages/pyright-internal/src/tests/renameModuleTestUtils.ts
+++ b/packages/pyright-internal/src/tests/renameModuleTestUtils.ts
@@ -30,7 +30,8 @@ export function testMoveSymbolAtPosition(
     newFilePath: string,
     position: Position,
     text?: string,
-    replacementText?: string
+    replacementText?: string,
+    expectsMissingImport = false
 ) {
     const actions = state.program.moveSymbolAtPosition(
         filePath,
@@ -60,7 +61,7 @@ export function testMoveSymbolAtPosition(
             .join('|')}`
     );
 
-    _verifyFileOperations(state, actions, ranges, replacementText);
+    _verifyFileOperations(state, actions, ranges, replacementText, expectsMissingImport);
 }
 
 export function testRenameModule(
@@ -102,18 +103,23 @@ function _verifyFileOperations(
     state: TestState,
     fileEditActions: FileEditActions,
     ranges: Range[],
-    replacementText: string | undefined
+    replacementText: string | undefined,
+    expectsMissingImport = false
 ) {
     const editsPerFileMap = createMapFromItems(fileEditActions.edits, (e) => e.filePath);
 
-    _verifyMissingImports();
+    if (!expectsMissingImport) {
+        _verifyMissingImports();
+    }
 
     verifyEdits(state, fileEditActions, ranges, replacementText);
 
     applyFileOperations(state, fileEditActions);
 
     // Make sure we don't have missing imports after the change.
-    _verifyMissingImports();
+    if (!expectsMissingImport) {
+        _verifyMissingImports();
+    }
 
     function _verifyMissingImports() {
         for (const editFileName of editsPerFileMap.keys()) {


### PR DESCRIPTION
rollup of the following changes:

- made auto parenthese to check snippet support 
- node in a variable decl just points to the variable name. it should be expanded to the assignment statement to get proper end position. 
- Fix error node parsing for completions 
- Fix type ignore ending up on the wrong line
- Fix slots doc strings 
- Fix action warnings about deprecated features
- Remove unused imports after moving symbol.
- Fix offset when checking if current indent should be retained
- Fixed move symbol bug 