### PR TITLE
Moved the evaluation of the first iterator in a comprehension express…

### DIFF
--- a/packages/pyright-internal/src/tests/typeEvaluator4.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator4.test.ts
@@ -108,7 +108,7 @@ test('AssignmentExpr3', () => {
 
 test('AssignmentExpr4', () => {
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['assignmentExpr4.py']);
-    TestUtils.validateResults(analysisResults, 17);
+    TestUtils.validateResults(analysisResults, 16);
 });
 
 test('AssignmentExpr5', () => {


### PR DESCRIPTION
…ion out of the comprehension scope to better reflect runtime behavior.