### PR TITLE
Some tweak on performQuickAction

### DIFF
--- a/packages/pyright-internal/src/commands/quickActionCommand.ts
+++ b/packages/pyright-internal/src/commands/quickActionCommand.ts
@@ -29,7 +29,7 @@ export class QuickActionCommand implements ServerCommand {
             }
 
             const editActions = workspace.service.run((p) => {
-                return performQuickAction(filePath, params.command, otherArgs, p, token);
+                return performQuickAction(p, filePath, params.command, otherArgs, token);
             }, token);
 
             return convertToWorkspaceEdit(workspace.service.fs, convertToFileTextEdits(filePath, editActions ?? []));

--- a/packages/pyright-internal/src/languageService/quickActions.ts
+++ b/packages/pyright-internal/src/languageService/quickActions.ts
@@ -28,22 +28,22 @@ import { ParseResults } from '../parser/parser';
 import { ImportSorter } from './importSorter';
 
 export function performQuickAction(
+    programView: ProgramView,
     filePath: string,
     command: string,
     args: any[],
-    programView: ProgramView,
     token: CancellationToken
 ) {
-    const sourceFileInfo = programView.getBoundSourceFileInfo(filePath);
+    const sourceFileInfo = programView.getSourceFileInfo(filePath);
 
     // This command should be called only for open files, in which
     // case we should have the file contents already loaded.
-    if (!sourceFileInfo || sourceFileInfo.sourceFile.getClientVersion() === undefined) {
+    if (!sourceFileInfo || !sourceFileInfo.isOpenByClient) {
         return [];
     }
 
-    const parseResults = sourceFileInfo.sourceFile.getParseResults();
     // If we have no completed analysis job, there's nothing to do.
+    const parseResults = programView.getParseResults(filePath);
     if (!parseResults) {
         return [];
     }


### PR DESCRIPTION
I am trying to get rid of `getBoundSourceFileInfo` from `ProgramView`.

reasoning is having both `getSourceFileInfo` and `getBoundSourceFileInfo` is confusing since both return same `SourceFileInfo` and things like `getParseResults` depends on which way `SourceFileInfo` is obtained to return valid value.

we could introduce `SourceFileInfo` and `BoundSourceFileInfo` where only `BoundSourceFileInfo` has `getParseResults` and etc, but for now, I am thinking we just make it simpler by exposing only `getSourceFileInfo` and `getParseResults` directly off `ProgramView`

we want `getSourceFileInfo` since we don't want to do expansive file reading/parsing/binding just to see dependency graph and etc. also, there is no guarantee `SourceFileInfo` people got from things like `SourceFileInfo.ImportedBy` are bound. and if people ends up consume `getParseResults` off those file info, they will get undetermined behavior based on what happened before.