### PR TITLE
Improved type inference for lambdas in the case where a parameter inc…

### DIFF
--- a/packages/pyright-internal/src/tests/samples/lambda12.py
+++ b/packages/pyright-internal/src/tests/samples/lambda12.py
@@ -1,0 +1,12 @@
+# This sample tests the case where a lambda includes one or more parameters
+# that accept a default value and the the expected type does not include
+# these parameters. In this case, the types of the extra parameters should
+# be inferred based on the default value type.
+
+# pyright: strict
+
+from typing import Callable
+
+
+def func1() -> list[Callable[[int], int]]:
+    return [lambda x, i=i: i * x for i in range(5)]

--- a/packages/pyright-internal/src/tests/typeEvaluator1.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator1.test.ts
@@ -681,6 +681,12 @@ test('Lambda11', () => {
     TestUtils.validateResults(analysisResults, 0);
 });
 
+test('Lambda12', () => {
+    const analysisResults = TestUtils.typeAnalyzeSampleFiles(['lambda12.py']);
+
+    TestUtils.validateResults(analysisResults, 0);
+});
+
 test('Call1', () => {
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['call1.py']);
 


### PR DESCRIPTION
…ludes a default value and the expected type doesn't include that parameter. This improvement was suggested in the [mypy issue tracker](https://github.com/python/mypy/issues/15459).