### PR TITLE
Refactored DefinitionProvider

### DIFF
--- a/packages/pyright-internal/src/analyzer/checker.ts
+++ b/packages/pyright-internal/src/analyzer/checker.ts
@@ -22,7 +22,7 @@ import { DiagnosticRule } from '../common/diagnosticRules';
 import { getFileExtension } from '../common/pathUtils';
 import { PythonVersion, versionToString } from '../common/pythonVersion';
 import { TextRange } from '../common/textRange';
-import { DefinitionFilter, DefinitionProvider } from '../languageService/definitionProvider';
+import { DefinitionProvider } from '../languageService/definitionProvider';
 import { Localizer } from '../localization/localize';
 import {
     ArgumentCategory,
@@ -3883,9 +3883,8 @@ export class Checker extends ParseTreeWalker {
             // If the definition for this name is in 'user' module, it is overwriting the stdlib module.
             const definitions = DefinitionProvider.getDefinitionsForNode(
                 this._sourceMapper,
-                namePartNodes[namePartNodes.length - 1],
-                DefinitionFilter.All,
                 this._evaluator,
+                namePartNodes[namePartNodes.length - 1],
                 CancellationToken.None
             );
             const paths = definitions ? definitions.map((d) => d.path) : [];

--- a/packages/pyright-internal/src/analyzer/program.ts
+++ b/packages/pyright-internal/src/analyzer/program.ts
@@ -46,15 +46,7 @@ import {
 import { convertPositionToOffset, convertRangeToTextRange, convertTextRangeToRange } from '../common/positionUtils';
 import { computeCompletionSimilarity } from '../common/stringUtils';
 import { TextEditTracker } from '../common/textEditTracker';
-import {
-    DocumentRange,
-    doesRangeContain,
-    doRangesIntersect,
-    getEmptyRange,
-    Position,
-    Range,
-    TextRange,
-} from '../common/textRange';
+import { doesRangeContain, doRangesIntersect, getEmptyRange, Position, Range, TextRange } from '../common/textRange';
 import { TextRangeCollection } from '../common/textRangeCollection';
 import { Duration, timingStats } from '../common/timing';
 import { applyTextEditsToString } from '../common/workspaceEditUtils';
@@ -73,7 +65,6 @@ import {
     CompletionOptions,
     CompletionResultsList,
 } from '../languageService/completionProvider';
-import { DefinitionFilter } from '../languageService/definitionProvider';
 import { DocumentSymbolCollector, DocumentSymbolCollectorUseCase } from '../languageService/documentSymbolCollector';
 import { IndexOptions, IndexResults, WorkspaceSymbolCallback } from '../languageService/documentSymbolProvider';
 import { ImportAdder, ImportData } from '../languageService/importAdder';
@@ -1683,61 +1674,6 @@ export class Program {
 
         return unfilteredDiagnostics.filter((diag) => {
             return doRangesIntersect(diag.range, range);
-        });
-    }
-
-    getDefinitionsForPosition(
-        filePath: string,
-        position: Position,
-        filter: DefinitionFilter,
-        token: CancellationToken
-    ): DocumentRange[] | undefined {
-        return this._runEvaluatorWithCancellationToken(token, () => {
-            const sourceFileInfo = this.getSourceFileInfo(filePath);
-            if (!sourceFileInfo) {
-                return undefined;
-            }
-
-            this._bindFile(sourceFileInfo);
-
-            const execEnv = this._configOptions.findExecEnvironment(filePath);
-            return sourceFileInfo.sourceFile.getDefinitionsForPosition(
-                this._createSourceMapper(execEnv, token, sourceFileInfo),
-                position,
-                filter,
-                this._evaluator!,
-                token
-            );
-        });
-    }
-
-    getTypeDefinitionsForPosition(
-        filePath: string,
-        position: Position,
-        token: CancellationToken
-    ): DocumentRange[] | undefined {
-        return this._runEvaluatorWithCancellationToken(token, () => {
-            const sourceFileInfo = this.getSourceFileInfo(filePath);
-            if (!sourceFileInfo) {
-                return undefined;
-            }
-
-            this._bindFile(sourceFileInfo);
-
-            const execEnv = this._configOptions.findExecEnvironment(filePath);
-            return sourceFileInfo.sourceFile.getTypeDefinitionsForPosition(
-                this._createSourceMapper(
-                    execEnv,
-                    token,
-                    sourceFileInfo,
-                    /* mapCompiled */ false,
-                    /* preferStubs */ true
-                ),
-                position,
-                this._evaluator!,
-                filePath,
-                token
-            );
         });
     }
 

--- a/packages/pyright-internal/src/analyzer/service.ts
+++ b/packages/pyright-internal/src/analyzer/service.ts
@@ -55,11 +55,10 @@ import {
     tryRealpath,
     tryStat,
 } from '../common/pathUtils';
-import { DocumentRange, Position, Range } from '../common/textRange';
+import { Position, Range } from '../common/textRange';
 import { timingStats } from '../common/timing';
 import { AutoImportOptions, ImportFormat } from '../languageService/autoImporter';
 import { AbbreviationMap, CompletionOptions, CompletionResultsList } from '../languageService/completionProvider';
-import { DefinitionFilter } from '../languageService/definitionProvider';
 import { WorkspaceSymbolCallback } from '../languageService/documentSymbolProvider';
 import { ReferenceCallback } from '../languageService/referencesProvider';
 import { SignatureHelpResults } from '../languageService/signatureHelpProvider';
@@ -376,23 +375,6 @@ export class AnalyzerService {
     ) {
         options.libraryMap = options.libraryMap ?? this._backgroundAnalysisProgram.getIndexing(filePath);
         return this._program.getAutoImports(filePath, range, similarityLimit, nameMap, options, token);
-    }
-
-    getDefinitionForPosition(
-        filePath: string,
-        position: Position,
-        filter: DefinitionFilter,
-        token: CancellationToken
-    ): DocumentRange[] | undefined {
-        return this._program.getDefinitionsForPosition(filePath, position, filter, token);
-    }
-
-    getTypeDefinitionForPosition(
-        filePath: string,
-        position: Position,
-        token: CancellationToken
-    ): DocumentRange[] | undefined {
-        return this._program.getTypeDefinitionsForPosition(filePath, position, token);
     }
 
     reportReferencesForPosition(

--- a/packages/pyright-internal/src/analyzer/sourceFile.ts
+++ b/packages/pyright-internal/src/analyzer/sourceFile.ts
@@ -33,7 +33,7 @@ import { fromLSPAny } from '../common/lspUtils';
 import { getFileName, normalizeSlashes, stripFileExtension } from '../common/pathUtils';
 import { convertOffsetsToRange, convertTextRangeToRange } from '../common/positionUtils';
 import * as StringUtils from '../common/stringUtils';
-import { DocumentRange, Position, Range, TextRange, getEmptyRange } from '../common/textRange';
+import { Position, Range, TextRange, getEmptyRange } from '../common/textRange';
 import { TextRangeCollection } from '../common/textRangeCollection';
 import { Duration, timingStats } from '../common/timing';
 import { ModuleSymbolMap } from '../languageService/autoImporter';
@@ -44,7 +44,6 @@ import {
     CompletionProvider,
     CompletionResults,
 } from '../languageService/completionProvider';
-import { DefinitionFilter, DefinitionProvider } from '../languageService/definitionProvider';
 import { DocumentHighlightProvider } from '../languageService/documentHighlightProvider';
 import { DocumentSymbolCollectorUseCase } from '../languageService/documentSymbolCollector';
 import { DocumentSymbolProvider, IndexOptions, IndexResults } from '../languageService/documentSymbolProvider';
@@ -1011,50 +1010,6 @@ export class SourceFile {
             const privateOrProtected = SymbolNameUtils.isPrivateOrProtectedName(name);
             return { privateOrProtected, symbols };
         });
-    }
-
-    getDefinitionsForPosition(
-        sourceMapper: SourceMapper,
-        position: Position,
-        filter: DefinitionFilter,
-        evaluator: TypeEvaluator,
-        token: CancellationToken
-    ): DocumentRange[] | undefined {
-        // If we have no completed analysis job, there's nothing to do.
-        if (!this._parseResults) {
-            return undefined;
-        }
-
-        return DefinitionProvider.getDefinitionsForPosition(
-            sourceMapper,
-            this._parseResults,
-            position,
-            filter,
-            evaluator,
-            token
-        );
-    }
-
-    getTypeDefinitionsForPosition(
-        sourceMapper: SourceMapper,
-        position: Position,
-        evaluator: TypeEvaluator,
-        filePath: string,
-        token: CancellationToken
-    ): DocumentRange[] | undefined {
-        // If we have no completed analysis job, there's nothing to do.
-        if (!this._parseResults) {
-            return undefined;
-        }
-
-        return DefinitionProvider.getTypeDefinitionsForPosition(
-            sourceMapper,
-            this._parseResults,
-            position,
-            evaluator,
-            filePath,
-            token
-        );
     }
 
     getDeclarationForPosition(

--- a/packages/pyright-internal/src/languageServerBase.ts
+++ b/packages/pyright-internal/src/languageServerBase.ts
@@ -114,7 +114,7 @@ import { convertToWorkspaceEdit } from './common/workspaceEditUtils';
 import { AnalyzerServiceExecutor } from './languageService/analyzerServiceExecutor';
 import { ImportFormat } from './languageService/autoImporter';
 import { CompletionItemData, CompletionOptions, CompletionResultsList } from './languageService/completionProvider';
-import { DefinitionFilter } from './languageService/definitionProvider';
+import { DefinitionFilter, DefinitionProvider, TypeDefinitionProvider } from './languageService/definitionProvider';
 import { WorkspaceSymbolCallback, convertToFlatSymbols } from './languageService/documentSymbolProvider';
 import { HoverProvider } from './languageService/hoverProvider';
 import { ReferenceCallback } from './languageService/referencesProvider';
@@ -789,7 +789,9 @@ export abstract class LanguageServerBase implements LanguageServerInterface {
             token,
             this.client.hasGoToDeclarationCapability ? DefinitionFilter.PreferSource : DefinitionFilter.All,
             (workspace, filePath, position, filter, token) =>
-                workspace.service.getDefinitionForPosition(filePath, position, filter, token)
+                workspace.service.run((program) => {
+                    return new DefinitionProvider(program, filePath, position, filter, token).getDefinitions();
+                }, token)
         );
     }
 
@@ -802,7 +804,9 @@ export abstract class LanguageServerBase implements LanguageServerInterface {
             token,
             this.client.hasGoToDeclarationCapability ? DefinitionFilter.PreferStubs : DefinitionFilter.All,
             (workspace, filePath, position, filter, token) =>
-                workspace.service.getDefinitionForPosition(filePath, position, filter, token)
+                workspace.service.run((program) => {
+                    return new DefinitionProvider(program, filePath, position, filter, token).getDefinitions();
+                }, token)
         );
     }
 
@@ -811,7 +815,9 @@ export abstract class LanguageServerBase implements LanguageServerInterface {
         token: CancellationToken
     ): Promise<Definition | DefinitionLink[] | undefined | null> {
         return this.getDefinitions(params, token, DefinitionFilter.All, (workspace, filePath, position, _, token) =>
-            workspace.service.getTypeDefinitionForPosition(filePath, position, token)
+            workspace.service.run((program) => {
+                return new TypeDefinitionProvider(program, filePath, position, token).getDefinitions();
+            }, token)
         );
     }
 

--- a/packages/pyright-internal/src/tests/harness/fourslash/testState.ts
+++ b/packages/pyright-internal/src/tests/harness/fourslash/testState.ts
@@ -53,7 +53,11 @@ import { TextRangeCollection } from '../../../common/textRangeCollection';
 import { LanguageServerInterface } from '../../../languageServerBase';
 import { AbbreviationInfo, ImportFormat } from '../../../languageService/autoImporter';
 import { CompletionOptions } from '../../../languageService/completionProvider';
-import { DefinitionFilter } from '../../../languageService/definitionProvider';
+import {
+    DefinitionFilter,
+    DefinitionProvider,
+    TypeDefinitionProvider,
+} from '../../../languageService/definitionProvider';
 import { HoverProvider } from '../../../languageService/hoverProvider';
 import { ParseNode } from '../../../parser/parseNodes';
 import { ParseResults } from '../../../parser/parser';
@@ -1330,7 +1334,13 @@ export class TestState {
             }
 
             const position = this.convertOffsetToPosition(fileName, marker.position);
-            const actual = this.program.getDefinitionsForPosition(fileName, position, filter, CancellationToken.None);
+            const actual = new DefinitionProvider(
+                this.program,
+                fileName,
+                position,
+                filter,
+                CancellationToken.None
+            ).getDefinitions();
 
             assert.equal(actual?.length ?? 0, expected.length, `No definitions found for marker "${name}"`);
 
@@ -1362,7 +1372,12 @@ export class TestState {
             const expected = map[name].definitions;
 
             const position = this.convertOffsetToPosition(fileName, marker.position);
-            const actual = this.program.getTypeDefinitionsForPosition(fileName, position, CancellationToken.None);
+            const actual = new TypeDefinitionProvider(
+                this.program,
+                fileName,
+                position,
+                CancellationToken.None
+            ).getDefinitions();
 
             assert.strictEqual(actual?.length ?? 0, expected.length, name);
 


### PR DESCRIPTION
moved `go to definition`, `go to declaration` and `go to type definition` out of `program`