### PR TITLE
Fixed a bug that led to a hang and eventual crash (due to memory exha…

### DIFF
--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -11115,7 +11115,18 @@ export function createTypeEvaluator(importLookup: ImportLookup, evaluatorOptions
         // specific use case. We may need to make this more sophisticated in
         // the future.
         if (isFunction(returnType) && !returnType.details.name) {
-            return FunctionType.cloneWithNewTypeVarScopeId(returnType, WildcardTypeVarScopeId);
+            const typeVarsInReturnType = getTypeVarArgumentsRecursive(returnType);
+
+            // If there are no unsolved type variables, we're done. If there are
+            // unsolved type parameters, treat them as though they are rescoped
+            // to the callable.
+            if (typeVarsInReturnType.length > 0) {
+                return FunctionType.cloneWithNewTypeVarScopeId(
+                    returnType,
+                    WildcardTypeVarScopeId,
+                    typeVarsInReturnType
+                );
+            }
         }
 
         return returnType;

--- a/packages/pyright-internal/src/analyzer/types.ts
+++ b/packages/pyright-internal/src/analyzer/types.ts
@@ -1648,12 +1648,17 @@ export namespace FunctionType {
         return newFunction;
     }
 
-    export function cloneWithNewTypeVarScopeId(type: FunctionType, newScopeId: TypeVarScopeId): FunctionType {
+    export function cloneWithNewTypeVarScopeId(
+        type: FunctionType,
+        newScopeId: TypeVarScopeId,
+        typeParameters: TypeVarType[]
+    ): FunctionType {
         const newFunction = TypeBase.cloneType(type);
 
         // Make a shallow clone of the details.
         newFunction.details = { ...type.details };
         newFunction.details.typeVarScopeId = newScopeId;
+        newFunction.details.typeParameters = typeParameters;
 
         return newFunction;
     }

--- a/packages/pyright-internal/src/tests/samples/typeVar12.py
+++ b/packages/pyright-internal/src/tests/samples/typeVar12.py
@@ -48,6 +48,17 @@ def func7() -> Callable[P, None] | None:
     return
 
 
+def func8() -> Callable[[T], T]:
+    ...
+
+
+func9 = func8()
+v1 = func9(func9)
+reveal_type(v1, expected_text="(T(1)@func8) -> T(1)@func8")
+v2 = func9(func9(func9))
+reveal_type(v2, expected_text="(T(2)(1)@func8) -> T(2)(1)@func8")
+
+
 class A(Generic[T]):
     def method1(self) -> Callable[[T], T] | None:
         x: Optional[T] = None


### PR DESCRIPTION
…ustion) under certain circumstances where a function returns a generic `Callable` whose type parameters are not used in the input parameters for the function. This addresses #5540.