### PR TITLE
Added heuristic to constraint solver logic to better handle the case …

### DIFF
--- a/packages/pyright-internal/src/tests/samples/solver29.py
+++ b/packages/pyright-internal/src/tests/samples/solver29.py
@@ -1,0 +1,36 @@
+# This sample tests the case where a union of two "bare" TypeVars are
+# used in the annotation of a function parameter.
+
+from typing import Any, TypeVar, Callable
+
+S = TypeVar("S")
+T = TypeVar("T")
+
+
+def accepts_bool(b: bool) -> None:
+    ...
+
+
+def accepts_int(i: int) -> None:
+    ...
+
+
+def func1(x: S | T, l2: Callable[[S], Any], l3: Callable[[T], Any]) -> tuple[S, T]:
+    ...
+
+
+def func2(x: T | S, l2: Callable[[S], Any], l3: Callable[[T], Any]) -> tuple[S, T]:
+    ...
+
+
+x1 = func1(0, accepts_int, accepts_bool)
+reveal_type(x1, expected_text="tuple[int, bool]")
+
+x2 = func1(True, accepts_int, accepts_bool)
+reveal_type(x2, expected_text="tuple[int, bool]")
+
+x3 = func1(0, accepts_int, accepts_bool)
+reveal_type(x3, expected_text="tuple[int, bool]")
+
+x4 = func1(True, accepts_int, accepts_bool)
+reveal_type(x4, expected_text="tuple[int, bool]")

--- a/packages/pyright-internal/src/tests/typeEvaluator2.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator2.test.ts
@@ -671,6 +671,12 @@ test('Solver28', () => {
     TestUtils.validateResults(analysisResults, 0);
 });
 
+test('Solver29', () => {
+    const analysisResults = TestUtils.typeAnalyzeSampleFiles(['solver29.py']);
+
+    TestUtils.validateResults(analysisResults, 0);
+});
+
 test('SolverScoring1', () => {
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['solverScoring1.py']);
 


### PR DESCRIPTION
…where a parameter is annotated with a union of multiple "bare" TypeVars (like `S | T`). In this case, it's not clear whether the corresponding argument type should constrain `S` or `T` or both. We now defer the constraint during the first pass of arg/param type validation so additional references to `S` or `T` can help establish the appropriate constraint. This addresses #5768.