### PR TITLE
Added detection and reporting of illegal use of `type[Callable]` with…

### DIFF
--- a/packages/pyright-internal/src/localization/localize.ts
+++ b/packages/pyright-internal/src/localization/localize.ts
@@ -869,6 +869,7 @@ export namespace Localizer {
         export const typeAliasTypeParamInvalid = () => getRawString('Diagnostic.typeAliasTypeParamInvalid');
         export const typeAnnotationCall = () => getRawString('Diagnostic.typeAnnotationCall');
         export const typeAnnotationVariable = () => getRawString('Diagnostic.typeAnnotationVariable');
+        export const typeAnnotationWithCallable = () => getRawString('Diagnostic.typeAnnotationWithCallable');
         export const typeArgListExpected = () => getRawString('Diagnostic.typeArgListExpected');
         export const typeArgListNotAllowed = () => getRawString('Diagnostic.typeArgListNotAllowed');
         export const typeArgsExpectingNone = () =>

--- a/packages/pyright-internal/src/localization/package.nls.en-us.json
+++ b/packages/pyright-internal/src/localization/package.nls.en-us.json
@@ -429,6 +429,7 @@
         "typeArgListExpected": "Expected ParamSpec, ellipsis, or list of types",
         "typeAnnotationCall": "Call expression not allowed in type expression",
         "typeAnnotationVariable": "Variable not allowed in type expression",
+        "typeAnnotationWithCallable": "Type argument for \"type\" must be a class; callables are not supported",
         "typeArgListNotAllowed": "List expression not allowed for this type argument",
         "typeArgsExpectingNone": "Expected no type arguments for class \"{name}\"",
         "typeArgsMismatchOne": "Expected one type argument but received {received}",

--- a/packages/pyright-internal/src/tests/samples/annotations1.py
+++ b/packages/pyright-internal/src/tests/samples/annotations1.py
@@ -1,7 +1,7 @@
 # This sample tests the handling of type annotations within a
 # python source file (as opposed to a stub file).
 
-from typing import TypeVar, Union
+from typing import Any, Callable, TypeVar, Union
 import uuid
 from datetime import datetime
 
@@ -43,9 +43,9 @@ def func10():
 
 # This should generate an error because function calls
 # are not allowed within a type annotation.
-x: func10()
+x1: func10()
 
-y: """
+x2: """
     Union[
         int,
         str
@@ -76,7 +76,7 @@ class ClassD:
 
 # This should generate an error because modules are not allowed in
 # type annotations.
-z: typing
+x3: typing
 
 
 class ClassG:
@@ -106,8 +106,8 @@ def func12(x: type[int]):
     print(x | None)
 
 
-# This should generate an error because foo isn't defined.
-foo: int = foo
+# This should generate an error because x4 isn't defined.
+x4: int = x4
 
 
 class ClassJ:
@@ -121,12 +121,24 @@ def func13(x: type[T]) -> type[T]:
     return x
 
 
-v1 = func13(int)
+x5 = func13(int)
 
 # This should generate an error because variables are not allowed
 # in a type annotation.
-v2: v1 = 1
+x6: x5 = 1
 
 # This should generate an error because variables are not allowed
 # in a type annotation.
-v3: list[v1] = [1]
+x7: list[x5] = [1]
+
+# This should generate an error because a Callable isn't allowed
+# in a "type".
+x8: type[Callable]
+
+# This should generate an error because a Callable isn't allowed
+# in a "type".
+x9: type[func11]
+
+# This should generate an error because a Callable isn't allowed
+# in a "type".
+x10: type[Callable[..., Any]]

--- a/packages/pyright-internal/src/tests/samples/solverHigherOrder5.py
+++ b/packages/pyright-internal/src/tests/samples/solverHigherOrder5.py
@@ -117,7 +117,7 @@ def test_4(pair: Pair[Pair[Pair[A, B], C], D]) -> Pair[Pair[Pair[A, B], C], D]:
 
 @overload
 def test_5(
-    a: type[Callable[P, type[T]]], *, b: Literal[False, None] = ...
+    a: Callable[P, type[T]], *, b: Literal[False, None] = ...
 ) -> type[list[type[T]]]:
     ...
 
@@ -145,5 +145,5 @@ reveal_type(
 val4 = test_5(test_5, b=True)
 reveal_type(
     val4,
-    expected_text="type[list[Overload[(a: type[(**P(1)@test_5) -> type[T(1)@test_5]], *, b: Literal[False] | None = ...) -> type[list[type[T(1)@test_5]]], (a: T(1)@test_5, *args: int, b: Literal[False] | None = ...) -> type[list[T(1)@test_5]], (a: T(1)@test_5, *args: int, b: Literal[True] = ...) -> type[list[T(1)@test_5]], (a: Any, *args: int, b: Any = ...) -> Any]]]",
+    expected_text="type[list[Overload[(a: (**P(1)@test_5) -> type[T(1)@test_5], *, b: Literal[False] | None = ...) -> type[list[type[T(1)@test_5]]], (a: T(1)@test_5, *args: int, b: Literal[False] | None = ...) -> type[list[T(1)@test_5]], (a: T(1)@test_5, *args: int, b: Literal[True] = ...) -> type[list[T(1)@test_5]], (a: Any, *args: int, b: Any = ...) -> Any]]]",
 )

--- a/packages/pyright-internal/src/tests/typeEvaluator1.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator1.test.ts
@@ -890,7 +890,7 @@ test('FunctionMember2', () => {
 test('Annotations1', () => {
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['annotations1.py']);
 
-    TestUtils.validateResults(analysisResults, 13);
+    TestUtils.validateResults(analysisResults, 16);
 });
 
 test('Annotations2', () => {


### PR DESCRIPTION
…in a type annotation. This addresses https://github.com/microsoft/pyright/issues/5546.