### PR TITLE
Updated heuristics for how to handle custom metaclass `__call__` meth…

### DIFF
--- a/packages/pyright-internal/src/analyzer/constructors.ts
+++ b/packages/pyright-internal/src/analyzer/constructors.ts
@@ -74,9 +74,6 @@ export function validateConstructorArguments(
     skipUnknownArgCheck: boolean,
     inferenceContext: InferenceContext | undefined
 ): CallResult {
-    // If there a custom `__call__` method on the metaclass, assume that it
-    // overrides the normal `type.__call__` logic and don't perform the usual
-    // __new__ and __init__ validation.
     const metaclassResult = validateMetaclassCall(
         evaluator,
         errorNode,
@@ -85,8 +82,17 @@ export function validateConstructorArguments(
         skipUnknownArgCheck,
         inferenceContext
     );
+
     if (metaclassResult) {
-        return metaclassResult;
+        const metaclassReturnType = metaclassResult.returnType ?? UnknownType.create();
+
+        // If there a custom `__call__` method on the metaclass that returns
+        // something other than Any or an instance of the class, assume that it
+        // overrides the normal `type.__call__` logic and don't perform the usual
+        // __new__ and __init__ validation.
+        if (metaclassResult.argumentErrors || !evaluator.assignType(convertToInstance(type), metaclassReturnType)) {
+            return metaclassResult;
+        }
     }
 
     // Determine whether the class overrides the object.__new__ method.
@@ -107,7 +113,7 @@ export function validateConstructorArguments(
 
     // If there is a constructor transform, evaluate all arguments speculatively
     // so we can later re-evaluate them in the context of the transform.
-    const returnResult = evaluator.useSpeculativeMode(useConstructorTransform ? errorNode : undefined, () => {
+    let returnResult = evaluator.useSpeculativeMode(useConstructorTransform ? errorNode : undefined, () => {
         return validateNewAndInitMethods(
             evaluator,
             errorNode,
@@ -167,6 +173,21 @@ export function validateConstructorArguments(
                 evaluator.getTypeOfExpression(arg.valueExpression);
             }
         });
+    }
+
+    // Reconcile the metaclass __call__ return type and the __new__ return type.
+    // This is a heuristic because we have no way of knowing how these actually
+    // interact based on the method signatures alone.
+    if (metaclassResult?.returnType) {
+        // If the __new__ and __init__ methods returned `Any` or `Unknown` or `NoReturn`,
+        // use the metaclass return type instead.
+        if (!returnResult.returnType || isAnyOrUnknown(returnResult.returnType)) {
+            if (!isAnyOrUnknown(metaclassResult.returnType)) {
+                returnResult = { ...returnResult, returnType: metaclassResult.returnType };
+            }
+        } else if (returnResult.returnType && isNever(returnResult.returnType)) {
+            returnResult = { ...returnResult, returnType: metaclassResult.returnType };
+        }
     }
 
     return returnResult;

--- a/packages/pyright-internal/src/tests/samples/metaclass7.py
+++ b/packages/pyright-internal/src/tests/samples/metaclass7.py
@@ -3,36 +3,42 @@
 # that are created from it.
 
 
-class FactoryMetaClass1(type):
+class MetaClass1(type):
     def __call__(cls, **kwargs):
-        return cls()
+        return object.__new__(**kwargs)
 
 
-class BaseFactory1:
+class Class1(metaclass=MetaClass1):
     def __new__(cls, *args, **kwargs):
-        raise RuntimeError("You cannot instantiate BaseFactory")
+        raise RuntimeError("Cannot instantiate directly")
 
 
-class Factory1(BaseFactory1, metaclass=FactoryMetaClass1):
-    ...
+v1 = Class1()
+reveal_type(v1, expected_text="Class1")
 
 
-v1 = Factory1()
-reveal_type(v1, expected_text="Factory1")
+class MetaClass2(type):
+    pass
 
 
-class FactoryMetaClass2(type):
-    ...
-
-
-class BaseFactory2:
+class Class2(metaclass=MetaClass2):
     def __new__(cls, *args, **kwargs):
-        raise RuntimeError("You cannot instantiate BaseFactory")
+        raise RuntimeError("Cannot instantiate directly")
 
 
-class Factory2(BaseFactory2, metaclass=FactoryMetaClass2):
-    ...
-
-
-v2 = Factory2()
+v2 = Class2()
 reveal_type(v2, expected_text="NoReturn")
+
+
+class MetaClass3(type):
+    def __call__(cls, *args, **kwargs):
+        return super().__call__(*args, **kwargs)
+
+
+class Class3(metaclass=MetaClass3):
+    def __new__(cls, *args, **kwargs):
+        raise RuntimeError("You cannot instantiate BaseFactory")
+
+
+v3 = Class3()
+reveal_type(v3, expected_text="Any")


### PR DESCRIPTION
…ods based on feedback. Previously, if a metaclass `__call__` method was present, pyright assumed that `__new__` and `__init__` may not be called, so it ignored them. The new heuristic assumes that if the metaclass `__call__` returns a type that is consistent with the expected return type of `type.__call__` that it is probably mirroring the behavior of `type.__call__` and calling the class' `__new__` and `__init__` methods. This addresses https://github.com/microsoft/pyright/issues/5586.