### PR TITLE
Fixed a bug that resulted in incorrect type evaluation (and a false p…

### DIFF
--- a/packages/pyright-internal/src/analyzer/operations.ts
+++ b/packages/pyright-internal/src/analyzer/operations.ts
@@ -111,7 +111,7 @@ export function validateBinaryOperation(
     inferenceContext: InferenceContext | undefined,
     diag: DiagnosticAddendum,
     options: BinaryOperationOptions
-): Type | undefined {
+): Type {
     const leftType = leftTypeResult.type;
     const rightType = rightTypeResult.type;
     let type: Type | undefined;
@@ -481,7 +481,7 @@ export function validateBinaryOperation(
         }
     }
 
-    return type && isNever(type) ? undefined : type;
+    return type ?? UnknownType.create();
 }
 
 export function getTypeOfBinaryOperation(
@@ -714,7 +714,7 @@ export function getTypeOfBinaryOperation(
         { isLiteralMathAllowed, isTupleAddAllowed }
     );
 
-    if (!diag.isEmpty() || !type) {
+    if (!diag.isEmpty()) {
         typeErrors = true;
 
         if (!isIncomplete) {

--- a/packages/pyright-internal/src/tests/samples/operator1.py
+++ b/packages/pyright-internal/src/tests/samples/operator1.py
@@ -2,6 +2,9 @@
 # custom operator overrides.
 
 
+from typing import NoReturn
+
+
 class A:
     def __eq__(self, Foo):
         return "equal"
@@ -97,3 +100,12 @@ class E:
 e = E()
 
 _ = e + e
+
+
+class F:
+    def __add__(self, other: object) -> NoReturn:
+        ...
+
+
+f = F() + ""
+reveal_type(f, expected_text="NoReturn")


### PR DESCRIPTION
…ositive error) when a binary operator overload method was annotated to return `NoReturn`. This addresses #5711.