### PR TITLE
[PylanceBot] Pull Pylance with Pyright 1.1.320

### DIFF
--- a/packages/pyright-internal/src/analyzer/service.ts
+++ b/packages/pyright-internal/src/analyzer/service.ts
@@ -20,7 +20,8 @@ import { ConsoleInterface, LogLevel, StandardConsole, log } from '../common/cons
 import { Diagnostic } from '../common/diagnostic';
 import { FileEditAction } from '../common/editAction';
 import { EditableProgram, Extensions, ProgramMutator, ProgramView } from '../common/extensibility';
-import { FileSystem, FileWatcher, FileWatcherEventType, ignoredWatchEventFunction } from '../common/fileSystem';
+import { FileSystem } from '../common/fileSystem';
+import { FileWatcher, FileWatcherEventType, ignoredWatchEventFunction } from '../common/fileWatcher';
 import { Host, HostFactory, NoAccessHost } from '../common/host';
 import { defaultStubsDirectory } from '../common/pathConsts';
 import {

--- a/packages/pyright-internal/src/backgroundAnalysisBase.ts
+++ b/packages/pyright-internal/src/backgroundAnalysisBase.ts
@@ -37,6 +37,7 @@ import { Host, HostKind } from './common/host';
 import { LogTracker } from './common/logTracker';
 import { Range } from './common/textRange';
 import { BackgroundAnalysisProgram, InvalidatedReason } from './analyzer/backgroundAnalysisProgram';
+import { PyrightFileSystem } from './pyrightFileSystem';
 
 export class BackgroundAnalysisBase {
     private _worker: Worker | undefined;
@@ -264,7 +265,7 @@ export abstract class BackgroundAnalysisRunnerBase extends BackgroundThreadBase 
     protected importResolver: ImportResolver;
     protected logTracker: LogTracker;
 
-    protected constructor(fileSystem?: FileSystem, sourceFileFactory?: ISourceFileFactory) {
+    protected constructor(fileSystem?: PyrightFileSystem, sourceFileFactory?: ISourceFileFactory) {
         super(workerData as InitializationData, fileSystem);
 
         // Stash the base directory into a global variable.

--- a/packages/pyright-internal/src/backgroundThreadBase.ts
+++ b/packages/pyright-internal/src/backgroundThreadBase.ts
@@ -45,13 +45,13 @@ export class BackgroundThreadBase {
     private _console = new BackgroundConsole();
     protected fs: FileSystem;
 
-    protected constructor(data: InitializationData, fileSystem?: FileSystem) {
+    protected constructor(data: InitializationData, fileSystem?: PyrightFileSystem) {
         setCancellationFolderName(data.cancellationFolderName);
 
         // Stash the base directory into a global variable.
         (global as any).__rootDirectory = data.rootDirectory;
 
-        this.fs = new PyrightFileSystem(fileSystem ?? createFromRealFileSystem(this.getConsole()));
+        this.fs = fileSystem ?? new PyrightFileSystem(createFromRealFileSystem(this.getConsole()));
     }
 
     protected log(level: LogLevel, msg: string) {

--- a/packages/pyright-internal/src/common/chokidarFileWatcherProvider.ts
+++ b/packages/pyright-internal/src/common/chokidarFileWatcherProvider.ts
@@ -9,7 +9,7 @@
 import * as chokidar from 'chokidar';
 
 import { ConsoleInterface } from './console';
-import { FileWatcher, FileWatcherEventHandler, FileWatcherProvider } from './fileSystem';
+import { FileWatcher, FileWatcherEventHandler, FileWatcherProvider } from './fileWatcher';
 
 const _isMacintosh = process.platform === 'darwin';
 const _isLinux = process.platform === 'linux';

--- a/packages/pyright-internal/src/common/fileSystem.ts
+++ b/packages/pyright-internal/src/common/fileSystem.ts
@@ -10,21 +10,7 @@
 
 // * NOTE * except tests, this should be only file that import "fs"
 import type * as fs from 'fs';
-
-export type FileWatcherEventType = 'add' | 'addDir' | 'change' | 'unlink' | 'unlinkDir';
-export type FileWatcherEventHandler = (eventName: FileWatcherEventType, path: string, stats?: Stats) => void;
-
-export interface FileWatcher {
-    close(): void;
-}
-
-export interface FileWatcherHandler {
-    onFileChange(eventType: FileWatcherEventType, path: string): void;
-}
-
-export interface FileWatcherProvider {
-    createFileWatcher(paths: string[], listener: FileWatcherEventHandler): FileWatcher;
-}
+import { FileWatcher, FileWatcherEventHandler } from './fileWatcher';
 
 export interface Stats {
     size: number;
@@ -100,39 +86,6 @@ export interface FileSystem extends ReadOnlyFileSystem {
     tmpfile(options?: TmpfileOptions): string;
     dispose(): void;
 }
-
-// File watchers can give "changed" event even for a file open. but for those cases,
-// it will give relative path rather than absolute path. To get rid of such cases,
-// we will drop any event with relative paths. this trick is copied from VS Code
-// (https://github.com/microsoft/vscode/blob/main/src/vs/platform/files/node/watcher/unix/chokidarWatcherService.ts)
-export function ignoredWatchEventFunction(paths: string[]) {
-    const normalizedPaths = paths.map((p) => p.toLowerCase());
-    return (path: string): boolean => {
-        if (!path || path.indexOf('__pycache__') >= 0) {
-            return true;
-        }
-        const normalizedPath = path.toLowerCase();
-        return normalizedPaths.every((p) => normalizedPath.indexOf(p) < 0);
-    };
-}
-
-const nullFileWatcher: FileWatcher = {
-    close() {
-        // empty;
-    },
-};
-
-export const nullFileWatcherHandler: FileWatcherHandler = {
-    onFileChange(_1: FileWatcherEventType, _2: string): void {
-        // do nothing
-    },
-};
-
-export const nullFileWatcherProvider: FileWatcherProvider = {
-    createFileWatcher(_1: string[], _2: FileWatcherEventHandler): FileWatcher {
-        return nullFileWatcher;
-    },
-};
 
 export class VirtualDirent implements fs.Dirent {
     constructor(public name: string, private _file: boolean) {}

--- a/packages/pyright-internal/src/common/fileWatcher.ts
+++ b/packages/pyright-internal/src/common/fileWatcher.ts
@@ -1,0 +1,56 @@
+/*
+ * fileWatcher.ts
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT license.
+ *
+ * file watcher related functionality.
+ */
+import { Stats } from './fileSystem';
+
+export type FileWatcherEventType = 'add' | 'addDir' | 'change' | 'unlink' | 'unlinkDir';
+export type FileWatcherEventHandler = (eventName: FileWatcherEventType, path: string, stats?: Stats) => void;
+
+export interface FileWatcher {
+    close(): void;
+}
+
+export interface FileWatcherHandler {
+    onFileChange(eventType: FileWatcherEventType, path: string): void;
+}
+
+export interface FileWatcherProvider {
+    createFileWatcher(paths: string[], listener: FileWatcherEventHandler): FileWatcher;
+}
+
+export const nullFileWatcherHandler: FileWatcherHandler = {
+    onFileChange(_1: FileWatcherEventType, _2: string): void {
+        // do nothing
+    },
+};
+
+export const nullFileWatcherProvider: FileWatcherProvider = {
+    createFileWatcher(_1: string[], _2: FileWatcherEventHandler): FileWatcher {
+        return nullFileWatcher;
+    },
+};
+
+// File watchers can give "changed" event even for a file open. but for those cases,
+// it will give relative path rather than absolute path. To get rid of such cases,
+// we will drop any event with relative paths. this trick is copied from VS Code
+// (https://github.com/microsoft/vscode/blob/main/src/vs/platform/files/node/watcher/unix/chokidarWatcherService.ts)
+export function ignoredWatchEventFunction(paths: string[]) {
+    const normalizedPaths = paths.map((p) => p.toLowerCase());
+    return (path: string): boolean => {
+        if (!path || path.indexOf('__pycache__') >= 0) {
+            return true;
+        }
+        const normalizedPath = path.toLowerCase();
+        return normalizedPaths.every((p) => normalizedPath.indexOf(p) < 0);
+    };
+}
+
+const nullFileWatcher: FileWatcher = {
+    close() {
+        // empty;
+    },
+};

--- a/packages/pyright-internal/src/common/realFileSystem.ts
+++ b/packages/pyright-internal/src/common/realFileSystem.ts
@@ -12,18 +12,16 @@ import { URI } from 'vscode-uri';
 import { isMainThread } from 'worker_threads';
 
 import { ConsoleInterface, NullConsole } from './console';
-import {
-    FileSystem,
-    FileWatcher,
-    FileWatcherEventHandler,
-    FileWatcherEventType,
-    FileWatcherHandler,
-    FileWatcherProvider,
-    MkDirOptions,
-    nullFileWatcherProvider,
-    TmpfileOptions,
-} from './fileSystem';
+import { FileSystem, MkDirOptions, TmpfileOptions } from './fileSystem';
 import { getRootLength } from './pathUtils';
+import {
+    FileWatcherProvider,
+    nullFileWatcherProvider,
+    FileWatcherEventHandler,
+    FileWatcherHandler,
+    FileWatcherEventType,
+    FileWatcher,
+} from './fileWatcher';
 
 // Automatically remove files created by tmp at process exit.
 tmp.setGracefulCleanup();

--- a/packages/pyright-internal/src/languageService/hoverProvider.ts
+++ b/packages/pyright-internal/src/languageService/hoverProvider.ts
@@ -409,16 +409,7 @@ export class HoverProvider {
                 }
 
                 let type = this._getType(node);
-                const resolvedType =
-                    Extensions.getProgramExtensions(resolvedDecl.node)
-                        .map((e) =>
-                            e.typeProviderExtension?.tryGetFunctionNodeType(
-                                resolvedDecl.node,
-                                this._evaluator,
-                                this._token
-                            )
-                        )
-                        .find((t) => !!t) || this._getType(resolvedDecl.node.name);
+                const resolvedType = this._getType(resolvedDecl.node.name);
                 type = isAnyOrUnknown(type) ? resolvedType : type;
                 const signatureString = getToolTipForType(
                     type,

--- a/packages/pyright-internal/src/localization/package.nls.cs.json
+++ b/packages/pyright-internal/src/localization/package.nls.cs.json
@@ -438,6 +438,7 @@
         "typeAliasTypeParamInvalid": "Seznam parametrů typu musí být řazená kolekce členů obsahující pouze typeVar, TypeVarTuple nebo ParamSpec",
         "typeAnnotationCall": "Výraz volání není ve výrazu typu povolený",
         "typeAnnotationVariable": "Proměnná není ve výrazu typu povolená",
+        "typeAnnotationWithCallable": "Type argument for \"type\" must be a class; callables are not supported",
         "typeArgListExpected": "Očekával se parametr ParamSpec, tři tečky nebo seznam typů",
         "typeArgListNotAllowed": "Výraz seznamu není pro tento argument typu povolený",
         "typeArgsExpectingNone": "Pro třídu {name} se neočekávaly žádné argumenty typu",

--- a/packages/pyright-internal/src/localization/package.nls.de.json
+++ b/packages/pyright-internal/src/localization/package.nls.de.json
@@ -438,6 +438,7 @@
         "typeAliasTypeParamInvalid": "Die Typparameterliste muss ein Tupel sein, das nur TypeVar, TypeVarTuple oder ParamSpec enthält.",
         "typeAnnotationCall": "Der Aufrufausdruck ist im Typausdruck nicht zulässig",
         "typeAnnotationVariable": "Variable im Typausdruck nicht zulässig",
+        "typeAnnotationWithCallable": "Type argument for \"type\" must be a class; callables are not supported",
         "typeArgListExpected": "ParamSpec, Ellipse oder Liste der Typen erwartet",
         "typeArgListNotAllowed": "Der Listenausdruck ist für dieses Typargument nicht zulässig.",
         "typeArgsExpectingNone": "Für die Klasse \"{name}\" werden keine Typargumente erwartet.",

--- a/packages/pyright-internal/src/localization/package.nls.es.json
+++ b/packages/pyright-internal/src/localization/package.nls.es.json
@@ -438,6 +438,7 @@
         "typeAliasTypeParamInvalid": "La lista de parámetros de tipo debe ser una tupla que contenga solo TypeVar, TypeVarTuple o ParamSpec.",
         "typeAnnotationCall": "No se permite la expresión de llamada en la expresión de tipo",
         "typeAnnotationVariable": "Variable no permitida en la expresión de tipo",
+        "typeAnnotationWithCallable": "Type argument for \"type\" must be a class; callables are not supported",
         "typeArgListExpected": "ParamSpec esperado, elipsis o lista de tipos",
         "typeArgListNotAllowed": "Expresión de lista no permitida para este argumento de tipo",
         "typeArgsExpectingNone": "No se esperaban argumentos de tipo para la clase \"{name}\"",

--- a/packages/pyright-internal/src/localization/package.nls.fr.json
+++ b/packages/pyright-internal/src/localization/package.nls.fr.json
@@ -438,6 +438,7 @@
         "typeAliasTypeParamInvalid": "La liste de paramètres de type doit être un tuple contenant uniquement TypeVar, TypeVarTuple ou ParamSpec",
         "typeAnnotationCall": "Expression d'appel non autorisée dans l'expression de type",
         "typeAnnotationVariable": "Variable non autorisée dans l'expression de type",
+        "typeAnnotationWithCallable": "Type argument for \"type\" must be a class; callables are not supported",
         "typeArgListExpected": "ParamSpec, ellipse ou liste de types attendue",
         "typeArgListNotAllowed": "Expression de liste non autorisée pour cet argument de type",
         "typeArgsExpectingNone": "Aucun argument de type attendu pour la classe « {name} »",

--- a/packages/pyright-internal/src/localization/package.nls.it.json
+++ b/packages/pyright-internal/src/localization/package.nls.it.json
@@ -438,6 +438,7 @@
         "typeAliasTypeParamInvalid": "L'elenco dei parametri del tipo deve essere una tupla contenente solo TypeVar, TypeVarTuple o ParamSpec.",
         "typeAnnotationCall": "Espressione di chiamata non consentita nell'espressione di tipo",
         "typeAnnotationVariable": "Variabile non consentita nell'espressione di tipo",
+        "typeAnnotationWithCallable": "Type argument for \"type\" must be a class; callables are not supported",
         "typeArgListExpected": "Previsto ParamSpec, puntini di sospensione o elenco di tipi",
         "typeArgListNotAllowed": "Espressione di elenco non consentita per questo argomento tipo",
         "typeArgsExpectingNone": "Non sono previsti argomenti di tipo per la classe \"{name}\"",

--- a/packages/pyright-internal/src/localization/package.nls.ja.json
+++ b/packages/pyright-internal/src/localization/package.nls.ja.json
@@ -438,6 +438,7 @@
         "typeAliasTypeParamInvalid": "型パラメーター リストは、TypeVar、TypeVarTuple、または ParamSpec のみを含むタプルである必要があります",
         "typeAnnotationCall": "型式では呼び出し式を使用できません",
         "typeAnnotationVariable": "型式では変数を使用できません",
+        "typeAnnotationWithCallable": "Type argument for \"type\" must be a class; callables are not supported",
         "typeArgListExpected": "ParamSpec、省略記号、または型の一覧が必要です",
         "typeArgListNotAllowed": "この型引数にはリスト式を使用できません",
         "typeArgsExpectingNone": "クラス \"{name}\" に型引数が必要ありません",

--- a/packages/pyright-internal/src/localization/package.nls.ko.json
+++ b/packages/pyright-internal/src/localization/package.nls.ko.json
@@ -438,6 +438,7 @@
         "typeAliasTypeParamInvalid": "형식 매개 변수 목록은 TypeVar, TypeVarTuple 또는 ParamSpec만 포함하는 튜플이어야 합니다.",
         "typeAnnotationCall": "형식 식에는 호출 식을 사용할 수 없습니다.",
         "typeAnnotationVariable": "형식 식에는 변수를 사용할 수 없습니다.",
+        "typeAnnotationWithCallable": "Type argument for \"type\" must be a class; callables are not supported",
         "typeArgListExpected": "ParamSpec, 줄임표 또는 형식 목록이 필요합니다.",
         "typeArgListNotAllowed": "이 형식 인수에는 목록 식을 사용할 수 없습니다.",
         "typeArgsExpectingNone": "클래스 \"{name}\"에 형식 인수가 필요하지 않습니다.",

--- a/packages/pyright-internal/src/localization/package.nls.pl.json
+++ b/packages/pyright-internal/src/localization/package.nls.pl.json
@@ -438,6 +438,7 @@
         "typeAliasTypeParamInvalid": "Lista parametrów typu musi być krotką zawierającą tylko parametry TypeVar, TypeVarTuple lub ParamSpec",
         "typeAnnotationCall": "Wyrażenie wywołania jest niedozwolone w wyrażeniu typu",
         "typeAnnotationVariable": "Zmienna niedozwolona w wyrażeniu typu",
+        "typeAnnotationWithCallable": "Type argument for \"type\" must be a class; callables are not supported",
         "typeArgListExpected": "Oczekiwano parametru ParamSpec, wielokropka lub listy typów",
         "typeArgListNotAllowed": "Wyrażenie listy jest niedozwolone dla tego argumentu typu",
         "typeArgsExpectingNone": "Oczekiwano braku argumentów typu dla klasy „{name}”",

--- a/packages/pyright-internal/src/localization/package.nls.pt-br.json
+++ b/packages/pyright-internal/src/localization/package.nls.pt-br.json
@@ -438,6 +438,7 @@
         "typeAliasTypeParamInvalid": "A lista de parâmetros de tipo deve ser uma tupla contendo apenas TypeVar, TypeVarTuple ou ParamSpec",
         "typeAnnotationCall": "Expressão de chamada não permitida na expressão de tipo",
         "typeAnnotationVariable": "Variável não permitida na expressão de tipo",
+        "typeAnnotationWithCallable": "Type argument for \"type\" must be a class; callables are not supported",
         "typeArgListExpected": "ParamSpec, reticências ou lista de tipos esperados",
         "typeArgListNotAllowed": "Expressão de lista não permitida para este argumento de tipo",
         "typeArgsExpectingNone": "Nenhum argumento de tipo era esperado para a classe \"{name}\"",

--- a/packages/pyright-internal/src/localization/package.nls.qps-ploc.json
+++ b/packages/pyright-internal/src/localization/package.nls.qps-ploc.json
@@ -438,6 +438,7 @@
         "typeAliasTypeParamInvalid": "[RdHRE][นั้Tÿpë pæræmëtër lïst mµst þë æ tµplë çøñtæïñïñg øñlÿ TÿpëVær, TÿpëVærTµplë, ør Pæræm§pëçẤğ倪İЂҰक्र्तिृまẤğ倪İЂҰक्र्तिृまẤğ倪İЂҰक्นั้ढूँ]",
         "typeAnnotationCall": "[7pNts][นั้Çæll ëxprëssïøñ ñøt ælløwëð ïñ tÿpë ëxprëssïøñẤğ倪İЂҰक्र्तिृまẤğ倪İนั้ढूँ]",
         "typeAnnotationVariable": "[GeXWQ][นั้Værïæþlë ñøt ælløwëð ïñ tÿpë ëxprëssïøñẤğ倪İЂҰक्र्तिृまẤğนั้ढूँ]",
+        "typeAnnotationWithCallable": "[JJENJ][นั้Tÿpë ærgµmëñt før \"tÿpë\" mµst þë æ çlæss; çællæþlës ærë ñøt sµppørtëðẤğ倪İЂҰक्र्तिृまẤğ倪İЂҰक्र्तिृまนั้ढूँ]",
         "typeArgListExpected": "[2efoA][นั้Ëxpëçtëð Pæræm§pëç, ëllïpsïs, ør lïst øf tÿpësẤğ倪İЂҰक्र्तिृまẤğ倪İนั้ढूँ]",
         "typeArgListNotAllowed": "[oV7JF][นั้£ïst ëxprëssïøñ ñøt ælløwëð før thïs tÿpë ærgµmëñtẤğ倪İЂҰक्र्तिृまẤğ倪İЂҰนั้ढूँ]",
         "typeArgsExpectingNone": "[faycH][นั้Ëxpëçtëð ñø tÿpë ærgµmëñts før çlæss \"{ñæmë}\"Ấğ倪İЂҰक्र्तिृまẤğ倪İนั้ढूँ]",

--- a/packages/pyright-internal/src/localization/package.nls.ru.json
+++ b/packages/pyright-internal/src/localization/package.nls.ru.json
@@ -438,6 +438,7 @@
         "typeAliasTypeParamInvalid": "Список параметров типа должен быть кортежем, содержащим только TypeVar, TypeVarTuple или ParamSpec",
         "typeAnnotationCall": "Выражение вызова не разрешено в выражении типа",
         "typeAnnotationVariable": "Переменная не разрешена в выражении типа",
+        "typeAnnotationWithCallable": "Type argument for \"type\" must be a class; callables are not supported",
         "typeArgListExpected": "Ожидается ParamSpec, многоточие или список типов",
         "typeArgListNotAllowed": "Выражение списка не разрешено для аргумента этого типа",
         "typeArgsExpectingNone": "Для класса \"{name}\" не ожидается аргументов типа",

--- a/packages/pyright-internal/src/localization/package.nls.tr.json
+++ b/packages/pyright-internal/src/localization/package.nls.tr.json
@@ -438,6 +438,7 @@
         "typeAliasTypeParamInvalid": "Tür parametresi listesi yalnızca TypeVar, TypeVarTuple veya ParamSpec içeren bir demet olmalıdır",
         "typeAnnotationCall": "Tür ifadesinde çağrı ifadesine izin verilmiyor",
         "typeAnnotationVariable": "Tür ifadesinde değişkene izin verilmiyor",
+        "typeAnnotationWithCallable": "Type argument for \"type\" must be a class; callables are not supported",
         "typeArgListExpected": "ParamSpec, üç nokta veya tür listesi bekleniyordu",
         "typeArgListNotAllowed": "Bu tür bağımsız değişkeni için liste ifadesine izin verilmiyor",
         "typeArgsExpectingNone": "\"{name}\" sınıfı için tür bağımsız değişkeni beklenmiyordu",

--- a/packages/pyright-internal/src/localization/package.nls.zh-cn.json
+++ b/packages/pyright-internal/src/localization/package.nls.zh-cn.json
@@ -438,6 +438,7 @@
         "typeAliasTypeParamInvalid": "类型参数列表必须是仅包含 TypeVar、TypeVarTuple 或 ParamSpec 的元组",
         "typeAnnotationCall": "类型表达式中不允许使用调用表达式",
         "typeAnnotationVariable": "类型表达式中不允许使用变量",
+        "typeAnnotationWithCallable": "Type argument for \"type\" must be a class; callables are not supported",
         "typeArgListExpected": "应为 ParamSpec、省略号或类型列表",
         "typeArgListNotAllowed": "不允许此类型参数使用列表表达式",
         "typeArgsExpectingNone": "类“{name}”不应有类型参数",

--- a/packages/pyright-internal/src/localization/package.nls.zh-tw.json
+++ b/packages/pyright-internal/src/localization/package.nls.zh-tw.json
@@ -438,6 +438,7 @@
         "typeAliasTypeParamInvalid": "型別參數清單必須是只包含 TypeVar、TypeVarTuple 或 ParamSpec 的元組",
         "typeAnnotationCall": "型別運算式中不允許呼叫運算式",
         "typeAnnotationVariable": "型別運算式中不允許變數",
+        "typeAnnotationWithCallable": "Type argument for \"type\" must be a class; callables are not supported",
         "typeArgListExpected": "預期為 ParamSpec、省略符號或類型清單",
         "typeArgListNotAllowed": "此型別引數不允許清單運算式",
         "typeArgsExpectingNone": "預期類別 \"{name}\" 沒有類型引數",

--- a/packages/pyright-internal/src/readonlyAugmentedFileSystem.ts
+++ b/packages/pyright-internal/src/readonlyAugmentedFileSystem.ts
@@ -10,16 +10,9 @@
 import type * as fs from 'fs';
 
 import { appendArray, getOrAdd } from './common/collectionUtils';
-import {
-    FileSystem,
-    FileWatcher,
-    FileWatcherEventHandler,
-    MkDirOptions,
-    Stats,
-    TmpfileOptions,
-    VirtualDirent,
-} from './common/fileSystem';
+import { FileSystem, MkDirOptions, Stats, TmpfileOptions, VirtualDirent } from './common/fileSystem';
 import { combinePaths, ensureTrailingDirectorySeparator, getDirectoryPath, getFileName } from './common/pathUtils';
+import { FileWatcher, FileWatcherEventHandler } from './common/fileWatcher';
 
 export class ReadOnlyAugmentedFileSystem implements FileSystem {
     // Mapped file to original file map

--- a/packages/pyright-internal/src/server.ts
+++ b/packages/pyright-internal/src/server.ts
@@ -36,6 +36,7 @@ import { WorkspaceFileWatcherProvider, createFromRealFileSystem } from './common
 import { LanguageServerBase, ServerSettings } from './languageServerBase';
 import { CodeActionProvider } from './languageService/codeActionProvider';
 import { Workspace } from './workspaceFactory';
+import { PyrightFileSystem } from './pyrightFileSystem';
 
 const maxAnalysisTimeInForeground = { openFilesTimeInMs: 50, noOpenFilesTimeInMs: 200 };
 
@@ -60,7 +61,7 @@ export class PyrightServer extends LanguageServerBase {
                 productName: 'Pyright',
                 rootDirectory,
                 version,
-                fileSystem,
+                fileSystem: new PyrightFileSystem(fileSystem),
                 fileWatcherHandler: fileWatcherProvider,
                 cancellationProvider: new FileBasedCancellationProvider('bg'),
                 maxAnalysisTimeInForeground,

--- a/packages/pyright-internal/src/tests/docStringConversion.test.ts
+++ b/packages/pyright-internal/src/tests/docStringConversion.test.ts
@@ -14,6 +14,7 @@ import { convertDocStringToMarkdown, convertDocStringToPlainText } from '../anal
 const singleTick = '`';
 const doubleTick = '``';
 const tripleTick = '```';
+const tripleTilda = '~~~';
 
 test('PlaintextIndention', () => {
     const all: string[][] = [
@@ -270,6 +271,34 @@ And some text after.
     _testConvertToMarkdown(docstring, markdown);
 });
 
+test('MarkdownStyleTildaBlock', () => {
+    const docstring = `Backtick block:
+
+${tripleTilda}
+print(foo_bar)
+
+if True:
+    print(bar_foo)
+${tripleTilda}
+
+And some text after.
+`;
+
+    const markdown = `Backtick block:
+
+${tripleTilda}
+print(foo_bar)
+
+if True:
+    print(bar_foo)
+${tripleTilda}
+
+And some text after.
+`;
+
+    _testConvertToMarkdown(docstring, markdown);
+});
+
 test('RestLiteralBlock', () => {
     const docstring = `
 Take a look at this code::
@@ -421,6 +450,14 @@ test('UnfinishedBacktickBlock', () => {
     const docstring = '```\nsomething\n';
 
     const markdown = '```\nsomething\n```\n';
+
+    _testConvertToMarkdown(docstring, markdown);
+});
+
+test('UnfinishedTildaBlock', () => {
+    const docstring = '~~~\nsomething\n';
+
+    const markdown = '~~~\nsomething\n~~~\n';
 
     _testConvertToMarkdown(docstring, markdown);
 });
@@ -854,6 +891,73 @@ ${tripleTick}python
         ${tripleTick}
         """
 ${tripleTick}
+`;
+    _testConvertToMarkdown(docstring, markdown);
+});
+
+test('IndentedCodeBlockTilda', () => {
+    const docstring = `
+Expected:
+    ${tripleTilda}python
+    def some_fn():
+        """
+        Backticks on a different indentation level don't close the code block.
+        ${tripleTilda}
+        """
+    ${tripleTilda}
+`;
+
+    const markdown = `
+Expected:
+${tripleTilda}python
+    def some_fn():
+        """
+        Backticks on a different indentation level don't close the code block.
+        ${tripleTilda}
+        """
+${tripleTilda}
+`;
+    _testConvertToMarkdown(docstring, markdown);
+});
+
+test('MixedCodeBlockBacktick', () => {
+    const docstring = `
+Expected:
+    ${tripleTick}python
+    def some_fn():
+        """
+        Backticks on a different indentation level don't close the code block.
+        ${tripleTick}
+        """
+    ${tripleTick}
+Expected:
+    ${tripleTilda}python
+    def some_fn():
+        """
+        Backticks on a different indentation level don't close the code block.
+        ${tripleTick}
+        """
+    ${tripleTilda}
+`;
+
+    const markdown = `
+Expected:
+${tripleTick}python
+    def some_fn():
+        """
+        Backticks on a different indentation level don't close the code block.
+        ${tripleTick}
+        """
+${tripleTick}
+
+Expected:
+${tripleTilda}python
+    def some_fn():
+        """
+        Backticks on a different indentation level don't close the code block.
+        ${tripleTick}
+        """
+${tripleTilda}
 `;
     _testConvertToMarkdown(docstring, markdown);
 });

--- a/packages/pyright-internal/src/tests/harness/vfs/filesystem.ts
+++ b/packages/pyright-internal/src/tests/harness/vfs/filesystem.ts
@@ -10,18 +10,12 @@
 import { Dirent, ReadStream, WriteStream } from 'fs';
 import { URI } from 'vscode-uri';
 
-import {
-    FileSystem,
-    FileWatcher,
-    FileWatcherEventHandler,
-    FileWatcherEventType,
-    MkDirOptions,
-    TmpfileOptions,
-} from '../../../common/fileSystem';
+import { FileSystem, MkDirOptions, TmpfileOptions } from '../../../common/fileSystem';
 import * as pathUtil from '../../../common/pathUtils';
 import { bufferFrom, createIOError } from '../utils';
 import { Metadata, SortedMap, closeIterator, getIterator, nextResult } from './../utils';
 import { ValidationFlags, validate } from './pathValidation';
+import { FileWatcher, FileWatcherEventHandler, FileWatcherEventType } from '../../../common/fileWatcher';
 
 export const MODULE_PATH = pathUtil.normalizeSlashes('/');
 


### PR DESCRIPTION
rollup of the following changes:
    1. Extracted out `pyTest` hover parts https://github.com/microsoft/pyrx/pull/3954
    2. Move out pyTest inlay from extension. https://github.com/microsoft/pyrx/pull/3952
    3. moved pyTest code actions out https://github.com/microsoft/pyrx/pull/3941
    4. pylance loc update 20230801.1 https://github.com/microsoft/pyrx/pull/3943

    Co-authored-by: Bill Schnurr <bschnurr@microsoft.com>
    Co-authored-by: HeeJae Chang <hechang@microsoft.com>
    Co-authored-by: Erik De Bonte <erikd@microsoft.com>
    Co-authored-by: Rich Chiodo <rchiodo@microsoft.com>
    Co-authored-by: Stella Huang <stellahuang@microsoft.com>
    