### PR TITLE
Skip real case path on pythonPath

### DIFF
--- a/packages/pyright-internal/src/analyzer/service.ts
+++ b/packages/pyright-internal/src/analyzer/service.ts
@@ -615,7 +615,7 @@ export class AnalyzerService {
             this._console.info(
                 `Setting pythonPath for service "${this._instanceName}": ` + `"${commandLineOptions.pythonPath}"`
             );
-            configOptions.pythonPath = realCasePath(commandLineOptions.pythonPath, this.fs);
+            configOptions.pythonPath = commandLineOptions.pythonPath, this.fs;
         }
         if (commandLineOptions.pythonEnvironmentName) {
             this._console.info(
@@ -738,7 +738,7 @@ export class AnalyzerService {
         // duplicates.
         if (commandLineOptions.venvPath) {
             if (!configOptions.venvPath) {
-                configOptions.venvPath = realCasePath(commandLineOptions.venvPath, this.fs);
+                configOptions.venvPath = commandLineOptions.venvPath;
             } else {
                 reportDuplicateSetting('venvPath', configOptions.venvPath);
             }

--- a/packages/pyright-internal/src/analyzer/service.ts
+++ b/packages/pyright-internal/src/analyzer/service.ts
@@ -615,7 +615,7 @@ export class AnalyzerService {
             this._console.info(
                 `Setting pythonPath for service "${this._instanceName}": ` + `"${commandLineOptions.pythonPath}"`
             );
-            configOptions.pythonPath = commandLineOptions.pythonPath, this.fs;
+            (configOptions.pythonPath = commandLineOptions.pythonPath), this.fs;
         }
         if (commandLineOptions.pythonEnvironmentName) {
             this._console.info(

--- a/packages/pyright-internal/src/common/pathUtils.ts
+++ b/packages/pyright-internal/src/common/pathUtils.ts
@@ -536,7 +536,7 @@ export function stripFileExtension(fileName: string, multiDotExtension = false) 
 }
 
 export function realCasePath(pathString: string, fileSystem: ReadOnlyFileSystem): string {
-    return normalizePath(pathString);
+    return normalizePath(fileSystem.realCasePath(pathString));
 }
 
 export function normalizePath(pathString: string): string {

--- a/packages/pyright-internal/src/languageServerBase.ts
+++ b/packages/pyright-internal/src/languageServerBase.ts
@@ -109,10 +109,10 @@ import {
     deduplicateFolders,
     getDirectoryPath,
     getFileName,
-    isFile,
-    realCasePath,
+    isFile
 } from './common/pathUtils';
 import { ProgressReportTracker, ProgressReporter } from './common/progressReporter';
+import { ServiceProvider } from './common/serviceProvider';
 import { DocumentRange, Position, Range } from './common/textRange';
 import { UriParser } from './common/uriParser';
 import { AnalyzerServiceExecutor } from './languageService/analyzerServiceExecutor';
@@ -124,13 +124,12 @@ import { DocumentSymbolProvider } from './languageService/documentSymbolProvider
 import { HoverProvider } from './languageService/hoverProvider';
 import { canNavigateToFile } from './languageService/navigationUtils';
 import { ReferencesProvider } from './languageService/referencesProvider';
+import { RenameProvider } from './languageService/renameProvider';
 import { SignatureHelpProvider } from './languageService/signatureHelpProvider';
+import { WorkspaceSymbolProvider } from './languageService/workspaceSymbolProvider';
 import { Localizer, setLocaleOverride } from './localization/localize';
 import { SupportUriToPathMapping } from './pyrightFileSystem';
 import { InitStatus, WellKnownWorkspaceKinds, Workspace, WorkspaceFactory } from './workspaceFactory';
-import { RenameProvider } from './languageService/renameProvider';
-import { WorkspaceSymbolProvider } from './languageService/workspaceSymbolProvider';
-import { ServiceProvider } from './common/serviceProvider';
 
 export interface ServerSettings {
     venvPath?: string | undefined;
@@ -525,7 +524,7 @@ export abstract class LanguageServerBase implements LanguageServerInterface, Dis
         // Apply the new path to the workspace (before restarting the service).
         serverSettings.pythonPath = this.workspaceFactory.applyPythonPath(
             workspace,
-            serverSettings.pythonPath ? realCasePath(serverSettings.pythonPath, this.fs) : undefined
+            serverSettings.pythonPath
         );
 
         // Then use the updated settings to restart the service.

--- a/packages/pyright-internal/src/languageServerBase.ts
+++ b/packages/pyright-internal/src/languageServerBase.ts
@@ -104,13 +104,7 @@ import { FileSystem } from './common/fileSystem';
 import { FileWatcherEventType, FileWatcherHandler } from './common/fileWatcher';
 import { Host } from './common/host';
 import { fromLSPAny } from './common/lspUtils';
-import {
-    convertPathToUri,
-    deduplicateFolders,
-    getDirectoryPath,
-    getFileName,
-    isFile
-} from './common/pathUtils';
+import { convertPathToUri, deduplicateFolders, getDirectoryPath, getFileName, isFile } from './common/pathUtils';
 import { ProgressReportTracker, ProgressReporter } from './common/progressReporter';
 import { ServiceProvider } from './common/serviceProvider';
 import { DocumentRange, Position, Range } from './common/textRange';
@@ -522,10 +516,7 @@ export abstract class LanguageServerBase implements LanguageServerInterface, Dis
         (this.console as ConsoleWithLogLevel).level = serverSettings.logLevel ?? LogLevel.Info;
 
         // Apply the new path to the workspace (before restarting the service).
-        serverSettings.pythonPath = this.workspaceFactory.applyPythonPath(
-            workspace,
-            serverSettings.pythonPath
-        );
+        serverSettings.pythonPath = this.workspaceFactory.applyPythonPath(workspace, serverSettings.pythonPath);
 
         // Then use the updated settings to restart the service.
         this.updateOptionsAndRestartService(workspace, serverSettings);


### PR DESCRIPTION
Alternative fix that maintains realCasePath for most cases, but skips it for pythonPath