### PR TITLE
Fix indented code blocks in docstrings

### DIFF
--- a/packages/pyright-internal/src/analyzer/docStringConversion.ts
+++ b/packages/pyright-internal/src/analyzer/docStringConversion.ts
@@ -427,7 +427,10 @@ class DocStringConverter {
         const match = this._currentLine().match(CodeBlockStartRegExp);
         if (match !== null) {
             this._blockIndent = this._currentIndent()
-            this._appendLine('```' + match[1]) // remove indentation, preserve language tag
+
+            // Remove indentation and preserve language tag.
+            this._appendLine('```' + match[1])
+
             this._pushAndSetState(this._parseBacktickBlock);
             this._eatLine();
             return true;
@@ -436,7 +439,7 @@ class DocStringConverter {
     }
 
     private _parseBacktickBlock(): void {
-        // only match closing ``` at same indent level of opening
+        // Only match closing ``` at same indent level of opening.
         if (CodeBlockEndRegExp.test(this._currentLine()) && this._currentIndent() === this._blockIndent) {
             this._appendLine('```');
             this._appendLine();

--- a/packages/pyright-internal/src/analyzer/docStringConversion.ts
+++ b/packages/pyright-internal/src/analyzer/docStringConversion.ts
@@ -80,6 +80,8 @@ const PlusRegExp = /\+/g;
 const UnescapedMarkdownCharsRegExp = /(?<!\\)([_*~[\]])/g;
 const linkRegExp = /(\[.*\]\(.*\))/g;
 
+const CodeBlockRegExp = /^\s*```/
+
 const HtmlEscapes: RegExpReplacement[] = [
     { exp: /</g, replacement: '&lt;' },
     { exp: />/g, replacement: '&gt;' },
@@ -421,7 +423,7 @@ class DocStringConverter {
     }
 
     private _beginBacktickBlock(): boolean {
-        if (this._currentLine().startsWith('```')) {
+        if (CodeBlockRegExp.test(this._currentLine())) {
             this._appendLine(this._currentLine());
             this._pushAndSetState(this._parseBacktickBlock);
             this._eatLine();

--- a/packages/pyright-internal/src/analyzer/docStringConversion.ts
+++ b/packages/pyright-internal/src/analyzer/docStringConversion.ts
@@ -426,10 +426,10 @@ class DocStringConverter {
     private _beginBacktickBlock(): boolean {
         const match = this._currentLine().match(CodeBlockStartRegExp);
         if (match !== null) {
-            this._blockIndent = this._currentIndent()
+            this._blockIndent = this._currentIndent();
 
             // Remove indentation and preserve language tag.
-            this._appendLine('```' + match[1])
+            this._appendLine('```' + match[1]);
 
             this._pushAndSetState(this._parseBacktickBlock);
             this._eatLine();

--- a/packages/pyright-internal/src/tests/docStringConversion.test.ts
+++ b/packages/pyright-internal/src/tests/docStringConversion.test.ts
@@ -749,24 +749,24 @@ test('EscapeHtmlTagsOutsideCodeBlocks', () => {
 test('IndentedCodeBlock', () => {
     const docstring = `
 Expected:
-    \`\`\`python
+    ${tripleTick}python
     def some_fn():
         """
         Backticks on a different indentation level don't close the code block.
-        \`\`\`
+        ${tripleTick}
         """
-    \`\`\`
+    ${tripleTick}
 `;
 
     const markdown = `
 Expected:
-\`\`\`python
+${tripleTick}python
     def some_fn():
         """
         Backticks on a different indentation level don't close the code block.
-        \`\`\`
+        ${tripleTick}
         """
-\`\`\`
+${tripleTick}
 `;
     _testConvertToMarkdown(docstring, markdown)
 })

--- a/packages/pyright-internal/src/tests/docStringConversion.test.ts
+++ b/packages/pyright-internal/src/tests/docStringConversion.test.ts
@@ -746,6 +746,32 @@ test('EscapeHtmlTagsOutsideCodeBlocks', () => {
     _testConvertToMarkdown(docstring, markdown);
 });
 
+test('IndentedCodeBlock', () => {
+    const docstring = `
+Expected:
+    \`\`\`python
+    def some_fn():
+        """
+        Backticks on a different indentation level don't close the code block.
+        \`\`\`
+        """
+    \`\`\`
+`;
+
+    const markdown = `
+Expected:
+\`\`\`python
+    def some_fn():
+        """
+        Backticks on a different indentation level don't close the code block.
+        \`\`\`
+        """
+\`\`\`
+`;
+    _testConvertToMarkdown(docstring, markdown)
+})
+
+
 test('RestTableWithHeader', () => {
     const docstring = `
 =============== =========================================================

--- a/packages/pyright-internal/src/tests/docStringConversion.test.ts
+++ b/packages/pyright-internal/src/tests/docStringConversion.test.ts
@@ -768,9 +768,8 @@ ${tripleTick}python
         """
 ${tripleTick}
 `;
-    _testConvertToMarkdown(docstring, markdown)
-})
-
+    _testConvertToMarkdown(docstring, markdown);
+});
 
 test('RestTableWithHeader', () => {
     const docstring = `


### PR DESCRIPTION
This PR fixes an issue where markdown code blocks do not parse correctly when they started on an indented line in a docstring.

```python
def test():
    """
    A test function

    Example:
        ```python
        print(test())
        ```
    """
    pass
```

Currently this docstring looks like this when hovering `test`: 
![image](https://user-images.githubusercontent.com/5047809/222246442-6db923e7-8d59-4236-84e0-d42ada48295d.png)

After the fix it renders correctly:
![image](https://user-images.githubusercontent.com/5047809/222276577-57ad01d1-5be2-41b3-92bd-4e5a71bdd8ef.png)
