### PR TITLE
Fixed a bug that led to a false negative when a generic class with ca…

### DIFF
--- a/packages/pyright-internal/src/tests/samples/constructor24.py
+++ b/packages/pyright-internal/src/tests/samples/constructor24.py
@@ -44,7 +44,7 @@ class Container(Generic[T]):
 
 class IntContainer(Container[int]):
     def increment(self):
-        # This should generate an error if strictParameterNoneValue is true.
+        # This should generate an error if strictParameterNoneValue is false.
         self.value += 1
 
 
@@ -57,10 +57,10 @@ class ContainerList(Generic[U]):
         Container()
         Container(123)
 
-        # This should generate an error if strictParameterNoneValue is false.
+        # This should generate an error if strictParameterNoneValue is true.
         Container[U]()
 
-        # This should generate an error if strictParameterNoneValue is false.
+        # This should generate an error if strictParameterNoneValue is true.
         Container[U](None)
 
     def method2(self):
@@ -68,6 +68,7 @@ class ContainerList(Generic[U]):
 
 
 def func1(obv: Container[T], default_value: T = None) -> None:
+    # This should generate an error if strictParameterNoneValue is false.
     obv.on_next(default_value)
 
 

--- a/packages/pyright-internal/src/tests/samples/constructor26.py
+++ b/packages/pyright-internal/src/tests/samples/constructor26.py
@@ -1,0 +1,59 @@
+# This sample tests the case where a generic class with multiple
+# type parameters invokes its own constructor and uses its own
+# type parameters to specialize the constructed type.
+
+from typing import Generic, TypeVar
+
+T = TypeVar("T")
+U = TypeVar("U")
+
+# This test is commented out because it doesn't yet work.
+# class Test1(Generic[T, U]):
+#     def __init__(self, t: T, u: U):
+#         pass
+
+#     def test1(self, ts: list[T], us: list[U]) -> None:
+#         # This should generate an error.
+#         x1: Test1[U, T] = Test1(us, ts)
+
+#         x2: Test1[list[U], list[T]] = Test1(us, ts)
+
+
+class Test2(Generic[T, U]):
+    def __init__(self):
+        pass
+
+    def test2(self) -> None:
+        x1: Test2[U, T]
+        x2: Test2[T, T]
+        x3: Test2[T, U]
+
+        x1 = Test2[U, T]()
+        # This should generate an error.
+        x2 = Test2[U, T]()
+        # This should generate an error.
+        x3 = Test2[U, T]()
+
+        # This should generate an error.
+        x1 = Test2[T, T]()
+        x2 = Test2[T, T]()
+        # This should generate an error.
+        x3 = Test2[T, T]()
+
+        # This should generate an error.
+        x1 = Test2[T, U]()
+        # This should generate an error.
+        x2 = Test2[T, U]()
+        x3 = Test2[T, U]()
+
+
+# This test is commented out because it doesn't yet work.
+# class Test3(Generic[T, U]):
+#     def __init__(self, ts: list[T], us: list[U]):
+#         pass
+
+#     def test3(self, ts: list[T], us: list[U]) -> None:
+#         # This should generate an error.
+#         x1: Test3[U, T] = Test3(us, ts)
+
+#         x2: Test3[list[U], list[T]] = Test3(us, ts)

--- a/packages/pyright-internal/src/tests/typeEvaluator3.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator3.test.ts
@@ -1484,13 +1484,19 @@ test('Constructor24', () => {
 
     configOptions.diagnosticRuleSet.strictParameterNoneValue = true;
     analysisResults = TestUtils.typeAnalyzeSampleFiles(['constructor24.py'], configOptions);
-    TestUtils.validateResults(analysisResults, 5);
+    TestUtils.validateResults(analysisResults, 4);
 });
 
 test('Constructor25', () => {
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['constructor25.py']);
 
     TestUtils.validateResults(analysisResults, 1);
+});
+
+test('Constructor26', () => {
+    const analysisResults = TestUtils.typeAnalyzeSampleFiles(['constructor26.py']);
+
+    TestUtils.validateResults(analysisResults, 6);
 });
 
 test('InconsistentConstructor1', () => {


### PR DESCRIPTION
…lled its own constructor using its own type parameters as type arguments. This partially addresses https://github.com/microsoft/pyright/issues/5373.