### PR TITLE
Added check for the use of an ellipsis for a default argument value f…

### DIFF
--- a/packages/pyright-internal/src/analyzer/decorators.ts
+++ b/packages/pyright-internal/src/analyzer/decorators.ts
@@ -91,6 +91,8 @@ export function getFunctionFlagsFromDecorators(evaluator: TypeEvaluator, node: F
                 flags |= FunctionTypeFlags.Overridden;
             } else if (decoratorType.details.builtInName === 'type_check_only') {
                 flags |= FunctionTypeFlags.TypeCheckOnly;
+            } else if (decoratorType.details.builtInName === 'overload') {
+                flags |= FunctionTypeFlags.Overloaded;
             }
         } else if (isInstantiableClass(decoratorType)) {
             if (ClassType.isBuiltIn(decoratorType, 'staticmethod')) {

--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -17278,9 +17278,20 @@ export function createTypeEvaluator(importLookup: ImportLookup, evaluatorOptions
 
             let defaultValueType: Type | undefined;
             if (param.defaultValue) {
+                // If this is a stub file, a protocol, an overload, or a class
+                // whose body is a placeholder implementation, treat a "...", as
+                // an "Any" value.
+                let treatEllipsisAsAny = fileInfo.isStubFile || ParseTreeUtils.isSuiteEmpty(node.suite);
+                if (containingClassType && ClassType.isProtocolClass(containingClassType)) {
+                    treatEllipsisAsAny = true;
+                }
+                if (FunctionType.isOverloaded(functionType)) {
+                    treatEllipsisAsAny = true;
+                }
+
                 defaultValueType = getTypeOfExpression(
                     param.defaultValue,
-                    EvaluatorFlags.ConvertEllipsisToAny,
+                    treatEllipsisAsAny ? EvaluatorFlags.ConvertEllipsisToAny : EvaluatorFlags.None,
                     makeInferenceContext(annotatedType)
                 ).type;
             }

--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -17285,7 +17285,7 @@ export function createTypeEvaluator(importLookup: ImportLookup, evaluatorOptions
                 if (containingClassType && ClassType.isProtocolClass(containingClassType)) {
                     treatEllipsisAsAny = true;
                 }
-                if (FunctionType.isOverloaded(functionType)) {
+                if (FunctionType.isOverloaded(functionType) || FunctionType.isAbstractMethod(functionType)) {
                     treatEllipsisAsAny = true;
                 }
 

--- a/packages/pyright-internal/src/tests/samples/constrainedTypeVar1.py
+++ b/packages/pyright-internal/src/tests/samples/constrainedTypeVar1.py
@@ -17,8 +17,8 @@ U = TypeVar("U", int, str)
 
 
 class Foo(Generic[U]):
-    def generic_func1(self, a: U, b: U = ..., **kwargs: U) -> U:
-        return b
+    def generic_func1(self, a: U, b: str = "", **kwargs: U) -> U:
+        return a
 
 
 foo = Foo[str]()

--- a/packages/pyright-internal/src/tests/samples/overload12.py
+++ b/packages/pyright-internal/src/tests/samples/overload12.py
@@ -276,7 +276,7 @@ def overload9(x: object, y: int, z: str, a: None) -> str:
     ...
 
 
-def overload9(x, y, z=..., a=...) -> Any:
+def overload9(x, y, z="", a=None) -> Any:
     pass
 
 


### PR DESCRIPTION
…or a function that is not in a stub, not overloaded, and without a placeholder implementation. This addresses #5985.