### PR TITLE
Fixed a bug that resulted in a false positive when passing a class to…

### DIFF
--- a/packages/pyright-internal/src/analyzer/constraintSolver.ts
+++ b/packages/pyright-internal/src/analyzer/constraintSolver.ts
@@ -55,6 +55,7 @@ import {
     isPartlyUnknown,
     mapSubtypes,
     specializeTupleClass,
+    specializeWithDefaultTypeArgs,
     transformExpectedType,
     transformPossibleRecursiveTypeAlias,
 } from './typeUtils';
@@ -393,6 +394,14 @@ export function assignTypeToTypeVar(
     const diagAddendum = diag ? new DiagnosticAddendum() : undefined;
 
     let adjSrcType = srcType;
+
+    // If the source is a class that is missing type arguments, fill
+    // in missing type arguments with Unknown.
+    if ((flags & AssignTypeFlags.AllowUnspecifiedTypeArguments) === 0) {
+        if (isClass(adjSrcType) && adjSrcType.includeSubclasses) {
+            adjSrcType = specializeWithDefaultTypeArgs(adjSrcType);
+        }
+    }
 
     if (TypeBase.isInstantiable(destType)) {
         if (isEffectivelyInstantiable(adjSrcType)) {

--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -25241,7 +25241,7 @@ export function createTypeEvaluator(importLookup: ImportLookup, evaluatorOptions
                     diag,
                     typeVarContext,
                     /* srcTypeVarContext */ undefined,
-                    AssignTypeFlags.Default,
+                    AssignTypeFlags.AllowUnspecifiedTypeArguments,
                     recursionCount
                 )
             ) {

--- a/packages/pyright-internal/src/tests/samples/solver26.py
+++ b/packages/pyright-internal/src/tests/samples/solver26.py
@@ -1,0 +1,10 @@
+# This sample tests that when an unspecialized generic class type is used as
+# a constraint in the constraint solver, default type arguments (typically
+# `Unknown`) are used.
+
+from collections import defaultdict
+
+
+def func1() -> None:
+    d1 = defaultdict(list)
+    reveal_type(d1, expected_text="defaultdict[Unknown, list[Unknown]]")

--- a/packages/pyright-internal/src/tests/typeEvaluator2.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator2.test.ts
@@ -647,6 +647,12 @@ test('Solver25', () => {
     TestUtils.validateResults(analysisResults, 0);
 });
 
+test('Solver26', () => {
+    const analysisResults = TestUtils.typeAnalyzeSampleFiles(['solver26.py']);
+
+    TestUtils.validateResults(analysisResults, 0);
+});
+
 test('SolverScoring1', () => {
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['solverScoring1.py']);
 


### PR DESCRIPTION
… the `defaultdict` constructor. If an unspecialized class type is used as a upper or lower constraint within the constraint solver, we now use default type arguments (typically `Unknown`) rather than leaving these type arguments unspecified. This addresses https://github.com/microsoft/pyright/issues/5354.