### PR TITLE
Fixed a regression that caused a false positive `reportMissingTypeArg…

### DIFF
--- a/packages/pyright-internal/src/analyzer/typeEvaluatorTypes.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluatorTypes.ts
@@ -89,6 +89,9 @@ export const enum EvaluatorFlags {
     // flagged as errors.
     ExpectingTypeAnnotation = 1 << 8,
 
+    // Suppress the reportMissingTypeArgument diagnostic in this context.
+    AllowMissingTypeArgs = 1 << 9,
+
     // The Generic class type is allowed in this context. It is
     // normally not allowed if ExpectingType is set.
     AllowGenericClassType = 1 << 10,
@@ -266,7 +269,7 @@ export interface ValidateArgTypeParams {
     paramName?: string | undefined;
     isParamNameSynthesized?: boolean;
     mapsToVarArgList?: boolean | undefined;
-    expectingType?: boolean;
+    isinstanceParam?: boolean;
 }
 
 export interface AnnotationTypeOptions {

--- a/packages/pyright-internal/src/tests/samples/genericTypes33.py
+++ b/packages/pyright-internal/src/tests/samples/genericTypes33.py
@@ -44,3 +44,10 @@ a = Class3[int]
 # This should generate an error when reportMissingTypeArgument is enabled.
 def func1() -> collections.deque:
     ...
+
+
+def func2(obj: object):
+    if isinstance(obj, Class1):
+        pass
+    if isinstance(obj, Class1 | Class2):
+        pass


### PR DESCRIPTION
…ument` diagnostic when using a generic type in conjunction with the `|` union operator in the second argument to an `isinstance` or `issubclass` call. This addresses https://github.com/microsoft/pyright/issues/5294.