### PR TITLE
Add support for finding definitions and hover text on TypedDict variable indexing

### DIFF
--- a/packages/pyright-internal/src/analyzer/typeEvaluatorTypes.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluatorTypes.ts
@@ -479,6 +479,7 @@ export interface TypeEvaluator {
     isAsymmetricDescriptorAssignment: (node: ParseNode) => boolean;
     suppressDiagnostics: (node: ParseNode, callback: () => void) => void;
 
+    getDictionaryTypeForStringNode: (node: StringNode) => Type | undefined;
     getDeclarationsForStringNode: (node: StringNode) => Declaration[] | undefined;
     getDeclarationsForNameNode: (node: NameNode, skipUnreachableCode?: boolean) => Declaration[] | undefined;
     getTypeForDeclaration: (declaration: Declaration) => DeclaredSymbolTypeInfo;

--- a/packages/pyright-internal/src/languageService/hoverProvider.ts
+++ b/packages/pyright-internal/src/languageService/hoverProvider.ts
@@ -244,7 +244,7 @@ export class HoverProvider {
                 }
             }
         } else if (node.nodeType === ParseNodeType.String) {
-            const type = this._evaluator.getExpectedType(node)?.type;
+            const type = this._evaluator.getDictionaryTypeForStringNode(node);
             if (type !== undefined) {
                 this._tryAddPartsForTypedDictKey(node, type, results.parts);
             }

--- a/packages/pyright-internal/src/tests/fourslash/findDefinitions.typedDict.keys.fourslash.ts
+++ b/packages/pyright-internal/src/tests/fourslash/findDefinitions.typedDict.keys.fourslash.ts
@@ -36,10 +36,14 @@
 //// foo(item={[|/*marker5*/'title'|]})
 //// foo(item={'title': [|/*marker6*/'title'|]})
 //// foo(item={[|/*marker7*/'name'|]})
+////
+//// untyped = {'name': 'Robert'}
+//// untyped[[|/*marker8*/'name'|]]
+//// author[[|/*marker9*/'name'|]]
+//// post['author'][[|/*marker10*/'name'|]]
 
 {
     const rangeMap = helper.getRangesByText();
-
     helper.verifyFindDefinitions(
         {
             marker1: {
@@ -86,6 +90,25 @@
                 definitions: [],
             },
             marker7: {
+                definitions: rangeMap
+                    .get('name')!
+                    .filter((r) => !r.marker)
+                    .map((r) => {
+                        return { path: r.fileName, range: helper.convertPositionRange(r) };
+                    }),
+            },
+            marker8: {
+                definitions: [],
+            },
+            marker9: {
+                definitions: rangeMap
+                    .get('name')!
+                    .filter((r) => !r.marker)
+                    .map((r) => {
+                        return { path: r.fileName, range: helper.convertPositionRange(r) };
+                    }),
+            },
+            marker10: {
                 definitions: rangeMap
                     .get('name')!
                     .filter((r) => !r.marker)

--- a/packages/pyright-internal/src/tests/fourslash/hover.typedDict.key.fourslash.ts
+++ b/packages/pyright-internal/src/tests/fourslash/hover.typedDict.key.fourslash.ts
@@ -35,6 +35,18 @@
 ////
 //// bar({[|/*marker9*/'title'|]})
 //// bar({[|/*marker10*/'age'|]})
+////
+//// untyped = {'name': 'Robert'}
+//// untyped[[|/*marker11*/'age'|]]
+//// untyped[[|/*marker12*/'name'|]]
+////
+//// user[[|/*marker13*/'name'|]]
+////
+//// def make_post_or_user() -> Post | User:
+////    ...
+////
+//// either = make_post_or_user()
+//// either[[|/*marker14*/'age'|]]
 
 helper.verifyHover('markdown', {
     marker1: '```python\n(key) name: str\n```\n---\nThe fullname of the User',
@@ -47,5 +59,10 @@ helper.verifyHover('markdown', {
     marker8: null,
     marker9: '```python\n(key) title: str\n```',
     marker10:
+        '```python\n(key) age: int\n```\n---\nThe age of the Post\n\n---\n```python\n(key) age: int\n```\n---\nThe age of the User, will not be over 200',
+    marker11: null,
+    marker12: null,
+    marker13: '```python\n(key) name: str\n```\n---\nThe fullname of the User',
+    marker14:
         '```python\n(key) age: int\n```\n---\nThe age of the Post\n\n---\n```python\n(key) age: int\n```\n---\nThe age of the User, will not be over 200',
 });


### PR DESCRIPTION
Fixes #5654 

![image](https://github.com/microsoft/pyright/assets/2784602/bae03585-4edf-40d6-88da-99b4bd60cd3f)

