### PR TITLE
Preserve parentheses around unary operators for printing

### DIFF
--- a/packages/pyright-internal/src/analyzer/parseTreeUtils.ts
+++ b/packages/pyright-internal/src/analyzer/parseTreeUtils.ts
@@ -214,7 +214,8 @@ export function printExpression(node: ExpressionNode, flags = PrintExpressionFla
         }
 
         case ParseNodeType.UnaryOperation: {
-            return printOperator(node.operator) + printExpression(node.expression, flags);
+            const exprStr = printOperator(node.operator) + printExpression(node.expression, flags);
+            return node.parenthesized ? `(${exprStr})` : exprStr;
         }
 
         case ParseNodeType.BinaryOperation: {
@@ -318,7 +319,8 @@ export function printExpression(node: ExpressionNode, flags = PrintExpressionFla
         }
 
         case ParseNodeType.Await: {
-            return 'await ' + printExpression(node.expression, flags);
+            const exprStr = 'await ' + printExpression(node.expression, flags);
+            return node.parenthesized ? `(${exprStr})` : exprStr;
         }
 
         case ParseNodeType.Ternary: {

--- a/packages/pyright-internal/src/parser/parseNodes.ts
+++ b/packages/pyright-internal/src/parser/parseNodes.ts
@@ -796,6 +796,7 @@ export interface UnaryOperationNode extends ParseNodeBase {
     expression: ExpressionNode;
     operatorToken: Token;
     operator: OperatorType;
+    parenthesized?: boolean;
 }
 
 export namespace UnaryOperationNode {
@@ -1126,6 +1127,7 @@ export namespace AugmentedAssignmentNode {
 export interface AwaitNode extends ParseNodeBase {
     readonly nodeType: ParseNodeType.Await;
     expression: ExpressionNode;
+    parenthesized?: boolean;
 }
 
 export namespace AwaitNode {

--- a/packages/pyright-internal/src/parser/parser.ts
+++ b/packages/pyright-internal/src/parser/parser.ts
@@ -3827,10 +3827,15 @@ export class Parser {
                 this._addError(Localizer.Diagnostic.tupleInAnnotation() + diag.getString(), possibleTupleNode);
             }
 
-            if (possibleTupleNode.nodeType === ParseNodeType.BinaryOperation) {
-                // Mark the binary expression as parenthesized so we don't attempt
+            if (
+                possibleTupleNode.nodeType === ParseNodeType.UnaryOperation ||
+                possibleTupleNode.nodeType === ParseNodeType.Await ||
+                possibleTupleNode.nodeType === ParseNodeType.BinaryOperation
+            ) {
+                // Mark binary expressions as parenthesized so we don't attempt
                 // to use comparison chaining, which isn't appropriate when the
-                // expression is parenthesized.
+                // expression is parenthesized. Unary and await expressions
+                // are also marked to be able to display them unambiguously.
                 possibleTupleNode.parenthesized = true;
             }
 


### PR DESCRIPTION
The current parser does not keep track of whether or not there are parentheses around unary operators. This causes ambiguity when it comes to converting the parse tree back into a string, as there are some operators tighter than unary operators; for example, `reveal_type((-2) ** 2)` currently incorrectly reports the expression to be `-2 ** 2`, which is actually equivalent to `-(2 ** 2)`.

This simple change makes it so that the nodes for unary operators and `await` expressions store whether or not they were parenthesized in the same manner that binary operators already did, fixing the printing of expressions such as `(await f())[0]`.