### PR TITLE
Push pylance changes to pyright

### DIFF
--- a/packages/pyright-internal/src/languageService/autoImporter.ts
+++ b/packages/pyright-internal/src/languageService/autoImporter.ts
@@ -106,7 +106,7 @@ type AutoImportResultMap = Map<string, AutoImportResult[]>;
 // level scope that contains the symbol table for the module.
 export function buildModuleSymbolsMap(
     files: SourceFileInfo[],
-    includeIndexUserSymbols: boolean,
+    includeSymbolsFromIndices: boolean,
     token: CancellationToken
 ): ModuleSymbolMap {
     const moduleSymbolMap = new Map<string, ModuleSymbolTable>();
@@ -169,7 +169,7 @@ export function buildModuleSymbolsMap(
 
         // Iterate through closed user files using indices if asked.
         const indexResults = file.sourceFile.getCachedIndexResults();
-        if (indexResults && includeIndexUserSymbols && !indexResults.privateOrProtected) {
+        if (indexResults && includeSymbolsFromIndices && !indexResults.privateOrProtected) {
             moduleSymbolMap.set(filePath, createModuleSymbolTableFromIndexResult(indexResults, /* library */ false));
             return;
         }

--- a/packages/pyright-internal/src/tests/fourslash/completions.override2.fourslash.ts
+++ b/packages/pyright-internal/src/tests/fourslash/completions.override2.fourslash.ts
@@ -32,7 +32,7 @@
                     kind: Consts.CompletionItemKind.Method,
                     textEdit: {
                         range: helper.getPositionRange('marker'),
-                        newText: 'append(self, __object: _T) -> None:\n    return super().append(__object)',
+                        newText: 'append(self, __object: Any) -> None:\n    return super().append(__object)',
                     },
                 },
             ],

--- a/packages/pyright-internal/src/tests/moveSymbol.insertion.test.ts
+++ b/packages/pyright-internal/src/tests/moveSymbol.insertion.test.ts
@@ -118,7 +118,7 @@ test('insert to empty file with comments', () => {
 
 // @filename: moved.py
 //// # comment
-//// [|{|"r":"!n!!n!!n!def foo():!n!    pass", "name": "dest"|}|]
+//// [|{|"r":"!n!def foo():!n!    pass", "name": "dest"|}|]
         `;
 
     testFromCode(code);
@@ -132,7 +132,7 @@ test('insert to empty file with comments and blank lines', () => {
 
 // @filename: moved.py
 //// # comment
-//// [|{|"r":"!n!!n!def foo():!n!    pass", "name": "dest"|}|]
+//// [|{|"r":"def foo():!n!    pass", "name": "dest"|}|]
 //// 
         `;
 
@@ -317,7 +317,7 @@ test('insert to a file with same symbol imported with alias', () => {
 // @filename: moved.py
 //// [|{|"r":""|}from test import foo as aliasFoo
 //// |]
-//// aliasFoo()[|{|"r":"!n!!n!def foo():!n!    pass", "name": "dest"|}|]
+//// aliasFoo()[|{|"r":"!n!!n!!n!def foo():!n!    pass", "name": "dest"|}|]
         `;
 
     testFromCode(code);
@@ -569,7 +569,7 @@ test('insert after comment', () => {
 //// [|{|"r":""|}[|/*marker*/b|] = 3|]
 
 // @filename: moved.py
-//// a = 1 # type: ignore[|{|"r":"!n!!n!!n!b = 3", "name": "dest"|}|]
+//// a = 1 # type: ignore[|{|"r":"!n!b = 3", "name": "dest"|}|]
     `;
 
     testFromCode(code);
@@ -583,6 +583,31 @@ test('keep comments', () => {
 
 // @filename: moved.py
 //// [|{|"r":"def test():!n!    return # comment", "name": "dest"|}|]
+    `;
+
+    testFromCode(code);
+});
+
+test('statement list', () => {
+    const code = `
+// @filename: test.py
+//// [|{|"r":""|}[|/*marker*/a|] = 1|]
+
+// @filename: moved.py
+//// print("hello")[|{|"r":"!n!a = 1", "name": "dest"|}|]
+    `;
+
+    testFromCode(code);
+});
+
+test('regular statement', () => {
+    const code = `
+// @filename: test.py
+//// [|{|"r":""|}[|/*marker*/a|] = 1|]
+
+// @filename: moved.py
+//// if True:
+////     pass[|{|"r":"!n!!n!a = 1", "name": "dest"|}|]
     `;
 
     testFromCode(code);


### PR DESCRIPTION
rollup of the following changes:
* improved move symbol's blank line handling
* made completion override to use semantic info rather than syntax info
* use indices if it exists even if `indexing` is off