### PR TITLE
Extended support for `reportUnusedExpression` check to simple forms o…

### DIFF
--- a/packages/pyright-internal/src/analyzer/checker.ts
+++ b/packages/pyright-internal/src/analyzer/checker.ts
@@ -1779,6 +1779,24 @@ export class Checker extends ParseTreeWalker {
             if (!node.entries.some((entry) => entry.nodeType === ParseNodeType.ListComprehension)) {
                 reportAsUnused = true;
             }
+        } else if (node.nodeType === ParseNodeType.MemberAccess) {
+            // Include member accesses if the left expression is a simple name
+            // or a member access.
+            reportAsUnused = true;
+
+            let leftExpr = node.leftExpression;
+            while (true) {
+                if (leftExpr.nodeType === ParseNodeType.Name) {
+                    break;
+                }
+
+                if (leftExpr.nodeType !== ParseNodeType.MemberAccess) {
+                    reportAsUnused = false;
+                    break;
+                }
+
+                leftExpr = leftExpr.leftExpression;
+            }
         }
 
         if (

--- a/packages/pyright-internal/src/tests/checker.test.ts
+++ b/packages/pyright-internal/src/tests/checker.test.ts
@@ -437,7 +437,7 @@ test('UnusedExpression1', () => {
 
     // By default, this is a warning.
     let analysisResults = TestUtils.typeAnalyzeSampleFiles(['unusedExpression1.py'], configOptions);
-    TestUtils.validateResults(analysisResults, 0, 14);
+    TestUtils.validateResults(analysisResults, 0, 17);
 
     // Disable it.
     configOptions.diagnosticRuleSet.reportUnusedExpression = 'none';
@@ -447,7 +447,7 @@ test('UnusedExpression1', () => {
     // Enable it as an error.
     configOptions.diagnosticRuleSet.reportUnusedExpression = 'error';
     analysisResults = TestUtils.typeAnalyzeSampleFiles(['unusedExpression1.py'], configOptions);
-    TestUtils.validateResults(analysisResults, 14);
+    TestUtils.validateResults(analysisResults, 17);
 });
 
 test('UnusedImport1', () => {

--- a/packages/pyright-internal/src/tests/fourslash/import.pytyped.privateSymbols.fourslash.ts
+++ b/packages/pyright-internal/src/tests/fourslash/import.pytyped.privateSymbols.fourslash.ts
@@ -32,12 +32,12 @@
 //// from testLib import [|/*marker3*/_five|]
 //// from testLib import _six
 //// import testLib
-//// testLib.one
-//// testLib.[|/*marker4*/two|]
-//// testLib.[|/*marker5*/three|]
-//// testLib.four
-//// testLib.[|/*marker6*/_five|]
-//// testLib._six
+//// v1 = testLib.one
+//// v2 = testLib.[|/*marker4*/two|]
+//// v3 = testLib.[|/*marker5*/three|]
+//// v4 = testLib.four
+//// v5 = testLib.[|/*marker6*/_five|]
+//// v6 = testLib._six
 
 // @ts-ignore
 await helper.verifyDiagnostics({

--- a/packages/pyright-internal/src/tests/samples/annotated1.py
+++ b/packages/pyright-internal/src/tests/samples/annotated1.py
@@ -69,7 +69,7 @@ class B:
 d1 = B(x=4)
 
 # This should generate an error because x is not an actual member.
-d1.x
+d2 = d1.x
 
 Alias1 = Annotated[_T, ""]
 Alias2 = str

--- a/packages/pyright-internal/src/tests/samples/annotations3.py
+++ b/packages/pyright-internal/src/tests/samples/annotations3.py
@@ -36,7 +36,7 @@ class ClassB(ClassA):
         ...
 
     def func6(self, x: ClassC):
-        x.my_int
+        v1 = x.my_int
 
 
 class ClassC:

--- a/packages/pyright-internal/src/tests/samples/assignmentExpr4.py
+++ b/packages/pyright-internal/src/tests/samples/assignmentExpr4.py
@@ -40,9 +40,9 @@ class Example:
     x = ((y := 1), (z := 2))
 
 
-Example.x
-Example.y
-Example.z
+v1 = Example.x
+v2 = Example.y
+v3 = Example.z
 
 # This should generate an error because 'j' is used as a
 # "for target" and the target of an assignment expression.

--- a/packages/pyright-internal/src/tests/samples/callbackProtocol5.py
+++ b/packages/pyright-internal/src/tests/samples/callbackProtocol5.py
@@ -41,10 +41,10 @@ def func1(x: int) -> str:
 
 reveal_type(func1, expected_text="CallbackProto1[(x: int), str]")
 
-func1.other_attribute
+v1 = func1.other_attribute
 
 # This should generate an error
-func1.other_attribute2
+v2 = func1.other_attribute2
 
 func1(x=3)
 
@@ -63,4 +63,4 @@ def func2() -> None:
     ...
 
 
-v: CallbackProto2 = func2
+v3: CallbackProto2 = func2

--- a/packages/pyright-internal/src/tests/samples/circular2.py
+++ b/packages/pyright-internal/src/tests/samples/circular2.py
@@ -35,4 +35,4 @@ class F(D):
     pass
 
 
-E.a_attr
+v1 = E.a_attr

--- a/packages/pyright-internal/src/tests/samples/classVar4.py
+++ b/packages/pyright-internal/src/tests/samples/classVar4.py
@@ -35,5 +35,5 @@ def func1() -> None:
 
     z: int = Class.z
 
-    Class.meth1
-    Class.meth2
+    v1 = Class.meth1
+    v2 = Class.meth2

--- a/packages/pyright-internal/src/tests/samples/classes3.py
+++ b/packages/pyright-internal/src/tests/samples/classes3.py
@@ -32,12 +32,12 @@ dummy = TestClass.__dummy__
 
 instance = TestClass()
 
-instance.__doc__
-instance.__module__
+v1 = instance.__doc__
+v2 = instance.__module__
 
 # These should generate an error because they are not visible to instances.
-instance.__name__
-instance.__qualname__
+v3 = instance.__name__
+v4 = instance.__qualname__
 
 
 class Meta(type):

--- a/packages/pyright-internal/src/tests/samples/dataclassSlots1.py
+++ b/packages/pyright-internal/src/tests/samples/dataclassSlots1.py
@@ -51,7 +51,7 @@ class E:
     a: int
 
 
-E.__slots__
+v1 = E.__slots__
 E(1).__slots__
 
 reveal_type(E.__slots__, expected_text="Iterable[str]")
@@ -63,7 +63,7 @@ class F:
 
 
 # This should generate an error.
-F.__slots__
+v2 = F.__slots__
 
 # This should generate an error.
-F(1).__slots__
+v3 = F(1).__slots__

--- a/packages/pyright-internal/src/tests/samples/initVar1.py
+++ b/packages/pyright-internal/src/tests/samples/initVar1.py
@@ -17,7 +17,7 @@ c = Container(1, 2, 3)
 reveal_type(c.not_init_var1, expected_text="int")
 
 # This should generate an error
-c.init_var1
+v1 = c.init_var1
 
 # This should generate an error
-c.init_var2
+v2 = c.init_var2

--- a/packages/pyright-internal/src/tests/samples/match1.py
+++ b/packages/pyright-internal/src/tests/samples/match1.py
@@ -157,7 +157,7 @@ def func1():
     match = Foo()
 
     # This should be treated as an expression statement, not a match statement.
-    match.x
+    v1 = match.x
 
 
 def func2():

--- a/packages/pyright-internal/src/tests/samples/memberAccess1.py
+++ b/packages/pyright-internal/src/tests/samples/memberAccess1.py
@@ -88,6 +88,6 @@ class ClassE(metaclass=MetaclassE):
     x = DescriptorE()
 
 
-ClassE.x
-ClassE().x
-ClassE.y
+v1 = ClassE.x
+v2 = ClassE().x
+v3 = ClassE.y

--- a/packages/pyright-internal/src/tests/samples/memberAccess22.py
+++ b/packages/pyright-internal/src/tests/samples/memberAccess22.py
@@ -8,7 +8,7 @@ from contextlib import contextmanager
 class A:
     @classmethod
     def method1(cls) -> None:
-        cls.method2
+        v1 = cls.method2
 
     @contextmanager
     def method2(self):

--- a/packages/pyright-internal/src/tests/samples/memberAccess6.py
+++ b/packages/pyright-internal/src/tests/samples/memberAccess6.py
@@ -34,10 +34,10 @@ class ChildA(ParentA):
     attr2 = Column(str)
 
 
-ChildA.attr1
-ChildA().attr1
-ChildA.attr2
-ChildA().attr2
+v1 = ChildA.attr1
+v2 = ChildA().attr1
+v3 = ChildA.attr2
+v4 = ChildA().attr2
 
 foo = ChildA()
 

--- a/packages/pyright-internal/src/tests/samples/none1.py
+++ b/packages/pyright-internal/src/tests/samples/none1.py
@@ -8,13 +8,13 @@ a: Hashable = None
 b: Iterable = None
 
 c = None
-c.__class__
-c.__doc__
+v1 = c.__class__
+v2 = c.__doc__
 
 
 def func1(a: int | None):
-    a.__class__
-    a.__doc__
+    v1 = a.__class__
+    v2 = a.__doc__
 
 
 def func2(x: type[None]):

--- a/packages/pyright-internal/src/tests/samples/operator1.py
+++ b/packages/pyright-internal/src/tests/samples/operator1.py
@@ -72,7 +72,7 @@ class C:
 
 
 a = C()
-a.__add__
+v1 = a.__add__
 
 # This should generate an error because __getattr__ is not used
 # when looking up operator overload methods.

--- a/packages/pyright-internal/src/tests/samples/tryExcept10.py
+++ b/packages/pyright-internal/src/tests/samples/tryExcept10.py
@@ -10,4 +10,4 @@ def func1() -> None:
         return None
     finally:
         # This should generate an error.
-        file.name
+        v1 = file.name

--- a/packages/pyright-internal/src/tests/samples/typeNarrowingIsinstance3.py
+++ b/packages/pyright-internal/src/tests/samples/typeNarrowingIsinstance3.py
@@ -24,52 +24,52 @@ class D:
 
 def func1(val: A):
     if isinstance(val, B):
-        val.a_val
-        val.b_val
+        v1 = val.a_val
+        v2 = val.b_val
 
         # This should generate an error
-        val.c_val
+        v3 = val.c_val
 
         reveal_type(val, expected_text="<subclass of A and B>")
 
         if isinstance(val, C):
-            val.a_val
-            val.b_val
-            val.c_val
+            v4 = val.a_val
+            v5 = val.b_val
+            v6 = val.c_val
             reveal_type(val, expected_text="<subclass of <subclass of A and B> and C>")
 
     else:
-        val.a_val
+        v7 = val.a_val
 
         # This should generate an error
-        val.b_val
+        v8 = val.b_val
 
         reveal_type(val, expected_text="A")
 
 
 def func2(val: type[A]):
     if issubclass(val, B):
-        val.a_val
-        val.b_val
+        v1 = val.a_val
+        v2 = val.b_val
 
         # This should generate an error
-        val.c_val
+        v3 = val.c_val
 
         reveal_type(val, expected_text="type[<subclass of A and B>]")
 
         if issubclass(val, C):
-            val.a_val
-            val.b_val
-            val.c_val
+            v4 = val.a_val
+            v5 = val.b_val
+            v6 = val.c_val
             reveal_type(
                 val, expected_text="type[<subclass of <subclass of A and B> and C>]"
             )
 
     else:
-        val.a_val
+        v7 = val.a_val
 
         # This should generate an error
-        val.b_val
+        v8 = val.b_val
 
         reveal_type(val, expected_text="type[A]")
 

--- a/packages/pyright-internal/src/tests/samples/typeVar8.py
+++ b/packages/pyright-internal/src/tests/samples/typeVar8.py
@@ -9,9 +9,9 @@ S = TypeVar("S", bound=str)
 
 # In these cases, the TypeVar symbol simply represents the TypeVar
 # object itself, rather than representing a type variable.
-T.__name__
-S.__name__
-S.__bound__
+v1 = T.__name__
+v2 = S.__name__
+v3 = S.__bound__
 
 
 def func1(x: bool, a: T, b: S) -> T | S:
@@ -19,10 +19,10 @@ def func1(x: bool, a: T, b: S) -> T | S:
     reveal_type(S.__name__, expected_text="str")
 
     # This should generate an error
-    a.__name__
+    v1 = a.__name__
 
     # This should generate an error
-    b.__name__
+    v2 = b.__name__
 
     if x:
         return a

--- a/packages/pyright-internal/src/tests/samples/unusedExpression1.py
+++ b/packages/pyright-internal/src/tests/samples/unusedExpression1.py
@@ -1,5 +1,8 @@
 # This sample tests the reportUnusedExpression diagnostic rule.
 
+import datetime
+import collections.abc
+
 t = 1
 
 
@@ -48,3 +51,15 @@ t
 [x for x in range(3)]
 {x: x for x in range(3)}
 {x for x in range(3)}
+
+
+x = []
+
+# This should generate a diagnostic.
+x.append
+
+# This should generate a diagnostic.
+datetime.datetime
+
+# This should generate a diagnostic.
+collections.abc.Awaitable


### PR DESCRIPTION
…f member access expressions. This addresses microsoft/pylance-release#4863.