### PR TITLE
Fixed a regression that caused an incorrect type evaluation of a func…

### DIFF
--- a/packages/pyright-internal/src/analyzer/typeUtils.ts
+++ b/packages/pyright-internal/src/analyzer/typeUtils.ts
@@ -3810,7 +3810,10 @@ class ApplySolvedTypeVarsTransformer extends TypeVarTransformer {
 
         let useDefaultOrUnknown = false;
         if (this._options.unknownIfNotFound && !this._typeVarContext.hasSolveForScope(WildcardTypeVarScopeId)) {
-            useDefaultOrUnknown = true;
+            const exemptTypeVars = this._options.unknownExemptTypeVars ?? [];
+            if (!exemptTypeVars.some((t) => isTypeSame(t, paramSpec))) {
+                useDefaultOrUnknown = true;
+            }
         } else if (this._options.applyInScopePlaceholders && paramSpec.isInScopePlaceholder) {
             useDefaultOrUnknown = true;
         }


### PR DESCRIPTION
…tion that returns a callable with a ParamSpec that does not appear outside of the return type annotation. This addresses https://github.com/microsoft/pyright/issues/5283.