### PR TITLE
Fixed bug that led to an incorrect type evaluation for nested call ex…

### DIFF
--- a/packages/pyright-internal/src/tests/samples/genericTypes105.py
+++ b/packages/pyright-internal/src/tests/samples/genericTypes105.py
@@ -139,5 +139,11 @@ def test_5(a: Any, *args: int, b: Any = ...) -> Any:
 val3 = test_5(test_5, **{})
 reveal_type(
     val3,
+    expected_text="Unknown",
+)
+
+val4 = test_5(test_5, b=True)
+reveal_type(
+    val4,
     expected_text="Type[list[Overload[(a: Type[(**P(1)@test_5) -> Type[T(1)@test_5]], *, b: Literal[False] | None = ...) -> Type[list[Type[T(1)@test_5]]], (a: T(1)@test_5, *args: int, b: Literal[False] | None = ...) -> Type[list[T(1)@test_5]], (a: T(1)@test_5, *args: int, b: Literal[True] = ...) -> Type[list[T(1)@test_5]], (a: Any, *args: int, b: Any = ...) -> Any]]]",
 )

--- a/packages/pyright-internal/src/tests/samples/genericTypes108.py
+++ b/packages/pyright-internal/src/tests/samples/genericTypes108.py
@@ -1,22 +1,48 @@
 # This sample tests the handling of nested calls to generic functions
 # when bidirectional type inference is involved.
 
-from typing import Literal, TypeVar
+from typing import Callable, Generic, Literal, ParamSpec, TypeVar
 
-T = TypeVar("T")
+_T = TypeVar("_T")
+_P = ParamSpec("_P")
 
 
-def identity(x: T) -> T:
+def identity1(x: _T) -> _T:
     return x
 
 
-def identity2(x: T) -> T:
+def identity2(x: _T) -> _T:
     return x
 
 
-def test(x: Literal[2]) -> Literal[2]:
-    return identity(identity2(x))
+def test1(x: Literal[2]) -> Literal[2]:
+    return identity1(identity2(x))
 
 
 v1 = min(1, max(2, 0.5))
 reveal_type(v1, expected_text="float")
+
+
+class Future(Generic[_T]):
+    ...
+
+
+def func1(future: Future[_T]) -> Future[_T]:
+    ...
+
+
+def func2(__fn: Callable[_P, _T], *args: _P.args, **kwargs: _P.kwargs) -> Future[_T]:
+    ...
+
+
+def func3() -> int:
+    ...
+
+
+def func4(a: int, b: int) -> str:
+    ...
+
+
+reveal_type(func1(func2(func3)), expected_text="Future[int]")
+reveal_type(func1(func2(func4, 1, 2)), expected_text="Future[str]")
+reveal_type(func1(func2(func4, a=1, b=2)), expected_text="Future[str]")

--- a/packages/pyright-internal/src/tests/samples/genericTypes71.py
+++ b/packages/pyright-internal/src/tests/samples/genericTypes71.py
@@ -75,7 +75,6 @@ class A:
     ...
 
 
-T = TypeVar("T")
 T_A = TypeVar("T_A", bound=A)
 
 


### PR DESCRIPTION
…pressions where an inner call expression used a ParamSpec. This addresses https://github.com/microsoft/pyright/issues/5281.