### PR TITLE
Fixed a bug that led to a false negative when passing an unpacked tup…

### DIFF
--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -9298,7 +9298,7 @@ export function createTypeEvaluator(importLookup: ImportLookup, evaluatorOptions
                 if (isClassInstance(combinedArgType) && isTupleClass(combinedArgType)) {
                     const tupleTypeArgs = combinedArgType.tupleTypeArguments ?? [];
 
-                    if (tupleTypeArgs.length !== 1) {
+                    if (tupleTypeArgs.length !== 1 || !tupleTypeArgs[0].isUnbounded) {
                         for (const tupleTypeArg of tupleTypeArgs) {
                             if (tupleTypeArg.isUnbounded) {
                                 expandedArgList.push({

--- a/packages/pyright-internal/src/tests/samples/call2.py
+++ b/packages/pyright-internal/src/tests/samples/call2.py
@@ -118,12 +118,24 @@ func9(0, *args4, **kwargs3)
 # This should generate an error.
 func9(*args4, **kwargs3)
 
-def func10(x: int): ...
+
+def func10(x: int):
+    ...
+
 
 func10(1, *())
 
 # This should generate an error.
-func10(1, *(1, ))
+func10(1, *(1,))
+
+func10(*(1,))
+
+# This should generate an error.
+func10(*(1, 1))
+
+# This should generate an error.
+func10(*("",))
+
 
 def func11(y: tuple[int, ...]):
     func10(1, *y)

--- a/packages/pyright-internal/src/tests/typeEvaluator1.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator1.test.ts
@@ -690,7 +690,7 @@ test('Call1', () => {
 test('Call2', () => {
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['call2.py']);
 
-    TestUtils.validateResults(analysisResults, 13);
+    TestUtils.validateResults(analysisResults, 15);
 });
 
 test('Call3', () => {


### PR DESCRIPTION
…le of length one to a function that requires more (or fewer) than one positional argument. This addresses https://github.com/microsoft/pyright/issues/5261.