### PR TITLE
Fixed a bug that led to a false positive error when using bidirection…

### DIFF
--- a/packages/pyright-internal/src/analyzer/constraintSolver.ts
+++ b/packages/pyright-internal/src/analyzer/constraintSolver.ts
@@ -939,7 +939,7 @@ export function populateTypeVarContextBasedOnExpectedType(
         typeVar.details.isSynthesized = true;
         typeVar.details.synthesizedIndex = index;
         typeVar.details.isExemptFromBoundCheck = true;
-        return typeVar;
+        return TypeVarType.cloneAsInScopePlaceholder(typeVar);
     });
 
     const specializedType = ClassType.cloneForSpecialization(type, typeArgs, /* isTypeArgumentExplicit */ true);
@@ -957,7 +957,31 @@ export function populateTypeVarContextBasedOnExpectedType(
         let isResultValid = true;
 
         synthExpectedTypeArgs.forEach((typeVar, index) => {
-            const synthTypeVar = syntheticTypeVarContext.getPrimarySignature().getTypeVarType(typeVar);
+            let synthTypeVar = syntheticTypeVarContext.getPrimarySignature().getTypeVarType(typeVar);
+            const otherSubtypes: Type[] = [];
+
+            // If the resulting type is a union, try to find a matching type var and move
+            // the remaining subtypes to the "otherSubtypes" array.
+            if (synthTypeVar && isUnion(synthTypeVar)) {
+                let foundSynthTypeVar: TypeVarType | undefined;
+
+                synthTypeVar.subtypes.forEach((subtype) => {
+                    if (
+                        isTypeVar(subtype) &&
+                        subtype.details.isSynthesized &&
+                        subtype.details.synthesizedIndex !== undefined &&
+                        !foundSynthTypeVar
+                    ) {
+                        foundSynthTypeVar = subtype;
+                    } else {
+                        otherSubtypes.push(subtype);
+                    }
+                });
+
+                if (foundSynthTypeVar) {
+                    synthTypeVar = foundSynthTypeVar;
+                }
+            }
 
             // Is this one of the synthesized type vars we allocated above? If so,
             // the type arg that corresponds to this type var maps back to the target type.
@@ -971,6 +995,10 @@ export function populateTypeVarContextBasedOnExpectedType(
                     ClassType.getTypeParameters(specializedType)[synthTypeVar.details.synthesizedIndex];
                 if (index < expectedTypeArgs.length) {
                     let typeArgValue: Type | undefined = transformPossibleRecursiveTypeAlias(expectedTypeArgs[index]);
+
+                    if (otherSubtypes.length > 0) {
+                        typeArgValue = combineTypes([typeArgValue, ...otherSubtypes]);
+                    }
 
                     if (liveTypeVarScopes) {
                         typeArgValue = transformExpectedType(typeArgValue, liveTypeVarScopes, usageOffset);

--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -12682,10 +12682,15 @@ export function createTypeEvaluator(importLookup: ImportLookup, evaluatorOptions
         // Dict and MutableMapping types have invariant value types, so they
         // cannot be narrowed further. Other super-types like Mapping, Collection,
         // and Iterable use covariant value types, so they can be narrowed.
-        const isValueTypeInvariant =
-            isClassInstance(inferenceContext.expectedType) &&
-            (ClassType.isBuiltIn(inferenceContext.expectedType, 'dict') ||
-                ClassType.isBuiltIn(inferenceContext.expectedType, 'MutableMapping'));
+        let isValueTypeInvariant = false;
+        if (isClassInstance(inferenceContext.expectedType)) {
+            if (inferenceContext.expectedType.details.typeParameters.length >= 2) {
+                const valueTypeParam = inferenceContext.expectedType.details.typeParameters[1];
+                if (TypeVarType.getVariance(valueTypeParam) === Variance.Invariant) {
+                    isValueTypeInvariant = true;
+                }
+            }
+        }
 
         // Infer the key and value types if possible.
         if (

--- a/packages/pyright-internal/src/tests/samples/protocol44.py
+++ b/packages/pyright-internal/src/tests/samples/protocol44.py
@@ -1,0 +1,25 @@
+# This sample tests the case where protocol matching requires that the type
+# parameter for the concrete class map to a union of types in the protocol.
+
+from typing import Iterable, Protocol, TypeVar
+
+K = TypeVar("K")
+V = TypeVar("V")
+
+
+class SpecialDict(Protocol[K, V]):
+    def items(self) -> Iterable[tuple[K, V | int]]:
+        ...
+
+    def __getitem__(self, __key: K) -> V | int:
+        ...
+
+    def __setitem__(self, __key: K, __value: V | int) -> None:
+        ...
+
+
+def func1(k: K, v: V) -> SpecialDict[K, V]:
+    x1: SpecialDict[K, V] = {k: v}
+    x2: SpecialDict[K, V] = {k: v, k: 1}
+    x3: SpecialDict[K, V] = {k: 0}
+    return {}

--- a/packages/pyright-internal/src/tests/typeEvaluator2.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator2.test.ts
@@ -1287,6 +1287,12 @@ test('Protocol43', () => {
     TestUtils.validateResults(analysisResults, 0);
 });
 
+test('Protocol44', () => {
+    const analysisResults = TestUtils.typeAnalyzeSampleFiles(['protocol44.py']);
+
+    TestUtils.validateResults(analysisResults, 0);
+});
+
 test('TypedDict1', () => {
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['typedDict1.py']);
 


### PR DESCRIPTION
…al type inference for a dictionary expression when the expected type is a protocol. This addresses #5552.