### PR TITLE
Fix real casing of UNC paths (including mounted paths)

### DIFF
--- a/packages/pyright-internal/src/common/pathUtils.ts
+++ b/packages/pyright-internal/src/common/pathUtils.ts
@@ -110,6 +110,9 @@ export function getRootLength(pathString: string): number {
         if (pathString.charAt(2) === path.sep) {
             return 3; // DOS: "c:/" or "c:\"
         }
+        if (pathString.length === 2) {
+            return 2; // DOS: "c:" (but not "c:d")
+        }
     }
     return 0;
 }

--- a/packages/pyright-internal/src/common/pathUtils.ts
+++ b/packages/pyright-internal/src/common/pathUtils.ts
@@ -92,24 +92,23 @@ export function getDirectoryPath(pathString: string): string {
     return pathString.substr(0, Math.max(getRootLength(pathString), pathString.lastIndexOf(path.sep)));
 }
 
+/**
+ * Returns length of the root part of a path or URL (i.e. length of "/", "x:/", "//server/").
+ */
 export function getRootLength(pathString: string): number {
     if (pathString.charAt(0) === path.sep) {
         if (pathString.charAt(1) !== path.sep) {
-            return 1;
+            return 1; // POSIX: "/" (or non-normalized "\")
         }
         const p1 = pathString.indexOf(path.sep, 2);
         if (p1 < 0) {
-            return 2;
+            return pathString.length; // UNC: "//server" or "\\server"
         }
-        const p2 = pathString.indexOf(path.sep, p1 + 1);
-        if (p2 < 0) {
-            return p1 + 1;
-        }
-        return p2 + 1;
+        return p1 + 1; // UNC: "//server/" or "\\server\"
     }
     if (pathString.charAt(1) === ':') {
         if (pathString.charAt(2) === path.sep) {
-            return 3;
+            return 3; // DOS: "c:/" or "c:\"
         }
     }
     return 0;
@@ -646,6 +645,10 @@ export function getWildcardRegexPattern(rootPath: string, fileSpec: string): str
     // Strip the directory separator from the root component.
     if (pathComponents.length > 0) {
         pathComponents[0] = stripTrailingDirectorySeparator(pathComponents[0]);
+
+        if (pathComponents[0].startsWith('\\\\')) {
+            pathComponents[0] = '\\\\' + pathComponents[0];
+        }
     }
 
     let regExPattern = '';

--- a/packages/pyright-internal/src/common/realFileSystem.ts
+++ b/packages/pyright-internal/src/common/realFileSystem.ts
@@ -21,7 +21,7 @@ import {
     FileWatcherProvider,
     nullFileWatcherProvider,
 } from './fileWatcher';
-import { combinePaths, getDirectoryPath, getFileName, getRootLength } from './pathUtils';
+import { combinePaths, getDirectoryPath, getFileName, isDiskPathRoot, isRootedDiskPath } from './pathUtils';
 
 // Automatically remove files created by tmp at process exit.
 tmp.setGracefulCleanup();
@@ -371,7 +371,7 @@ class RealFileSystem implements FileSystem {
         try {
             // If it doesn't exist in the real FS, try going up a level and combining it.
             if (!this.existsSync(path)) {
-                if (getRootLength(path) <= 0) {
+                if (!isRootedDiskPath(path) || isDiskPathRoot(path)) {
                     return path;
                 }
                 return combinePaths(this.realCasePath(getDirectoryPath(path)), getFileName(path));

--- a/packages/pyright-internal/src/tests/pathUtils.test.ts
+++ b/packages/pyright-internal/src/tests/pathUtils.test.ts
@@ -79,6 +79,15 @@ test('getPathComponents5', () => {
     assert.equal(components[1], 'hello.py');
 });
 
+test('getPathComponents6', () => {
+    const components = getPathComponents('\\\\server\\share\\dir\\file.py');
+    assert.equal(components.length, 4);
+    assert.equal(components[0], '\\\\server\\');
+    assert.equal(components[1], 'share');
+    assert.equal(components[2], 'dir');
+    assert.equal(components[3], 'file.py');
+});
+
 test('combinePaths1', () => {
     const p = combinePaths('/user', '1', '2', '3');
     assert.equal(p, normalizeSlashes('/user/1/2/3'));
@@ -160,6 +169,13 @@ test('getWildcardRegexPattern3', () => {
     const regex = new RegExp(pattern);
     assert.ok(regex.test(fixSeparators('/users/me/.blah/.foo.py')));
     assert.ok(!regex.test(fixSeparators('/users/me/.blah/foo.py')));
+});
+
+test('getWildcardRegexPattern4', () => {
+    const pattern = getWildcardRegexPattern('//server/share/dir', '.');
+    const regex = new RegExp(pattern);
+    assert.ok(regex.test(fixSeparators('//server/share/dir/foo.py')));
+    assert.ok(!regex.test(fixSeparators('//server/share/dix/foo.py')));
 });
 
 test('isDirectoryWildcardPatternPresent1', () => {

--- a/packages/pyright-internal/src/tests/pathUtils.test.ts
+++ b/packages/pyright-internal/src/tests/pathUtils.test.ts
@@ -80,9 +80,9 @@ test('getPathComponents5', () => {
 });
 
 test('getPathComponents6', () => {
-    const components = getPathComponents('\\\\server\\share\\dir\\file.py');
+    const components = getPathComponents(fixSeparators('//server/share/dir/file.py'));
     assert.equal(components.length, 4);
-    assert.equal(components[0], '\\\\server\\');
+    assert.equal(components[0], fixSeparators('//server/'));
     assert.equal(components[1], 'share');
     assert.equal(components[2], 'dir');
     assert.equal(components[3], 'file.py');

--- a/packages/pyright-internal/src/tests/pathUtils.test.ts
+++ b/packages/pyright-internal/src/tests/pathUtils.test.ts
@@ -28,6 +28,7 @@ import {
     getPathComponents,
     getRelativePath,
     getRelativePathFromDirectory,
+    getRootLength,
     getWildcardRegexPattern,
     getWildcardRoot,
     hasTrailingDirectorySeparator,
@@ -332,6 +333,34 @@ test('getRelativePathFromDirectory2', () => {
     assert.equal(getRelativePathFromDirectory('/a', '/b/c/d', true), normalizeSlashes('../b/c/d'));
 });
 
+test('getRootLength1', () => {
+    assert.equal(getRootLength('a'), 0);
+});
+
+test('getRootLength2', () => {
+    assert.equal(getRootLength(fixSeparators('/')), 1);
+});
+
+test('getRootLength3', () => {
+    assert.equal(getRootLength('c:'), 2);
+});
+
+test('getRootLength4', () => {
+    assert.equal(getRootLength('c:d'), 0);
+});
+
+test('getRootLength5', () => {
+    assert.equal(getRootLength(fixSeparators('c:/')), 3);
+});
+
+test('getRootLength6', () => {
+    assert.equal(getRootLength(fixSeparators('//server')), 8);
+});
+
+test('getRootLength7', () => {
+    assert.equal(getRootLength(fixSeparators('//server/share')), 9);
+});
+
 test('isRootedDiskPath1', () => {
     assert(isRootedDiskPath(normalizeSlashes('C:/a/b')));
 });
@@ -353,7 +382,11 @@ test('isDiskPathRoot2', () => {
 });
 
 test('isDiskPathRoot3', () => {
-    assert(!isRootedDiskPath(normalizeSlashes('c:')));
+    assert(isRootedDiskPath(normalizeSlashes('c:')));
+});
+
+test('isDiskPathRoot4', () => {
+    assert(!isRootedDiskPath(normalizeSlashes('c:d')));
 });
 
 test('getRelativePath', () => {


### PR DESCRIPTION
Addresses https://github.com/microsoft/pylance-release/issues/4862

In the user's repro steps, they have mounted a share as a drive letter. The recent real case path changes cause the drive letter-based path (ex. `z:\test`) to be changed to a UNC path (ex. `\\server\share\test`). And it seems that we had pre-existing issues with using UNC paths in file specs. 
- Fix `getRootLength` for `\\server\share\dir` to return `\\server\` rather than `\\server\share\`. This matches [TypeScript's behavior](https://github.com/microsoft/TypeScript/blob/55d8bed85c11672b2b6f9ee3e6e1d384bef6f4da/src/compiler/path.ts#L241). Also brought over the comments from the TS implementation to explain what `getRootLength` is doing.
- Fix `getWildcardRegexPattern` to double-escape both leading backslashes in `\\server\share`. The result should be `\\\\\\\\server\\\\share` but was `\\\\server\\\\share`.
- Fix the "try going up a level" logic in `realCasePath` to not go up another level if `getRootLength(path)` returns the length of `path`. In this case `path` is a root and we need to bail at this point to avoid stack overflow -- the "go up a level" logic would just call `realCasePath` with `path` again.