### PR TITLE
Fixed a false negative where an unpacked dictionary argument was not …

### DIFF
--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -9950,6 +9950,19 @@ export function createTypeEvaluator(importLookup: ImportLookup, evaluatorOptions
                                 }
                             }
 
+                            if (paramDetails.kwargsIndex !== undefined && unpackedDictionaryArgType) {
+                                const paramType = paramDetails.params[paramDetails.kwargsIndex].type;
+                                validateArgTypeParams.push({
+                                    paramCategory: ParameterCategory.Simple,
+                                    paramType,
+                                    requiresTypeVarMatching: requiresSpecialization(paramType),
+                                    argType: unpackedDictionaryArgType,
+                                    argument: argList[argIndex],
+                                    errorNode: argList[argIndex].valueExpression || errorNode,
+                                    paramName: paramDetails.params[paramDetails.kwargsIndex].param.name,
+                                });
+                            }
+
                             if (!isValidMappingType) {
                                 if (!isDiagnosticSuppressedForNode(errorNode)) {
                                     addDiagnostic(

--- a/packages/pyright-internal/src/localization/localize.ts
+++ b/packages/pyright-internal/src/localization/localize.ts
@@ -1025,6 +1025,7 @@ export namespace Localizer {
         export const unpackedArgInTypeArgument = () => getRawString('Diagnostic.unpackedArgInTypeArgument');
         export const unpackedArgWithVariadicParam = () => getRawString('Diagnostic.unpackedArgWithVariadicParam');
         export const unpackedDictArgumentNotMapping = () => getRawString('Diagnostic.unpackedDictArgumentNotMapping');
+        export const unpackedDictSubscriptIllegal = () => getRawString('Diagnostic.unpackedDictSubscriptIllegal');
         export const unpackedSubscriptIllegal = () => getRawString('Diagnostic.unpackedSubscriptIllegal');
         export const unpackedTypedDictArgument = () => getRawString('Diagnostic.unpackedTypedDictArgument');
         export const unpackedTypeVarTupleExpected = () =>

--- a/packages/pyright-internal/src/localization/package.nls.en-us.json
+++ b/packages/pyright-internal/src/localization/package.nls.en-us.json
@@ -530,6 +530,7 @@
         "unpackedArgInTypeArgument": "Unpacked arguments cannot be used in type argument lists",
         "unpackedArgWithVariadicParam": "Unpacked argument cannot be used for TypeVarTuple parameter",
         "unpackedDictArgumentNotMapping": "Argument expression after ** must be a mapping with a \"str\" key type",
+        "unpackedDictSubscriptIllegal": "Dictionary unpack operator in subscript is not allowed",
         "unpackedSubscriptIllegal": "Unpack operator in subscript requires Python 3.11 or newer",
         "unpackedTypedDictArgument": "Unable to match unpacked TypedDict argument to parameters",
         "unpackedTypeVarTupleExpected": "Expected unpacked TypeVarTuple; use Unpack[{name1}] or *{name2}",

--- a/packages/pyright-internal/src/parser/parser.ts
+++ b/packages/pyright-internal/src/parser/parser.ts
@@ -3600,13 +3600,17 @@ export class Parser {
             }
 
             if (argType !== ArgumentCategory.Simple) {
-                const unpackAllowed =
+                const unpackListAllowed =
                     this._parseOptions.isStubFile ||
                     this._isParsingQuotedText ||
                     this._getLanguageVersion() >= PythonVersion.V3_11;
 
-                if (argType === ArgumentCategory.UnpackedDictionary || !unpackAllowed) {
+                if (argType === ArgumentCategory.UnpackedList && !unpackListAllowed) {
                     this._addError(Localizer.Diagnostic.unpackedSubscriptIllegal(), argNode);
+                }
+
+                if (argType === ArgumentCategory.UnpackedDictionary) {
+                    this._addError(Localizer.Diagnostic.unpackedDictSubscriptIllegal(), argNode);
                 }
             }
 

--- a/packages/pyright-internal/src/tests/samples/call2.py
+++ b/packages/pyright-internal/src/tests/samples/call2.py
@@ -35,6 +35,8 @@ func2("hi")
 func2("hi", b=3, c=4, d=5)
 
 str_dict = {"a": "3", "b": "2"}
+
+# This should generate a type error
 func2("hi", **str_dict)
 
 

--- a/packages/pyright-internal/src/tests/samples/subscript3.py
+++ b/packages/pyright-internal/src/tests/samples/subscript3.py
@@ -117,9 +117,15 @@ class ClassC:
     
 c_obj = ClassC()
 
-z1 = c_obj[1, *val_list, **val_dict]
+z1 = c_obj[1, *val_list]
 reveal_type(z1, expected_text="complex")
 
+# This should generate an error because dictionary unpack isn't allowed in subscript.
+z2 = c_obj[1, *val_list, **val_dict]
+
+c_obj[1, *val_list] = 4.3
+
+# This should generate an error because dictionary unpack isn't allowed in subscript.
 c_obj[1, *val_list, **val_dict] = 4.3
 
 # This should generate an error because complex isn't assignable.

--- a/packages/pyright-internal/src/tests/typeEvaluator1.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator1.test.ts
@@ -690,7 +690,7 @@ test('Call1', () => {
 test('Call2', () => {
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['call2.py']);
 
-    TestUtils.validateResults(analysisResults, 15);
+    TestUtils.validateResults(analysisResults, 16);
 });
 
 test('Call3', () => {

--- a/packages/pyright-internal/src/tests/typeEvaluator3.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator3.test.ts
@@ -1524,7 +1524,7 @@ test('Subscript3', () => {
     // Analyze with Python 3.9 settings.
     configOptions.defaultPythonVersion = PythonVersion.V3_9;
     const analysisResults39 = TestUtils.typeAnalyzeSampleFiles(['subscript3.py'], configOptions);
-    TestUtils.validateResults(analysisResults39, 30);
+    TestUtils.validateResults(analysisResults39, 32);
 
     // Analyze with Python 3.10 settings.
     // These are disabled because PEP 637 was rejected.


### PR DESCRIPTION
…validated against the `**kwargs` parameter type. This addresses https://github.com/microsoft/pyright/issues/5309.