### PR TITLE
[PylanceBot] Pull Pylance with Pyright 1.1.310

### DIFF
--- a/packages/pyright-internal/src/analyzer/docStringConversion.ts
+++ b/packages/pyright-internal/src/analyzer/docStringConversion.ts
@@ -584,7 +584,7 @@ class DocStringConverter {
 
         // catch-all for styles except reST
         const hasArguments =
-            !line?.endsWith(':') && !line?.endsWith('::') && !!line.match(/^\s*.*?\w+(\s*\(\w+\))*\s*:\s*\w+/g);
+            !line?.endsWith(':') && !line?.endsWith('::') && !!line.match(/^\s*.*?\w+(\s*\(.*?\))*\s*:\s*\w+/g);
 
         // reSt params. Attempt to put directives lines into their own paragraphs.
         const restDirective = DirectivesExtraNewlineRegExp.test(line); //line.match(/^\s*:param/);

--- a/packages/pyright-internal/src/common/uriParser.ts
+++ b/packages/pyright-internal/src/common/uriParser.ts
@@ -26,6 +26,18 @@ export class UriParser {
         return convertUriToPath(this.fs, uriString);
     }
 
+    isUntitled(uri: URI | string | undefined) {
+        if (!uri) {
+            return false;
+        }
+
+        if (isString(uri)) {
+            uri = URI.parse(uri);
+        }
+
+        return uri.scheme === 'untitled';
+    }
+
     isLocal(uri: URI | string | undefined) {
         if (!uri) {
             return false;

--- a/packages/pyright-internal/src/languageServerBase.ts
+++ b/packages/pyright-internal/src/languageServerBase.ts
@@ -1066,6 +1066,7 @@ export abstract class LanguageServerBase implements LanguageServerInterface {
         token: CancellationToken
     ): Promise<Range | { range: Range; placeholder: string } | null> {
         const { filePath, position } = this.uriParser.decodeTextDocumentPosition(params.textDocument, params.position);
+        const isUntitled = this.uriParser.isUntitled(params.textDocument.uri);
 
         const workspace = await this.getWorkspaceForFile(filePath);
         if (workspace.disableLanguageServices) {
@@ -1074,7 +1075,8 @@ export abstract class LanguageServerBase implements LanguageServerInterface {
 
         return workspace.service.run((program) => {
             return new RenameProvider(program, filePath, position, token).canRenameSymbol(
-                workspace.kinds.includes(WellKnownWorkspaceKinds.Default)
+                workspace.kinds.includes(WellKnownWorkspaceKinds.Default),
+                isUntitled
             );
         }, token);
     }
@@ -1084,6 +1086,7 @@ export abstract class LanguageServerBase implements LanguageServerInterface {
         token: CancellationToken
     ): Promise<WorkspaceEdit | null | undefined> {
         const { filePath, position } = this.uriParser.decodeTextDocumentPosition(params.textDocument, params.position);
+        const isUntitled = this.uriParser.isUntitled(params.textDocument.uri);
 
         const workspace = await this.getWorkspaceForFile(filePath);
         if (workspace.disableLanguageServices) {
@@ -1093,7 +1096,8 @@ export abstract class LanguageServerBase implements LanguageServerInterface {
         return workspace.service.run((program) => {
             return new RenameProvider(program, filePath, position, token).renameSymbol(
                 params.newName,
-                workspace.kinds.includes(WellKnownWorkspaceKinds.Default)
+                workspace.kinds.includes(WellKnownWorkspaceKinds.Default),
+                isUntitled
             );
         }, token);
     }

--- a/packages/pyright-internal/src/languageService/renameProvider.ts
+++ b/packages/pyright-internal/src/languageService/renameProvider.ts
@@ -33,7 +33,7 @@ export class RenameProvider {
         this._parseResults = this._program.getParseResults(this._filePath);
     }
 
-    canRenameSymbol(isDefaultWorkspace: boolean): Range | null {
+    canRenameSymbol(isDefaultWorkspace: boolean, isUntitled: boolean): Range | null {
         throwIfCancellationRequested(this._token);
         if (!this._parseResults) {
             return null;
@@ -48,7 +48,8 @@ export class RenameProvider {
             this._program,
             this._filePath,
             referencesResult,
-            isDefaultWorkspace
+            isDefaultWorkspace,
+            isUntitled
         );
         if (renameMode === 'none') {
             return null;
@@ -58,7 +59,7 @@ export class RenameProvider {
         return convertTextRangeToRange(referencesResult.nodeAtOffset, this._parseResults.tokenizerOutput.lines);
     }
 
-    renameSymbol(newName: string, isDefaultWorkspace: boolean): WorkspaceEdit | null {
+    renameSymbol(newName: string, isDefaultWorkspace: boolean, isUntitled: boolean): WorkspaceEdit | null {
         throwIfCancellationRequested(this._token);
         if (!this._parseResults) {
             return null;
@@ -74,7 +75,8 @@ export class RenameProvider {
             this._program,
             this._filePath,
             referencesResult,
-            isDefaultWorkspace
+            isDefaultWorkspace,
+            isUntitled
         );
 
         switch (renameMode) {
@@ -136,7 +138,8 @@ export class RenameProvider {
         program: ProgramView,
         filePath: string,
         referencesResult: ReferencesResult,
-        isDefaultWorkspace: boolean
+        isDefaultWorkspace: boolean,
+        isUntitled: boolean
     ) {
         const sourceFileInfo = program.getSourceFileInfo(filePath)!;
 
@@ -159,7 +162,7 @@ export class RenameProvider {
             return 'singleFileMode';
         }
 
-        if (referencesResult.declarations.every((d) => isUserCode(program.getSourceFileInfo(d.path)))) {
+        if (!isUntitled && referencesResult.declarations.every((d) => isUserCode(program.getSourceFileInfo(d.path)))) {
             return 'multiFileMode';
         }
 

--- a/packages/pyright-internal/src/tests/docStringConversion.test.ts
+++ b/packages/pyright-internal/src/tests/docStringConversion.test.ts
@@ -658,6 +658,56 @@ Returns:
     _testConvertToMarkdown(docstring, markdown);
 });
 
+test('GoogleWithComplexTypes', () => {
+    const docstring = `
+    Example function with types documented in the docstring.
+
+    Args:
+        param1 (int|bool): The first parameter.
+        param2 (list[str] with others): The second parameter.
+
+    Returns:
+        bool: The return value. True for success, False otherwise.
+`;
+
+    const markdown = `
+Example function with types documented in the docstring.
+
+Args:  
+&nbsp;&nbsp;&nbsp;&nbsp;param1 (int|bool): The first parameter.  
+&nbsp;&nbsp;&nbsp;&nbsp;param2 (list\\[str\\] with others): The second parameter.
+
+Returns:  
+&nbsp;&nbsp;&nbsp;&nbsp;bool: The return value. True for success, False otherwise.`;
+
+    _testConvertToMarkdown(docstring, markdown);
+});
+
+test('GoogleWithInvalidTypes', () => {
+    const docstring = `
+    Example function with types documented in the docstring.
+
+    Args:
+        param1: (int|bool))): The first parameter.
+        param2: (list[str] with others): The second parameter.
+
+    Returns:
+        bool: The return value. True for success, False otherwise.
+`;
+
+    const markdown = `
+Example function with types documented in the docstring.
+
+Args:  
+&nbsp;&nbsp;&nbsp;&nbsp;param1: (int|bool))): The first parameter.
+param2: (list\\[str\\] with others): The second parameter.
+
+Returns:  
+&nbsp;&nbsp;&nbsp;&nbsp;bool: The return value. True for success, False otherwise.`;
+
+    _testConvertToMarkdown(docstring, markdown);
+});
+
 test('FieldListDontAddLineBreaksToHeaders', () => {
     const docstring = `
     Parameters

--- a/packages/pyright-internal/src/tests/fourslash/fourslash.ts
+++ b/packages/pyright-internal/src/tests/fourslash/fourslash.ts
@@ -337,12 +337,15 @@ declare namespace _ {
                 definitions: DocumentRange[];
             };
         }): void;
-        verifyRename(map: {
-            [marker: string]: {
-                newName: string;
-                changes: FileEditAction[];
-            };
-        }): void;
+        verifyRename(
+            map: {
+                [marker: string]: {
+                    newName: string;
+                    changes: FileEditAction[];
+                };
+            },
+            isUntitled?: boolean
+        ): void;
 
         /* not tested yet
         paste(text: string): void;

--- a/packages/pyright-internal/src/tests/fourslash/rename.function.untitledFile.fourslash.ts
+++ b/packages/pyright-internal/src/tests/fourslash/rename.function.untitledFile.fourslash.ts
@@ -1,0 +1,21 @@
+/// <reference path="fourslash.ts" />
+
+// @filename: declare.py
+//// def func():
+////    pass
+
+// @filename: Untitled-1.py
+//// from declare import func
+//// /*marker*/func()
+
+{
+    helper.verifyRename(
+        {
+            marker: {
+                newName: 'func1',
+                changes: [],
+            },
+        },
+        true
+    );
+}

--- a/packages/pyright-internal/src/tests/harness/fourslash/testState.ts
+++ b/packages/pyright-internal/src/tests/harness/fourslash/testState.ts
@@ -1364,12 +1364,15 @@ export class TestState {
         }
     }
 
-    verifyRename(map: {
-        [marker: string]: {
-            newName: string;
-            changes: FileEditAction[];
-        };
-    }) {
+    verifyRename(
+        map: {
+            [marker: string]: {
+                newName: string;
+                changes: FileEditAction[];
+            };
+        },
+        isUntitled = false
+    ) {
         this.analyze();
 
         for (const marker of this.getMarkers()) {
@@ -1385,7 +1388,8 @@ export class TestState {
             const position = this.convertOffsetToPosition(fileName, marker.position);
             const actual = new RenameProvider(this.program, fileName, position, CancellationToken.None).renameSymbol(
                 expected.newName,
-                /* isDefaultWorkspace */ false
+                /* isDefaultWorkspace */ false,
+                isUntitled
             );
 
             verifyWorkspaceEdit(

--- a/packages/pyright-internal/src/workspaceFactory.ts
+++ b/packages/pyright-internal/src/workspaceFactory.ts
@@ -449,7 +449,7 @@ export class WorkspaceFactory {
         await bestInstance.isInitialized.promise;
 
         // If this best instance doesn't match the pythonPath, then we need to create a new one.
-        if (pythonPath && bestInstance.pythonPath !== pythonPath) {
+        if (pythonPath !== undefined && bestInstance.pythonPath !== pythonPath) {
             bestInstance = this._createImmutableCopy(bestInstance, pythonPath);
         }
 
@@ -461,7 +461,7 @@ export class WorkspaceFactory {
         let bestInstance = this._getBestWorkspaceForFile(filePath, pythonPath);
 
         // If this best instance doesn't match the pythonPath, then we need to create a new one.
-        if (pythonPath && bestInstance.pythonPath !== pythonPath) {
+        if (pythonPath !== undefined && bestInstance.pythonPath !== pythonPath) {
             bestInstance = this._createImmutableCopy(bestInstance, pythonPath);
         }
 
@@ -561,7 +561,7 @@ export class WorkspaceFactory {
                 '',
                 this._defaultWorkspacePath,
                 pythonPath,
-                pythonPath ? WorkspacePythonPathKind.Immutable : WorkspacePythonPathKind.Mutable,
+                pythonPath !== undefined ? WorkspacePythonPathKind.Immutable : WorkspacePythonPathKind.Mutable,
                 [WellKnownWorkspaceKinds.Default]
             );
         }
@@ -594,7 +594,7 @@ export class WorkspaceFactory {
         }
 
         // If there's any that match the python path, take the one with the longest path from those.
-        if (pythonPath) {
+        if (pythonPath !== undefined) {
             const matchingWorkspaces = workspaces.filter((w) => w.pythonPath === pythonPath);
             if (matchingWorkspaces.length > 0) {
                 return this._getLongestPathWorkspace(matchingWorkspaces);


### PR DESCRIPTION
rollup of the following changes:
    1. Tweaked our server so that if python path is not set, we will turn off semantic features https://github.com/microsoft/pyrx/pull/3525
    2. Support anything for the 'type' comment https://github.com/microsoft/pyrx/pull/3524
    3. Only allow rename local symbols in untitled files
    4. Add isUntitled to renameProvider

    Co-authored-by: Bill Schnurr <bschnurr@microsoft.com>
    Co-authored-by: HeeJae Chang <hechang@microsoft.com>
    Co-authored-by: Erik De Bonte <erikd@microsoft.com>
    Co-authored-by: Rich Chiodo <rchiodo@microsoft.com>
    Co-authored-by: Stella Huang <stellahuang@microsoft.com>
    