### PR TITLE
Removed support for experimental `StrictTypeGuard` and replaced it wi…

### DIFF
--- a/packages/pyright-internal/src/analyzer/binder.ts
+++ b/packages/pyright-internal/src/analyzer/binder.ts
@@ -4055,7 +4055,6 @@ export class Binder extends ParseTreeWalker {
             'OrderedDict',
             'Concatenate',
             'TypeGuard',
-            'StrictTypeGuard',
             'Unpack',
             'Self',
             'NoReturn',

--- a/packages/pyright-internal/src/analyzer/typeGuards.ts
+++ b/packages/pyright-internal/src/analyzer/typeGuards.ts
@@ -695,7 +695,7 @@ export function getTypeNarrowingCallback(
                     return (
                         type.details.declaredReturnType &&
                         isClassInstance(type.details.declaredReturnType) &&
-                        ClassType.isBuiltIn(type.details.declaredReturnType, ['TypeGuard', 'StrictTypeGuard'])
+                        ClassType.isBuiltIn(type.details.declaredReturnType, 'TypeGuard')
                     );
                 };
 

--- a/packages/pyright-internal/src/analyzer/typeUtils.ts
+++ b/packages/pyright-internal/src/analyzer/typeUtils.ts
@@ -2527,7 +2527,6 @@ export function requiresTypeArguments(classType: ClassType) {
             'Literal',
             'Annotated',
             'TypeGuard',
-            'StrictTypeGuard',
         ];
 
         if (specialClasses.some((t) => t === (classType.aliasName || classType.details.name))) {

--- a/packages/pyright-internal/src/localization/localize.ts
+++ b/packages/pyright-internal/src/localization/localize.ts
@@ -821,11 +821,6 @@ export namespace Localizer {
         export const staticClsSelfParam = () => getRawString('Diagnostic.staticClsSelfParam');
         export const stdlibModuleOverridden = () =>
             new ParameterizedString<{ name: string; path: string }>(getRawString('Diagnostic.stdlibModuleOverridden'));
-
-        export const strictTypeGuardReturnType = () =>
-            new ParameterizedString<{ type: string; returnType: string }>(
-                getRawString('Diagnostic.strictTypeGuardReturnType')
-            );
         export const stringNonAsciiBytes = () => getRawString('Diagnostic.stringNonAsciiBytes');
         export const stringNotSubscriptable = () => getRawString('Diagnostic.stringNotSubscriptable');
         export const stringUnsupportedEscape = () => getRawString('Diagnostic.stringUnsupportedEscape');

--- a/packages/pyright-internal/src/localization/package.nls.cs.json
+++ b/packages/pyright-internal/src/localization/package.nls.cs.json
@@ -406,7 +406,6 @@
         "starStarWildcardNotAllowed": "** není možné použít se zástupným znakem _",
         "staticClsSelfParam": "Statické metody by neměly přijímat parametr self nebo cls",
         "stdlibModuleOverridden": "„{path}“ přepisuje modul stdlib „{name}“",
-        "strictTypeGuardReturnType": "Návratový typ StrictTypeGuard ({returnType}) se nedá přiřadit k typu parametru hodnoty ({type})",
         "stringNonAsciiBytes": "Znak jiný než ASCII není povolený v bajtech řetězcového literálu",
         "stringNotSubscriptable": "Řetězcový výraz není možné v poznámce typu zadat jako dolní index uzavření celé poznámky do uvozovek",
         "stringUnsupportedEscape": "Nepodporovaná řídicí sekvence v řetězcovém literálu",

--- a/packages/pyright-internal/src/localization/package.nls.de.json
+++ b/packages/pyright-internal/src/localization/package.nls.de.json
@@ -406,7 +406,6 @@
         "starStarWildcardNotAllowed": "** kann nicht zusammen mit Platzhalter \"_\" verwendet werden",
         "staticClsSelfParam": "Statische Methoden dürfen keinen \"self\"- oder \"cls\"-Parameter annehmen.",
         "stdlibModuleOverridden": "\"{path}\" überschreibt das stdlib-Modul \"{name}\"",
-        "strictTypeGuardReturnType": "Der Rückgabetyp von StrictTypeGuard (\"{returnType}\") kann dem Wertparametertyp nicht zugewiesen werden (\"{type}\").",
         "stringNonAsciiBytes": "Ein Nicht-ASCII-Zeichen ist im Zeichenfolgenliteral in Bytes nicht zulässig.",
         "stringNotSubscriptable": "Der Zeichenfolgenausdruck kann nicht in der Typanmerkung tiefgestellt werden; schließen Sie die gesamte Anmerkung in Anführungszeichen ein",
         "stringUnsupportedEscape": "Nicht unterstützte Escapesequenz im Zeichenfolgenliteral.",

--- a/packages/pyright-internal/src/localization/package.nls.en-us.json
+++ b/packages/pyright-internal/src/localization/package.nls.en-us.json
@@ -395,7 +395,6 @@
         "starStarWildcardNotAllowed": "** cannot be used with wildcard \"_\"",
         "staticClsSelfParam": "Static methods should not take a \"self\" or \"cls\" parameter",
         "stdlibModuleOverridden": "\"{path}\" is overriding the stdlib module \"{name}\"",
-        "strictTypeGuardReturnType": "Return type of StrictTypeGuard (\"{returnType}\") is not assignable to value parameter type (\"{type}\")",
         "stringNonAsciiBytes": "Non-ASCII character not allowed in bytes string literal",
         "stringNotSubscriptable": "String expression cannot be subscripted in type annotation; enclose entire annotation in quotes",
         "stringUnsupportedEscape": "Unsupported escape sequence in string literal",

--- a/packages/pyright-internal/src/localization/package.nls.es.json
+++ b/packages/pyright-internal/src/localization/package.nls.es.json
@@ -406,7 +406,6 @@
         "starStarWildcardNotAllowed": "** no puede utilizarse con el comodín \"_\".",
         "staticClsSelfParam": "Los métodos estáticos no deben tomar un parámetro \"auto\" o \"cls\".",
         "stdlibModuleOverridden": "\"{path}\" está reemplazando el módulo stdlib \"{name}\"",
-        "strictTypeGuardReturnType": "El tipo de retorno de StrictTypeGuard (\"{returnType}\") no es asignable al tipo de parámetro de valor (\"{type}\")",
         "stringNonAsciiBytes": "Carácter no ASCII no permitido en el literal de cadena de bytes",
         "stringNotSubscriptable": "La expresión de cadena no puede ir entre comillas en la anotación de tipo; encierre toda la anotación entre comillas.",
         "stringUnsupportedEscape": "Secuencia de escape no admitida en el literal de cadena",

--- a/packages/pyright-internal/src/localization/package.nls.fr.json
+++ b/packages/pyright-internal/src/localization/package.nls.fr.json
@@ -406,7 +406,6 @@
         "starStarWildcardNotAllowed": "** ne peut pas être utilisé avec le caractère générique « _ »",
         "staticClsSelfParam": "Les méthodes statiques ne doivent pas prendre de paramètre « self » ou « cls »",
         "stdlibModuleOverridden": "\"{path}\" remplace le module stdlib \"{name}\"",
-        "strictTypeGuardReturnType": "Le type de retour de StrictTypeGuard (« {returnType} ») n’est pas assignable au type de paramètre de valeur (« {type} »)",
         "stringNonAsciiBytes": "Caractère non-ASCII non autorisé dans le littéral de chaîne d'octets",
         "stringNotSubscriptable": "L’expression de chaîne ne peut pas être en indice dans l’annotation de type ; placer l’annotation entière entre guillemets",
         "stringUnsupportedEscape": "Séquence d'échappement non prise en charge dans le littéral de chaîne",

--- a/packages/pyright-internal/src/localization/package.nls.it.json
+++ b/packages/pyright-internal/src/localization/package.nls.it.json
@@ -406,7 +406,6 @@
         "starStarWildcardNotAllowed": "** non può essere usato con il carattere jolly \"_\"",
         "staticClsSelfParam": "I metodi statici non devono accettare un parametro \"self\" o \"cls\"",
         "stdlibModuleOverridden": "\"{path}\" sta eseguendo l'override del modulo stdlib \"{name}\"",
-        "strictTypeGuardReturnType": "Il tipo restituito di StrictTypeGuard (\"{returnType}\") non è assegnabile al tipo di parametro di valore (\"{type}\")",
         "stringNonAsciiBytes": "Carattere non ASCII non consentito nel valore letterale stringa dei byte",
         "stringNotSubscriptable": "L'espressione stringa non può essere in pedice nell'annotazione di tipo. Racchiudere l'intera annotazione tra virgolette",
         "stringUnsupportedEscape": "Sequenza di escape non supportata nel valore letterale stringa",

--- a/packages/pyright-internal/src/localization/package.nls.ja.json
+++ b/packages/pyright-internal/src/localization/package.nls.ja.json
@@ -406,7 +406,6 @@
         "starStarWildcardNotAllowed": "** はワイルドカード \"_\" と共に使用できません",
         "staticClsSelfParam": "静的メソッドに \"self\" または \"cls\" パラメーターを指定することはできません",
         "stdlibModuleOverridden": "\"{path}\" は stdlib モジュール \"{name}\" をオーバーライドしています",
-        "strictTypeGuardReturnType": "StrictTypeGuard (\"{returnType}\") の戻り値の型は、値パラメーター型 (\"{type}\") に割り当てできません",
         "stringNonAsciiBytes": "非 ASCII 文字はバイト文字列リテラルでは使用できません",
         "stringNotSubscriptable": "型注釈では文字列式を添字にすることはできません。注釈全体を引用符で囲んでください",
         "stringUnsupportedEscape": "文字列リテラルでサポートされていないエスケープ シーケンス",

--- a/packages/pyright-internal/src/localization/package.nls.ko.json
+++ b/packages/pyright-internal/src/localization/package.nls.ko.json
@@ -406,7 +406,6 @@
         "starStarWildcardNotAllowed": "**는 와일드카드 \"_\"와 함께 사용할 수 없습니다.",
         "staticClsSelfParam": "정적 메서드는 \"self\" 또는 \"cls\" 매개 변수를 사용하면 안 됩니다.",
         "stdlibModuleOverridden": "‘{path}’이(가) ‘{name}’ stdlib 모듈을 재정의하고 있습니다.",
-        "strictTypeGuardReturnType": "StrictTypeGuard의 반환 형식(\"{returnType}\")은 값 매개 변수 형식(\"{type}\")에 할당할 수 없습니다.",
         "stringNonAsciiBytes": "ASCII가 아닌 문자는 바이트 문자열 리터럴에 허용되지 않습니다.",
         "stringNotSubscriptable": "형식 주석에는 문자열 식을 첨자할 수 없습니다. 전체 주석을 따옴표로 묶습니다.",
         "stringUnsupportedEscape": "문자열 리터럴에 지원되지 않는 이스케이프 시퀀스가 있습니다.",

--- a/packages/pyright-internal/src/localization/package.nls.pl.json
+++ b/packages/pyright-internal/src/localization/package.nls.pl.json
@@ -406,7 +406,6 @@
         "starStarWildcardNotAllowed": "Symbolu ** nie można używać z symbolem wieloznacznym „_”",
         "staticClsSelfParam": "Metody statyczne nie powinny przyjmować parametru „self” ani „cls”.",
         "stdlibModuleOverridden": "Ścieżka „{path}” zastępuje moduł stdlib „{name}”",
-        "strictTypeGuardReturnType": "Zwracanego typu StrictTypeGuard („{returnType}”) nie można przypisać do typu parametru wartości („{type}”)",
         "stringNonAsciiBytes": "Znak inny niż ASCII jest niedozwolony w literale ciągu bajtów",
         "stringNotSubscriptable": "Wyrażenie ciągu nie może być indeksowane w adnotacji typu; ujmij całą adnotację w cudzysłów",
         "stringUnsupportedEscape": "Nieobsługiwana sekwencja ucieczki w literale ciągu",

--- a/packages/pyright-internal/src/localization/package.nls.pt-br.json
+++ b/packages/pyright-internal/src/localization/package.nls.pt-br.json
@@ -406,7 +406,6 @@
         "starStarWildcardNotAllowed": "** não pode ser usado com curinga \"_\"",
         "staticClsSelfParam": "Os métodos estáticos não devem usar um parâmetro \"self\" ou \"cls\"",
         "stdlibModuleOverridden": "\"{path}\" está substituindo o módulo stdlib \"{name}\"",
-        "strictTypeGuardReturnType": "O tipo de retorno strictTypeGuard (\"{returnType}\") não é atribuível ao tipo de parâmetro de valor (\"{type}\")",
         "stringNonAsciiBytes": "Caractere não ASCII não permitido em literal de cadeia de caracteres de bytes",
         "stringNotSubscriptable": "A expressão de cadeia de caracteres não pode ser subscrito na anotação de tipo. Coloque a anotação inteira entre aspas",
         "stringUnsupportedEscape": "Sequência de escape sem suporte no literal de cadeia de caracteres",

--- a/packages/pyright-internal/src/localization/package.nls.qps-ploc.json
+++ b/packages/pyright-internal/src/localization/package.nls.qps-ploc.json
@@ -406,7 +406,6 @@
         "starStarWildcardNotAllowed": "[Ll1UV][นั้** çæññøt þë µsëð wïth wïlðçærð \"_\"Ấğ倪İЂҰक्र्तिृまนั้ढूँ]",
         "staticClsSelfParam": "[mO4QU][นั้§tætïç mëthøðs shøµlð ñøt tækë æ \"sëlf\" ør \"çls\" pæræmëtërẤğ倪İЂҰक्र्तिृまẤğ倪İЂҰक्र्นั้ढूँ]",
         "stdlibModuleOverridden": "[AV6K3][นั้\"{pæth}\" ïs øvërrïðïñg thë stðlïþ møðµlë \"{ñæmë}\"Ấğ倪İЂҰक्र्तिृまẤğ倪İЂҰนั้ढूँ]",
-        "strictTypeGuardReturnType": "[Kn87D][นั้Rëtµrñ tÿpë øf §trïçtTÿpëGµærð (\"{rëtµrñTÿpë}\") ïs ñøt æssïgñæþlë tø vælµë pæræmëtër tÿpë (\"{tÿpë}\")Ấğ倪İЂҰक्र्तिृまẤğ倪İЂҰक्र्तिृまẤğ倪İЂҰक्र्तिृนั้ढूँ]",
         "stringNonAsciiBytes": "[dFNRn][นั้Ñøñ-Æ§ÇÏÏ çhæræçtër ñøt ælløwëð ïñ þÿtës strïñg lïtërælẤğ倪İЂҰक्र्तिृまẤğ倪İЂҰक्นั้ढूँ]",
         "stringNotSubscriptable": "[hKZT7][นั้§trïñg ëxprëssïøñ çæññøt þë sµþsçrïptëð ïñ tÿpë æññøtætïøñ; ëñçløsë ëñtïrë æññøtætïøñ ïñ qµøtësẤğ倪İЂҰक्र्तिृまẤğ倪İЂҰक्र्तिृまẤğ倪İЂҰक्र्นั้ढूँ]",
         "stringUnsupportedEscape": "[K2WsY][นั้Üñsµppørtëð ësçæpë sëqµëñçë ïñ strïñg lïtërælẤğ倪İЂҰक्र्तिृまẤğ倪İนั้ढूँ]",

--- a/packages/pyright-internal/src/localization/package.nls.ru.json
+++ b/packages/pyright-internal/src/localization/package.nls.ru.json
@@ -406,7 +406,6 @@
         "starStarWildcardNotAllowed": "** нельзя использовать с символом подстановки \"_\"",
         "staticClsSelfParam": "Статические методы не принимают в качестве параметра \"self\" и \"cls\"",
         "stdlibModuleOverridden": "\"{path}\" переопределяет модуль stdlib \"{name}\"",
-        "strictTypeGuardReturnType": "Тип значения, возвращаемого StrictTypeGuard (\"{returnType}\"), нельзя присвоить типу параметра значения (\"{type}\")",
         "stringNonAsciiBytes": "Символы, отличные от ASCII, не допускаются в строковом литерале байтов",
         "stringNotSubscriptable": "От строкового выражения нельзя взять подстроку в заметке типа; заключите всю заметку в кавычки",
         "stringUnsupportedEscape": "Неподдерживаемая escape-последовательность в строковом литерале",

--- a/packages/pyright-internal/src/localization/package.nls.tr.json
+++ b/packages/pyright-internal/src/localization/package.nls.tr.json
@@ -406,7 +406,6 @@
         "starStarWildcardNotAllowed": "\"_\" joker karakteriyle ** kullanılamaz",
         "staticClsSelfParam": "Static metotları \"self\" veya \"cls\" parametresi almamalıdır",
         "stdlibModuleOverridden": "\"{path}\", \"{name}\" stdlib modülünü geçersiz kılıyor",
-        "strictTypeGuardReturnType": "StrictTypeGuard’ın dönüş türü (\"{returnType}\") değer parametresi türüne (\"{type}\") atanamaz",
         "stringNonAsciiBytes": "ASCII olmayan karaktere bayt sabit değerli dizesinde izin verilmez",
         "stringNotSubscriptable": "Tür ek açıklamasında dize ifadesi alt simge olarak belirtilemez; ek açıklamanın tamamını tırnak içine alın",
         "stringUnsupportedEscape": "Dize sabit değerinde desteklenmeyen kaçış dizisi",

--- a/packages/pyright-internal/src/localization/package.nls.zh-cn.json
+++ b/packages/pyright-internal/src/localization/package.nls.zh-cn.json
@@ -406,7 +406,6 @@
         "starStarWildcardNotAllowed": "** 不能与通配符“_”一起使用",
         "staticClsSelfParam": "静态方法不应采用“self”或“cls”参数",
         "stdlibModuleOverridden": "\"{path}\"正在替代 stdlib 模块\"{name}\"",
-        "strictTypeGuardReturnType": "StrictTypeGuard(\"{returnType}\")的返回类型不可分配给值参数类型 (\"{type}\")",
         "stringNonAsciiBytes": "不允许使用非 ASCII 字符(以字节为单位)字符串文本",
         "stringNotSubscriptable": "字符串表达式不能在类型批注中下标；将整个批注括在引号中",
         "stringUnsupportedEscape": "字符串文本中不受支持的转义序列",

--- a/packages/pyright-internal/src/localization/package.nls.zh-tw.json
+++ b/packages/pyright-internal/src/localization/package.nls.zh-tw.json
@@ -406,7 +406,6 @@
         "starStarWildcardNotAllowed": "** 不能與萬用字元 \"_\" 搭配使用",
         "staticClsSelfParam": "靜態方法不應採用 \"self\" 或 \"cls\" 參數",
         "stdlibModuleOverridden": "\"{path}\" 正在覆寫 stdlib 模組 \"{name}\"",
-        "strictTypeGuardReturnType": "StrictTypeGuard 的傳回類型 (\"{returnType}\") 不能指派至數值參數類型 (\"{type}\")",
         "stringNonAsciiBytes": "位元組字串常值中不允許非 ASCII 字元",
         "stringNotSubscriptable": "字串運算式不能在類型註釋中下標; 以引號括住整個註釋",
         "stringUnsupportedEscape": "字串常值中不支援的逸出序列",

--- a/packages/pyright-internal/src/tests/samples/typeGuard3.py
+++ b/packages/pyright-internal/src/tests/samples/typeGuard3.py
@@ -1,10 +1,10 @@
-# This sample tests the StrictTypeGuard form.
+# This sample tests the TypeGuard using "strict" semantics.
 
 from typing import Any, Literal, Mapping, Sequence, TypeVar, Union
-from typing_extensions import StrictTypeGuard
+from typing_extensions import TypeGuard
 
 
-def is_str1(val: Union[str, int]) -> StrictTypeGuard[str]:
+def is_str1(val: Union[str, int]) -> TypeGuard[str]:
     return isinstance(val, str)
 
 
@@ -15,7 +15,7 @@ def func1(val: Union[str, int]):
         reveal_type(val, expected_text="int")
 
 
-def is_true(o: object) -> StrictTypeGuard[Literal[True]]:
+def is_true(o: object) -> TypeGuard[Literal[True]]:
     ...
 
 
@@ -28,7 +28,7 @@ def func2(val: bool):
     reveal_type(val, expected_text="bool")
 
 
-def is_list(val: object) -> StrictTypeGuard[list[Any]]:
+def is_list(val: object) -> TypeGuard[list[Any]]:
     return isinstance(val, list)
 
 
@@ -50,7 +50,7 @@ _K = TypeVar("_K")
 _V = TypeVar("_V")
 
 
-def is_dict(val: Mapping[_K, _V]) -> StrictTypeGuard[dict[_K, _V]]:
+def is_dict(val: Mapping[_K, _V]) -> TypeGuard[dict[_K, _V]]:
     return isinstance(val, dict)
 
 
@@ -61,7 +61,7 @@ def func5(val: dict[_K, _V] | Mapping[_K, _V]):
         reveal_type(val, expected_text="dict[_K@func5, _V@func5]")
 
 
-def is_cardinal_direction(val: str) -> StrictTypeGuard[Literal["N", "S", "E", "W"]]:
+def is_cardinal_direction(val: str) -> TypeGuard[Literal["N", "S", "E", "W"]]:
     return val in ("N", "S", "E", "W")
 
 
@@ -87,12 +87,5 @@ class Koala(Animal):
 T = TypeVar("T")
 
 
-def is_marsupial(val: Animal) -> StrictTypeGuard[Kangaroo | Koala]:
+def is_marsupial(val: Animal) -> TypeGuard[Kangaroo | Koala]:
     return isinstance(val, Kangaroo | Koala)
-
-
-# This should generate an error because list[T] isn't assignable to list[T | None].
-def has_no_nones(
-    val: list[T | None],
-) -> StrictTypeGuard[list[T]]:
-    return None not in val

--- a/packages/pyright-internal/src/tests/samples/typeGuard4.py
+++ b/packages/pyright-internal/src/tests/samples/typeGuard4.py
@@ -1,15 +1,14 @@
-# This sample tests that user-defined TypeGuard and StrictTypeGuard can
+# This sample tests that user-defined TypeGuard can
 # be used in an overloaded function.
 
 from enum import Enum
 from typing import Literal, overload
-from typing_extensions import StrictTypeGuard, TypeGuard
+from typing_extensions import TypeGuard
 
 
 class TypeGuardMode(Enum):
     NoTypeGuard = 0
     TypeGuard = 1
-    StrictTypeGuard = 2
 
 
 @overload
@@ -22,16 +21,7 @@ def is_int(obj: object, mode: Literal[TypeGuardMode.TypeGuard]) -> TypeGuard[int
     ...
 
 
-@overload
-def is_int(
-    obj: object, mode: Literal[TypeGuardMode.StrictTypeGuard]
-) -> StrictTypeGuard[int]:
-    ...
-
-
-def is_int(
-    obj: object, mode: TypeGuardMode
-) -> bool | TypeGuard[int] | StrictTypeGuard[int]:
+def is_int(obj: object, mode: TypeGuardMode) -> bool | TypeGuard[int]:
     ...
 
 
@@ -44,13 +34,6 @@ def func_no_typeguard(val: int | str):
 
 def func_typeguard(val: int | str):
     if is_int(val, TypeGuardMode.TypeGuard):
-        reveal_type(val, expected_text="int")
-    else:
-        reveal_type(val, expected_text="int | str")
-
-
-def func_stricttypeguard(val: int | str):
-    if is_int(val, TypeGuardMode.StrictTypeGuard):
         reveal_type(val, expected_text="int")
     else:
         reveal_type(val, expected_text="str")

--- a/packages/pyright-internal/src/tests/typeEvaluator3.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator3.test.ts
@@ -939,7 +939,7 @@ test('TypeGuard3', () => {
     configOptions.diagnosticRuleSet.enableExperimentalFeatures = true;
 
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['typeGuard3.py'], configOptions);
-    TestUtils.validateResults(analysisResults, 1);
+    TestUtils.validateResults(analysisResults, 0);
 });
 
 test('TypeGuard4', () => {

--- a/packages/pyright-internal/typeshed-fallback/stdlib/typing_extensions.pyi
+++ b/packages/pyright-internal/typeshed-fallback/stdlib/typing_extensions.pyi
@@ -485,6 +485,3 @@ else:
 # PEP 705
 ReadOnly: _SpecialForm
 
-
-# Proposed extension to PEP 647
-StrictTypeGuard: _SpecialForm = ...


### PR DESCRIPTION
…th an experimental variant of `TypeGuard` that applies strict semantics if certain conditions are met. This addresses #5601.