### PR TITLE
Fix realCasePath changing empty paths to .

### DIFF
--- a/packages/pyright-internal/src/common/pathUtils.ts
+++ b/packages/pyright-internal/src/common/pathUtils.ts
@@ -536,7 +536,7 @@ export function stripFileExtension(fileName: string, multiDotExtension = false) 
 }
 
 export function realCasePath(pathString: string, fileSystem: ReadOnlyFileSystem): string {
-    return normalizePath(fileSystem.realCasePath(pathString));
+    return fileSystem.realCasePath(pathString);
 }
 
 export function normalizePath(pathString: string): string {

--- a/packages/pyright-internal/src/tests/pathUtils.test.ts
+++ b/packages/pyright-internal/src/tests/pathUtils.test.ts
@@ -403,10 +403,13 @@ test('Realcase', () => {
     // Check that the '..' has been removed.
     assert.ok(!fspaths.some((p) => p.indexOf('..') >= 0));
 
-    for (const p of fspaths) {
-        const upper = p.toUpperCase();
-        const real = fs.realCasePath(upper);
-        assert.strictEqual(p, real);
+    // If windows, check that the case is correct.
+    if (process.platform === 'win32') {
+        for (const p of fspaths) {
+            const upper = p.toUpperCase();
+            const real = fs.realCasePath(upper);
+            assert.strictEqual(p, real);
+        }
     }
 });
 

--- a/packages/pyright-internal/src/tests/pathUtils.test.ts
+++ b/packages/pyright-internal/src/tests/pathUtils.test.ts
@@ -400,6 +400,9 @@ test('Realcase', () => {
     const fspaths = fsentries.map((entry) => fs.realCasePath(path.join(dir, entry)));
     assert.deepStrictEqual(paths, fspaths);
 
+    // Check that the '..' has been removed.
+    assert.ok(!fspaths.some((p) => p.indexOf('..') >= 0));
+
     for (const p of fspaths) {
         const upper = p.toUpperCase();
         const real = fs.realCasePath(upper);

--- a/packages/pyright-internal/src/tests/pathUtils.test.ts
+++ b/packages/pyright-internal/src/tests/pathUtils.test.ts
@@ -8,9 +8,9 @@
  */
 
 import assert from 'assert';
+import * as nodefs from 'fs-extra';
 import * as os from 'os';
 import * as path from 'path';
-import * as nodefs from 'fs-extra';
 
 import { expandPathVariables } from '../common/envVarUtils';
 import {
@@ -35,13 +35,14 @@ import {
     isFileSystemCaseSensitiveInternal,
     isRootedDiskPath,
     normalizeSlashes,
+    realCasePath,
     reducePathComponents,
     resolvePaths,
     stripFileExtension,
     stripTrailingDirectorySeparator,
 } from '../common/pathUtils';
-import * as vfs from './harness/vfs/filesystem';
 import { createFromRealFileSystem } from '../common/realFileSystem';
+import * as vfs from './harness/vfs/filesystem';
 
 test('getPathComponents1', () => {
     const components = getPathComponents('');
@@ -390,11 +391,31 @@ test('convert UNC path', () => {
 test('Realcase', () => {
     const fs = createFromRealFileSystem();
     const cwd = process.cwd();
-    const dir = path.join(cwd, 'src', 'tests');
+    const dir = path.join(cwd, 'src', 'tests', '..', 'tests');
     const entries = nodefs.readdirSync(dir).map((entry) => path.basename(nodefs.realpathSync(path.join(dir, entry))));
     const fsentries = fs.readdirSync(dir);
     assert.deepStrictEqual(entries, fsentries);
 
+    const paths = entries.map((entry) => nodefs.realpathSync(path.join(dir, entry)));
+    const fspaths = fsentries.map((entry) => fs.realCasePath(path.join(dir, entry)));
+    assert.deepStrictEqual(paths, fspaths);
+
+    for (const p of fspaths) {
+        const upper = p.toUpperCase();
+        const real = fs.realCasePath(upper);
+        assert.strictEqual(p, real);
+    }
+});
+
+test('Realcase use cwd implicitly', () => {
+    const fs = createFromRealFileSystem();
+    const empty = realCasePath('', fs);
+    assert.deepStrictEqual(empty, '');
+    const cwd = process.cwd();
+    const dir = path.join(cwd, 'src', 'tests');
+
+    const entries = nodefs.readdirSync(dir).map((entry) => path.basename(nodefs.realpathSync(path.join(dir, entry))));
+    const fsentries = fs.readdirSync(path.join('src', 'tests'));
     const paths = entries.map((entry) => nodefs.realpathSync(path.join(dir, entry)));
     const fspaths = fsentries.map((entry) => fs.realCasePath(path.join(dir, entry)));
     assert.deepStrictEqual(paths, fspaths);


### PR DESCRIPTION
Addresses https://github.com/microsoft/pylance-release/issues/4861

The root cause of this bug is that for a loose file (no workspace), the current execution root for command line options is just ''. Normalizing this changes it to '.' for some reason and that breaks all the other logic after that point.

The fix here is to not normalize when calling realCasePath. Nodefs.realCase can normalize paths on its own, so it's not necessary to normalize them ahead of time.