### PR TITLE
Add pretty-printing to inline type-dicts

### DIFF
--- a/packages/pyright-internal/src/analyzer/typedDicts.ts
+++ b/packages/pyright-internal/src/analyzer/typedDicts.ts
@@ -220,6 +220,22 @@ export function createTypedDictTypeInlined(
     getTypedDictFieldsFromDictSyntax(evaluator, dictNode, classType.details.fields);
     synthesizeTypedDictClassMethods(evaluator, dictNode, classType, /* isClassFinal */ true);
 
+    const innerRepr = (
+        [...classType.details.fields.entries()]
+        .filter(([_, sym]) => sym.isInstanceMember())
+        .map(([rawName, sym]) => {
+            const [decl] = sym.getDeclarations() as [VariableDeclaration];
+            const declType = evaluator.getTypeForDeclaration(decl).type;
+            const fieldTypeRepr = declType ? evaluator.printType(declType) : 'Unknown';
+
+            const quotedName = JSON.stringify(rawName)
+
+            return `${quotedName}: ${fieldTypeRepr}`
+        })
+        .join(', ')
+    );
+    classType.details.name = 'dict[{' + innerRepr + '}]';
+
     return classType;
 }
 


### PR DESCRIPTION
Before:
```
def origin() -> dict[{"x": int, "y": int}]:
    return {"x": 0, "y": 0}

p = origin()
reveal_type(p)  # Type of "p" is "<TypedDict>"
```

After:
```
def origin() -> dict[{"x": int, "y": int}]:
    return {"x": 0, "y": 0}

p = origin()
reveal_type(p)  # Type of "p" is "dict[{"x": int, "y": int}]"
```

I think it's a much more helpful description of the type