### PR TITLE
Added code to detect more cases where a runtime "object is not hashab…

### DIFF
--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -15567,6 +15567,15 @@ export function createTypeEvaluator(importLookup: ImportLookup, evaluatorOptions
             ? new Map<string, Symbol>(innerScope.symbolTable)
             : new Map<string, Symbol>();
 
+        // Determine whether the class should inherit __hash__. If a class defines
+        // __eq__ but doesn't define __hash__ then __hash__ is set to None.
+        if (classType.details.fields.has('__eq__') && !classType.details.fields.has('__hash__')) {
+            classType.details.fields.set(
+                '__hash__',
+                Symbol.createWithType(SymbolFlags.ClassMember | SymbolFlags.ClassVar, NoneType.createInstance())
+            );
+        }
+
         // Determine whether the class's instance variables are constrained
         // to those defined by __slots__. We need to do this prior to dataclass
         // processing because dataclasses can implicitly add to the slots

--- a/packages/pyright-internal/src/tests/samples/hashability2.py
+++ b/packages/pyright-internal/src/tests/samples/hashability2.py
@@ -1,0 +1,55 @@
+# This sample tests that unhashable user classes are detected as unhashable.
+
+
+class A:
+    ...
+
+
+s1 = {A()}
+d1 = {A(): 100}
+
+
+class B:
+    def __eq__(self, other):
+        ...
+
+
+# Both of these should generate an error because a class that
+# defines __eq__ but not __hash__ is not hashable.
+s2 = {B()}
+d2 = {B(): 100}
+
+
+class C:
+    __hash__: None = None
+
+
+class D(B, C):
+    ...
+
+
+# Both of these should generate an error because B is unhashable.
+s3 = {UnhashableSub()}
+d3 = {UnhashableSub(): 100}
+
+
+class E:
+    def __hash__(self):
+        ...
+
+
+class F(D, E):
+    ...
+
+
+# Both of these should generate an error because D is unhashable.
+s4 = {F()}
+d4 = {F(): 100}
+
+
+class G(E, D):
+    ...
+
+
+s5 = {G()}
+d5 = {G(): 100}

--- a/packages/pyright-internal/src/tests/samples/hashability3.py
+++ b/packages/pyright-internal/src/tests/samples/hashability3.py
@@ -1,0 +1,21 @@
+# This sample tests that __hash__ is set to None if
+# __hash__ isn't set but __eq__ is.
+
+
+class A:
+    ...
+
+
+A().__hash__()
+
+
+class B:
+    def __eq__(self, value: object) -> bool:
+        ...
+
+    ...
+
+
+# This should generate an error because __hash__ is implicitly set to None
+# for a class that defines __eq__ but not __hash__.
+B().__hash__()

--- a/packages/pyright-internal/src/tests/typeEvaluator5.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator5.test.ts
@@ -145,6 +145,16 @@ test('Hashability1', () => {
     TestUtils.validateResults(analysisResults, 10);
 });
 
+test('Hashability2', () => {
+    const analysisResults = TestUtils.typeAnalyzeSampleFiles(['hashability2.py']);
+    TestUtils.validateResults(analysisResults, 6);
+});
+
+test('Hashability3', () => {
+    const analysisResults = TestUtils.typeAnalyzeSampleFiles(['hashability3.py']);
+    TestUtils.validateResults(analysisResults, 1);
+});
+
 test('Override1', () => {
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['override1.py']);
     TestUtils.validateResults(analysisResults, 3);


### PR DESCRIPTION
…le" error is generated. This occurs when a class overrides `__eq__` but does not supply a custom `__hash__` method. This addresses #5446.