### PR TITLE
Add fsevents as optional dependency to public package

### DIFF
--- a/packages/pyright/package.json
+++ b/packages/pyright/package.json
@@ -22,6 +22,9 @@
         "prepack": "npm run clean && shx cp ../../README.md . && shx cp ../../LICENSE.txt . && npm run build",
         "webpack": "webpack --mode development --progress"
     },
+    "optionalDependencies": {
+        "fsevents": "~2.3.2"
+    },
     "devDependencies": {
         "@types/copy-webpack-plugin": "^10.1.0",
         "@types/node": "^17.0.45",


### PR DESCRIPTION
I believe this should resolve https://github.com/microsoft/pyright/issues/5415, but I'm not an expert here. My understanding is that the published pyright package does the npm equivalent of statically linking the chokidar dependency, which means that fsevents is not pulled in if that linking is done on a machine that is not run on MacOS. 

This setup is not ideal since the version could drift from the one expected the chokidar embedded in `pyright`, but I think it's probably okay. 