### PR TITLE
Added a flag in `resolveAliasDeclaration` so that we can skip early bail out (perf optimization) when needed.

### DIFF
--- a/packages/pyright-internal/src/analyzer/analyzerFileInfo.ts
+++ b/packages/pyright-internal/src/analyzer/analyzerFileInfo.ts
@@ -22,7 +22,15 @@ export interface AbsoluteModuleDescriptor {
     importingFilePath: string;
     nameParts: string[];
 }
-export type ImportLookup = (filePathOrModule: string | AbsoluteModuleDescriptor) => ImportLookupResult | undefined;
+
+export interface LookupImportOptions {
+    skipFileNeededCheck: boolean;
+}
+
+export type ImportLookup = (
+    filePathOrModule: string | AbsoluteModuleDescriptor,
+    options?: LookupImportOptions
+) => ImportLookupResult | undefined;
 
 export interface ImportLookupResult {
     symbolTable: SymbolTable;

--- a/packages/pyright-internal/src/analyzer/typeEvaluatorTypes.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluatorTypes.ts
@@ -350,6 +350,11 @@ export interface DeclaredSymbolTypeInfo {
     isTypeAlias?: boolean;
 }
 
+export interface ResolveAliasOptions {
+    allowExternallyHiddenAccess?: boolean;
+    skipFileNeededCheck?: boolean;
+}
+
 export interface TypeEvaluator {
     runWithCancellationToken<T>(token: CancellationToken, callback: () => T): T;
 
@@ -396,12 +401,12 @@ export interface TypeEvaluator {
     resolveAliasDeclaration: (
         declaration: Declaration,
         resolveLocalNames: boolean,
-        allowExternallyHiddenAccess?: boolean
+        options?: ResolveAliasOptions
     ) => Declaration | undefined;
     resolveAliasDeclarationWithInfo: (
         declaration: Declaration,
         resolveLocalNames: boolean,
-        allowExternallyHiddenAccess?: boolean
+        options?: ResolveAliasOptions
     ) => DeclarationUtils.ResolvedAliasInfo | undefined;
     getTypeOfIterable: (
         typeResult: TypeResult,

--- a/packages/pyright-internal/src/languageService/definitionProvider.ts
+++ b/packages/pyright-internal/src/languageService/definitionProvider.ts
@@ -96,11 +96,9 @@ class DefinitionProviderBase {
     protected resolveDeclarations(declarations: Declaration[] | undefined, definitions: DocumentRange[]) {
         if (declarations) {
             declarations.forEach((decl) => {
-                let resolvedDecl = this.evaluator.resolveAliasDeclaration(
-                    decl,
-                    /* resolveLocalNames */ true,
-                    /* allowExternallyHiddenAccess */ true
-                );
+                let resolvedDecl = this.evaluator.resolveAliasDeclaration(decl, /* resolveLocalNames */ true, {
+                    allowExternallyHiddenAccess: true,
+                });
                 if (resolvedDecl && resolvedDecl.path) {
                     // If the decl is an unresolved import, skip it.
                     if (resolvedDecl.type === DeclarationType.Alias && resolvedDecl.isUnresolved) {

--- a/packages/pyright-internal/src/languageService/documentSymbolProvider.ts
+++ b/packages/pyright-internal/src/languageService/documentSymbolProvider.ts
@@ -70,12 +70,11 @@ export function getIndexAliasData(
         return undefined;
     }
 
-    const resolvedInfo = resolveAliasDeclaration(
-        importLookup,
-        declaration,
-        /* resolveLocalNames */ true,
-        /* allowExternallyHiddenAccess */ false
-    );
+    const resolvedInfo = resolveAliasDeclaration(importLookup, declaration, {
+        resolveLocalNames: true,
+        allowExternallyHiddenAccess: false,
+        skipFileNeededCheck: false,
+    });
     if (!resolvedInfo || !resolvedInfo.declaration) {
         return undefined;
     }

--- a/packages/pyright-internal/src/languageService/insertionPointUtils.ts
+++ b/packages/pyright-internal/src/languageService/insertionPointUtils.ts
@@ -108,11 +108,9 @@ function _getDeclarationsDefinedInCurrentModule(
     options?: InsertionOptions
 ) {
     return declarations.filter((d) => {
-        const resolved = evaluator.resolveAliasDeclaration(
-            d,
-            /* resolveLocalNames */ true,
-            /* allowExternallyHiddenAccess */ true
-        );
+        const resolved = evaluator.resolveAliasDeclaration(d, /* resolveLocalNames */ true, {
+            allowExternallyHiddenAccess: true,
+        });
 
         if (!resolved) {
             return false;


### PR DESCRIPTION
fix https://github.com/microsoft/pyright/issues/5025