### PR TITLE
Added support for type narrowing of a class pattern when the specifie…

### DIFF
--- a/packages/pyright-internal/src/tests/samples/matchClass4.py
+++ b/packages/pyright-internal/src/tests/samples/matchClass4.py
@@ -1,0 +1,47 @@
+# This sample tests the case where a subject is narrowed against a
+# class pattern that includes a type() or subclass thereof and
+# the subject contains a type[T].
+
+
+class MyMeta(type):
+    pass
+
+
+class A:
+    pass
+
+
+class B(A, metaclass=MyMeta):
+    pass
+
+
+def func1(subj: type[A]):
+    match subj:
+        case type():
+            reveal_type(subj, expected_text="type[A]")
+        case _:
+            reveal_type(subj, expected_text="Never")
+
+
+def func2(subj: type[A]):
+    match subj:
+        case MyMeta():
+            reveal_type(subj, expected_text="type[A]")
+        case _:
+            reveal_type(subj, expected_text="type[A]")
+
+
+def func3(subj: type[B]):
+    match subj:
+        case MyMeta():
+            reveal_type(subj, expected_text="type[B]")
+        case _:
+            reveal_type(subj, expected_text="Never")
+
+
+def func4(subj: type[B] | type[int]):
+    match subj:
+        case MyMeta():
+            reveal_type(subj, expected_text="type[B] | type[int]")
+        case _:
+            reveal_type(subj, expected_text="type[int]")

--- a/packages/pyright-internal/src/tests/typeEvaluator3.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator3.test.ts
@@ -1222,6 +1222,14 @@ test('MatchClass3', () => {
     TestUtils.validateResults(analysisResults, 0);
 });
 
+test('MatchClass4', () => {
+    const configOptions = new ConfigOptions('.');
+
+    configOptions.defaultPythonVersion = PythonVersion.V3_10;
+    const analysisResults = TestUtils.typeAnalyzeSampleFiles(['matchClass4.py'], configOptions);
+    TestUtils.validateResults(analysisResults, 0);
+});
+
 test('MatchValue1', () => {
     const configOptions = new ConfigOptions('.');
 


### PR DESCRIPTION
…d class is `type()` or a subtype thereof and the subject contains a `type[X]` whose metaclass potentially matches the pattern. This addresses https://github.com/microsoft/pyright/issues/5573.