### PR TITLE
Fixed a bug that led to an incorrect type evaluation in certain cases…

### DIFF
--- a/packages/pyright-internal/src/analyzer/constraintSolver.ts
+++ b/packages/pyright-internal/src/analyzer/constraintSolver.ts
@@ -435,6 +435,12 @@ export function assignTypeToTypeVar(
     }
 
     if ((flags & AssignTypeFlags.PopulatingExpectedType) !== 0) {
+        // If we're populating the expected type and the srcType is
+        // Unknown, ignore it.
+        if (isUnknown(adjSrcType)) {
+            return true;
+        }
+
         // If we're populating the expected type, constrain either the
         // narrow type bound, wide type bound or both. Don't overwrite
         // an existing entry.

--- a/packages/pyright-internal/src/analyzer/typeUtils.ts
+++ b/packages/pyright-internal/src/analyzer/typeUtils.ts
@@ -3768,19 +3768,6 @@ class ApplySolvedTypeVarsTransformer extends TypeVarTransformer {
         if (typeVar.scopeId && this._typeVarContext.hasSolveForScope(typeVar.scopeId)) {
             let replacement = signatureContext.getTypeVarType(typeVar, !!this._options.useNarrowBoundOnly);
 
-            // If the type is unknown, see if there's a known wide bound that we can use.
-            if (
-                replacement &&
-                isUnknown(replacement) &&
-                !this._options.useNarrowBoundOnly &&
-                this._options.unknownIfNotFound
-            ) {
-                const entry = signatureContext.getTypeVar(typeVar);
-                if (entry?.wideBound) {
-                    replacement = entry?.wideBound;
-                }
-            }
-
             // If there was no narrow bound but there is a wide bound that
             // contains literals or a TypeVar, we'll use the wide bound even if
             // "useNarrowBoundOnly" is specified.


### PR DESCRIPTION
… where a type argument for a function call argument type is left unspecified (and is therefore assumed to be Unknown). This addresses #5879.