### PR TITLE
Fixed a bug that resulted in a false positive when an expression of t…

### DIFF
--- a/packages/pyright-internal/src/tests/samples/memberAccess22.py
+++ b/packages/pyright-internal/src/tests/samples/memberAccess22.py
@@ -1,0 +1,15 @@
+# This sample tests the case where a `type[T]` or `type[Self]` typevar is
+# used as the base for a member access but is then used to call an
+# instance method on the resulting class.
+
+from contextlib import contextmanager
+
+
+class A:
+    @classmethod
+    def method1(cls) -> None:
+        cls.method2
+
+    @contextmanager
+    def method2(self):
+        yield

--- a/packages/pyright-internal/src/tests/typeEvaluator4.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator4.test.ts
@@ -525,6 +525,11 @@ test('MemberAccess21', () => {
     TestUtils.validateResults(analysisResults, 1);
 });
 
+test('MemberAccess22', () => {
+    const analysisResults = TestUtils.typeAnalyzeSampleFiles(['memberAccess22.py']);
+    TestUtils.validateResults(analysisResults, 0);
+});
+
 test('DataClassNamedTuple1', () => {
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['dataclassNamedTuple1.py']);
 


### PR DESCRIPTION
…ype `type[Self]` was used as the base type for a member access expression that was then used to call an instance method on that class. This addresses #5530.