### PR TITLE
Improved the heuristic used to determine which subtypes of a union wi…

### DIFF
--- a/packages/pyright-internal/src/tests/samples/genericTypes116.py
+++ b/packages/pyright-internal/src/tests/samples/genericTypes116.py
@@ -1,0 +1,28 @@
+# This sample tests bidirectional type inference in cases where the
+# expected type is a union of multiple class instances.
+
+from typing import Iterable, Sequence
+
+
+def func1(points: tuple[float, float] | Iterable[tuple[float, float]]) -> None:
+    ...
+
+
+def test1(val: tuple[float, float]):
+    func1(tuple((val, val)))
+
+
+def func2(points: tuple[float, float] | Sequence[tuple[float, float]]) -> None:
+    ...
+
+
+def test2(val: tuple[float, float]):
+    func2(tuple([val, val]))
+
+
+def func3(points: tuple[float, float] | tuple[str, str]) -> None:
+    ...
+
+
+def test3(val: tuple[float, float]):
+    func3(tuple(val))

--- a/packages/pyright-internal/src/tests/typeEvaluator2.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator2.test.ts
@@ -1115,6 +1115,12 @@ test('GenericTypes115', () => {
     TestUtils.validateResults(analysisResults, 0);
 });
 
+test('GenericTypes116', () => {
+    const analysisResults = TestUtils.typeAnalyzeSampleFiles(['genericTypes116.py']);
+
+    TestUtils.validateResults(analysisResults, 0);
+});
+
 test('Protocol1', () => {
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['protocol1.py']);
 


### PR DESCRIPTION
…thin an "expected type" should be used for bidirectional type inference. This addresses https://github.com/microsoft/pyright/issues/5312.