### PR TITLE
Changed logic for handling the `__get__` method of a descriptor so py…

### DIFF
--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -5765,14 +5765,10 @@ export function createTypeEvaluator(importLookup: ImportLookup, evaluatorOptions
 
                         if (usage.method === 'get') {
                             // Provide "owner" argument.
-                            // Use Any rather than None for the owner argument if accessing through an object.
-                            // None is more correct, but it doesn't really matter, and many descriptor classes
-                            // incorrectly annotate the owner parameter. Rather than create a bunch of noise,
-                            // we'll use Any here.
                             argList.push({
                                 argumentCategory: ArgumentCategory.Simple,
                                 typeResult: {
-                                    type: isAccessedThroughObject ? AnyType.create() : baseTypeClass,
+                                    type: baseTypeClass,
                                 },
                             });
                         } else if (usage.method === 'set') {

--- a/packages/pyright-internal/src/tests/samples/memberAccess1.py
+++ b/packages/pyright-internal/src/tests/samples/memberAccess1.py
@@ -8,9 +8,9 @@ from functools import cached_property
 _T = TypeVar("_T")
 
 
-class Column(Generic[_T]):
+class DescriptorA(Generic[_T]):
     @overload
-    def __get__(self, instance: None, owner: Any) -> "Column[_T]":  # type: ignore
+    def __get__(self, instance: None, owner: Any) -> "DescriptorA[_T]":  # type: ignore
         ...
 
     @overload
@@ -19,14 +19,14 @@ class Column(Generic[_T]):
 
 
 class ClassA:
-    bar = Column[str]()
+    bar = DescriptorA[str]()
 
     @classmethod
     def func1(cls):
-        a: Column[str] = cls.bar
+        a: DescriptorA[str] = cls.bar
 
 
-reveal_type(ClassA.bar, expected_text="Column[str]")
+reveal_type(ClassA.bar, expected_text="DescriptorA[str]")
 reveal_type(ClassA().bar, expected_text="str")
 
 
@@ -52,7 +52,7 @@ class ClassC:
 reveal_type(ClassC.instance, expected_text="ClassC")
 
 
-class GenericDescriptor(Generic[_T]):
+class DescriptorD(Generic[_T]):
     value: _T
 
     def __get__(self, instance: object | None, cls: type[object]) -> _T:
@@ -63,8 +63,31 @@ class GenericDescriptor(Generic[_T]):
 
 
 class ClassD:
-    abc: GenericDescriptor[str] = GenericDescriptor()
+    abc: DescriptorD[str] = DescriptorD()
     stack: ExitStack
 
     def test(self, value: ContextManager[str]) -> None:
         self.abc = self.stack.enter_context(value)
+
+
+class DescriptorE:
+    def __get__(self, instance: "ClassE | None", owner: "type[ClassE]"):
+        return None
+
+
+class MetaDescriptorE:
+    def __get__(self, instance: "type[ClassE] | None", owner: "type[MetaclassE]"):
+        return None
+
+
+class MetaclassE(type):
+    y = MetaDescriptorE()
+
+
+class ClassE(metaclass=MetaclassE):
+    x = DescriptorE()
+
+
+ClassE.x
+ClassE().x
+ClassE.y


### PR DESCRIPTION
…right more accurately models the runtime behavior when the descriptor is accessed through an object (as opposed to a class). Previously, pyright was modeling this as an `Any` value to avoid problems with type stubs that are not accurately modeling the runtime behavior, but this caused other unintended side effects. This addresses #5778.