### PR TITLE
Improved error messages for situations where a call expression target…

### DIFF
--- a/packages/pyright-internal/src/tests/typeEvaluator2.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator2.test.ts
@@ -75,7 +75,7 @@ test('Assignment1', () => {
 test('Assignment2', () => {
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['assignment2.py']);
 
-    TestUtils.validateResults(analysisResults, 3);
+    TestUtils.validateResults(analysisResults, 2);
 });
 
 test('Assignment3', () => {


### PR DESCRIPTION
…s an overloaded function or method and there are no matches. Added some heuristics to pick the "best" overload function for the error message. Previously, pyright used the last overload, but this sometimes led to confusing errors. This addresses #5525.