### PR TITLE
Fixed recent regression that led to a false positive when assigning a…

### DIFF
--- a/packages/pyright-internal/src/analyzer/protocols.ts
+++ b/packages/pyright-internal/src/analyzer/protocols.ts
@@ -663,13 +663,18 @@ function createProtocolTypeVarContext(
             const typeArg = specializedDestType.typeArguments[index];
 
             if (!requiresSpecialization(typeArg)) {
+                // If the caller hasn't provided a destTypeVarContext, assume that
+                // the destType represents an "expected type" and populate the
+                // typeVarContext accordingly. For example, if the destType is
+                // MyProto[Literal[0]], we want to constrain the type argument to be
+                // no wider than Literal[0] if the type param is not contravariant.
                 assignTypeToTypeVar(
                     evaluator,
                     typeParam,
                     typeArg,
                     /* diag */ undefined,
                     protocolTypeVarContext,
-                    AssignTypeFlags.PopulatingExpectedType
+                    destTypeVarContext ? AssignTypeFlags.Default : AssignTypeFlags.PopulatingExpectedType
                 );
             }
         }

--- a/packages/pyright-internal/src/tests/samples/protocol38.py
+++ b/packages/pyright-internal/src/tests/samples/protocol38.py
@@ -30,3 +30,12 @@ class SupportsGetItem(Protocol[T]):
 
 def func3(a: tuple[Any, ...]):
     x: SupportsGetItem[Literal["a"]] = a
+
+
+def func4(x: SupportsGetItem[T]) -> T:
+    return x[0]
+
+
+def func5(x: list[int] | list[str]) -> None:
+    y = func4(x)
+    reveal_type(y, expected_text="int | str")


### PR DESCRIPTION
… union of types that use invariant type parameters to a protocol that uses a covariant type parameter. This addresses #5673.