### PR TITLE
Add more logging for SSH failure

### DIFF
--- a/packages/pyright-internal/src/backgroundAnalysisBase.ts
+++ b/packages/pyright-internal/src/backgroundAnalysisBase.ts
@@ -238,7 +238,7 @@ export class BackgroundAnalysisBase {
             }
 
             default:
-                debug.fail(`${msg.requestType} is not expected`);
+                debug.fail(`${msg.requestType} is not expected. Message structure: ${JSON.stringify(msg)}`);
         }
     }
 


### PR DESCRIPTION
This [issue](https://github.com/microsoft/pylance-release/issues/4854) is showing us handling an undefined message in the background thread. Not sure how this is possible. Adding more logging.