### PR TITLE
Fixed a bug that led to a false positive error under certain circumst…

### DIFF
--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -21780,7 +21780,7 @@ export function createTypeEvaluator(importLookup: ImportLookup, evaluatorOptions
                             assignmentDiag,
                             destTypeVarContext,
                             srcTypeVarContext,
-                            flags | AssignTypeFlags.EnforceInvariance,
+                            flags | AssignTypeFlags.EnforceInvariance | AssignTypeFlags.RetainLiteralsForTypeVar,
                             recursionCount
                         )
                     ) {

--- a/packages/pyright-internal/src/tests/samples/genericTypes119.py
+++ b/packages/pyright-internal/src/tests/samples/genericTypes119.py
@@ -1,0 +1,28 @@
+# This sample tests the case where a protocol uses a covariant
+# type parameter but a corresponding implementation uses an
+# invariant type parameter. Literal types need to be handled
+# carefully in this case.
+
+from typing import Awaitable, Literal, TypeVar
+
+_T = TypeVar("_T")
+
+
+class Future(Awaitable[_T]):
+    ...
+
+
+def func1(future: Future[_T]) -> Future[_T]:
+    ...
+
+
+def func2(coro: Awaitable[_T]) -> Future[_T]:
+    ...
+
+
+def func3() -> Awaitable[Literal[True]]:
+    ...
+
+
+v1 = func1(func2(func3()))
+reveal_type(v1, expected_text="Future[Literal[True]]")

--- a/packages/pyright-internal/src/tests/typeEvaluator2.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator2.test.ts
@@ -1130,6 +1130,12 @@ test('GenericTypes118', () => {
     TestUtils.validateResults(analysisResults, 0);
 });
 
+test('GenericTypes119', () => {
+    const analysisResults = TestUtils.typeAnalyzeSampleFiles(['genericTypes119.py']);
+
+    TestUtils.validateResults(analysisResults, 0);
+});
+
 test('Protocol1', () => {
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['protocol1.py']);
 


### PR DESCRIPTION
…ances when a literal type argument was used in conjunction with a protocol that used a covariant type parameter and an implementation of that protocol that used an invariant type parameter. This addresses https://github.com/microsoft/pyright/issues/5282.