### PR TITLE
Fix extra references being returned for duplicate symbols

### DIFF
--- a/packages/pyright-internal/src/languageService/documentSymbolCollector.ts
+++ b/packages/pyright-internal/src/languageService/documentSymbolCollector.ts
@@ -158,7 +158,6 @@ export class DocumentSymbolCollector extends ParseTreeWalker {
         );
 
         const fileInfo = AnalyzerNodeInfo.getFileInfo(node);
-        const sourceMapper = program.getSourceMapper(fileInfo.filePath, token);
         // Resolve the first set of declarations. It provides the basis for which declarations
         // are a match.
         const resolvedInitials = DocumentSymbolCollector._resolveDeclarations(

--- a/packages/pyright-internal/src/tests/documentSymbolCollector.test.ts
+++ b/packages/pyright-internal/src/tests/documentSymbolCollector.test.ts
@@ -806,6 +806,28 @@ test('variable overridden test 2', () => {
     }
 });
 
+test('duplicate symbols from reference', () => {
+    const code = `
+// @filename: a.py
+//// class Test:
+////     foo = 1
+////
+// @filename: b.py
+//// class [|T/*marker*/est|]:
+////     foo = 2
+////
+// @filename: ref.py
+//// from .a import *
+//// from .b import *
+    `;
+
+    const state = parseAndGetTestState(code).state;
+    const marker = state.getMarkerByName('marker');
+    const ranges = state.getRangesByText().get('Test')!;
+
+    verifyReferencesAtPosition(state.program, state.configOptions, 'Test', marker.fileName, marker.position, ranges);
+});
+
 function verifyReferencesAtPosition(
     program: Program,
     configOption: ConfigOptions,


### PR DESCRIPTION
Addresses https://github.com/microsoft/pylance-release/issues/4285

In the bug the same symbol is defined in two different modules and because both modules are referenced as implicit imports, both symbols get pulled in.

The fix here is to skip declarations that resolve to a different module than the original position.

All of the changes were in pyright, so I submitted the PR here.