### PR TITLE
Added code to enforce invariance of class-scoped variables in overrid…

### DIFF
--- a/packages/pyright-internal/src/localization/localize.ts
+++ b/packages/pyright-internal/src/localization/localize.ts
@@ -1248,6 +1248,11 @@ export namespace Localizer {
             new ParameterizedString<{ name: string }>(getRawString('DiagnosticAddendum.overloadNotAssignable'));
         export const overriddenMethod = () => getRawString('DiagnosticAddendum.overriddenMethod');
         export const overriddenSymbol = () => getRawString('DiagnosticAddendum.overriddenSymbol');
+        export const overrideIsInvariant = () => getRawString('DiagnosticAddendum.overrideIsInvariant');
+        export const overrideInvariantMismatch = () =>
+            new ParameterizedString<{ overrideType: string; baseType: string }>(
+                getRawString('DiagnosticAddendum.overrideInvariantMismatch')
+            );
         export const overrideNoOverloadMatches = () => getRawString('DiagnosticAddendum.overrideNoOverloadMatches');
         export const overrideNotClassMethod = () => getRawString('DiagnosticAddendum.overrideNotClassMethod');
         export const overrideNotInstanceMethod = () => getRawString('DiagnosticAddendum.overrideNotInstanceMethod');

--- a/packages/pyright-internal/src/localization/package.nls.en-us.json
+++ b/packages/pyright-internal/src/localization/package.nls.en-us.json
@@ -634,6 +634,8 @@
         "overloadNotAssignable": "One or more overloads of \"{name}\" is not assignable",
         "overriddenMethod": "Overridden method",
         "overriddenSymbol": "Overridden symbol",
+        "overrideIsInvariant": "Variable is mutable so its type is invariant",
+        "overrideInvariantMismatch": "Override type \"{overrideType}\" is not the same as base type \"{baseType}\"",
         "overrideNoOverloadMatches": "No overload signature in override is compatible with base method",
         "overrideNotClassMethod": "Base method is declared as a classmethod but override is not",
         "overrideNotInstanceMethod": "Base method is declared as an instance method but override is not",

--- a/packages/pyright-internal/src/tests/samples/classes5.py
+++ b/packages/pyright-internal/src/tests/samples/classes5.py
@@ -49,6 +49,8 @@ class Subclass1(ParentClass1):
 
     var2: str
 
+    # This should generate an error if reportIncompatibleVariableOverride is
+    # enabled because the member is mutable, and is therefore invariant.
     var3: int
 
     # This should generate an error.
@@ -119,7 +121,7 @@ class ParentClass2:
 
 
 class SubclassDeclared2(ParentClass2):
-    cv_decl_1: int
+    cv_decl_1: float
 
     # This should generate an error if reportIncompatibleVariableOverride
     # is enabled.
@@ -134,6 +136,8 @@ class SubclassDeclared2(ParentClass2):
     cv_infer_3: float | None
 
     def __init__(self):
+        # This should generate an error if reportIncompatibleVariableOverride
+        # is enabled because the member is mutable and therefore invariant.
         self.cv_decl_4: int
 
         # This should generate an error if reportIncompatibleVariableOverride
@@ -241,6 +245,7 @@ class PeerClass1:
     test4: int
     test5: Any
     test6: float
+    test7: float
 
 
 class PeerClass2:
@@ -254,9 +259,10 @@ class PeerClass2:
 
     test5: int
     test6: Any
+    test7: int
 
 
-# This should generate 3 errors if reportIncompatibleVariableOverride
+# This should generate 4 errors if reportIncompatibleVariableOverride
 # is enabled.
 class MultipleInheritance1(PeerClass1, PeerClass2):
     pass

--- a/packages/pyright-internal/src/tests/typeEvaluator3.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator3.test.ts
@@ -760,7 +760,7 @@ test('Classes5', () => {
     // Turn on reportIncompatibleVariableOverride.
     configOptions.diagnosticRuleSet.reportIncompatibleVariableOverride = 'error';
     analysisResults = TestUtils.typeAnalyzeSampleFiles(['classes5.py'], configOptions);
-    TestUtils.validateResults(analysisResults, 32);
+    TestUtils.validateResults(analysisResults, 36);
 });
 
 test('Classes6', () => {


### PR DESCRIPTION
…es when the `reportIncompatibleVariableOverride` rule is enabled. This addresses #5933.