### PR TITLE
Changed logic for handling the `__get__` method of a descriptor so py…

### DIFF
--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -5765,14 +5765,10 @@ export function createTypeEvaluator(importLookup: ImportLookup, evaluatorOptions
 
                         if (usage.method === 'get') {
                             // Provide "owner" argument.
-                            // Use Any rather than None for the owner argument if accessing through an object.
-                            // None is more correct, but it doesn't really matter, and many descriptor classes
-                            // incorrectly annotate the owner parameter. Rather than create a bunch of noise,
-                            // we'll use Any here.
                             argList.push({
                                 argumentCategory: ArgumentCategory.Simple,
                                 typeResult: {
-                                    type: isAccessedThroughObject ? AnyType.create() : baseTypeClass,
+                                    type: isAccessedThroughObject ? NoneType.createInstance() : baseTypeClass,
                                 },
                             });
                         } else if (usage.method === 'set') {

--- a/packages/pyright-internal/src/tests/samples/memberAccess8.py
+++ b/packages/pyright-internal/src/tests/samples/memberAccess8.py
@@ -48,10 +48,10 @@ class Minimal(Generic[_T, _T_co]):
         ...
 
     @overload
-    def __get__(self, instance: _T, owner: type[_T]) -> _T_co:
+    def __get__(self, instance: _T, owner: None) -> _T_co:
         ...
 
-    def __get__(self, instance: _T | None, owner: type[_T]) -> Any:
+    def __get__(self, instance: _T | None, owner: type[_T] | None) -> Any:
         ...
 
 

--- a/packages/pyright-internal/src/tests/samples/paramSpec24.py
+++ b/packages/pyright-internal/src/tests/samples/paramSpec24.py
@@ -30,7 +30,7 @@ class _wrapped_cache(_callable_cache[P, T], Generic[O, P, T]):
         ...
 
     @overload
-    def __get__(self, instance: O, owner: type[O]) -> Self:
+    def __get__(self, instance: O, owner: None) -> Self:
         ...
 
 


### PR DESCRIPTION
…right more accurately models the runtime behavior when the descriptor is accessed through an object (as opposed to a class). In this case, the `owner` parameter of the `__get__` method will receive a `None` value at runtime. Previously, pyright was modeling this as an `Any` value to avoid problems with type stubs that are not accurately modeling the runtime behavior, but this caused other unintended side effects. This addresses #5778.