### PR TITLE
Improved logic that determines whether an object is callable. The `__…

### DIFF
--- a/packages/pyright-internal/src/analyzer/constructorTransform.ts
+++ b/packages/pyright-internal/src/analyzer/constructorTransform.ts
@@ -36,6 +36,7 @@ import {
 } from './types';
 import {
     applySolvedTypeVars,
+    ClassMemberLookupFlags,
     convertToInstance,
     getTypeVarScopeId,
     lookUpObjectMember,
@@ -78,7 +79,11 @@ function applyPartialTransform(
         return result;
     }
 
-    const callMemberResult = lookUpObjectMember(result.returnType, '__call__');
+    const callMemberResult = lookUpObjectMember(
+        result.returnType,
+        '__call__',
+        ClassMemberLookupFlags.SkipInstanceVariables
+    );
     if (!callMemberResult || !isTypeSame(convertToInstance(callMemberResult.classType), result.returnType)) {
         return result;
     }

--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -9550,7 +9550,7 @@ export function createTypeEvaluator(importLookup: ImportLookup, evaluatorOptions
             '__call__',
             /* usage */ undefined,
             /* diag */ undefined,
-            MemberAccessFlags.SkipAttributeAccessOverride
+            MemberAccessFlags.SkipAttributeAccessOverride | MemberAccessFlags.AccessClassMembersOnly
         )?.type;
 
         if (!memberType) {
@@ -11776,7 +11776,11 @@ export function createTypeEvaluator(importLookup: ImportLookup, evaluatorOptions
                 }
 
                 if (isClassInstance(argType)) {
-                    const callMember = lookUpObjectMember(argType, '__call__');
+                    const callMember = lookUpObjectMember(
+                        argType,
+                        '__call__',
+                        ClassMemberLookupFlags.SkipInstanceVariables
+                    );
                     if (callMember) {
                         const memberType = getTypeOfMember(callMember);
                         if (isOverloadedFunction(memberType)) {

--- a/packages/pyright-internal/src/analyzer/typeGuards.ts
+++ b/packages/pyright-internal/src/analyzer/typeGuards.ts
@@ -65,6 +65,7 @@ import {
     applySolvedTypeVars,
     AssignTypeFlags,
     ClassMember,
+    ClassMemberLookupFlags,
     computeMroLinearization,
     convertToInstance,
     convertToInstantiable,
@@ -1437,7 +1438,11 @@ function narrowTypeForIsInstance(
                         if (TypeBase.isInstantiable(unexpandedType)) {
                             isCallable = true;
                         } else {
-                            isCallable = !!lookUpClassMember(varType, '__call__');
+                            isCallable = !!lookUpClassMember(
+                                varType,
+                                '__call__',
+                                ClassMemberLookupFlags.SkipInstanceVariables
+                            );
                         }
                     }
 
@@ -2252,7 +2257,12 @@ function narrowTypeForCallable(
                 }
 
                 // See if the object is callable.
-                const callMemberType = lookUpClassMember(subtype, '__call__');
+                const callMemberType = lookUpClassMember(
+                    subtype,
+                    '__call__',
+                    ClassMemberLookupFlags.SkipInstanceVariables
+                );
+
                 if (!callMemberType) {
                     if (!isPositiveTest) {
                         return subtype;

--- a/packages/pyright-internal/src/analyzer/typeUtils.ts
+++ b/packages/pyright-internal/src/analyzer/typeUtils.ts
@@ -945,7 +945,7 @@ export function isCallableType(type: Type): boolean {
             return true;
         }
 
-        const callMember = lookUpObjectMember(type, '__call__');
+        const callMember = lookUpObjectMember(type, '__call__', ClassMemberLookupFlags.SkipInstanceVariables);
         return !!callMember;
     }
 

--- a/packages/pyright-internal/src/tests/samples/callable7.py
+++ b/packages/pyright-internal/src/tests/samples/callable7.py
@@ -1,0 +1,23 @@
+# This sample tests the handling of the `__call__` attribute.
+
+class A:
+    def __init__(self):
+        self.__call__ = self.method1
+
+    def method1(self, a: int):
+        return a
+
+
+# This should generate an error because `__call__` is
+# callable only if it's a class variable.
+A()(0)
+
+
+class B:
+    def method1(self, a: int):
+        return a
+
+    __call__ = method1
+
+
+B()(0)

--- a/packages/pyright-internal/src/tests/typeEvaluator4.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator4.test.ts
@@ -753,6 +753,12 @@ test('Callable6', () => {
     TestUtils.validateResults(analysisResults, 9);
 });
 
+test('Callable7', () => {
+    const analysisResults = TestUtils.typeAnalyzeSampleFiles(['callable7.py']);
+
+    TestUtils.validateResults(analysisResults, 1);
+});
+
 test('Generic1', () => {
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['generic1.py']);
 


### PR DESCRIPTION
…call__` attribute must be a class variable, not an instance variable. This addresses #5796.