### PR TITLE
Added check for improper use of a type alias defined using the `type`…

### DIFF
--- a/packages/pyright-internal/src/analyzer/codeFlowEngine.ts
+++ b/packages/pyright-internal/src/analyzer/codeFlowEngine.ts
@@ -1452,7 +1452,7 @@ export function getCodeFlowEngine(
             let subtypeCount = 0;
 
             // Evaluate the call base type.
-            const callTypeResult = evaluator.getTypeOfExpression(node.leftExpression, EvaluatorFlags.DoNotSpecialize);
+            const callTypeResult = evaluator.getTypeOfExpression(node.leftExpression, EvaluatorFlags.CallBaseDefaults);
             const callType = callTypeResult.type;
 
             doForEachSubtype(callType, (callSubtype) => {

--- a/packages/pyright-internal/src/analyzer/dataClasses.ts
+++ b/packages/pyright-internal/src/analyzer/dataClasses.ts
@@ -201,7 +201,7 @@ export function synthesizeDataClassMethods(
                     if (statement.rightExpression.nodeType === ParseNodeType.Call) {
                         const callTypeResult = evaluator.getTypeOfExpression(
                             statement.rightExpression.leftExpression,
-                            EvaluatorFlags.DoNotSpecialize
+                            EvaluatorFlags.CallBaseDefaults
                         );
                         const callType = callTypeResult.type;
 
@@ -461,7 +461,7 @@ export function synthesizeDataClassMethods(
                 if (statement.rightExpression.nodeType === ParseNodeType.Call) {
                     const callType = evaluator.getTypeOfExpression(
                         statement.rightExpression.leftExpression,
-                        EvaluatorFlags.DoNotSpecialize
+                        EvaluatorFlags.CallBaseDefaults
                     ).type;
 
                     if (

--- a/packages/pyright-internal/src/analyzer/decorators.ts
+++ b/packages/pyright-internal/src/analyzer/decorators.ts
@@ -74,7 +74,7 @@ export function getFunctionFlagsFromDecorators(evaluator: TypeEvaluator, node: F
         // Some stub files (e.g. builtins.pyi) rely on forward declarations of decorators.
         let evaluatorFlags = fileInfo.isStubFile ? EvaluatorFlags.AllowForwardReferences : EvaluatorFlags.None;
         if (decoratorNode.expression.nodeType !== ParseNodeType.Call) {
-            evaluatorFlags |= EvaluatorFlags.DoNotSpecialize;
+            evaluatorFlags |= EvaluatorFlags.CallBaseDefaults;
         }
 
         const decoratorTypeResult = evaluator.getTypeOfExpression(decoratorNode.expression, evaluatorFlags);
@@ -120,7 +120,7 @@ export function applyFunctionDecorator(
     // Some stub files (e.g. builtins.pyi) rely on forward declarations of decorators.
     let evaluatorFlags = fileInfo.isStubFile ? EvaluatorFlags.AllowForwardReferences : EvaluatorFlags.None;
     if (decoratorNode.expression.nodeType !== ParseNodeType.Call) {
-        evaluatorFlags |= EvaluatorFlags.DoNotSpecialize;
+        evaluatorFlags |= EvaluatorFlags.CallBaseDefaults;
     }
 
     const decoratorTypeResult = evaluator.getTypeOfExpression(decoratorNode.expression, evaluatorFlags);
@@ -142,7 +142,7 @@ export function applyFunctionDecorator(
     if (decoratorNode.expression.nodeType === ParseNodeType.Call) {
         const decoratorCallType = evaluator.getTypeOfExpression(
             decoratorNode.expression.leftExpression,
-            evaluatorFlags | EvaluatorFlags.DoNotSpecialize
+            evaluatorFlags | EvaluatorFlags.CallBaseDefaults
         ).type;
 
         if (isFunction(decoratorCallType)) {
@@ -191,7 +191,7 @@ export function applyFunctionDecorator(
         if (decoratorNode.expression.nodeType === ParseNodeType.MemberAccess) {
             const baseType = evaluator.getTypeOfExpression(
                 decoratorNode.expression.leftExpression,
-                evaluatorFlags | EvaluatorFlags.DoNotSpecialize
+                evaluatorFlags | EvaluatorFlags.MemberAccessBaseDefaults
             ).type;
 
             if (isProperty(baseType)) {
@@ -290,14 +290,14 @@ export function applyClassDecorator(
     const fileInfo = getFileInfo(decoratorNode);
     let flags = fileInfo.isStubFile ? EvaluatorFlags.AllowForwardReferences : EvaluatorFlags.None;
     if (decoratorNode.expression.nodeType !== ParseNodeType.Call) {
-        flags |= EvaluatorFlags.DoNotSpecialize;
+        flags |= EvaluatorFlags.CallBaseDefaults;
     }
     const decoratorType = evaluator.getTypeOfExpression(decoratorNode.expression, flags).type;
 
     if (decoratorNode.expression.nodeType === ParseNodeType.Call) {
         const decoratorCallType = evaluator.getTypeOfExpression(
             decoratorNode.expression.leftExpression,
-            flags | EvaluatorFlags.DoNotSpecialize
+            flags | EvaluatorFlags.CallBaseDefaults
         ).type;
 
         if (isFunction(decoratorCallType)) {
@@ -375,7 +375,7 @@ export function applyClassDecorator(
             callNode = decoratorNode.expression;
             const decoratorCallType = evaluator.getTypeOfExpression(
                 callNode.leftExpression,
-                flags | EvaluatorFlags.DoNotSpecialize
+                flags | EvaluatorFlags.CallBaseDefaults
             ).type;
             dataclassBehaviors = getDataclassDecoratorBehaviors(decoratorCallType);
         } else {
@@ -396,7 +396,7 @@ function getTypeOfDecorator(evaluator: TypeEvaluator, node: DecoratorNode, funct
     // Evaluate the type of the decorator expression.
     let flags = getFileInfo(node).isStubFile ? EvaluatorFlags.AllowForwardReferences : EvaluatorFlags.None;
     if (node.expression.nodeType !== ParseNodeType.Call) {
-        flags |= EvaluatorFlags.DoNotSpecialize;
+        flags |= EvaluatorFlags.CallBaseDefaults;
     }
 
     const decoratorTypeResult = evaluator.getTypeOfExpression(node.expression, flags);

--- a/packages/pyright-internal/src/analyzer/patternMatching.ts
+++ b/packages/pyright-internal/src/analyzer/patternMatching.ts
@@ -648,7 +648,7 @@ function narrowTypeBasedOnClassPattern(
     pattern: PatternClassNode,
     isPositiveTest: boolean
 ): Type {
-    let exprType = evaluator.getTypeOfExpression(pattern.className, EvaluatorFlags.DoNotSpecialize).type;
+    let exprType = evaluator.getTypeOfExpression(pattern.className, EvaluatorFlags.CallBaseDefaults).type;
 
     // If this is a class (but not a type alias that refers to a class),
     // specialize it with Unknown type arguments.
@@ -1598,7 +1598,7 @@ function wrapTypeInList(evaluator: TypeEvaluator, node: ParseNode, type: Type): 
 }
 
 export function validateClassPattern(evaluator: TypeEvaluator, pattern: PatternClassNode) {
-    const exprType = evaluator.getTypeOfExpression(pattern.className, EvaluatorFlags.DoNotSpecialize).type;
+    const exprType = evaluator.getTypeOfExpression(pattern.className, EvaluatorFlags.CallBaseDefaults).type;
 
     if (isAnyOrUnknown(exprType)) {
         return;
@@ -1675,7 +1675,7 @@ export function getPatternSubtypeNarrowingCallback(
             if (ClassType.isBuiltIn(indexType, ['int', 'str'])) {
                 const unnarrowedReferenceTypeResult = evaluator.getTypeOfExpression(
                     subjectExpression.baseExpression,
-                    EvaluatorFlags.DoNotSpecialize
+                    EvaluatorFlags.CallBaseDefaults
                 );
                 const unnarrowedReferenceType = unnarrowedReferenceTypeResult.type;
 

--- a/packages/pyright-internal/src/analyzer/typeEvaluatorTypes.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluatorTypes.ts
@@ -140,6 +140,18 @@ export const enum EvaluatorFlags {
 
     // Allow Unpack annotation for TypedDict.
     AllowUnpackedTypedDict = 1 << 23,
+
+    // Disallow a type alias defined with a "type" statement.
+    DisallowPep695TypeAlias = 1 << 24,
+
+    // Defaults used for evaluating the LHS of a call expression.
+    CallBaseDefaults = DoNotSpecialize | DisallowPep695TypeAlias,
+
+    // Defaults used for evaluating the LHS of a member access expression.
+    IndexBaseDefaults = DoNotSpecialize,
+
+    // Defaults used for evaluating the LHS of a member access expression.
+    MemberAccessBaseDefaults = DoNotSpecialize | DisallowPep695TypeAlias,
 }
 
 export interface TypeResult<T extends Type = Type> {

--- a/packages/pyright-internal/src/analyzer/typeGuards.ts
+++ b/packages/pyright-internal/src/analyzer/typeGuards.ts
@@ -202,7 +202,7 @@ export function getTypeNarrowingCallback(
                     if (ParseTreeUtils.isMatchingExpression(reference, arg0Expr)) {
                         const callType = evaluator.getTypeOfExpression(
                             testExpression.leftExpression.leftExpression,
-                            EvaluatorFlags.DoNotSpecialize
+                            EvaluatorFlags.CallBaseDefaults
                         ).type;
 
                         if (isInstantiableClass(callType) && ClassType.isBuiltIn(callType, 'type')) {
@@ -410,7 +410,7 @@ export function getTypeNarrowingCallback(
                 if (ParseTreeUtils.isMatchingExpression(reference, arg0Expr)) {
                     const callTypeResult = evaluator.getTypeOfExpression(
                         testExpression.leftExpression.leftExpression,
-                        EvaluatorFlags.DoNotSpecialize
+                        EvaluatorFlags.CallBaseDefaults
                     );
                     const callType = callTypeResult.type;
 
@@ -561,7 +561,7 @@ export function getTypeNarrowingCallback(
             if (ParseTreeUtils.isMatchingExpression(reference, arg0Expr)) {
                 const callTypeResult = evaluator.getTypeOfExpression(
                     testExpression.leftExpression,
-                    EvaluatorFlags.DoNotSpecialize
+                    EvaluatorFlags.CallBaseDefaults
                 );
                 const callType = callTypeResult.type;
 
@@ -634,7 +634,7 @@ export function getTypeNarrowingCallback(
             if (ParseTreeUtils.isMatchingExpression(reference, arg0Expr)) {
                 const callTypeResult = evaluator.getTypeOfExpression(
                     testExpression.leftExpression,
-                    EvaluatorFlags.DoNotSpecialize
+                    EvaluatorFlags.CallBaseDefaults
                 );
                 const callType = callTypeResult.type;
 
@@ -669,7 +669,7 @@ export function getTypeNarrowingCallback(
             if (ParseTreeUtils.isMatchingExpression(reference, testExpression.arguments[0].valueExpression)) {
                 const callTypeResult = evaluator.getTypeOfExpression(
                     testExpression.leftExpression,
-                    EvaluatorFlags.DoNotSpecialize
+                    EvaluatorFlags.CallBaseDefaults
                 );
                 const callType = callTypeResult.type;
 
@@ -701,7 +701,7 @@ export function getTypeNarrowingCallback(
 
                 const callTypeResult = evaluator.getTypeOfExpression(
                     testExpression.leftExpression,
-                    EvaluatorFlags.DoNotSpecialize
+                    EvaluatorFlags.CallBaseDefaults
                 );
                 const callType = callTypeResult.type;
 

--- a/packages/pyright-internal/src/analyzer/typeUtils.ts
+++ b/packages/pyright-internal/src/analyzer/typeUtils.ts
@@ -741,6 +741,7 @@ export function transformPossibleRecursiveTypeAlias(type: Type | undefined): Typ
                     type.typeAliasInfo.name,
                     type.typeAliasInfo.fullName,
                     type.typeAliasInfo.typeVarScopeId,
+                    type.typeAliasInfo.isPep695Syntax,
                     type.typeAliasInfo.typeParameters,
                     type.typeAliasInfo.typeArguments
                 );
@@ -2072,6 +2073,7 @@ export function convertToInstance(type: Type, includeSubclasses = true): Type {
             type.typeAliasInfo.name,
             type.typeAliasInfo.fullName,
             type.typeAliasInfo.typeVarScopeId,
+            type.typeAliasInfo.isPep695Syntax,
             type.typeAliasInfo.typeParameters,
             type.typeAliasInfo.typeArguments
         );
@@ -2123,6 +2125,7 @@ export function convertToInstantiable(type: Type, includeSubclasses = true): Typ
             type.typeAliasInfo.name,
             type.typeAliasInfo.fullName,
             type.typeAliasInfo.typeVarScopeId,
+            type.typeAliasInfo.isPep695Syntax,
             type.typeAliasInfo.typeParameters,
             type.typeAliasInfo.typeArguments
         );
@@ -3097,6 +3100,7 @@ class TypeVarTransformer {
                         type.typeAliasInfo.name,
                         type.typeAliasInfo.fullName,
                         type.typeAliasInfo.typeVarScopeId,
+                        type.typeAliasInfo.isPep695Syntax,
                         type.typeAliasInfo.typeParameters,
                         typeArgs
                     );
@@ -3258,6 +3262,7 @@ class TypeVarTransformer {
                   type.typeAliasInfo.name,
                   type.typeAliasInfo.fullName,
                   type.typeAliasInfo.typeVarScopeId,
+                  type.typeAliasInfo.isPep695Syntax,
                   type.typeAliasInfo.typeParameters,
                   newTypeArgs
               )

--- a/packages/pyright-internal/src/analyzer/types.ts
+++ b/packages/pyright-internal/src/analyzer/types.ts
@@ -124,6 +124,10 @@ export interface TypeAliasInfo {
     fullName: string;
     typeVarScopeId: TypeVarScopeId;
 
+    // Indicates whether the type alias was declared with the
+    // "type" syntax introduced in PEP 695.
+    isPep695Syntax: boolean;
+
     // Type parameters, if type alias is generic
     typeParameters?: TypeVarType[] | undefined;
 
@@ -260,6 +264,7 @@ export namespace TypeBase {
         name: string,
         fullName: string,
         typeVarScopeId: TypeVarScopeId,
+        isPep695Syntax: boolean,
         typeParams?: TypeVarType[],
         typeArgs?: Type[]
     ): Type {
@@ -271,6 +276,7 @@ export namespace TypeBase {
             typeParameters: typeParams,
             typeArguments: typeArgs,
             typeVarScopeId,
+            isPep695Syntax,
         };
 
         return typeClone;
@@ -2309,6 +2315,7 @@ export interface TypeVarDetails {
     // Used for recursive type aliases.
     recursiveTypeAliasName?: string | undefined;
     recursiveTypeAliasScopeId?: TypeVarScopeId | undefined;
+    recursiveTypeAliasIsPep695Syntax?: boolean;
 
     // Type parameters for a recursive type alias.
     recursiveTypeParameters?: TypeVarType[] | undefined;

--- a/packages/pyright-internal/src/localization/localize.ts
+++ b/packages/pyright-internal/src/localization/localize.ts
@@ -854,6 +854,8 @@ export namespace Localizer {
         export const typeAliasIllegalExpressionForm = () => getRawString('Diagnostic.typeAliasIllegalExpressionForm');
         export const typeAliasIsRecursiveDirect = () =>
             new ParameterizedString<{ name: string }>(getRawString('Diagnostic.typeAliasIsRecursiveDirect'));
+        export const typeAliasNotAllowed = () =>
+            new ParameterizedString<{ name: string }>(getRawString('Diagnostic.typeAliasNotAllowed'));
         export const typeAliasNotInModuleOrClass = () => getRawString('Diagnostic.typeAliasNotInModuleOrClass');
         export const typeAliasRedeclared = () =>
             new ParameterizedString<{ name: string }>(getRawString('Diagnostic.typeAliasRedeclared'));

--- a/packages/pyright-internal/src/localization/package.nls.en-us.json
+++ b/packages/pyright-internal/src/localization/package.nls.en-us.json
@@ -418,6 +418,7 @@
         "tupleIndexOutOfRange": "Index {index} is out of range for type {type}",
         "typeAliasIllegalExpressionForm": "Invalid expression form for type alias definition",
         "typeAliasIsRecursiveDirect": "Type alias \"{name}\" cannot use itself in its definition",
+        "typeAliasNotAllowed": "Type alias \"{name}\" cannot be used in this context",
         "typeAliasNotInModuleOrClass": "A TypeAlias can be defined only within a module or class scope",
         "typeAliasRedeclared": "\"{name}\" is declared as a TypeAlias and can be assigned only once",
         "typeAliasStatementIllegal": "Type alias statement requires Python 3.12 or newer",

--- a/packages/pyright-internal/src/tests/samples/typeAliasStatement1.py
+++ b/packages/pyright-internal/src/tests/samples/typeAliasStatement1.py
@@ -46,3 +46,20 @@ type TA8 = func1()
 # allowed in a type alias definition.
 type TA9 = (int, str, str)[0]
 
+
+type TA10 = int
+
+# This should generate an error.
+TA10.bit_count(1)
+
+# This should generate an error.
+TA10(0)
+
+# This should generate an error.
+class DerivedInt(TA10): pass
+
+def func2(x: object):
+    # This should generate an error.
+    if isinstance(x, TA10):
+        reveal_type(x)
+

--- a/packages/pyright-internal/src/tests/typeEvaluator5.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator5.test.ts
@@ -109,7 +109,7 @@ test('TypeAliasStatement1', () => {
     configOptions.defaultPythonVersion = PythonVersion.V3_12;
 
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['typeAliasStatement1.py'], configOptions);
-    TestUtils.validateResults(analysisResults, 3);
+    TestUtils.validateResults(analysisResults, 7);
 });
 
 test('TypeAliasStatement2', () => {


### PR DESCRIPTION
… statement introduced in PEP 695. This addresses #5662.