### PR TITLE
Fixed a bug in type evaluation of the two-argument form of the `super…

### DIFF
--- a/packages/pyright-internal/src/analyzer/checker.ts
+++ b/packages/pyright-internal/src/analyzer/checker.ts
@@ -5451,6 +5451,7 @@ export class Checker extends ParseTreeWalker {
                     continue;
                 }
 
+                assert(isClass(mroBaseClass));
                 const baseClassAndSymbol = lookUpClassMember(mroBaseClass, name, ClassMemberLookupFlags.Default);
                 if (!baseClassAndSymbol) {
                     continue;

--- a/packages/pyright-internal/src/analyzer/typeGuards.ts
+++ b/packages/pyright-internal/src/analyzer/typeGuards.ts
@@ -1932,7 +1932,7 @@ function narrowTypeForDiscriminatedLiteralFieldComparison(
 
             // Handle the case where the field is a property
             // that has a declared literal return type for its getter.
-            if (isClassInstance(subtype) && isProperty(memberType)) {
+            if (isClassInstance(subtype) && isClassInstance(memberType) && isProperty(memberType)) {
                 const getterInfo = lookUpObjectMember(memberType, 'fget');
 
                 if (getterInfo && getterInfo.isTypeDeclared) {

--- a/packages/pyright-internal/src/tests/samples/super1.py
+++ b/packages/pyright-internal/src/tests/samples/super1.py
@@ -36,7 +36,7 @@ class Bar(Foo1, Foo2):
         super().goodbye()
 
 
-super(Bar).aaa()
+super(Bar)
 
 # This should generate an error
 super(Bar).bbb()

--- a/packages/pyright-internal/src/tests/samples/super2.py
+++ b/packages/pyright-internal/src/tests/samples/super2.py
@@ -27,3 +27,38 @@ reveal_type(b1, expected_text="B")
 
 b2 = B.factoryB()
 reveal_type(b2, expected_text="B")
+
+
+class C:
+    def __init__(self) -> None:
+        ...
+
+
+class CChild(C):
+    def __init__(self, name: str) -> None:
+        ...
+
+
+class D:
+    def __init__(self, name: str, num: int):
+        ...
+
+
+class DChild1(CChild, D):
+    def __init__(self, name: str, num: int) -> None:
+        super(C, self).__init__(name, num)
+
+
+class DChild2(CChild, D):
+    def __init__(self, name: str) -> None:
+        super(DChild2, self).__init__(name)
+
+
+class DChild3(CChild, D):
+    def __init__(self) -> None:
+        super(CChild, self).__init__()
+
+
+d1 = DChild1("", 1)
+d2 = DChild2("")
+d3 = DChild3()

--- a/packages/pyright-internal/src/tests/samples/super4.py
+++ b/packages/pyright-internal/src/tests/samples/super4.py
@@ -2,23 +2,37 @@
 # and a base class with an annotated cls or self parameter that
 # relies on the subclass being passed as a parameter.
 
+from typing import Generic, TypeVar
 
-from __future__ import annotations
-import typing
-
-T = typing.TypeVar("T")
+_T1 = TypeVar("_T1")
+_T2 = TypeVar("_T2", bound="Parent2")
 
 
-class Base(typing.Generic[T]):
+class Parent1(Generic[_T1]):
     @classmethod
-    def construct(cls: typing.Type[T]) -> T:
+    def construct(cls: type[_T1]) -> _T1:
         return cls()
 
 
-class Derived(Base["Derived"]):
+class Child1(Parent1["Child1"]):
     @classmethod
-    def construct(cls) -> Derived:
+    def construct(cls) -> "Child1":
         return super().construct()
 
 
-d: Derived = Derived.construct()
+reveal_type(Child1.construct(), expected_text="Child1")
+
+
+class Parent2:
+    @classmethod
+    def construct(cls: type[_T2]) -> _T2:
+        ...
+
+
+class Child2(Parent2):
+    @classmethod
+    def construct(cls: type[_T2]) -> _T2:
+        return super().construct()
+
+
+reveal_type(Child2.construct(), expected_text="Child2")


### PR DESCRIPTION
…` call. There were situations where the incorrect MRO class was used. This addresses https://github.com/microsoft/pyright/issues/5299.