### PR TITLE
Added detection of errors when a namedtuple definition includes a lan…

### DIFF
--- a/packages/pyright-internal/src/localization/localize.ts
+++ b/packages/pyright-internal/src/localization/localize.ts
@@ -583,6 +583,7 @@ export namespace Localizer {
         export const namedTupleEmptyName = () => getRawString('Diagnostic.namedTupleEmptyName');
         export const namedTupleFirstArg = () => getRawString('Diagnostic.namedTupleFirstArg');
         export const namedTupleMultipleInheritance = () => getRawString('Diagnostic.namedTupleMultipleInheritance');
+        export const namedTupleNameKeyword = () => getRawString('Diagnostic.namedTupleNameKeyword');
         export const namedTupleNameType = () => getRawString('Diagnostic.namedTupleNameType');
         export const namedTupleNameUnique = () => getRawString('Diagnostic.namedTupleNameUnique');
         export const namedTupleNoTypes = () => getRawString('Diagnostic.namedTupleNoTypes');

--- a/packages/pyright-internal/src/localization/package.nls.en-us.json
+++ b/packages/pyright-internal/src/localization/package.nls.en-us.json
@@ -268,6 +268,7 @@
         "namedTupleEmptyName": "Names within a named tuple cannot be empty",
         "namedTupleMultipleInheritance": "Multiple inheritance with NamedTuple is not supported",
         "namedTupleFirstArg": "Expected named tuple class name as first argument",
+        "namedTupleNameKeyword": "Field names cannot be a keyword",
         "namedTupleNameType": "Expected two-entry tuple specifying entry name and type",
         "namedTupleNameUnique": "Names within a named tuple must be unique",
         "namedTupleNoTypes": "\"namedtuple\" provides no types for tuple entries; use \"NamedTuple\" instead",

--- a/packages/pyright-internal/src/parser/tokenizer.ts
+++ b/packages/pyright-internal/src/parser/tokenizer.ts
@@ -91,6 +91,8 @@ const _keywords: Map<string, KeywordType> = new Map([
     ['True', KeywordType.True],
 ]);
 
+const _softKeywords = new Set(['match', 'case', 'type']);
+
 const _operatorInfo: { [key: number]: OperatorFlags } = {
     [OperatorType.Add]: OperatorFlags.Unary | OperatorFlags.Binary,
     [OperatorType.AddEqual]: OperatorFlags.Assignment,
@@ -362,6 +364,19 @@ export class Tokenizer {
 
     static getOperatorInfo(operatorType: OperatorType): OperatorFlags {
         return _operatorInfo[operatorType];
+    }
+
+    static isKeyword(name: string, includeSoftKeywords = false): boolean {
+        const keyword = _keywords.get(name);
+        if (!keyword) {
+            return false;
+        }
+
+        if (includeSoftKeywords) {
+            return true;
+        }
+
+        return !_softKeywords.has(name);
     }
 
     static isOperatorAssignment(operatorType?: OperatorType): boolean {

--- a/packages/pyright-internal/src/tests/samples/namedTuple9.py
+++ b/packages/pyright-internal/src/tests/samples/namedTuple9.py
@@ -1,0 +1,24 @@
+# This sample tests the detection of keywords in a named tuple
+# definition and support for the "rename" parameter.
+
+
+from collections import namedtuple
+from typing import NamedTuple
+
+
+# This should generate an error because "def" is a keyword.
+NT1 = namedtuple("NT1", ["abc", "def"])
+
+# This should generate an error because "class" is a keyword.
+NT2 = namedtuple("NT2", ["abc", "class"], rename=False)
+
+NT3 = namedtuple("NT3", ["abc", "def"], rename=True)
+
+v3 = NT3(abc=0, _1=0)
+
+# This should generate an error because "def" is a keyword.
+NT4 = NamedTuple("NT4", [("abc", int), ("def", int)])
+
+
+# These are soft keywords, so they shouldn't generate an error.
+NT5 = namedtuple("NT5", ["type", "match"])

--- a/packages/pyright-internal/src/tests/typeEvaluator1.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator1.test.ts
@@ -1374,6 +1374,12 @@ test('NamedTuple8', () => {
     TestUtils.validateResults(analysisResults, 0);
 });
 
+test('NamedTuple9', () => {
+    const analysisResults = TestUtils.typeAnalyzeSampleFiles(['namedTuple9.py']);
+
+    TestUtils.validateResults(analysisResults, 3);
+});
+
 test('Slots1', () => {
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['slots1.py']);
 


### PR DESCRIPTION
…guage keyword. Also added minimal support for the `rename` parameter to the `namedtuple` function. This addresses #5423.