### PR TITLE
Fixed a bug that results in a false positive error when attempting to…

### DIFF
--- a/packages/pyright-internal/src/analyzer/constructors.ts
+++ b/packages/pyright-internal/src/analyzer/constructors.ts
@@ -734,6 +734,7 @@ export function createFunctionFromConstructor(
             if (constructorFunction) {
                 constructorFunction = FunctionType.clone(constructorFunction);
                 constructorFunction.details.declaredReturnType = objectType;
+                constructorFunction.details.typeVarScopeId = initSubtype.details.typeVarScopeId;
 
                 if (constructorFunction.specializedTypes) {
                     constructorFunction.specializedTypes.returnType = objectType;
@@ -744,6 +745,7 @@ export function createFunctionFromConstructor(
                 }
 
                 constructorFunction.details.flags &= ~FunctionTypeFlags.StaticMethod;
+                constructorFunction.details.constructorTypeVarScopeId = getTypeVarScopeId(classType);
             }
 
             return constructorFunction;
@@ -792,6 +794,7 @@ export function createFunctionFromConstructor(
 
             if (constructorFunction) {
                 constructorFunction = FunctionType.clone(constructorFunction);
+                constructorFunction.details.typeVarScopeId = newSubtype.details.typeVarScopeId;
 
                 if (!constructorFunction.details.docString && classType.details.docString) {
                     constructorFunction.details.docString = classType.details.docString;
@@ -800,6 +803,7 @@ export function createFunctionFromConstructor(
                 constructorFunction.details.flags &= ~(
                     FunctionTypeFlags.StaticMethod | FunctionTypeFlags.ConstructorMethod
                 );
+                constructorFunction.details.constructorTypeVarScopeId = getTypeVarScopeId(classType);
             }
 
             return constructorFunction;

--- a/packages/pyright-internal/src/analyzer/typeUtils.ts
+++ b/packages/pyright-internal/src/analyzer/typeUtils.ts
@@ -758,11 +758,14 @@ export function getTypeVarScopeId(type: Type): TypeVarScopeId | undefined {
 // This is similar to getTypeVarScopeId except that it includes
 // the secondary scope IDs for functions.
 export function getTypeVarScopeIds(type: Type): TypeVarScopeId[] | TypeVarScopeId | undefined {
+    const scopeIds: TypeVarScopeId[] = [];
+
     const scopeId = getTypeVarScopeId(type);
+    if (scopeId) {
+        scopeIds.push(scopeId);
+    }
 
-    if (scopeId && isFunction(type)) {
-        const scopeIds: TypeVarScopeId[] = [scopeId];
-
+    if (isFunction(type)) {
         if (type.details.constructorTypeVarScopeId) {
             scopeIds.push(type.details.constructorTypeVarScopeId);
         }
@@ -770,11 +773,9 @@ export function getTypeVarScopeIds(type: Type): TypeVarScopeId[] | TypeVarScopeI
         if (type.details.paramSpecTypeVarScopeId) {
             scopeIds.push(type.details.paramSpecTypeVarScopeId);
         }
-
-        return scopeIds;
     }
 
-    return scopeId;
+    return scopeIds;
 }
 
 // If the class type is generic and does not already have type arguments

--- a/packages/pyright-internal/src/analyzer/types.ts
+++ b/packages/pyright-internal/src/analyzer/types.ts
@@ -1451,7 +1451,7 @@ export namespace FunctionType {
         );
 
         newFunction.details = { ...type.details };
-        newFunction.boundToType = boundToType;
+        newFunction.boundToType = boundToType ?? type.boundToType;
         newFunction.preBoundFlags = newFunction.details.flags;
 
         if (stripFirstParam) {
@@ -1491,7 +1491,7 @@ export namespace FunctionType {
         }
 
         newFunction.inferredReturnType = type.inferredReturnType;
-        newFunction.boundTypeVarScopeId = boundTypeVarScopeId;
+        newFunction.boundTypeVarScopeId = boundTypeVarScopeId ?? type.boundTypeVarScopeId;
 
         return newFunction;
     }

--- a/packages/pyright-internal/src/tests/samples/constructor8.py
+++ b/packages/pyright-internal/src/tests/samples/constructor8.py
@@ -1,6 +1,7 @@
 # This sample verifies that a class can be assigned to a Callable
 # type if its constructor conforms to that type.
 
+from dataclasses import dataclass
 from typing import Any, Callable, Generic, Literal, TypeVar, Union, overload
 
 _T1 = TypeVar("_T1")
@@ -97,3 +98,18 @@ reveal_type(d4, expected_text="D[int | str]")
 
 d5 = func1(D[Union[int, str]], "3")
 reveal_type(d5, expected_text="D[int | str]")
+
+
+@dataclass(frozen=True, slots=True)
+class E(Generic[_T1]):
+    x: _T1
+
+
+e1: Callable[[int], E[int]] = E
+
+
+def func2(x: _T1) -> E[_T1]:
+    ...
+
+
+e2: Callable[[int], E[int]] = func2


### PR DESCRIPTION
… assign a class to a `Callable` type when the class is generic and the constructor includes class-scoped type variables in its parameter annotations. This addresses https://github.com/microsoft/pyright/issues/5369.