### PR TITLE
Clarification of --version argument usage string

### DIFF
--- a/docs/command-line.md
+++ b/docs/command-line.md
@@ -22,7 +22,7 @@ Pyright can be run as either a VS Code extension or as a node-based command-line
 | -v, --venvpath `<DIRECTORY>`            | Directory that contains virtual environments (4)     |
 | --verbose                               | Emit verbose diagnostics                             |
 | --verifytypes `<IMPORT>`                | Verify completeness of types in py.typed package     |
-| --version                               | Print pyright version                                |
+| --version                               | Print pyright version and exit                       |
 | --warnings                              | Use exit code of 1 if warnings are reported          |
 | -w, --watch                             | Continue to run and watch for changes (5)            |
 

--- a/packages/pyright-internal/src/pyright.ts
+++ b/packages/pyright-internal/src/pyright.ts
@@ -727,7 +727,7 @@ function printUsage() {
             '  -v,--venvpath <DIRECTORY>          Directory that contains virtual environments\n' +
             '  --verbose                          Emit verbose diagnostics\n' +
             '  --verifytypes <PACKAGE>            Verify type completeness of a py.typed package\n' +
-            '  --version                          Print Pyright version\n' +
+            '  --version                          Print Pyright version and exit\n' +
             '  --warnings                         Use exit code of 1 if warnings are reported\n' +
             '  -w,--watch                         Continue to run and watch for changes\n'
     );


### PR DESCRIPTION
Clarifies that `--version` prints the version *and exits*, this is fairly common language used by most CLI apps to indicate what the behavior of `--version` is. It may surprise new users that `--version` exits rather than appending the version with the previous language.