### PR TITLE
Fixed long-standing bug that caused various problems (including poor …

### DIFF
--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -22163,16 +22163,20 @@ export function createTypeEvaluator(importLookup: ImportLookup, evaluatorOptions
         if (isTypeVar(destType)) {
             if (isTypeVarSame(destType, srcType)) {
                 if (destType.scopeId && destTypeVarContext?.hasSolveForScope(destType.scopeId)) {
-                    return assignTypeToTypeVar(
-                        evaluatorInterface,
-                        destType,
-                        srcType,
-                        diag,
-                        destTypeVarContext,
-                        flags,
-                        recursionCount
-                    );
+                    // If the dest TypeVar has no current value bound to it, bind itself.
+                    if (!destTypeVarContext.getPrimarySignature().getTypeVar(destType)) {
+                        return assignTypeToTypeVar(
+                            evaluatorInterface,
+                            destType,
+                            srcType,
+                            diag,
+                            destTypeVarContext,
+                            flags,
+                            recursionCount
+                        );
+                    }
                 }
+
                 return true;
             }
 

--- a/packages/pyright-internal/src/tests/samples/constructor26.py
+++ b/packages/pyright-internal/src/tests/samples/constructor26.py
@@ -7,16 +7,16 @@ from typing import Generic, TypeVar
 T = TypeVar("T")
 U = TypeVar("U")
 
-# This test is commented out because it doesn't yet work.
-# class Test1(Generic[T, U]):
-#     def __init__(self, t: T, u: U):
-#         pass
 
-#     def test1(self, ts: list[T], us: list[U]) -> None:
-#         # This should generate an error.
-#         x1: Test1[U, T] = Test1(us, ts)
+class Test1(Generic[T, U]):
+    def __init__(self, t: T, u: U):
+        pass
 
-#         x2: Test1[list[U], list[T]] = Test1(us, ts)
+    def test1(self, ts: list[T], us: list[U]) -> None:
+        # This should generate an error.
+        x1: Test1[U, T] = Test1(us, ts)
+
+        x2: Test1[list[U], list[T]] = Test1(us, ts)
 
 
 class Test2(Generic[T, U]):
@@ -47,13 +47,12 @@ class Test2(Generic[T, U]):
         x3 = Test2[T, U]()
 
 
-# This test is commented out because it doesn't yet work.
-# class Test3(Generic[T, U]):
-#     def __init__(self, ts: list[T], us: list[U]):
-#         pass
+class Test3(Generic[T, U]):
+    def __init__(self, ts: list[T], us: list[U]):
+        pass
 
-#     def test3(self, ts: list[T], us: list[U]) -> None:
-#         # This should generate an error.
-#         x1: Test3[U, T] = Test3(us, ts)
+    def test3(self, ts: list[T], us: list[U]) -> None:
+        x1: Test3[U, T] = Test3(us, ts)
 
-#         x2: Test3[list[U], list[T]] = Test3(us, ts)
+        # This should generate an error.
+        x2: Test3[list[U], list[T]] = Test3(us, ts)

--- a/packages/pyright-internal/src/tests/typeEvaluator3.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator3.test.ts
@@ -1522,7 +1522,7 @@ test('Constructor25', () => {
 test('Constructor26', () => {
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['constructor26.py']);
 
-    TestUtils.validateResults(analysisResults, 6);
+    TestUtils.validateResults(analysisResults, 8);
 });
 
 test('Constructor27', () => {


### PR DESCRIPTION
…performance, incorrect type evaluations, and false negatives and false positives) when calling a constructor for a generic class within the class implementation. This addresses #5373.