### PR TITLE
Fixed bug that resulted in a false positive `reportOverlappingOverloa…

### DIFF
--- a/packages/pyright-internal/src/analyzer/checker.ts
+++ b/packages/pyright-internal/src/analyzer/checker.ts
@@ -2500,9 +2500,7 @@ export class Checker extends ParseTreeWalker {
             /* diag */ undefined,
             new TypeVarContext(getTypeVarScopeId(functionType)),
             /* srcTypeVarContext */ undefined,
-            AssignTypeFlags.SkipSolveTypeVars |
-                AssignTypeFlags.SkipFunctionReturnTypeCheck |
-                AssignTypeFlags.OverloadOverlapCheck
+            AssignTypeFlags.SkipFunctionReturnTypeCheck | AssignTypeFlags.OverloadOverlapCheck
         );
     }
 

--- a/packages/pyright-internal/src/tests/samples/overload5.py
+++ b/packages/pyright-internal/src/tests/samples/overload5.py
@@ -1,7 +1,7 @@
 # This sample tests the type checker's detection of overlapping
 # overload declarations.
 
-from typing import Any, Generic, Literal, Protocol, Sequence, TypeVar, overload
+from typing import Any, AnyStr, Generic, Literal, Protocol, Sequence, TypeVar, overload
 
 
 @overload
@@ -348,3 +348,20 @@ def func19(a: Any, b: DProto1) -> Any:
 
 def func19(a: Any, b: Any) -> Any:
     return a + b
+
+
+AllStr = bytes | str
+
+
+@overload
+def func20(choices: AnyStr) -> AnyStr:
+    ...
+
+
+@overload
+def func20(choices: AllStr) -> AllStr:
+    ...
+
+
+def func20(choices: AllStr) -> AllStr:
+    ...


### PR DESCRIPTION
…d` error when overload contained the use of a constrained TypeVar. This addresses #5511.