### PR TITLE
Fixed a bug that led to a false positive during overload matching whe…

### DIFF
--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -8358,15 +8358,9 @@ export function createTypeEvaluator(importLookup: ImportLookup, evaluatorOptions
                     });
                 }
 
-                // Clone the typeVarContext so we don't modify the original. If this is
-                // not the first time through the loop, clone the type var context
-                // from the previous successful match.
-                const typeVarContextToClone =
-                    matchedOverloads.length > 0
-                        ? matchedOverloads[matchedOverloads.length - 1].typeVarContext.clone()
-                        : typeVarContext;
+                // Clone the typeVarContext so we don't modify the original.
                 const effectiveTypeVarContext =
-                    typeVarContextToClone?.clone() ?? new TypeVarContext(getTypeVarScopeId(overload));
+                    typeVarContext?.clone() ?? new TypeVarContext(getTypeVarScopeId(overload));
                 effectiveTypeVarContext.addSolveForScope(getTypeVarScopeIds(overload));
                 effectiveTypeVarContext.unlock();
 

--- a/packages/pyright-internal/src/tests/samples/overload8.py
+++ b/packages/pyright-internal/src/tests/samples/overload8.py
@@ -1,7 +1,7 @@
 # This sample tests the expansion of union types during overload matching.
 
 
-from typing import Literal, TypeVar, overload
+from typing import AnyStr, Literal, TypeVar, overload
 
 
 class A:
@@ -131,3 +131,25 @@ def overloaded4(b: str | int) -> str | int:
 
 def func6(x: str | int) -> None:
     y: str | int = overloaded4(func5(x))
+
+
+@overload
+def overloaded5(pattern: AnyStr) -> AnyStr:
+    ...
+
+
+@overload
+def overloaded5(pattern: int) -> int:
+    ...
+
+
+def overloaded5(pattern: AnyStr | int) -> AnyStr | int:
+    return 0
+
+
+def func7(a: str | bytes) -> str | bytes:
+    return overloaded5(a)
+
+
+def func8(a: AnyStr | str | bytes) -> str | bytes:
+    return overloaded5(a)


### PR DESCRIPTION
…n the arg type includes a union where one of the subtypes is a constrained TypeVar. This addresses #5794.