### PR TITLE
Fixed bug that led to a false positive error when checking for out-of…

### DIFF
--- a/packages/pyright-internal/src/analyzer/checker.ts
+++ b/packages/pyright-internal/src/analyzer/checker.ts
@@ -1182,7 +1182,12 @@ export class Checker extends ParseTreeWalker {
         const baseType = this._evaluator.getType(node.baseExpression);
         if (baseType) {
             doForEachSubtype(baseType, (subtype) => {
-                if (isClassInstance(subtype) && subtype.tupleTypeArguments && !isUnboundedTupleClass(subtype)) {
+                if (
+                    isClassInstance(subtype) &&
+                    subtype.tupleTypeArguments &&
+                    !isUnboundedTupleClass(subtype) &&
+                    !this._evaluator.isTypeSubsumedByOtherType(subtype, baseType, /* allowAnyToSubsume */ false)
+                ) {
                     const tupleLength = subtype.tupleTypeArguments.length;
 
                     if (

--- a/packages/pyright-internal/src/analyzer/codeFlowEngine.ts
+++ b/packages/pyright-internal/src/analyzer/codeFlowEngine.ts
@@ -466,7 +466,7 @@ export function getCodeFlowEngine(
                                         flowTypeResult = undefined;
                                     } else if (
                                         reference.nodeType === ParseNodeType.MemberAccess &&
-                                        evaluator.isAsymmetricDescriptorAssignment(targetNode)
+                                        evaluator.isAsymmetricAccessorAssignment(targetNode)
                                     ) {
                                         flowTypeResult = undefined;
                                     }

--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -23233,7 +23233,7 @@ export function createTypeEvaluator(importLookup: ImportLookup, evaluatorOptions
                         return remainingDestSubtypes.every((destSubtype) =>
                             isTypeSubsumedByOtherType(
                                 destSubtype,
-                                destType.subtypes,
+                                destType,
                                 /* allowAnyToSubsume */ true,
                                 recursionCount
                             )
@@ -23337,7 +23337,7 @@ export function createTypeEvaluator(importLookup: ImportLookup, evaluatorOptions
                 // in the same union. If so, we can ignore this.
                 const isSubtypeSubsumed = isTypeSubsumedByOtherType(
                     subtype,
-                    srcType.subtypes,
+                    srcType,
                     /* allowAnyToSubsume */ false,
                     recursionCount
                 );
@@ -23371,9 +23371,10 @@ export function createTypeEvaluator(importLookup: ImportLookup, evaluatorOptions
     }
 
     // Determines whether a type is "subsumed by" (i.e. is a proper subtype of) one
-    // of the other types in a list.
-    function isTypeSubsumedByOtherType(type: Type, otherTypes: Type[], allowAnyToSubsume: boolean, recursionCount = 0) {
+    // of the other type.
+    function isTypeSubsumedByOtherType(type: Type, otherType: Type, allowAnyToSubsume: boolean, recursionCount = 0) {
         const concreteType = makeTopLevelTypeVarsConcrete(type);
+        const otherTypes = isUnion(otherType) ? otherType.subtypes : [otherType];
 
         for (const otherType of otherTypes) {
             if (isTypeSame(otherType, type)) {
@@ -25998,7 +25999,7 @@ export function createTypeEvaluator(importLookup: ImportLookup, evaluatorOptions
         validateInitSubclassArgs,
         isAfterNodeReachable,
         isNodeReachable,
-        isAsymmetricDescriptorAssignment: isAsymmetricAccessorAssignment,
+        isAsymmetricAccessorAssignment,
         suppressDiagnostics,
         getDeclarationsForStringNode,
         getDeclarationsForNameNode,
@@ -26012,6 +26013,7 @@ export function createTypeEvaluator(importLookup: ImportLookup, evaluatorOptions
         markNamesAccessed,
         makeTopLevelTypeVarsConcrete,
         mapSubtypesExpandTypeVars,
+        isTypeSubsumedByOtherType,
         lookUpSymbolRecursive,
         getDeclaredTypeOfSymbol,
         getEffectiveTypeOfSymbol,

--- a/packages/pyright-internal/src/analyzer/typeEvaluatorTypes.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluatorTypes.ts
@@ -495,7 +495,7 @@ export interface TypeEvaluator {
 
     isAfterNodeReachable: (node: ParseNode) => boolean;
     isNodeReachable: (node: ParseNode, sourceNode?: ParseNode | undefined) => boolean;
-    isAsymmetricDescriptorAssignment: (node: ParseNode) => boolean;
+    isAsymmetricAccessorAssignment: (node: ParseNode) => boolean;
     suppressDiagnostics: (node: ParseNode, callback: () => void) => void;
 
     getDeclarationsForStringNode: (node: StringNode) => Declaration[] | undefined;
@@ -530,6 +530,7 @@ export interface TypeEvaluator {
         conditionFilter: TypeCondition[] | undefined,
         callback: (expandedSubtype: Type, unexpandedSubtype: Type) => Type | undefined
     ) => Type;
+    isTypeSubsumedByOtherType: (type: Type, otherType: Type, allowAnyToSubsume: boolean) => boolean;
     lookUpSymbolRecursive: (node: ParseNode, name: string, honorCodeFlow: boolean) => SymbolWithScope | undefined;
     getDeclaredTypeOfSymbol: (symbol: Symbol) => DeclaredSymbolTypeInfo;
     getEffectiveTypeOfSymbol: (symbol: Symbol) => Type;

--- a/packages/pyright-internal/src/tests/samples/tuple1.py
+++ b/packages/pyright-internal/src/tests/samples/tuple1.py
@@ -174,10 +174,9 @@ def func13(
 
     v10 = d[0]
 
-    # This should generate one error.
     v11 = d[1]
 
-    # This should generate two errors.
+    # This should generate an error.
     v12 = d[2]
 
     v13: tuple[()] = ()

--- a/packages/pyright-internal/src/tests/typeEvaluator1.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator1.test.ts
@@ -1239,7 +1239,7 @@ test('Optional2', () => {
 test('Tuple1', () => {
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['tuple1.py']);
 
-    TestUtils.validateResults(analysisResults, 17);
+    TestUtils.validateResults(analysisResults, 15);
 });
 
 test('Tuple2', () => {


### PR DESCRIPTION
…-bounds tuple accesses if the indexed type is a union that includes both a bounded tuple and an unbounded tuple. This addresses #5968.