### PR TITLE
Removed the type promotion of `bytearray` and `memoryview` to `bytes`…

### DIFF
--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -416,7 +416,6 @@ const nonSubscriptableBuiltinTypes: Map<string, PythonVersion> = new Map([
 const typePromotions: Map<string, string[]> = new Map([
     ['builtins.float', ['builtins.int']],
     ['builtins.complex', ['builtins.float', 'builtins.int']],
-    ['builtins.bytes', ['builtins.bytearray', 'builtins.memoryview']],
 ]);
 
 interface SymbolResolutionStackEntry {

--- a/packages/pyright-internal/src/tests/samples/typePromotions1.py
+++ b/packages/pyright-internal/src/tests/samples/typePromotions1.py
@@ -10,11 +10,6 @@ def func1(float_val: float, int_val: int):
     v3: complex = int_val
 
 
-def func2(mem_view_val: memoryview, byte_array_val: bytearray):
-    v1: bytes = mem_view_val
-    v2: bytes = byte_array_val
-
-
 class IntSubclass(int):
     ...
 


### PR DESCRIPTION
…. PEP 688 eliminates the need for this hack, and it indicates that type checkers should remove support for this older behavior. This addresses #5697.