### PR TITLE
Fixed a bug that resulted in a false negative when assigning a `T | N…

### DIFF
--- a/packages/pyright-internal/src/tests/samples/protocol17.py
+++ b/packages/pyright-internal/src/tests/samples/protocol17.py
@@ -97,3 +97,7 @@ class Protocol9(Protocol[_T1_co]):
 class Protocol10(Protocol[_T1_co]):
     def m1(self) -> type[_T1_co]:
         ...
+
+
+class Protocol11(Protocol[_T1]):
+    x: _T1 | None


### PR DESCRIPTION
…one` type to `object | None` in an invariant context. This same bug led to issues with the validation of TypeVar variance within a Protocol. This addresses https://github.com/microsoft/pylance-release/issues/4613.