### PR TITLE
Fixed a bug that leads to a false positive error in the `reportIncomp…

### DIFF
--- a/packages/pyright-internal/src/analyzer/checker.ts
+++ b/packages/pyright-internal/src/analyzer/checker.ts
@@ -5328,6 +5328,7 @@ export class Checker extends ParseTreeWalker {
                     !this._evaluator.validateOverrideMethod(
                         overriddenType,
                         overrideFunction,
+                        /* baseClass */ undefined,
                         diagAddendum,
                         /* enforceParamNameMatch */ true
                     )
@@ -5613,6 +5614,7 @@ export class Checker extends ParseTreeWalker {
                         !this._evaluator.validateOverrideMethod(
                             baseType,
                             overrideType,
+                            childClassType,
                             diagAddendum,
                             enforceParamNameMatch
                         )
@@ -5768,6 +5770,7 @@ export class Checker extends ParseTreeWalker {
                                         !this._evaluator.validateOverrideMethod(
                                             baseClassMethodType,
                                             subclassMethodType,
+                                            childClassType,
                                             diagAddendum.createAddendum()
                                         )
                                     ) {

--- a/packages/pyright-internal/src/analyzer/typeEvaluatorTypes.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluatorTypes.ts
@@ -584,6 +584,7 @@ export interface TypeEvaluator {
     validateOverrideMethod: (
         baseMethod: Type,
         overrideMethod: FunctionType | OverloadedFunctionType,
+        baseClass: ClassType | undefined,
         diag: DiagnosticAddendum,
         enforceParamNames?: boolean
     ) => boolean;

--- a/packages/pyright-internal/src/tests/samples/methodOverride6.py
+++ b/packages/pyright-internal/src/tests/samples/methodOverride6.py
@@ -102,3 +102,104 @@ class Child1_6(Parent1[bytes]):
 
     def m1(self, x: bool | bytes) -> int | float | bytes:
         return x
+
+
+class Parent2(Generic[_T]):
+    @overload
+    def method1(self: "Parent2[int]", x: list[int]) -> list[int]:
+        ...
+
+    @overload
+    def method1(self, x: str) -> dict[str, str]:
+        ...
+
+    def method1(self, x: Any) -> Any:
+        ...
+
+    @overload
+    def method2(self: "Parent2[int]", x: list[int]) -> list[int]:
+        ...
+
+    @overload
+    def method2(self, x: str) -> dict[str, str]:
+        ...
+
+    @overload
+    def method2(self, x: int) -> int:
+        ...
+
+    def method2(self, x: Any) -> Any:
+        ...
+
+    @overload
+    @classmethod
+    def method3(cls: "type[Parent2[int]]", x: list[int]) -> list[int]:
+        ...
+
+    @overload
+    @classmethod
+    def method3(cls, x: str) -> dict[str, str]:
+        ...
+
+    @classmethod
+    def method3(cls, x: Any) -> Any:
+        ...
+
+    @overload
+    @classmethod
+    def method4(cls: "type[Parent2[int]]", x: list[int]) -> list[int]:
+        ...
+
+    @overload
+    @classmethod
+    def method4(cls, x: str) -> dict[str, str]:
+        ...
+
+    @overload
+    @classmethod
+    def method4(cls, x: int) -> int:
+        ...
+
+    @classmethod
+    def method4(cls, x: Any) -> Any:
+        ...
+
+
+class Child2_1(Parent2[str]):
+    def method1(self, x: str) -> dict[str, str]:
+        ...
+
+
+class Child2_2(Parent2[str]):
+    @overload
+    def method2(self, x: str) -> dict[str, str]:
+        ...
+
+    @overload
+    def method2(self, x: int) -> int:
+        ...
+
+    def method2(self, x: Any) -> Any:
+        ...
+
+
+class Child2_3(Parent2[str]):
+    @classmethod
+    def method3(cls, x: str) -> dict[str, str]:
+        ...
+
+
+class Child2_4(Parent2[str]):
+    @overload
+    @classmethod
+    def method4(cls, x: str) -> dict[str, str]:
+        ...
+
+    @overload
+    @classmethod
+    def method4(cls, x: int) -> int:
+        ...
+
+    @classmethod
+    def method4(cls, x: Any) -> Any:
+        ...


### PR DESCRIPTION
…atibleMethodOverride` check when a child class is overriding an overloaded method in the base class and one or more of the overloads doesn't apply because the `self` or `cls` parameter is explicitly annotated in a way that's not applicable to the child class. This addresses https://github.com/microsoft/pyright/issues/5288.