### PR TITLE
Make typeguard non experimental just to test mypy primer

### DIFF
--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -11182,7 +11182,7 @@ export function createTypeEvaluator(importLookup: ImportLookup, evaluatorOptions
 
                 let useStrictTypeGuardSemantics = false;
 
-                if (AnalyzerNodeInfo.getFileInfo(errorNode).diagnosticRuleSet.enableExperimentalFeatures) {
+                if (errorNode) {
                     // Determine the type of the first parameter.
                     const paramIndex = type.boundToType ? 1 : 0;
                     if (paramIndex < type.details.parameters.length) {


### PR DESCRIPTION
This is just an experiment for the https://github.com/python/peps/pull/3266. This is to verify backwards compatibility isn't an issue.