### PR TITLE
Modified protocol matching and the constraint solver to handle an edg…

### DIFF
--- a/packages/pyright-internal/src/analyzer/constraintSolver.ts
+++ b/packages/pyright-internal/src/analyzer/constraintSolver.ts
@@ -451,7 +451,10 @@ export function assignTypeToTypeVar(
                 )
             ) {
                 // The srcType is narrower than the current wideTypeBound, so replace it.
-                newWideTypeBound = adjSrcType;
+                // If it's Any, don't replace it because Any is the narrowest type already.
+                if (!isAny(curWideTypeBound)) {
+                    newWideTypeBound = adjSrcType;
+                }
             } else if (
                 !evaluator.assignType(
                     adjSrcType,

--- a/packages/pyright-internal/src/analyzer/protocols.ts
+++ b/packages/pyright-internal/src/analyzer/protocols.ts
@@ -15,7 +15,6 @@ import { assignProperty } from './properties';
 import { TypeEvaluator } from './typeEvaluatorTypes';
 import {
     ClassType,
-    isAnyOrUnknown,
     isClassInstance,
     isFunction,
     isInstantiableClass,
@@ -605,7 +604,7 @@ function createProtocolTypeVarContext(
             if (index < specializedDestType.typeArguments!.length) {
                 const typeArg = specializedDestType.typeArguments![index];
 
-                if (!requiresSpecialization(typeArg) && !isAnyOrUnknown(typeArg)) {
+                if (!requiresSpecialization(typeArg)) {
                     const typeParamVariance = TypeVarType.getVariance(typeParam);
                     protocolTypeVarContext.setTypeVarType(
                         typeParam,

--- a/packages/pyright-internal/src/tests/samples/protocol41.py
+++ b/packages/pyright-internal/src/tests/samples/protocol41.py
@@ -2,7 +2,7 @@
 # a type variable can be matched if that type variable's type is
 # supplied by another argument in a call.
 
-from typing import Protocol, TypeVar
+from typing import Any, Protocol, TypeVar
 
 _T_co = TypeVar("_T_co", covariant=True)
 _T_contra = TypeVar("_T_contra", contravariant=True)
@@ -40,9 +40,13 @@ class BufferedWriter:
         raise NotImplementedError
 
 
-def f(s: SupportsRead[MyAnyStr], t: SupportsWrite[MyAnyStr]) -> None:
+def func1(s: SupportsRead[MyAnyStr], t: SupportsWrite[MyAnyStr]) -> None:
     ...
 
 
-def h(src: SupportsRead[MyBytes], tgt: BufferedWriter) -> None:
-    f(src, tgt)
+def test1(src: SupportsRead[MyBytes], tgt: BufferedWriter) -> None:
+    func1(src, tgt)
+
+
+def test2(src: Any, tgt: BufferedWriter) -> None:
+    func1(src, tgt)


### PR DESCRIPTION
…e case where a partially-solved type variable with a solution of `Any` are provided by other argument types in a call. This addresses https://github.com/microsoft/pyright/issues/5243.