### PR TITLE
Fixed a bug that led to a false negative when determining whether two…

### DIFF
--- a/packages/pyright-internal/src/analyzer/checker.ts
+++ b/packages/pyright-internal/src/analyzer/checker.ts
@@ -5177,7 +5177,7 @@ export class Checker extends ParseTreeWalker {
             return getClassFieldsRecursive(specializedBaseClass);
         });
 
-        const childClassSymbolMap = getClassFieldsRecursive(classType);
+        const childClassSymbolMap = getClassFieldsRecursive(classType, /* skipInitialClass */ true);
 
         for (let symbolMapBaseIndex = 1; symbolMapBaseIndex < baseClassSymbolMaps.length; symbolMapBaseIndex++) {
             const baseSymbolMap = baseClassSymbolMaps[symbolMapBaseIndex];

--- a/packages/pyright-internal/src/analyzer/typeUtils.ts
+++ b/packages/pyright-internal/src/analyzer/typeUtils.ts
@@ -1464,11 +1464,15 @@ export function* getClassIterator(classType: Type, flags = ClassIteratorFlags.De
     return undefined;
 }
 
-export function getClassFieldsRecursive(classType: ClassType): Map<string, ClassMember> {
+export function getClassFieldsRecursive(classType: ClassType, skipInitialClass = false): Map<string, ClassMember> {
     const memberMap = new Map<string, ClassMember>();
 
     // Evaluate the types of members from the end of the MRO to the beginning.
     ClassType.getReverseMro(classType).forEach((mroClass) => {
+        if (skipInitialClass && isClass(mroClass) && ClassType.isSameGenericClass(mroClass, classType)) {
+            return;
+        }
+
         const specializedMroClass = partiallySpecializeType(mroClass, classType);
 
         if (isClass(specializedMroClass)) {

--- a/packages/pyright-internal/src/tests/samples/methodOverride3.py
+++ b/packages/pyright-internal/src/tests/samples/methodOverride3.py
@@ -2,8 +2,7 @@
 # This functionality is controlled by the reportIncompatibleMethodOverride
 # diagnostic rule.
 
-
-from typing import Generic, Iterable, ParamSpec, TypeVar
+from typing import Any, Generic, Iterable, ParamSpec, TypeVar
 
 
 class A1:
@@ -18,7 +17,8 @@ class A2:
 
 # This should generate an error because func1 is incompatible.
 class ASub(A1, A2):
-    ...
+    def func1(self, *args: Any, **kwargs: Any) -> str:
+        ...
 
 
 class B1:


### PR DESCRIPTION
… base classes that are combined using multiple inheritance implement the same method in an incompatible way. The bug caused the check to be skipped if the child class also implemented the same method as the two base classes. This addresses https://github.com/python/mypy/issues/15790.