### PR TITLE
Fixed a bug that resulted in a false positive error when attempting t…

### DIFF
--- a/packages/pyright-internal/src/analyzer/constraintSolver.ts
+++ b/packages/pyright-internal/src/analyzer/constraintSolver.ts
@@ -412,12 +412,19 @@ export function assignTypeToTypeVar(
         if (isEffectivelyInstantiable(adjSrcType)) {
             adjSrcType = convertToInstance(adjSrcType, /* includeSubclasses */ false);
         } else {
-            diag?.addMessage(
-                Localizer.DiagnosticAddendum.typeAssignmentMismatch().format(
-                    evaluator.printSrcDestTypes(srcType, destType)
-                )
-            );
-            return false;
+            // Handle the case of a TypeVar that has a bound of `type`.
+            const concreteAdjSrcType = evaluator.makeTopLevelTypeVarsConcrete(adjSrcType);
+
+            if (isEffectivelyInstantiable(concreteAdjSrcType)) {
+                adjSrcType = convertToInstance(concreteAdjSrcType);
+            } else {
+                diag?.addMessage(
+                    Localizer.DiagnosticAddendum.typeAssignmentMismatch().format(
+                        evaluator.printSrcDestTypes(srcType, destType)
+                    )
+                );
+                return false;
+            }
         }
     } else if (
         isTypeVar(srcType) &&

--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -5636,7 +5636,7 @@ export function createTypeEvaluator(importLookup: ImportLookup, evaluatorOptions
                         // a descriptor protocol, only 'get' operations are allowed. If it's accessed
                         // through the object, all access methods are supported.
                         if (isAccessedThroughObject || usage.method === 'get') {
-                            lookupClass = convertToInstance(concreteSubtype.details.effectiveMetaclass) as ClassType;
+                            lookupClass = ClassType.cloneAsInstance(concreteSubtype.details.effectiveMetaclass);
                             isAccessedThroughMetaclass = true;
                         } else {
                             lookupClass = undefined;

--- a/packages/pyright-internal/src/analyzer/typeUtils.ts
+++ b/packages/pyright-internal/src/analyzer/typeUtils.ts
@@ -1988,12 +1988,18 @@ export function convertToInstance(type: Type, includeSubclasses = true): Type {
     let result = mapSubtypes(type, (subtype) => {
         switch (subtype.category) {
             case TypeCategory.Class: {
-                // Handle Type[x] as a special case.
-                if (ClassType.isBuiltIn(subtype, 'Type')) {
-                    if (!subtype.typeArguments || subtype.typeArguments.length < 1) {
-                        return UnknownType.create();
+                // Handle type[x] as a special case.
+                if (ClassType.isBuiltIn(subtype, 'type')) {
+                    if (TypeBase.isInstance(subtype)) {
+                        if (!subtype.typeArguments || subtype.typeArguments.length < 1) {
+                            return UnknownType.create();
+                        } else {
+                            return subtype.typeArguments[0];
+                        }
                     } else {
-                        return convertToInstantiable(subtype.typeArguments[0]);
+                        if (subtype.typeArguments && subtype.typeArguments.length > 0) {
+                            return convertToInstantiable(subtype.typeArguments[0]);
+                        }
                     }
                 }
 

--- a/packages/pyright-internal/src/tests/samples/solver28.py
+++ b/packages/pyright-internal/src/tests/samples/solver28.py
@@ -1,0 +1,17 @@
+# This sample tests the case where a TypeVar has a bound of `type` and
+# is assigned to a `type[T]`.
+
+from typing import TypeVar
+
+T = TypeVar("T")
+S = TypeVar("S", bound=type)
+
+
+def func1(x: type[T]) -> type[T]:
+    return x
+
+
+def func2(x: S) -> S:
+    v1 = func1(x)
+    reveal_type(v1, expected_text="Unknown")
+    return v1

--- a/packages/pyright-internal/src/tests/typeEvaluator2.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator2.test.ts
@@ -665,6 +665,12 @@ test('Solver27', () => {
     TestUtils.validateResults(analysisResults, 0);
 });
 
+test('Solver28', () => {
+    const analysisResults = TestUtils.typeAnalyzeSampleFiles(['solver28.py']);
+
+    TestUtils.validateResults(analysisResults, 0);
+});
+
 test('SolverScoring1', () => {
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['solverScoring1.py']);
 


### PR DESCRIPTION
…o assign a TypeVar `T` that has a bound of `type` to an expression `type[S]`. This addresses #5581.