### PR TITLE
Fixed a bug that resulted in a false positive error when `*args` and …

### DIFF
--- a/packages/pyright-internal/src/analyzer/typePrinter.ts
+++ b/packages/pyright-internal/src/analyzer/typePrinter.ts
@@ -675,10 +675,15 @@ function printTypeInternal(
                 }
 
                 if (type.details.isParamSpec) {
+                    const paramSpecText = _getReadableTypeVarName(
+                        type,
+                        (printTypeFlags & PrintTypeFlags.PythonSyntax) !== 0
+                    );
+
                     if (type.paramSpecAccess) {
-                        return `${type.details.name}.${type.paramSpecAccess}`;
+                        return `${paramSpecText}.${type.paramSpecAccess}`;
                     }
-                    return `${_getReadableTypeVarName(type, (printTypeFlags & PrintTypeFlags.PythonSyntax) !== 0)}`;
+                    return paramSpecText;
                 }
 
                 let typeVarName = _getReadableTypeVarName(type, (printTypeFlags & PrintTypeFlags.PythonSyntax) !== 0);

--- a/packages/pyright-internal/src/analyzer/typeUtils.ts
+++ b/packages/pyright-internal/src/analyzer/typeUtils.ts
@@ -3193,10 +3193,27 @@ class TypeVarTransformer {
             // _pendingTypeVarTransformations set.
             if (!this._isTypeVarScopePending(type.scopeId)) {
                 if (type.details.isParamSpec) {
-                    if (!type.paramSpecAccess) {
-                        const paramSpecValue = this.transformParamSpec(type, recursionCount);
-                        if (paramSpecValue) {
-                            replacementType = convertParamSpecValueToType(paramSpecValue);
+                    let paramSpecWithoutAccess = type;
+
+                    if (type.paramSpecAccess) {
+                        paramSpecWithoutAccess = TypeVarType.cloneForParamSpecAccess(type, /* access */ undefined);
+                    }
+
+                    const paramSpecValue = this.transformParamSpec(paramSpecWithoutAccess, recursionCount);
+                    if (paramSpecValue) {
+                        const paramSpecType = convertParamSpecValueToType(paramSpecValue);
+
+                        if (type.paramSpecAccess) {
+                            if (isParamSpec(paramSpecType)) {
+                                replacementType = TypeVarType.cloneForParamSpecAccess(
+                                    paramSpecType,
+                                    type.paramSpecAccess
+                                );
+                            } else {
+                                replacementType = UnknownType.create();
+                            }
+                        } else {
+                            replacementType = paramSpecType;
                         }
                     }
                 } else {

--- a/packages/pyright-internal/src/tests/samples/paramSpec37.py
+++ b/packages/pyright-internal/src/tests/samples/paramSpec37.py
@@ -19,10 +19,10 @@ def noop(v: T) -> T:
 
 def func1(maker: Callable[P, R]) -> ClassA[R]:
     def inner(n: int, /, *args: P.args, **kwargs: P.kwargs) -> list[R]:
-        reveal_type(args, expected_text="P.args")
-        reveal_type(noop(args), expected_text="P.args")
-        reveal_type(kwargs, expected_text="P.kwargs")
-        reveal_type(noop(kwargs), expected_text="P.kwargs")
+        reveal_type(args, expected_text="P@func1.args")
+        reveal_type(noop(args), expected_text="P@func1.args")
+        reveal_type(kwargs, expected_text="P@func1.kwargs")
+        reveal_type(noop(kwargs), expected_text="P@func1.kwargs")
 
         return [maker(*args, **kwargs) for _ in range(n)]
 

--- a/packages/pyright-internal/src/tests/samples/paramSpec48.py
+++ b/packages/pyright-internal/src/tests/samples/paramSpec48.py
@@ -1,0 +1,15 @@
+# This sample tests the case where a function with a ParamSpec is called
+# with *args and **kwargs that are defined as Any.
+
+from typing import Any, Callable, Concatenate, ParamSpec
+
+
+P = ParamSpec("P")
+
+
+def func3(f: Callable[Concatenate[int, P], int], *args: Any, **kwargs: Any) -> int:
+    return f(*args, **kwargs)
+
+
+def func4(f: Callable[Concatenate[int, ...], int], *args: Any, **kwargs: Any) -> int:
+    return f(*args, **kwargs)

--- a/packages/pyright-internal/src/tests/typeEvaluator4.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator4.test.ts
@@ -1074,6 +1074,11 @@ test('ParamSpec47', () => {
     TestUtils.validateResults(results, 2);
 });
 
+test('ParamSpec48', () => {
+    const results = TestUtils.typeAnalyzeSampleFiles(['paramSpec48.py']);
+    TestUtils.validateResults(results, 0);
+});
+
 test('ClassVar1', () => {
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['classVar1.py']);
 


### PR DESCRIPTION
…`**kwargs` are passed as arguments to a function with a `ParamSpec` and the types of `*args` and `**kwargs` is `Any`. This addresses #5899.