### PR TITLE
Fixed a bug that caused an incorrect false positive error for an `ass…

### DIFF
--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -13676,11 +13676,14 @@ export function createTypeEvaluator(importLookup: ImportLookup, evaluatorOptions
                     });
                 });
 
-                FunctionType.addParameter(functionType, {
-                    category: ParameterCategory.Simple,
-                    isNameSynthesized: false,
-                    type: UnknownType.create(),
-                });
+                if (typeList.length > 0) {
+                    // Add a positional-only separator to the end of the parameter list.
+                    FunctionType.addParameter(functionType, {
+                        category: ParameterCategory.Simple,
+                        isNameSynthesized: false,
+                        type: UnknownType.create(),
+                    });
+                }
             } else if (isEllipsisType(typeArgs[0].type)) {
                 FunctionType.addDefaultParameters(functionType);
                 functionType.details.flags |= FunctionTypeFlags.SkipArgsKwargsCompatibilityCheck;


### PR DESCRIPTION
…ert_type` call involving a `Callable[[], X]` type. Pyright was generating a signature with a positional-only separator in this case. This addresses https://github.com/python/typeshed/pull/10325#issuecomment-1598858415.