### PR TITLE
Added support for bidirectional type inference when using a dictionar…

### DIFF
--- a/packages/pyright-internal/src/analyzer/parameterUtils.ts
+++ b/packages/pyright-internal/src/analyzer/parameterUtils.ts
@@ -61,6 +61,7 @@ export interface ParameterListDetails {
     // Other information
     hasUnpackedVariadicTypeVar: boolean;
     hasUnpackedTypedDict: boolean;
+    unpackedKwargsTypedDictType?: ClassType;
 }
 
 // Examines the input parameters within a function signature and creates a
@@ -248,6 +249,7 @@ export function getParameterListDetails(type: FunctionType): ParameterListDetail
                 });
 
                 result.hasUnpackedTypedDict = true;
+                result.unpackedKwargsTypedDictType = paramType;
             } else if (param.name) {
                 if (result.kwargsIndex === undefined) {
                     result.kwargsIndex = result.params.length;

--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -9888,7 +9888,11 @@ export function createTypeEvaluator(importLookup: ImportLookup, evaluatorOptions
             while (argIndex < argList.length) {
                 if (argList[argIndex].argumentCategory === ArgumentCategory.UnpackedDictionary) {
                     // Verify that the type used in this expression is a SupportsKeysAndGetItem[str, T].
-                    const argType = getTypeOfArgument(argList[argIndex]).type;
+                    const argType = getTypeOfArgument(
+                        argList[argIndex],
+                        makeInferenceContext(paramDetails.unpackedKwargsTypedDictType)
+                    ).type;
+
                     if (isAnyOrUnknown(argType)) {
                         unpackedDictionaryArgType = argType;
                     } else if (isClassInstance(argType) && ClassType.isTypedDictClass(argType)) {
@@ -19222,7 +19226,7 @@ export function createTypeEvaluator(importLookup: ImportLookup, evaluatorOptions
         return { type: specializedClass };
     }
 
-    function getTypeOfArgument(arg: FunctionArgument): TypeResult {
+    function getTypeOfArgument(arg: FunctionArgument, inferenceContext?: InferenceContext): TypeResult {
         if (arg.typeResult) {
             return { type: arg.typeResult.type, isIncomplete: arg.typeResult.isIncomplete };
         }
@@ -19234,7 +19238,7 @@ export function createTypeEvaluator(importLookup: ImportLookup, evaluatorOptions
 
         // If there was no defined type provided, there should always
         // be a value expression from which we can retrieve the type.
-        return getTypeOfExpression(arg.valueExpression);
+        return getTypeOfExpression(arg.valueExpression, /* flags */ undefined, inferenceContext);
     }
 
     // This function is like getTypeOfArgument except that it is

--- a/packages/pyright-internal/src/tests/samples/call7.py
+++ b/packages/pyright-internal/src/tests/samples/call7.py
@@ -1,7 +1,7 @@
 # This sample tests the handling of an unpacked TypedDict passed as
 # an argument to a function.
 
-from typing import TypedDict
+from typing import TypedDict, Unpack
 
 
 class TD1(TypedDict):
@@ -55,3 +55,17 @@ func4(**td1)
 # This should generate an error because "arg3" cannot be matched
 # due to the type of the **kwargs parameter.
 func4(**td2)
+
+
+class Options(TypedDict, total=False):
+    opt1: bool
+    opt2: str
+
+
+def func5(code: str | None = None, **options: Unpack[Options]):
+    pass
+
+
+func5(**{})
+func5(**{"opt1": True})
+func5(**{"opt2": "hi"})

--- a/packages/pyright-internal/src/tests/samples/kwargsUnpack1.py
+++ b/packages/pyright-internal/src/tests/samples/kwargsUnpack1.py
@@ -56,7 +56,8 @@ def func3():
     # This should generate an error because it's an untyped dict.
     func1(**my_dict)
 
-    func1(**{"v1": 2, "v3": "4", "v4": 4})
+    d1 = {"v1": 2, "v3": "4", "v4": 4}
+    func1(**d1)
 
     func2(**td2)
 


### PR DESCRIPTION
…y expansion and a dictionary literal expression for an argument corresponding to an unpacked TypedDict `**kwargs` parameter. This addresses https://github.com/microsoft/pyright/issues/5358.