### PR TITLE
Changed auto-variance algorithm to ignore `__new__` and `__init__` me…

### DIFF
--- a/packages/pyright-internal/src/tests/samples/autoVariance1.py
+++ b/packages/pyright-internal/src/tests/samples/autoVariance1.py
@@ -33,6 +33,10 @@ class ShouldBeInvariant1[T]:
     def value(self):
         return self._value
 
+    @value.setter
+    def value(self, value: T):
+        self._value = value
+
 # This should generate an error based on variance
 vinv1_1: ShouldBeInvariant1[float] = ShouldBeInvariant1[int](1)
 
@@ -46,6 +50,9 @@ class ShouldBeInvariant2[T]:
 
     def get_value(self) ->T:
         return self._value
+
+    def set_value(self, value: T):
+        self._value = value
 
 # This should generate an error based on variance
 vinv2_1: ShouldBeInvariant2[float] = ShouldBeInvariant2[int](1)
@@ -72,6 +79,9 @@ vinv3_4: ShouldBeInvariant3[str, int] = ShouldBeInvariant3[str, float]()
 
 class ShouldBeContravariant1[T]:
     def __init__(self, value: T) -> None:
+        self._value = value
+    
+    def set_value(self, value: T) -> None:
         self._value = value
 
 

--- a/packages/pyright-internal/src/tests/samples/autoVariance3.py
+++ b/packages/pyright-internal/src/tests/samples/autoVariance3.py
@@ -17,8 +17,11 @@ S2 = TypeVar("S2", contravariant=True, infer_variance=True)
 
 
 class ShouldBeCovariant1(Generic[T]):
-    def __getitem__(self, index: int) -> T: ...
-    def __iter__(self) -> Iterator[T]: ...
+    def __getitem__(self, index: int) -> T:
+        ...
+
+    def __iter__(self) -> Iterator[T]:
+        ...
 
 
 vco1_1: ShouldBeCovariant1[float] = ShouldBeCovariant1[int]()
@@ -30,11 +33,11 @@ vco1_2: ShouldBeCovariant1[int] = ShouldBeCovariant1[float]()
 class ShouldBeCovariant2(Sequence[T]):
     pass
 
+
 vco2_1: ShouldBeCovariant2[float] = ShouldBeCovariant2[int]()
 
 # This should generate an error based on variance
 vco2_2: ShouldBeCovariant2[int] = ShouldBeCovariant2[float]()
-
 
 
 class ShouldBeInvariant1(Generic[T]):
@@ -44,6 +47,11 @@ class ShouldBeInvariant1(Generic[T]):
     @property
     def value(self):
         return self._value
+
+    @value.setter
+    def value(self, value: T):
+        self._value = value
+
 
 # This should generate an error based on variance
 vinv1_1: ShouldBeInvariant1[float] = ShouldBeInvariant1[int](1)
@@ -56,8 +64,12 @@ class ShouldBeInvariant2(Generic[T]):
     def __init__(self, value: T) -> None:
         self._value = value
 
-    def get_value(self) ->T:
+    def get_value(self) -> T:
         return self._value
+
+    def set_value(self, value: T):
+        self._value = value
+
 
 # This should generate an error based on variance
 vinv2_1: ShouldBeInvariant2[float] = ShouldBeInvariant2[int](1)
@@ -68,6 +80,7 @@ vinv2_2: ShouldBeInvariant2[int] = ShouldBeInvariant2[float](1.1)
 
 class ShouldBeInvariant3(dict[K, V]):
     pass
+
 
 # This should generate an error based on variance
 vinv3_1: ShouldBeInvariant3[float, str] = ShouldBeInvariant3[int, str]()
@@ -84,6 +97,9 @@ vinv3_4: ShouldBeInvariant3[str, int] = ShouldBeInvariant3[str, float]()
 
 class ShouldBeContravariant1(Generic[T]):
     def __init__(self, value: T) -> None:
+        self._value = value
+
+    def set_value(self, value: T):
         self._value = value
 
 

--- a/packages/pyright-internal/src/tests/samples/partial1.py
+++ b/packages/pyright-internal/src/tests/samples/partial1.py
@@ -4,7 +4,7 @@ from functools import partial
 from typing import Callable, Protocol, Self, TypeVar
 
 _T1 = TypeVar("_T1")
-_T2 = TypeVar("_T2", contravariant=True)
+_T2 = TypeVar("_T2", covariant=True)
 
 
 def func1():

--- a/packages/pyright-internal/src/tests/samples/protocol29.py
+++ b/packages/pyright-internal/src/tests/samples/protocol29.py
@@ -5,7 +5,7 @@ from functools import partial
 from typing_extensions import Protocol, Self
 from typing import Any, Callable, Type, TypeVar
 
-_T = TypeVar("_T")
+_T = TypeVar("_T", covariant=True)
 
 
 class Partial(Protocol[_T]):


### PR DESCRIPTION
…thods for purposes of calculating the variance of a TypeVar. This mirrors the behavior of mypy.