### PR TITLE
Update ci-integration.md

### DIFF
--- a/docs/ci-integration.md
+++ b/docs/ci-integration.md
@@ -33,6 +33,7 @@ job_name:
     - npm i -g pyright-to-gitlab-ci
   script:
    - pyright <python source> --outputjson > report_raw.json
+  after_script:
    - pyright-to-gitlab-ci --src report_raw.json --output report.json --base_path .
   artifacts:
     paths:


### PR DESCRIPTION
When both scripts are executed in `scripts:` section, and `pyright` reports error, second script is not executed.

Best way to ensure report are always converted, is to use `after_script:` block.