### PR TITLE
Added support for the `X is C` and `X is not C` type guard pattern (w…

### DIFF
--- a/docs/type-concepts-advanced.md
+++ b/docs/type-concepts-advanced.md
@@ -62,6 +62,7 @@ In addition to assignment-based type narrowing, Pyright supports the following t
 * `type(x) is T` and `type(x) is not T`
 * `type(x) == T` and `type(x) != T`
 * `x is E` and `x is not E` (where E is a literal enum or bool)
+* `x is C` and `x is not C` (where C is a class)
 * `x == L` and `x != L` (where L is an expression that evaluates to a literal type)
 * `x.y is None` and `x.y is not None` (where x is a type that is distinguished by a field with a None)
 * `x.y is E` and `x.y is not E` (where E is a literal enum or bool and x is a type that is distinguished by a field with a literal type)

--- a/packages/pyright-internal/src/tests/samples/typeNarrowingIsClass1.py
+++ b/packages/pyright-internal/src/tests/samples/typeNarrowingIsClass1.py
@@ -1,0 +1,58 @@
+# This sample tests type narrowing for conditional
+# statements of the form X is <class> or X is not <class>.
+
+from typing import Any, TypeVar, final
+
+
+@final
+class A:
+    ...
+
+
+@final
+class B:
+    ...
+
+
+class C:
+    ...
+
+
+def func1(x: type[A] | type[B] | None | int):
+    if x is A:
+        reveal_type(x, expected_text="type[A]")
+    else:
+        reveal_type(x, expected_text="type[B] | int | None")
+
+
+def func2(x: type[A] | type[B] | None | int, y: type[A]):
+    if x is not y:
+        reveal_type(x, expected_text="type[B] | int | None")
+    else:
+        reveal_type(x, expected_text="type[A]")
+
+
+def func3(x: type[A] | type[B] | Any):
+    if x is A:
+        reveal_type(x, expected_text="type[A] | Any")
+    else:
+        reveal_type(x, expected_text="type[B] | Any")
+
+
+def func4(x: type[A] | type[B] | type[C]):
+    if x is C:
+        reveal_type(x, expected_text="type[C]")
+    else:
+        reveal_type(x, expected_text="type[A] | type[B] | type[C]")
+
+
+T = TypeVar("T")
+
+
+def func5(x: type[A] | type[B] | type[T]) -> type[A] | type[B] | type[T]:
+    if x is A:
+        reveal_type(x, expected_text="type[A] | type[T@func5]")
+    else:
+        reveal_type(x, expected_text="type[B] | type[T@func5]")
+
+    return x

--- a/packages/pyright-internal/src/tests/typeEvaluator1.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator1.test.ts
@@ -315,6 +315,12 @@ test('TypeNarrowingIsNone2', () => {
     TestUtils.validateResults(analysisResults, 0);
 });
 
+test('TypeNarrowingIsClass1', () => {
+    const analysisResults = TestUtils.typeAnalyzeSampleFiles(['typeNarrowingIsClass1.py']);
+
+    TestUtils.validateResults(analysisResults, 0);
+});
+
 test('TypeNarrowingIsNoneTuple1', () => {
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['typeNarrowingIsNoneTuple1.py']);
 


### PR DESCRIPTION
…here `C` is a class). This addresses #5490.