### PR TITLE
Performance: Changed the logic in the type evaluator's code flow engi…

### DIFF
--- a/packages/pyright-internal/src/analyzer/codeFlowEngine.ts
+++ b/packages/pyright-internal/src/analyzer/codeFlowEngine.ts
@@ -1583,7 +1583,15 @@ export function getCodeFlowEngine(
             return true;
         }
 
-        return evaluator.isAfterNodeReachable(functionType.details.declaration.node);
+        // This call is very expensive because it requires a full code flow analysis
+        // of this function and all (unannotated) functions that it calls, recursively.
+        // Rather than incurring this expense, we assume here that all unannotated
+        // functions are not NoReturn functions. To reverse this decision, uncomment
+        // the following line.
+
+        // return evaluator.isAfterNodeReachable(functionType.details.declaration.node);
+
+        return true;
     }
 
     // Performs a cursory analysis to determine whether the expression

--- a/packages/pyright-internal/src/tests/samples/unreachable1.py
+++ b/packages/pyright-internal/src/tests/samples/unreachable1.py
@@ -3,6 +3,7 @@
 from abc import abstractmethod
 import os
 import sys
+from typing import NoReturn
 
 
 def func1():
@@ -38,7 +39,7 @@ class Foo:
         print(self.b)
         raise RuntimeError()
 
-    def method5(self):
+    def method5(self) -> NoReturn:
         print(self.b)
         raise RuntimeError()
 
@@ -78,7 +79,7 @@ def func7(foo: Foo):
     return 3
 
 
-def func8():
+def func8() -> NoReturn:
     raise NameError()
 
 
@@ -93,20 +94,18 @@ def func10():
     e = OSError()
     a1 = os.name == "nt" and None == e.errno
     reveal_type(a1, expected_text="bool")
-  
+
     a2 = True and os.name == "nt"
     reveal_type(a2, expected_text="bool")
-              
+
     if os.name == "nt":
         # This should be marked unreachable.
-        b = e.errno                            
+        b = e.errno
 
     if sys.version_info >= (4, 0):
         # This should be marked unreachable.
         b = e.errno
-         
+
     return
     # This should be marked unreachable.
     b = e.errno
-
-    


### PR DESCRIPTION
…ne to assume that any function that lacks a return type annotation is _not_ a NoReturn function. This greatly speeds up type analysis in certain unannotated code bases, but it results in less accurate type analysis.