### PR TITLE
Changed type evaluation behavior for a class variable that uses `Self…

### DIFF
--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -5527,13 +5527,23 @@ export function createTypeEvaluator(importLookup: ImportLookup, evaluatorOptions
             }
 
             if (!type) {
+                let selfClass: ClassType | TypeVarType | undefined = classType;
+
                 // Determine whether to replace Self variables with a specific
                 // class. Avoid doing this if there's a "bindToType" specified
                 // because that case is used for super() calls where we want
                 // to leave the Self type generic (not specialized). We'll also
                 // skip this for __new__ methods because they are not bound
                 // to the class but rather assume the type of the cls argument.
-                const selfClass = !!bindToType || memberName === '__new__' ? undefined : classType;
+                if (bindToType) {
+                    if (isTypeVar(bindToType) && bindToType.details.isSynthesizedSelf) {
+                        selfClass = bindToType;
+                    } else {
+                        selfClass = undefined;
+                    }
+                } else if (memberName === '__new__') {
+                    selfClass = undefined;
+                }
 
                 const typeResult = getTypeOfMemberInternal(memberInfo, selfClass);
 
@@ -21266,7 +21276,10 @@ export function createTypeEvaluator(importLookup: ImportLookup, evaluatorOptions
         return UnknownType.create();
     }
 
-    function getTypeOfMemberInternal(member: ClassMember, selfClass: ClassType | undefined): TypeResult | undefined {
+    function getTypeOfMemberInternal(
+        member: ClassMember,
+        selfClass: ClassType | TypeVarType | undefined
+    ): TypeResult | undefined {
         if (isInstantiableClass(member.classType)) {
             const typeResult = getEffectiveTypeOfSymbolForUsage(member.symbol);
 

--- a/packages/pyright-internal/src/analyzer/typeUtils.ts
+++ b/packages/pyright-internal/src/analyzer/typeUtils.ts
@@ -1027,7 +1027,7 @@ export function isTupleIndexUnambiguous(type: ClassType, index: number) {
 export function partiallySpecializeType(
     type: Type,
     contextClassType: ClassType,
-    selfClass?: ClassType,
+    selfClass?: ClassType | TypeVarType,
     typeClassType?: Type
 ): Type {
     // If the context class is not specialized (or doesn't need specialization),
@@ -1049,7 +1049,7 @@ export function partiallySpecializeType(
 export function populateTypeVarContextForSelfType(
     typeVarContext: TypeVarContext,
     contextClassType: ClassType,
-    selfClass: ClassType
+    selfClass: ClassType | TypeVarType
 ) {
     const synthesizedSelfTypeVar = synthesizeTypeVarForSelfCls(contextClassType, /* isClsParam */ false);
     const selfInstance = convertToInstance(selfClass);

--- a/packages/pyright-internal/src/tests/samples/self9.py
+++ b/packages/pyright-internal/src/tests/samples/self9.py
@@ -1,0 +1,23 @@
+# This sample tests the case where a parent class defines a class variable
+# that uses Self and a child class accesses this through self or cls.
+
+from typing import Self
+
+
+class ParentA:
+    a: list[Self]
+
+
+class ChildA(ParentA):
+    b: int
+
+    @classmethod
+    def method1(cls) -> None:
+        reveal_type(cls.a, expected_text="list[Self@ChildA]")
+        reveal_type(cls.a[0], expected_text="Self@ChildA")
+        print(cls.a[0].b)
+
+    def method2(self) -> None:
+        reveal_type(self.a, expected_text="list[Self@ChildA]")
+        reveal_type(self.a[0], expected_text="Self@ChildA")
+        print(self.a[0].b)

--- a/packages/pyright-internal/src/tests/typeEvaluator1.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator1.test.ts
@@ -1470,6 +1470,12 @@ test('Self8', () => {
     TestUtils.validateResults(analysisResults, 0);
 });
 
+test('Self9', () => {
+    const analysisResults = TestUtils.typeAnalyzeSampleFiles(['self9.py']);
+
+    TestUtils.validateResults(analysisResults, 0);
+});
+
 test('UnusedVariable1', () => {
     const configOptions = new ConfigOptions('.');
 


### PR DESCRIPTION
…` in its type definition. When accessed via a subclass (either through `cls` or `self`), the type is now assumed to be changed to `Self` of the child class. This makes pyright's behavior closer to mypy's in this case. It addresses #5803.