### PR TITLE
Don't modify `Comment` range data

### DIFF
--- a/packages/pyright-internal/src/analyzer/checker.ts
+++ b/packages/pyright-internal/src/analyzer/checker.ts
@@ -6218,11 +6218,10 @@ export class Checker extends ParseTreeWalker {
     }
 
     private _addDiagnosticForRegionComment(regionComment: RegionComment, message: string): Diagnostic | undefined {
-        // extend range to include # character
-        const range: TextRange = regionComment.comment;
-        range.start -= 1;
-        range.length += 1;
-
-        return this._evaluator.addDiagnosticForTextRange(this._fileInfo, 'error', '', message, range);
+        return this._evaluator.addDiagnosticForTextRange(this._fileInfo, 'error', '', message, {
+            // extend range to include # character
+            start: regionComment.comment.start - 1,
+            length: regionComment.comment.length + 1,
+        });
     }
 }

--- a/packages/pyright-internal/src/analyzer/regions.ts
+++ b/packages/pyright-internal/src/analyzer/regions.ts
@@ -46,11 +46,6 @@ const EndRegionRegEx = /^\s*endregion\b/;
 
 function getRegionCommentType(comment: Comment, parseResults: ParseResults): RegionCommentType | undefined {
     const hashOffset = comment.start - 1;
-
-    if (hashOffset < 0 || hashOffset > parseResults.tokenizerOutput.lines.end) {
-        return undefined;
-    }
-
     const hashPosition = convertOffsetToPosition(hashOffset, parseResults.tokenizerOutput.lines);
 
     // If anything other than whitespace is found before the #region (ex. a statement)

--- a/packages/pyright-internal/src/analyzer/regions.ts
+++ b/packages/pyright-internal/src/analyzer/regions.ts
@@ -46,6 +46,11 @@ const EndRegionRegEx = /^\s*endregion\b/;
 
 function getRegionCommentType(comment: Comment, parseResults: ParseResults): RegionCommentType | undefined {
     const hashOffset = comment.start - 1;
+
+    if (hashOffset < 0 || hashOffset > parseResults.tokenizerOutput.lines.end) {
+        return undefined;
+    }
+
     const hashPosition = convertOffsetToPosition(hashOffset, parseResults.tokenizerOutput.lines);
 
     // If anything other than whitespace is found before the #region (ex. a statement)


### PR DESCRIPTION
Addresses https://github.com/microsoft/pylance-release/issues/4157

I haven't been able to reproduce this crash. Also I don't see a way for a `Comment` to be created with an out-of-range `start` value.

However, I noticed that `_addDiagnosticForRegionComment` was modifying `start` and `length` on `Comment` ranges to include the `#` sign. This was modifying the `Comment` data in `ParseResults`, so I could imagine it causing downstream problems. I verified that if `Checker` called `_checkRegions()` twice in a row we hit the `convertOffsetToPosition` assertion in the bug.

I considered [returning](https://github.com/microsoft/pyright/commit/9af9c78f32d27b1f77ec868549b9791da2e6fd8d) `undefined` from `getRegionCommentType` when `hashOffset` was out of range. But I think it's best to make this change and see if the crash disappears in telemetry.