### PR TITLE
`TextRange.combine` should not modify input ranges

### DIFF
--- a/packages/pyright-internal/src/common/textRange.ts
+++ b/packages/pyright-internal/src/common/textRange.ts
@@ -77,7 +77,7 @@ export namespace TextRange {
             return undefined;
         }
 
-        const combinedRange = ranges[0];
+        const combinedRange = { start: ranges[0].start, length: ranges[0].length };
         for (let i = 1; i < ranges.length; i++) {
             extend(combinedRange, ranges[i]);
         }

--- a/packages/pyright-internal/src/tests/textRange.test.ts
+++ b/packages/pyright-internal/src/tests/textRange.test.ts
@@ -1,0 +1,26 @@
+/*
+ * textRange.test.ts
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT license.
+ */
+
+import * as assert from 'assert';
+
+import { TextRange } from '../common/textRange';
+
+test('textRange combine', () => {
+    const range1 = TextRange.create(10, 2);
+    const range2 = TextRange.create(12, 2);
+
+    const combined = TextRange.combine([range1, range2]);
+
+    assert.ok(combined);
+    assert.equal(combined.start, 10);
+    assert.equal(combined.length, 4);
+
+    // Ensure input ranges are unchanged
+    assert.equal(range1.start, 10);
+    assert.equal(range1.length, 2);
+    assert.equal(range2.start, 12);
+    assert.equal(range2.length, 2);
+});

--- a/packages/pyright-internal/src/tests/textRange.test.ts
+++ b/packages/pyright-internal/src/tests/textRange.test.ts
@@ -11,16 +11,19 @@ import { TextRange } from '../common/textRange';
 test('textRange combine', () => {
     const range1 = TextRange.create(10, 2);
     const range2 = TextRange.create(12, 2);
+    const range3 = TextRange.create(8, 2);
 
-    const combined = TextRange.combine([range1, range2]);
+    const combined = TextRange.combine([range1, range2, range3]);
 
     assert.ok(combined);
-    assert.equal(combined.start, 10);
-    assert.equal(combined.length, 4);
+    assert.equal(combined.start, 8);
+    assert.equal(combined.length, 6);
 
     // Ensure input ranges are unchanged
     assert.equal(range1.start, 10);
     assert.equal(range1.length, 2);
     assert.equal(range2.start, 12);
     assert.equal(range2.length, 2);
+    assert.equal(range3.start, 8);
+    assert.equal(range3.length, 2);
 });


### PR DESCRIPTION
Addresses https://github.com/microsoft/pylance-release/issues/4393

`SmartSelectionProvider` calls `TextRange.combine` on `ParseNode` arrays. Currently that causes the `start` and/or `length` of the first node in the array to be changed to the combined range's length.

This would be an easy mistake to make in other places. In fact, I believe these other two usages are also resulting in unintended `ParseNode` changes:
- https://github.com/microsoft/pyright/blob/fedcafb706c335b17ca2617d3d2d1ab07030f51f/packages/pyright-internal/src/analyzer/typeEvaluator.ts#LL15171
- https://github.com/microsoft/pyrx/blob/main/packages/pylance-internal/src/languageService/completionProvider.ts#L579

So I've modified `combine` to leave the input ranges unchanged.

I looked through the other calls to `TextRange.combine` and none of them are relying on the current behavior. 