### PR TITLE
Fixed a bug that led to incorrect type narrowing on assignment in cer…

### DIFF
--- a/packages/pyright-internal/src/tests/samples/assignment10.py
+++ b/packages/pyright-internal/src/tests/samples/assignment10.py
@@ -1,7 +1,7 @@
 # This sample tests some cases where types are narrowed on assignment,
 # including some cases that involve "Any".
 
-from typing import Any
+from typing import Any, Generic, Iterable, TypeVar
 
 
 class A:
@@ -15,6 +15,13 @@ class A:
         if cls.instance is None:
             cls.instance = cls()
         return cls.instance.foo
+
+
+T = TypeVar("T")
+
+
+class B(Generic[T]):
+    ...
 
 
 def func1(v1: list[Any | None], v2: list[int | str]):
@@ -37,3 +44,25 @@ def func2(v1: dict[int, Any | None], v2: dict[int, int | str]):
 
     x3: dict[Any, Any | str] = v2
     reveal_type(x3, expected_text="dict[Any, Any | str]")
+
+
+def func3(y: list[int]):
+    x1: Iterable[int | B[Any]] = y
+    reveal_type(x1, expected_text="list[int]")
+
+    x2: Iterable[Any | B[Any]] = y
+    reveal_type(x2, expected_text="list[int]")
+
+    x3: Iterable[Any] = y
+    reveal_type(x3, expected_text="list[Any]")
+
+
+def func4(y: list[Any]):
+    x1: Iterable[int | B[Any]] = y
+    reveal_type(x1, expected_text="list[int | B[Any]]")
+
+    x2: Iterable[Any | B[Any]] = y
+    reveal_type(x2, expected_text="list[Any | B[Any]]")
+
+    x3: Iterable[Any] = y
+    reveal_type(x3, expected_text="list[Any]")


### PR DESCRIPTION
…tain cases where the declared type includes a type argument with an `Any` and the assigned type does not. This addresses #5628.