### PR TITLE
Changed the default of the `useLibraryCodeForTypes` from false to tru…

### DIFF
--- a/docs/command-line.md
+++ b/docs/command-line.md
@@ -10,7 +10,6 @@ Pyright can be run as either a VS Code extension or as a node-based command-line
 | --dependencies                          | Emit import dependency information                   |
 | -h, --help                              | Show help message                                    |
 | --ignoreexternal                        | Ignore external imports for --verifytypes            |
-| --lib                                   | Use library code for types when stubs are missing    |
 | --level <LEVEL>                         | Minimum diagnostic level (error or warning)          |
 | --outputjson                            | Output results in JSON format                        |
 | -p, --project `<FILE OR DIRECTORY>`     | Use the configuration file at this location          |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -38,7 +38,7 @@ Relative paths specified within the config file are relative to the config fileâ
 
 **typeCheckingMode** ["off", "basic", "strict"]: Specifies the default rule set to use. Some rules can be overridden using additional configuration flags documented below. The default value for this setting is "basic". If set to "off", all type-checking rules are disabled, but Python syntax and semantic errors are still reported.
 
-**useLibraryCodeForTypes** [boolean]: Determines whether pyright reads, parses and analyzes library code to extract type information in the absence of type stub files. Type information will typically be incomplete. We recommend using type stubs where possible. The default value for this option is false.
+**useLibraryCodeForTypes** [boolean]: Determines whether pyright reads, parses and analyzes library code to extract type information in the absence of type stub files. Type information will typically be incomplete. We recommend using type stubs where possible. The default value for this option is true.
 
 
 ## Type Check Diagnostics Settings

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -7,7 +7,6 @@ Here is a typical progression:
 ### 1. Initial Type Checking
 * Install pyright (either the language server or command-line tool).
 * Write a minimal `pyrightconfig.json` that defines `include` entries. Place the config file in your project’s top-level directory and commit it to your repo. Alternatively, you can add a pyright section to a `pyproject.toml` file. For additional details and a sample config file, refer to [this documentation](configuration.md).
-* Optionally enable the `python.analysis.useLibraryCodeForTypes` config option (or pass `--lib` to the command-line tool). This tells Pyright that it should attempt to infer type information from library code if a type stub is not available.
 * Run pyright over your source base with the default settings. Fix any errors and warnings that it emits. Optionally disable specific diagnostic rules if they are generating too many errors. They can be re-enabled at a later time.
 
 ### 2. Types For Imported Libraries

--- a/docs/import-resolution.md
+++ b/docs/import-resolution.md
@@ -20,7 +20,7 @@ For absolute (non-relative) imports, Pyright employs the following resolution or
     * For a given package, try to resolve first using a **stub package**. Stub packages, as defined in [PEP 561](https://www.python.org/dev/peps/pep-0561/#type-checker-module-resolution-order), are named the same as the original package but with “-stubs” appended.
     * Try to resolve using an **inline stub**, a “.pyi” file that ships within the package.
     * If the package contains a “py.typed” file as described in [PEP 561](https://www.python.org/dev/peps/pep-0561/), use inlined type annotations provided in “.py” files within the package.
-    * If the `python.analysis.useLibraryCodeForTypes` setting is set to true (or the `--lib` command-line argument was specified), try to resolve using the **library implementation** (“.py” file). Some “.py” files may contain partial or complete type annotations. Pyright will use type annotations that are provided and do its best to infer any missing type information. If you are using Pyright, `python.analysis.useLibraryCodeForTypes` is false by default. If you are using Pylance, it is true.
+    * If the `python.analysis.useLibraryCodeForTypes` setting is set to true, try to resolve using the **library implementation** (“.py” file). Some “.py” files may contain partial or complete type annotations. Pyright will use type annotations that are provided and do its best to infer any missing type information.
 
 4. Try to resolve using a **stdlib typeshed stub**. If the `typeshedPath` is configured, use this instead of the typeshed stubs that are packaged with Pyright. This allows for the use of a newer or a patched version of the typeshed stdlib stubs.
 

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -28,7 +28,7 @@ The Pyright language server honors the following settings.
 
 **python.analysis.typeshedPaths** [array of paths]: Paths to look for typeshed modules. Pyright currently honors only the first path in the array.
 
-**python.analysis.useLibraryCodeForTypes** [boolean]: Determines whether pyright reads, parses and analyzes library code to extract type information in the absence of type stub files. Type information will typically be incomplete. We recommend using type stubs where possible. The default value for this option is false.
+**python.analysis.useLibraryCodeForTypes** [boolean]: Determines whether pyright reads, parses and analyzes library code to extract type information in the absence of type stub files. Type information will typically be incomplete. We recommend using type stubs where possible. The default value for this option is true.
 
 **python.pythonPath** [path]: Path to Python interpreter. This setting is being deprecated by the VS Code Python extension in favor of a setting that is stored in the Python extension’s internal configuration store. Pyright supports both mechanisms but prefers the new one if both settings are present.
 

--- a/packages/pyright-internal/src/analyzer/service.ts
+++ b/packages/pyright-internal/src/analyzer/service.ts
@@ -834,6 +834,11 @@ export class AnalyzerService {
             reportDuplicateSetting('useLibraryCodeForTypes', configOptions.useLibraryCodeForTypes);
         }
 
+        // If useLibraryCodeForTypes is still unspecified, default it to true.
+        if (configOptions.useLibraryCodeForTypes === undefined) {
+            configOptions.useLibraryCodeForTypes = true;
+        }
+
         if (commandLineOptions.stubPath) {
             if (!configOptions.stubPath) {
                 configOptions.stubPath = commandLineOptions.stubPath;

--- a/packages/pyright-internal/src/pyright.ts
+++ b/packages/pyright-internal/src/pyright.ts
@@ -268,7 +268,7 @@ async function processArgs(): Promise<ExitStatus> {
     }
 
     if (args.lib) {
-        options.useLibraryCodeForTypes = true;
+        console.warn(`The --lib option is deprecated. Pyright now defaults to using library code to infer types.`);
     }
 
     let minSeverityLevel: SeverityLevel = 'information';
@@ -688,7 +688,6 @@ function printUsage() {
             '  --dependencies                     Emit import dependency information\n' +
             '  -h,--help                          Show this help message\n' +
             '  --ignoreexternal                   Ignore external imports for --verifytypes\n' +
-            '  --lib                              Use library code to infer types when stubs are missing\n' +
             '  --level <LEVEL>                    Minimum diagnostic level (error or warning)\n' +
             '  --outputjson                       Output results in JSON format\n' +
             '  -p,--project <FILE OR DIRECTORY>   Use the configuration file at this location\n' +

--- a/packages/vscode-pyright/package.json
+++ b/packages/vscode-pyright/package.json
@@ -903,7 +903,7 @@
                 },
                 "python.analysis.useLibraryCodeForTypes": {
                     "type": "boolean",
-                    "default": false,
+                    "default": true,
                     "description": "Use library implementations to extract type information when type stub is not present.",
                     "scope": "resource"
                 },

--- a/packages/vscode-pyright/schemas/pyrightconfig.schema.json
+++ b/packages/vscode-pyright/schemas/pyrightconfig.schema.json
@@ -93,7 +93,7 @@
       "$id": "#/properties/useLibraryCodeForTypes",
       "type": "boolean",
       "title": "Use library implementations to extract type information when type stub is not present",
-      "default": false
+      "default": true
     },
     "typeshedPath": {
       "$id": "#/properties/typeshedPath",


### PR DESCRIPTION
…e to bring pylance and pyright into alignment. Also deprecated the "--lib" command-line option, which was previously used to enable `useLibraryCodeForTypes` from the command line.