### PR TITLE
Filter import suggestions when py.typed is available

### DIFF
--- a/packages/pyright-internal/src/tests/fourslash/completions.importPrivateNoPytyped.fourslash.ts
+++ b/packages/pyright-internal/src/tests/fourslash/completions.importPrivateNoPytyped.fourslash.ts
@@ -1,0 +1,32 @@
+// @filename: test_private_completions.py
+//// import testLib.[|/*marker*/|]
+
+// @filename: testLib/__init__.py
+// @library: true
+//// # empty
+
+// @filename: testLib/__privateclass.py
+// @library: true
+//// class PrivateClass():
+////     pass
+
+// @filename: testLib/publicclass.py
+// @library: true
+//// class PublicClass():
+////     pass
+
+// @ts-ignore
+await helper.verifyCompletion('exact', 'markdown', {
+    marker: {
+        completions: [
+            {
+                label: 'publicclass',
+                kind: Consts.CompletionItemKind.Module,
+            },
+            {
+                label: '__privateclass',
+                kind: Consts.CompletionItemKind.Module,
+            },
+        ],
+    },
+});

--- a/packages/pyright-internal/src/tests/fourslash/completions.importPytyped.fourslash.ts
+++ b/packages/pyright-internal/src/tests/fourslash/completions.importPytyped.fourslash.ts
@@ -1,0 +1,32 @@
+// @filename: test_no_private_completions.py
+//// import testLib.[|/*marker*/|]
+
+// @filename: testLib/__init__.py
+// @library: true
+//// # empty
+
+// @filename: testLib/__privateclass.py
+// @library: true
+//// class PrivateClass():
+////     pass
+
+// @filename: testLib/publicclass.py
+// @library: true
+//// class PublicClass():
+////     pass
+
+// @filename: testLib/py.typed
+// @library: true
+//// # has to contain something for file to be written
+
+// @ts-ignore
+await helper.verifyCompletion('exact', 'markdown', {
+    marker: {
+        completions: [
+            {
+                label: 'publicclass',
+                kind: Consts.CompletionItemKind.Module,
+            },
+        ],
+    },
+});

--- a/packages/pyright-internal/src/tests/fourslash/completions.importPytypedLocal.fourslash.ts
+++ b/packages/pyright-internal/src/tests/fourslash/completions.importPytypedLocal.fourslash.ts
@@ -1,0 +1,32 @@
+// @filename: test_no_private_completions.py
+//// import testLib.[|/*marker*/|]
+
+// @filename: testLib/__init__.py
+//// # empty
+
+// @filename: testLib/__privateclass.py
+//// class PrivateClass():
+////     pass
+
+// @filename: testLib/publicclass.py
+//// class PublicClass():
+////     pass
+
+// @filename: testLib/py.typed
+//// # has to contain something for file to be written
+
+// @ts-ignore
+await helper.verifyCompletion('exact', 'markdown', {
+    marker: {
+        completions: [
+            {
+                label: 'publicclass',
+                kind: Consts.CompletionItemKind.Module,
+            },
+            {
+                label: '__privateclass',
+                kind: Consts.CompletionItemKind.Module,
+            },
+        ],
+    },
+});


### PR DESCRIPTION
Addresses https://github.com/microsoft/pylance-release/issues/4528

Apply some extra filtering to import suggestions when py.typed is available.