### PR TITLE
Refactored find all references out of program

### DIFF
--- a/packages/pyright-internal/src/analyzer/program.ts
+++ b/packages/pyright-internal/src/analyzer/program.ts
@@ -1856,7 +1856,7 @@ export class Program {
                 case 'singleFileMode':
                     referenceProvider.addReferencesToResult(
                         sourceFileInfo.sourceFile.getFilePath(),
-                        /*includeDeclaration*/ true,
+                        /* includeDeclaration */ true,
                         referencesResult
                     );
                     break;
@@ -1876,7 +1876,7 @@ export class Program {
 
                             referenceProvider.addReferencesToResult(
                                 curSourceFileInfo.sourceFile.getFilePath(),
-                                /*includeDeclaration*/ true,
+                                /* includeDeclaration */ true,
                                 referencesResult
                             );
                         }

--- a/packages/pyright-internal/src/analyzer/service.ts
+++ b/packages/pyright-internal/src/analyzer/service.ts
@@ -53,7 +53,6 @@ import { timingStats } from '../common/timing';
 import { AutoImportOptions, ImportFormat } from '../languageService/autoImporter';
 import { AbbreviationMap, CompletionOptions, CompletionResultsList } from '../languageService/completionProvider';
 import { WorkspaceSymbolCallback } from '../languageService/documentSymbolProvider';
-import { ReferenceCallback } from '../languageService/referencesProvider';
 import { AnalysisCompleteCallback } from './analysis';
 import { BackgroundAnalysisProgram, BackgroundAnalysisProgramFactory } from './backgroundAnalysisProgram';
 import { CacheManager } from './cacheManager';
@@ -367,16 +366,6 @@ export class AnalyzerService {
     ) {
         options.libraryMap = options.libraryMap ?? this._backgroundAnalysisProgram.getIndexing(filePath);
         return this._program.getAutoImports(filePath, range, similarityLimit, nameMap, options, token);
-    }
-
-    reportReferencesForPosition(
-        filePath: string,
-        position: Position,
-        includeDeclaration: boolean,
-        reporter: ReferenceCallback,
-        token: CancellationToken
-    ) {
-        this._program.reportReferencesForPosition(filePath, position, includeDeclaration, reporter, token);
     }
 
     addSymbolsForDocument(filePath: string, symbolList: DocumentSymbol[], token: CancellationToken) {

--- a/packages/pyright-internal/src/analyzer/sourceFile.ts
+++ b/packages/pyright-internal/src/analyzer/sourceFile.ts
@@ -38,7 +38,6 @@ import {
     CompletionResults,
 } from '../languageService/completionProvider';
 import { DocumentSymbolProvider, IndexOptions, IndexResults } from '../languageService/documentSymbolProvider';
-import { ReferencesProvider, ReferencesResult } from '../languageService/referencesProvider';
 import { Localizer } from '../localization/localize';
 import { ModuleNode } from '../parser/parseNodes';
 import { ModuleImport, ParseOptions, ParseResults, Parser } from '../parser/parser';
@@ -941,27 +940,6 @@ export class SourceFile {
             const privateOrProtected = SymbolNameUtils.isPrivateOrProtectedName(name);
             return { privateOrProtected, symbols };
         });
-    }
-
-    addReferences(
-        referencesResult: ReferencesResult,
-        includeDeclaration: boolean,
-        evaluator: TypeEvaluator,
-        token: CancellationToken
-    ): void {
-        // If we have no completed analysis job, there's nothing to do.
-        if (!this._parseResults) {
-            return;
-        }
-
-        ReferencesProvider.addReferences(
-            this._parseResults,
-            this._filePath,
-            referencesResult,
-            includeDeclaration,
-            evaluator,
-            token
-        );
     }
 
     addHierarchicalSymbolsForDocument(symbolList: DocumentSymbol[], token: CancellationToken) {

--- a/packages/pyright-internal/src/common/extensibility.ts
+++ b/packages/pyright-internal/src/common/extensibility.ts
@@ -41,6 +41,7 @@ export interface SourceFile {
     // See whether we can convert these to regular properties.
     getFilePath(): string;
     isStubFile(): boolean;
+    getFileContent(): string | undefined;
 }
 
 export interface SourceFileInfo {

--- a/packages/pyright-internal/src/languageService/navigationUtils.ts
+++ b/packages/pyright-internal/src/languageService/navigationUtils.ts
@@ -5,8 +5,23 @@
  *
  * Helper functions for navigating files.
  */
+import { Location } from 'vscode-languageserver-types';
 import { ReadOnlyFileSystem } from '../common/fileSystem';
+import { convertPathToUri } from '../common/pathUtils';
+import { DocumentRange } from '../common/textRange';
 
 export function canNavigateToFile(fs: ReadOnlyFileSystem, path: string): boolean {
     return !fs.isInZipOrEgg(path);
+}
+
+export function convertDocumentRangesToLocation(fs: ReadOnlyFileSystem, ranges: DocumentRange[]): Location[] {
+    return ranges.map((range) => convertDocumentRangeToLocation(fs, range)).filter((loc) => !!loc) as Location[];
+}
+
+export function convertDocumentRangeToLocation(fs: ReadOnlyFileSystem, range: DocumentRange): Location | undefined {
+    if (!canNavigateToFile(fs, range.path)) {
+        return undefined;
+    }
+
+    return Location.create(convertPathToUri(fs, range.path), range.range);
 }

--- a/packages/pyright-internal/src/tests/harness/fourslash/testState.ts
+++ b/packages/pyright-internal/src/tests/harness/fourslash/testState.ts
@@ -1187,7 +1187,7 @@ export class TestState {
             const actual = new ReferencesProvider(this.program, CancellationToken.None).reportReferences(
                 fileName,
                 position,
-                /*includeDeclaration*/ true
+                /* includeDeclaration */ true
             );
             assert.strictEqual(actual?.length ?? 0, expected.length, `${name} has failed`);
 

--- a/packages/pyright-internal/src/tests/harness/fourslash/testState.ts
+++ b/packages/pyright-internal/src/tests/harness/fourslash/testState.ts
@@ -30,7 +30,6 @@ import { findNodeByOffset } from '../../../analyzer/parseTreeUtils';
 import { Program } from '../../../analyzer/program';
 import { AnalyzerService } from '../../../analyzer/service';
 import { CommandResult } from '../../../commands/commandResult';
-import { appendArray } from '../../../common/collectionUtils';
 import { ConfigOptions, SignatureDisplayType } from '../../../common/configOptions';
 import { ConsoleInterface, NullConsole } from '../../../common/console';
 import { Comparison, isNumber, isString, toBoolean } from '../../../common/core';
@@ -61,6 +60,8 @@ import {
 } from '../../../languageService/definitionProvider';
 import { DocumentHighlightProvider } from '../../../languageService/documentHighlightProvider';
 import { HoverProvider } from '../../../languageService/hoverProvider';
+import { convertDocumentRangesToLocation } from '../../../languageService/navigationUtils';
+import { ReferencesProvider } from '../../../languageService/referencesProvider';
 import { SignatureHelpProvider } from '../../../languageService/signatureHelpProvider';
 import { ParseNode } from '../../../parser/parseNodes';
 import { ParseResults } from '../../../parser/parser';
@@ -1183,18 +1184,14 @@ export class TestState {
 
             const position = this.convertOffsetToPosition(fileName, marker.position);
 
-            const actual: DocumentRange[] = [];
-            this.program.reportReferencesForPosition(
+            const actual = new ReferencesProvider(this.program, CancellationToken.None).reportReferences(
                 fileName,
                 position,
-                true,
-                (locs) => appendArray(actual, locs),
-                CancellationToken.None
+                /*includeDeclaration*/ true
             );
-
             assert.strictEqual(actual?.length ?? 0, expected.length, `${name} has failed`);
 
-            for (const r of expected) {
+            for (const r of convertDocumentRangesToLocation(this.program.fileSystem, expected)) {
                 assert.equal(actual?.filter((d) => this._deepEqual(d, r)).length, 1);
             }
         }


### PR DESCRIPTION
I think the rest of IDE features will be refactored out from `pylance` side and pushed up to `pyright`

IDE features left are

1. completion provider - it uses indices so it needs to be refactored with related indexing code in pylance.
2. document symbol, workspace symbol provider - they use indices as well. so, we need to refactor indices portion out first in pylance.
3. rename, move symbol, rename module provider - since all of them, at the end, rename references of a name, these are all in reference each other internally. but move symbol and rename module provider are split between in pylance and pyright. so doing it from pylance is much easier.

after those changes, we will probably take out any APIs in the program that doesn't require any internal state of program to its own type sucn as `getAutoImport` and etc.