### PR TITLE
Fixed bug that resulted in a false negative when using the `reportMis…

### DIFF
--- a/packages/pyright-internal/src/analyzer/operations.ts
+++ b/packages/pyright-internal/src/analyzer/operations.ts
@@ -619,6 +619,17 @@ export function getTypeOfBinaryOperation(
                 return { type: UnknownType.create() };
             }
 
+            adjustedLeftType = evaluator.reportMissingTypeArguments(
+                node.leftExpression,
+                adjustedLeftType,
+                flags | EvaluatorFlags.ExpectingType
+            );
+            adjustedRightType = evaluator.reportMissingTypeArguments(
+                node.rightExpression,
+                adjustedRightType,
+                flags | EvaluatorFlags.ExpectingType
+            );
+
             const newUnion = combineTypes([adjustedLeftType, adjustedRightType]);
             if (isUnion(newUnion)) {
                 TypeBase.setSpecialForm(newUnion);

--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -4604,15 +4604,17 @@ export function createTypeEvaluator(importLookup: ImportLookup, evaluatorOptions
         // Is this a generic class that needs to be specialized?
         if (isInstantiableClass(type)) {
             if ((flags & EvaluatorFlags.ExpectingType) !== 0) {
-                if (requiresTypeArguments(type) && !type.typeArguments) {
-                    addDiagnostic(
-                        AnalyzerNodeInfo.getFileInfo(node).diagnosticRuleSet.reportMissingTypeArgument,
-                        DiagnosticRule.reportMissingTypeArgument,
-                        Localizer.Diagnostic.typeArgsMissingForClass().format({
-                            name: type.aliasName || type.details.name,
-                        }),
-                        node
-                    );
+                if (!type.typeAliasInfo && requiresTypeArguments(type)) {
+                    if (!type.typeArguments || !type.isTypeArgumentExplicit) {
+                        addDiagnostic(
+                            AnalyzerNodeInfo.getFileInfo(node).diagnosticRuleSet.reportMissingTypeArgument,
+                            DiagnosticRule.reportMissingTypeArgument,
+                            Localizer.Diagnostic.typeArgsMissingForClass().format({
+                                name: type.aliasName || type.details.name,
+                            }),
+                            node
+                        );
+                    }
                 }
             }
             if (!type.typeArguments) {
@@ -25291,6 +25293,7 @@ export function createTypeEvaluator(importLookup: ImportLookup, evaluatorOptions
         getBuiltInObject,
         getTypingType,
         verifyTypeArgumentsAssignable,
+        reportMissingTypeArguments,
         inferReturnTypeIfNecessary,
         inferTypeParameterVarianceForClass,
         isFinalVariable,

--- a/packages/pyright-internal/src/analyzer/typeEvaluatorTypes.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluatorTypes.ts
@@ -616,6 +616,7 @@ export interface TypeEvaluator {
         flags: AssignTypeFlags,
         recursionCount: number
     ) => boolean;
+    reportMissingTypeArguments: (node: ExpressionNode, type: Type, flags: EvaluatorFlags) => Type;
 
     isFinalVariable: (symbol: Symbol) => boolean;
     isFinalVariableDeclaration: (decl: Declaration) => boolean;

--- a/packages/pyright-internal/src/tests/samples/typeAlias17.py
+++ b/packages/pyright-internal/src/tests/samples/typeAlias17.py
@@ -11,7 +11,7 @@ Tv1 = TypeVarTuple("Tv1")
 
 TA1 = dict[T1, T2]
 
-# This should generate an error if reportMissingTypeArguments is enabled.
+# This should generate an error if reportMissingTypeArgument is enabled.
 a1: TA1
 # This should generate an error because of too few type arguments.
 a2: TA1[str]
@@ -21,7 +21,7 @@ a4: TA1[str, str, str]
 
 TA2 = Callable[P, T1]
 
-# This should generate an error if reportMissingTypeArguments is enabled.
+# This should generate an error if reportMissingTypeArgument is enabled.
 b1: TA2
 # This should generate an error because of too few type arguments.
 b2: TA2[...]
@@ -31,7 +31,7 @@ b4: TA2[..., int, int]
 
 TA3 = Callable[P, int]
 
-# This should generate an error if reportMissingTypeArguments is enabled.
+# This should generate an error if reportMissingTypeArgument is enabled.
 c1: TA3
 c2: TA3[int]
 c3: TA3[int, int]
@@ -40,8 +40,21 @@ c4: TA3[int, int, int]
 
 TA4 = list[T1] | tuple[Unpack[Tv1]]
 
-# This should generate an error if reportMissingTypeArguments is enabled.
+# This should generate an error if reportMissingTypeArgument is enabled.
 d1: TA4
 d2: TA4[int]
 d3: TA4[int, int]
 d4: TA4[int, int, int]
+
+
+_T = TypeVar("_T")
+TA5 = dict[_T, _T]
+
+# This should generate an error if reportMissingTypeArgument is enabled
+TA6 = TA5 | None
+
+# This should generate an error if reportMissingTypeArgument is enabled
+TA7 = list | str
+
+# This should generate an error if reportMissingTypeArgument is enabled
+TA8 = str | dict

--- a/packages/pyright-internal/src/tests/typeEvaluator3.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator3.test.ts
@@ -612,7 +612,7 @@ test('TypeAlias17', () => {
 
     configOptions.diagnosticRuleSet.reportMissingTypeArgument = 'error';
     const analysisResults2 = TestUtils.typeAnalyzeSampleFiles(['typeAlias17.py'], configOptions);
-    TestUtils.validateResults(analysisResults2, 8);
+    TestUtils.validateResults(analysisResults2, 11);
 });
 
 test('TypeAlias18', () => {


### PR DESCRIPTION
…singTypeArgument` check when defining an old-style type alias. This same bug resulted in inconsistent behavior between `Union` and `|`, which should be equivalent. This addresses https://github.com/microsoft/pyright/issues/5256.