### PR TITLE
Add capability for Pylance to override strings

### DIFF
--- a/packages/pyright-internal/src/localization/localize.ts
+++ b/packages/pyright-internal/src/localization/localize.ts
@@ -50,7 +50,7 @@ type StringLookupMap = { [key: string]: string | StringLookupMap };
 let localizedStrings: StringLookupMap | undefined = undefined;
 let defaultStrings: StringLookupMap = {};
 
-function getRawString(key: string): string {
+function getRawStringDefault(key: string): string {
     if (localizedStrings === undefined) {
         localizedStrings = initialize();
     }
@@ -63,6 +63,16 @@ function getRawString(key: string): string {
     }
 
     fail(`Missing localized string for key "${key}"`);
+}
+
+let getRawString = getRawStringDefault;
+
+// Function allowing different strings to be used for messages.
+// Returns the previous function used for getting messages.
+export function setGetRawString(func: (key: string) => string): (key: string) => string {
+    const oldLookup = getRawString;
+    getRawString = func;
+    return oldLookup;
 }
 
 export function getRawStringFromMap(map: StringLookupMap, keyParts: string[]): string | undefined {

--- a/packages/pyright-internal/src/tests/localizer.test.ts
+++ b/packages/pyright-internal/src/tests/localizer.test.ts
@@ -9,7 +9,7 @@
 
 import * as assert from 'assert';
 
-import { Localizer, ParameterizedString } from '../localization/localize';
+import { Localizer, ParameterizedString, setGetRawString } from '../localization/localize';
 
 const namespaces = [Localizer.Diagnostic, Localizer.DiagnosticAddendum, Localizer.CodeAction];
 
@@ -44,4 +44,26 @@ test('Raw strings present', () => {
             stringContentMap.set(formatString, key);
         });
     });
+});
+
+test('Override a specific string', () => {
+    // eslint-disable-next-line prefer-const
+    let originalRawString: ((key: string) => string) | undefined;
+    function overrideImportResolve(key: string): string {
+        if (key === 'Diagnostic.importResolveFailure') {
+            return 'Import is {importName}';
+        }
+        return originalRawString!(key);
+    }
+    originalRawString = setGetRawString(overrideImportResolve);
+
+    const value = Localizer.Diagnostic.importResolveFailure().format({ importName: 'foo' });
+
+    try {
+        assert.equal(value, 'Import is foo');
+        const nonMovedValue = Localizer.Diagnostic.abstractMethodInvocation().format({ method: 'foo' });
+        assert.equal(nonMovedValue, 'Method "foo" cannot be called because it is abstract');
+    } finally {
+        setGetRawString(originalRawString);
+    }
 });


### PR DESCRIPTION
This change allows Pylance to implement these two features:
https://github.com/microsoft/pylance-release/issues/4482
https://github.com/microsoft/pylance-release/issues/4368#issuecomment-1618831643

Essentially just a hook into when a string is loaded.