### PR TITLE
Match CPython's __hash__ overriding behavior when __eq__ exists

### DIFF
--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -15563,6 +15563,15 @@ export function createTypeEvaluator(importLookup: ImportLookup, evaluatorOptions
             ? new Map<string, Symbol>(innerScope.symbolTable)
             : new Map<string, Symbol>();
 
+        // Determine whether the class should inherit __hash__. If a class defines
+        // __eq__ but doesn't define __hash__ then __hash__ is set to None.
+        if (classType.details.fields.has('__eq__') && !classType.details.fields.has('__hash__')) {
+            classType.details.fields.set(
+                '__hash__',
+                Symbol.createWithType(SymbolFlags.ClassMember | SymbolFlags.ClassVar, NoneType.createInstance())
+            );
+        }
+
         // Determine whether the class's instance variables are constrained
         // to those defined by __slots__. We need to do this prior to dataclass
         // processing because dataclasses can implicitly add to the slots

--- a/packages/pyright-internal/src/tests/samples/hash1.py
+++ b/packages/pyright-internal/src/tests/samples/hash1.py
@@ -1,0 +1,18 @@
+# This sample tests that __hash__ is set to None if
+# __hash__isn't set but __eq__ is
+
+
+class A:
+    ...
+
+# This shouldn't error
+A().__hash__()
+
+
+class B:
+    def __eq__(self, value: object) -> bool:
+        ...
+    ...
+
+# This should error because __hash__ is set to None by Python
+B().__hash__()

--- a/packages/pyright-internal/src/tests/samples/hashability2.py
+++ b/packages/pyright-internal/src/tests/samples/hashability2.py
@@ -1,0 +1,44 @@
+# This sample tests that unhashable user classes are detected as unhashable.
+
+class A:
+    ...
+
+s1 = {A()}
+d1 = {A(): 100}
+
+class B:
+    def __eq__(self, other):
+        ...
+
+# Both of these should generate an error because a class that
+# defines __eq__ but not __hash__ is not hashable
+s2 = {B()}
+d2 = {B(): 100}
+
+class C:
+    __hash__: None = None # type: None
+
+class D(B, C):
+    ...
+
+# Both of these should generate an error because B is unhashable.
+s3 = {UnhashableSub()}
+d3 = {UnhashableSub(): 100}
+
+class E:
+    def __hash__(self):
+        ...
+
+class F(D, E):
+    ...
+
+# Both of these should generate an error because D is unhashable.
+s4 = {F()}
+d4 = {F(): 100}
+
+class G(E, D):
+    ...
+
+# Both of these should NOT generate an error because E defines __hash__.
+s5 = {G()}
+d5 = {G(): 100}

--- a/packages/pyright-internal/src/tests/typeEvaluator5.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator5.test.ts
@@ -145,6 +145,16 @@ test('Hashability1', () => {
     TestUtils.validateResults(analysisResults, 10);
 });
 
+test('Hashability2', () => {
+    const analysisResults = TestUtils.typeAnalyzeSampleFiles(['hashability2.py']);
+    TestUtils.validateResults(analysisResults, 6);
+});
+
+test('Hash1', () => {
+    const analysisResults = TestUtils.typeAnalyzeSampleFiles(['hash1.py']);
+    TestUtils.validateResults(analysisResults, 1);
+});
+
 test('Override1', () => {
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['override1.py']);
     TestUtils.validateResults(analysisResults, 3);


### PR DESCRIPTION
https://github.com/python/cpython/blob/main/Objects/typeobject.c#L6794 checks if `__hash__` is overridden (`__eq__` or `__hash__` is defined) and stops `__hash__` from being copied from the base (https://github.com/python/cpython/blob/main/Objects/typeobject.c#L6953). https://github.com/python/cpython/blob/main/Objects/typeobject.c#L7354 sets `__hash__` to `None` if `__hash__` isn't found in the dict.

This should match CPython's behavior.

closes #5446