### PR TITLE
Fixed a bug in type narrowing for pattern matching in the negative (f…

### DIFF
--- a/packages/pyright-internal/src/analyzer/patternMatching.ts
+++ b/packages/pyright-internal/src/analyzer/patternMatching.ts
@@ -61,6 +61,7 @@ import {
 import {
     addConditionToType,
     applySolvedTypeVars,
+    containsAnyOrUnknown,
     convertToInstance,
     doForEachSubtype,
     getTypeCondition,
@@ -207,7 +208,7 @@ function narrowTypeBasedOnSequencePattern(
         }
 
         let isPlausibleMatch = true;
-        let isDefiniteMatch = true;
+        let isDefiniteMatch = !containsAnyOrUnknown(type, /* recurse */ false);
         const narrowedEntryTypes: Type[] = [];
         let canNarrowTuple = entry.isTuple;
 

--- a/packages/pyright-internal/src/tests/samples/matchSequence1.py
+++ b/packages/pyright-internal/src/tests/samples/matchSequence1.py
@@ -32,6 +32,14 @@ def test_unknown(value_to_match):
             reveal_type(g1, expected_text="list[Unknown]")
 
 
+def test_any(value_to_match: Any):
+    match value_to_match:
+        case [*a1]:
+            reveal_type(a1, expected_text="list[Any]")
+        case b1:
+            reveal_type(b1, expected_text="Any")
+
+
 def test_list(value_to_match: List[str]):
     match value_to_match:
         case a1, a2:


### PR DESCRIPTION
…all-through) case when the subject type contains an `Any`. This addresses #5492.