### PR TITLE
Fixed a bug that resulted in a false positive error when `*args` and …

### DIFF
--- a/packages/pyright-internal/src/tests/samples/paramSpec48.py
+++ b/packages/pyright-internal/src/tests/samples/paramSpec48.py
@@ -1,0 +1,15 @@
+# This sample tests the case where a function with a ParamSpec is called
+# with *args and **kwargs that are defined as Any.
+
+from typing import Any, Callable, Concatenate, ParamSpec
+
+
+P = ParamSpec("P")
+
+
+def func3(f: Callable[Concatenate[int, P], int], *args: Any, **kwargs: Any) -> int:
+    return f(*args, **kwargs)
+
+
+def func4(f: Callable[Concatenate[int, ...], int], *args: Any, **kwargs: Any) -> int:
+    return f(*args, **kwargs)

--- a/packages/pyright-internal/src/tests/typeEvaluator4.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator4.test.ts
@@ -1074,6 +1074,11 @@ test('ParamSpec47', () => {
     TestUtils.validateResults(results, 2);
 });
 
+test('ParamSpec48', () => {
+    const results = TestUtils.typeAnalyzeSampleFiles(['paramSpec48.py']);
+    TestUtils.validateResults(results, 0);
+});
+
 test('ClassVar1', () => {
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['classVar1.py']);
 


### PR DESCRIPTION
…`**kwargs` are passed as arguments to a function with a `ParamSpec` and the types of `*args` and `**kwargs` is `Any`. This addresses #5899.