### PR TITLE
Modified the heuristics used for narrowing on assignment when the ass…

### DIFF
--- a/packages/pyright-internal/src/analyzer/typeUtils.ts
+++ b/packages/pyright-internal/src/analyzer/typeUtils.ts
@@ -2166,6 +2166,22 @@ export function getMembersForModule(moduleType: ModuleType, symbolTable: SymbolT
     });
 }
 
+// Determines if the type contains an Any recursively.
+export function containsAnyRecursive(type: Type): boolean {
+    class AnyWalker extends TypeWalker {
+        foundAny = false;
+
+        override visitAny(type: AnyType) {
+            this.foundAny = true;
+            this.cancelWalk();
+        }
+    }
+
+    const walker = new AnyWalker();
+    walker.walk(type);
+    return walker.foundAny;
+}
+
 // Determines if the type contains an Any or Unknown type. If so,
 // it returns the Any or Unknown type. Unknowns are preferred over
 // Any if both are present. If recurse is true, it will recurse

--- a/packages/pyright-internal/src/tests/samples/assignment10.py
+++ b/packages/pyright-internal/src/tests/samples/assignment10.py
@@ -1,4 +1,7 @@
-# This sample tests some cases where types are narrowed on assignment.
+# This sample tests some cases where types are narrowed on assignment,
+# including some cases that involve "Any".
+
+from typing import Any
 
 
 class A:
@@ -12,3 +15,25 @@ class A:
         if cls.instance is None:
             cls.instance = cls()
         return cls.instance.foo
+
+
+def func1(v1: list[Any | None], v2: list[int | str]):
+    x1: list[int | None] = v1
+    reveal_type(x1, expected_text="list[int | None]")
+
+    x2: list[Any] = v2
+    reveal_type(x2, expected_text="list[Any]")
+
+    x3: list[Any | str] = v2
+    reveal_type(x3, expected_text="list[Any | str]")
+
+
+def func2(v1: dict[int, Any | None], v2: dict[int, int | str]):
+    x1: dict[int, int | None] = v1
+    reveal_type(x1, expected_text="dict[int, int | None]")
+
+    x2: dict[Any, Any] = v2
+    reveal_type(x2, expected_text="dict[Any, Any]")
+
+    x3: dict[Any, Any | str] = v2
+    reveal_type(x3, expected_text="dict[Any, Any | str]")

--- a/packages/pyright-internal/src/tests/samples/expression6.py
+++ b/packages/pyright-internal/src/tests/samples/expression6.py
@@ -5,10 +5,10 @@ from typing import Any
 
 
 def func_or(a: dict[str, Any] | None):
-    a = a or dict()
+    a = a or {"": 0}
     reveal_type(a, expected_text="dict[str, Any]")
 
 
 def func_and():
-    a: dict[str, Any] | None = True and dict()
+    a: dict[str, Any] | None = True and {"": 0}
     reveal_type(a, expected_text="dict[str, Any]")


### PR DESCRIPTION
…igned type contains an `Any`. If the target's declared type does not contain `Any`, the assignment shouldn't produce an `Any` within the resulting type. This addresses #5413.