### PR TITLE
Wrong statSync used in realCasePath

### DIFF
--- a/packages/pyright-internal/src/common/realFileSystem.ts
+++ b/packages/pyright-internal/src/common/realFileSystem.ts
@@ -378,7 +378,7 @@ class RealFileSystem implements FileSystem {
             }
 
             // If it does exist, skip this for symlinks.
-            const stat = fs.statSync(path);
+            const stat = fs.lstatSync(path);
             if (stat.isSymbolicLink()) {
                 return path;
             }


### PR DESCRIPTION
statSync doesn't seem to detect symbol links.