### PR TITLE
Improved validation of generator return type. Previously, the check w…

### DIFF
--- a/packages/pyright-internal/src/tests/samples/generator1.py
+++ b/packages/pyright-internal/src/tests/samples/generator1.py
@@ -95,17 +95,20 @@ def generator8() -> Iterator[dict[str, int]]:
 
 # This should generate an error.
 def generator9() -> int:
+    # This should generate an error.
     yield None
     return 3
 
 
 # This should generate an error.
 async def generator10() -> int:
+    # This should generate an error.
     yield None
 
 
 # This should generate an error.
 def generator11() -> list[int]:
+    # This should generate an error.
     yield 3
 
 

--- a/packages/pyright-internal/src/tests/typeEvaluator3.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator3.test.ts
@@ -33,7 +33,7 @@ test('Ellipsis1', () => {
 test('Generator1', () => {
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['generator1.py']);
 
-    TestUtils.validateResults(analysisResults, 9);
+    TestUtils.validateResults(analysisResults, 12);
 });
 
 test('Generator2', () => {


### PR DESCRIPTION
…as performed only for `yield` statements, but it's possible to define a generator function that has no reachable yield statements. This addresses #5972.