### PR TITLE
Fixed an issue in type evaluation of call expressions where the calla…

### DIFF
--- a/packages/pyright-internal/src/tests/samples/call11.py
+++ b/packages/pyright-internal/src/tests/samples/call11.py
@@ -1,0 +1,44 @@
+# This sample tests the case where a call expression involves a union
+# on the LHS where the subtypes of the union have different signatures.
+
+# pyright: strict
+
+from __future__ import annotations
+from typing import Any, Callable, Generic, Self, TypeAlias, TypeVar
+
+T = TypeVar("T")
+E = TypeVar("E")
+U = TypeVar("U")
+F = TypeVar("F")
+
+Either: TypeAlias = "Left[T]" | "Right[E]"
+
+
+class Left(Generic[T]):
+    def __init__(self, value: T) -> None:
+        self.value = value
+
+    def map_left(self, fn: Callable[[T], U]) -> Left[U]:
+        return Left(fn(self.value))
+
+    def map_right(self, fn: Callable[[Any], Any]) -> Self:
+        return self
+
+
+class Right(Generic[E]):
+    def __init__(self, value: E) -> None:
+        self.value = value
+
+    def map_left(self, fn: Callable[[Any], Any]) -> Self:
+        return self
+
+    def map_right(self, fn: Callable[[E], F]) -> Right[F]:
+        return Right(fn(self.value))
+
+
+def func() -> Either[int, str]:
+    raise NotImplementedError
+
+
+result = func().map_left(lambda lv: lv + 1).map_right(lambda rv: rv + "a")
+reveal_type(result, expected_text="Left[int] | Right[str]")

--- a/packages/pyright-internal/src/tests/typeEvaluator1.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator1.test.ts
@@ -797,6 +797,12 @@ test('Call10', () => {
     TestUtils.validateResults(analysisResults, 3);
 });
 
+test('Call11', () => {
+    const analysisResults = TestUtils.typeAnalyzeSampleFiles(['call11.py']);
+
+    TestUtils.validateResults(analysisResults, 0);
+});
+
 test('Function1', () => {
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['function1.py']);
 


### PR DESCRIPTION
…ble subexpression evaluates to a union, and the callable subtypes have different signatures. Pyright was previously caching the types from the first subtype, so it didn't re-evaluate using the second subtype (which may require bidirectional type inference). This addresses #5428.