### PR TITLE
Fixed a bug that led to a false positive when a constrained type vari…

### DIFF
--- a/packages/pyright-internal/src/tests/samples/constrainedTypeVar15.py
+++ b/packages/pyright-internal/src/tests/samples/constrainedTypeVar15.py
@@ -1,7 +1,7 @@
 # This sample tests the case where a constrained TypeVar is used
 # as an argument for a constructor or function call.
 
-from typing import TypeVar, Generic
+from typing import AnyStr, Iterable, TypeVar, Generic
 from dataclasses import dataclass
 
 
@@ -26,3 +26,7 @@ def func1(a: Data[_T]) -> _T:
         reveal_type(value, expected_text="ClassA*")
 
     return value
+
+
+def func2(val: AnyStr, objs: Iterable[AnyStr]) -> AnyStr:
+    return val.join(objs)


### PR DESCRIPTION
…able was used as a type argument in an annotation for an argument passed to a method that's bound to the same type variable. This addresses #5556.