### PR TITLE
Fixed an inconsistency in reporting of unbound variables when the var…

### DIFF
--- a/docs/type-concepts-advanced.md
+++ b/docs/type-concepts-advanced.md
@@ -155,6 +155,7 @@ def func4(x: str | None):
 ```
 
 ### Narrowing for Implied Else
+
 When an “if” or “elif” clause is used without a corresponding “else”, Pyright will generally assume that the code can “fall through” without executing the “if” or “elif” block. However, there are cases where the analyzer can determine that a fall-through is not possible because the “if” or “elif” is guaranteed to be executed based on type analysis.
 
 ```python
@@ -220,6 +221,24 @@ reveal_type(b) # list[Any]
 c: Iterable[str] = [""]
 b = c
 reveal_type(b) # list[Any]
+```
+
+### Narrowing for Captured Variables
+
+If a variable’s type is narrowed in an outer scope and the variable is subsequently captured by an inner-scoped function or lambda, Pyright retains the narrowed type if it can determine that the value of the captured variable is not modified on any code path after the inner-scope function or lambda is defined and is not modified in another scope via a `nonlocal` or `global` binding.
+
+```python
+def func(val: int | None):
+    if val is not None:
+
+        def inner_1() -> None:
+            reveal_type(val)  # int
+            print(val + 1)
+
+        inner_2 = lambda: reveal_type(val) + 1  # int
+
+        inner_1()
+        inner_2()
 ```
 
 ### Constrained Type Variables

--- a/packages/pyright-internal/src/tests/samples/capturedVariable1.py
+++ b/packages/pyright-internal/src/tests/samples/capturedVariable1.py
@@ -104,3 +104,18 @@ def func9(x: str | None):
         return x.upper()
 
     return x.upper()
+
+
+def func10(cond: bool, val: str):
+    x: str | None = val if cond else None
+    y: str | None = val if cond else None
+
+    def inner1():
+        nonlocal x
+        x = None
+
+    if x is not None and y is not None:
+
+        def inner2():
+            reveal_type(x, expected_text="str | None")
+            reveal_type(y, expected_text="str")

--- a/packages/pyright-internal/src/tests/samples/unbound5.py
+++ b/packages/pyright-internal/src/tests/samples/unbound5.py
@@ -1,0 +1,31 @@
+# This sample tests the interplay between unbound symbol detection and
+# the code that handles conditional narrowing of captured variables.
+
+from random import random
+
+
+if random() > 0.5:
+    from datetime import datetime
+    from math import cos
+
+# The following should generate an error because datetime
+# is "narrowed" across execution scopes.
+test0 = lambda: datetime
+
+
+def test1():
+    # The following should generate an error because datetime
+    # is "narrowed" across execution scopes.
+    return datetime
+
+
+test2 = lambda: cos
+
+
+def test2():
+    return cos
+
+
+# This modification means that cos will not be narrowed
+# across execution scopes.
+cos = None

--- a/packages/pyright-internal/src/tests/typeEvaluator2.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator2.test.ts
@@ -322,6 +322,12 @@ test('Unbound4', () => {
     TestUtils.validateResults(analysisResults, 2);
 });
 
+test('Unbound5', () => {
+    const analysisResults = TestUtils.typeAnalyzeSampleFiles(['unbound5.py']);
+
+    TestUtils.validateResults(analysisResults, 2);
+});
+
 test('Assert1', () => {
     const configOptions = new ConfigOptions('.');
 


### PR DESCRIPTION
…iable is captured by an inner scope. The new behavior correctly identifies unbound (or potentially unbound) variables in cases where the captured variable is narrowed. This happens when there are no assignments to the variable after it is captured. This addresses #5548.

Fixed a bug in type narrowing for captured variables. Captured variables that are modified in other scopes using a `nonlocal` or `global` binding should be ineligible for type narrowing.