### PR TITLE
Changed typePrinter option `OmitTypeArgumentsIfAny` to `OmitTypeArgum…

### DIFF
--- a/packages/pyright-internal/src/analyzer/program.ts
+++ b/packages/pyright-internal/src/analyzer/program.ts
@@ -870,8 +870,8 @@ export class Program {
             flags |= PrintTypeFlags.OmitConditionalConstraint;
         }
 
-        if (configOptions.diagnosticRuleSet.omitTypeArgsIfAny) {
-            flags |= PrintTypeFlags.OmitTypeArgumentsIfAny;
+        if (configOptions.diagnosticRuleSet.omitTypeArgsIfUnknown) {
+            flags |= PrintTypeFlags.OmitTypeArgumentsIfUnknown;
         }
 
         if (configOptions.diagnosticRuleSet.omitUnannotatedParamType) {

--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -26206,6 +26206,12 @@ export function createTypeEvaluator(importLookup: ImportLookup, evaluatorOptions
         if (options?.useTypingUnpack) {
             flags |= TypePrinter.PrintTypeFlags.UseTypingUnpack;
         }
+        if (options?.printUnknownWithAny) {
+            flags |= TypePrinter.PrintTypeFlags.PrintUnknownWithAny;
+        }
+        if (options?.omitTypeArgumentsIfUnknown) {
+            flags |= TypePrinter.PrintTypeFlags.OmitTypeArgumentsIfUnknown;
+        }
 
         return TypePrinter.printType(type, flags, getFunctionEffectiveReturnType);
     }

--- a/packages/pyright-internal/src/analyzer/typeEvaluatorTypes.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluatorTypes.ts
@@ -343,6 +343,8 @@ export interface PrintTypeOptions {
     expandTypeAlias?: boolean;
     enforcePythonSyntax?: boolean;
     useTypingUnpack?: boolean;
+    printUnknownWithAny?: boolean;
+    omitTypeArgumentsIfUnknown?: boolean;
 }
 
 export interface DeclaredSymbolTypeInfo {

--- a/packages/pyright-internal/src/common/configOptions.ts
+++ b/packages/pyright-internal/src/common/configOptions.ts
@@ -76,8 +76,8 @@ export interface DiagnosticRuleSet {
     printUnknownAsAny: boolean;
 
     // Should type arguments to a generic class be omitted
-    // when printed if all arguments are Unknown or Any?
-    omitTypeArgsIfAny: boolean;
+    // when printed if all arguments are Unknown?
+    omitTypeArgsIfUnknown: boolean;
 
     // Should parameter type be omitted if it is not annotated?
     omitUnannotatedParamType: boolean;
@@ -421,7 +421,7 @@ export function getStrictModeNotOverriddenRules() {
 export function getOffDiagnosticRuleSet(): DiagnosticRuleSet {
     const diagSettings: DiagnosticRuleSet = {
         printUnknownAsAny: true,
-        omitTypeArgsIfAny: true,
+        omitTypeArgsIfUnknown: true,
         omitUnannotatedParamType: true,
         omitConditionalConstraint: true,
         pep604Printing: true,
@@ -503,7 +503,7 @@ export function getOffDiagnosticRuleSet(): DiagnosticRuleSet {
 export function getBasicDiagnosticRuleSet(): DiagnosticRuleSet {
     const diagSettings: DiagnosticRuleSet = {
         printUnknownAsAny: false,
-        omitTypeArgsIfAny: false,
+        omitTypeArgsIfUnknown: false,
         omitUnannotatedParamType: true,
         omitConditionalConstraint: false,
         pep604Printing: true,
@@ -585,7 +585,7 @@ export function getBasicDiagnosticRuleSet(): DiagnosticRuleSet {
 export function getStrictDiagnosticRuleSet(): DiagnosticRuleSet {
     const diagSettings: DiagnosticRuleSet = {
         printUnknownAsAny: false,
-        omitTypeArgsIfAny: false,
+        omitTypeArgsIfUnknown: false,
         omitUnannotatedParamType: false,
         omitConditionalConstraint: false,
         pep604Printing: true,


### PR DESCRIPTION
…entsIfUnknown`. Exposed this flag and `printUnknownWithAny` from the type evaluator. This addresses https://github.com/microsoft/pyright/issues/4933.