### PR TITLE
Fixed a bug that led to a false positive in the `reportIncompatibleMe…

### DIFF
--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -24528,7 +24528,6 @@ export function createTypeEvaluator(importLookup: ImportLookup, evaluatorOptions
         // has additional overloads that are not present in the override.
 
         let previousMatchIndex = -1;
-        let overrideOverloadIndex = 0;
         const baseOverloads = OverloadedFunctionType.getOverloads(baseMethod);
 
         for (const overrideOverload of OverloadedFunctionType.getOverloads(overrideMethod)) {
@@ -24548,10 +24547,7 @@ export function createTypeEvaluator(importLookup: ImportLookup, evaluatorOptions
             });
 
             if (matchIndex < 0) {
-                diag.addMessage(
-                    Localizer.DiagnosticAddendum.overrideOverloadNoMatch().format({ index: overrideOverloadIndex + 1 })
-                );
-                return false;
+                continue;
             }
 
             if (matchIndex < previousMatchIndex) {
@@ -24560,7 +24556,12 @@ export function createTypeEvaluator(importLookup: ImportLookup, evaluatorOptions
             }
 
             previousMatchIndex = matchIndex;
-            overrideOverloadIndex++;
+        }
+
+        if (previousMatchIndex < baseOverloads.length - 1) {
+            // We didn't find matches for all of the base overloads.
+            diag.addMessage(Localizer.DiagnosticAddendum.overrideOverloadNoMatch());
+            return false;
         }
 
         return true;

--- a/packages/pyright-internal/src/localization/localize.ts
+++ b/packages/pyright-internal/src/localization/localize.ts
@@ -1235,8 +1235,7 @@ export namespace Localizer {
         export const overrideNotClassMethod = () => getRawString('DiagnosticAddendum.overrideNotClassMethod');
         export const overrideNotInstanceMethod = () => getRawString('DiagnosticAddendum.overrideNotInstanceMethod');
         export const overrideNotStaticMethod = () => getRawString('DiagnosticAddendum.overrideNotStaticMethod');
-        export const overrideOverloadNoMatch = () =>
-            new ParameterizedString<{ index: number }>(getRawString('DiagnosticAddendum.overrideOverloadNoMatch'));
+        export const overrideOverloadNoMatch = () => getRawString('DiagnosticAddendum.overrideOverloadNoMatch');
         export const overrideOverloadOrder = () => getRawString('DiagnosticAddendum.overrideOverloadOrder');
         export const overrideParamKeywordNoDefault = () =>
             new ParameterizedString<{ name: string }>(getRawString('DiagnosticAddendum.overrideParamKeywordNoDefault'));

--- a/packages/pyright-internal/src/localization/package.nls.en-us.json
+++ b/packages/pyright-internal/src/localization/package.nls.en-us.json
@@ -634,7 +634,7 @@
         "overrideNotClassMethod": "Base method is declared as a classmethod but override is not",
         "overrideNotInstanceMethod": "Base method is declared as an instance method but override is not",
         "overrideNotStaticMethod": "Base method is declared as a staticmethod but override is not",
-        "overrideOverloadNoMatch": "Overload {index} is not compatible with base method",
+        "overrideOverloadNoMatch": "Override does not handle all overloads of base method",
         "overrideOverloadOrder": "Overloads for override method must be in the same order as the base method",
         "overrideParamKeywordNoDefault": "Keyword parameter \"{name}\" mismatch: base parameter has default argument value, override parameter does not",
         "overrideParamKeywordType": "Keyword parameter \"{name}\" type mismatch: base parameter is type \"{baseType}\", override parameter is type \"{overrideType}\"",

--- a/packages/pyright-internal/src/tests/samples/methodOverride6.py
+++ b/packages/pyright-internal/src/tests/samples/methodOverride6.py
@@ -203,3 +203,33 @@ class Child2_4(Parent2[str]):
     @classmethod
     def method4(cls, x: Any) -> Any:
         ...
+
+
+class Parent3:
+    @overload
+    def method(self, x: int) -> int:
+        ...
+
+    @overload
+    def method(self, x: str) -> str:
+        ...
+
+    def method(self, x: int | str) -> int | str:
+        return x
+
+
+class Child3_1(Parent3):
+    @overload
+    def method(self, x: int) -> int:
+        ...
+
+    @overload
+    def method(self, x: str) -> str:
+        ...
+
+    @overload
+    def method(self, x: list[float]) -> list[float]:
+        ...
+
+    def method(self, x: int | str | list[float]) -> int | str | list[float]:
+        return x


### PR DESCRIPTION
…thodOverride` check in certain circumstances where the method in both the base class and child class are overloaded. This addresses #5718.