### PR TITLE
Fixed a bug in type evaluation of the two-argument form of the `super…

### DIFF
--- a/packages/pyright-internal/src/analyzer/checker.ts
+++ b/packages/pyright-internal/src/analyzer/checker.ts
@@ -5450,6 +5450,7 @@ export class Checker extends ParseTreeWalker {
                     continue;
                 }
 
+                assert(isClass(mroBaseClass));
                 const baseClassAndSymbol = lookUpClassMember(mroBaseClass, name, ClassMemberLookupFlags.Default);
                 if (!baseClassAndSymbol) {
                     continue;

--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -8089,11 +8089,11 @@ export function createTypeEvaluator(importLookup: ImportLookup, evaluatorOptions
         const parentNode = node.parent!;
         if (parentNode.nodeType === ParseNodeType.MemberAccess) {
             const memberName = parentNode.memberName.value;
-            const lookupResults = lookUpClassMember(
-                targetClassType,
-                memberName,
-                ClassMemberLookupFlags.SkipOriginalClass
-            );
+            const effectiveTargetClass = isClass(targetClassType) ? targetClassType : undefined;
+
+            const lookupResults = bindToType
+                ? lookUpClassMember(bindToType, memberName, ClassMemberLookupFlags.Default, effectiveTargetClass)
+                : undefined;
             if (lookupResults && isInstantiableClass(lookupResults.classType)) {
                 return {
                     type: resultIsInstance

--- a/packages/pyright-internal/src/analyzer/typeGuards.ts
+++ b/packages/pyright-internal/src/analyzer/typeGuards.ts
@@ -1932,7 +1932,7 @@ function narrowTypeForDiscriminatedLiteralFieldComparison(
 
             // Handle the case where the field is a property
             // that has a declared literal return type for its getter.
-            if (isClassInstance(subtype) && isProperty(memberType)) {
+            if (isClassInstance(subtype) && isClassInstance(memberType) && isProperty(memberType)) {
                 const getterInfo = lookUpObjectMember(memberType, 'fget');
 
                 if (getterInfo && getterInfo.isTypeDeclared) {

--- a/packages/pyright-internal/src/tests/samples/super2.py
+++ b/packages/pyright-internal/src/tests/samples/super2.py
@@ -27,3 +27,38 @@ reveal_type(b1, expected_text="B")
 
 b2 = B.factoryB()
 reveal_type(b2, expected_text="B")
+
+
+class C:
+    def __init__(self) -> None:
+        ...
+
+
+class CChild(C):
+    def __init__(self, name: str) -> None:
+        ...
+
+
+class D:
+    def __init__(self, name: str, num: int):
+        ...
+
+
+class DChild1(CChild, D):
+    def __init__(self, name: str, num: int) -> None:
+        super(C, self).__init__(name, num)
+
+
+class DChild2(CChild, D):
+    def __init__(self, name: str) -> None:
+        super(DChild2, self).__init__(name)
+
+
+class DChild3(CChild, D):
+    def __init__(self) -> None:
+        super(CChild, self).__init__()
+
+
+d1 = DChild1("", 1)
+d2 = DChild2("")
+d3 = DChild3()


### PR DESCRIPTION
…` call. There were situations where the incorrect MRO class was used. This addresses https://github.com/microsoft/pyright/issues/5299.