### PR TITLE
Fixed bug in type compatibility checks for `LiteralString`. It should…

### DIFF
--- a/packages/pyright-internal/src/tests/samples/literalString1.py
+++ b/packages/pyright-internal/src/tests/samples/literalString1.py
@@ -80,3 +80,11 @@ def func7(a: Literal["a", "b"], b: Literal["a", 1]):
 
     # This should generate an error because "b" is not a string literal.
     v2: LiteralString = f"{b}"
+
+
+def func8(a: list[LiteralString], b: list[Literal["a"]]):
+    # This should generate an error because of invariance rules.
+    v1: list[str] = a
+
+    # This should generate an error because of invariance rules.
+    v2: list[LiteralString] = b

--- a/packages/pyright-internal/src/tests/typeEvaluator1.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator1.test.ts
@@ -1589,7 +1589,7 @@ test('PseudoGeneric3', () => {
 test('LiteralString1', () => {
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['literalString1.py']);
 
-    TestUtils.validateResults(analysisResults, 8);
+    TestUtils.validateResults(analysisResults, 10);
 });
 
 test('LiteralString2', () => {


### PR DESCRIPTION
… not be considered compatible with `str` or a specific literal str in an invariant context. This addresses #5999.