### PR TITLE
Fixed a regression that resulted in a false positive error when using…

### DIFF
--- a/packages/pyright-internal/src/analyzer/constructors.ts
+++ b/packages/pyright-internal/src/analyzer/constructors.ts
@@ -191,6 +191,20 @@ export function validateConstructorArguments(
         }
     }
 
+    // If the original type was known to be a specific class (as opposed to a type[T])
+    // and it was marked as including promotions, we can assume that the resulting
+    // instance type should not include promotions since we know precisely which
+    // class was instantiated.
+    if (
+        type.includePromotions &&
+        !type.includeSubclasses &&
+        returnResult.returnType &&
+        isClassInstance(returnResult.returnType) &&
+        returnResult.returnType.includePromotions
+    ) {
+        returnResult.returnType = ClassType.cloneRemoveTypePromotions(returnResult.returnType);
+    }
+
     return returnResult;
 }
 

--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -1364,6 +1364,11 @@ export function createTypeEvaluator(importLookup: ImportLookup, evaluatorOptions
         } else {
             typeResult = { type: getBuiltInObject(node, 'float') };
         }
+
+        if (isClass(typeResult.type)) {
+            typeResult.type = ClassType.cloneRemoveTypePromotions(typeResult.type);
+        }
+
         return typeResult;
     }
 

--- a/packages/pyright-internal/src/tests/samples/genericType1.py
+++ b/packages/pyright-internal/src/tests/samples/genericType1.py
@@ -15,7 +15,7 @@ b1: int = b["x"]
 b2: float = b["x"]
 
 c = dict(x=m, y=n)
-reveal_type(c, expected_text="dict[str, float]")
+reveal_type(c, expected_text="dict[str, int | float]")
 
 # This should generate an error.
 c1: int = c["x"]

--- a/packages/pyright-internal/src/tests/samples/namedTuple7.py
+++ b/packages/pyright-internal/src/tests/samples/namedTuple7.py
@@ -15,8 +15,8 @@ class NT1(NamedTuple, Generic[_T1]):
 
 reveal_type(NT1(3, 4, ["hi"]), expected_text="NT1[str | int]")
 reveal_type(NT1(3, 4, []), expected_text="NT1[int]")
-reveal_type(NT1(3.4, 4, [1, 2]), expected_text="NT1[float]")
-reveal_type(NT1(3.4, 4, [2j]), expected_text="NT1[complex]")
+reveal_type(NT1(3.4, 4, [1, 2]), expected_text="NT1[float | int]")
+reveal_type(NT1(3.4, 4, [2j]), expected_text="NT1[float | complex]")
 
 
 class NT2(NT1[str]):

--- a/packages/pyright-internal/src/tests/samples/paramSpec40.py
+++ b/packages/pyright-internal/src/tests/samples/paramSpec40.py
@@ -24,4 +24,4 @@ result1 = map(call, [func1])
 reveal_type(result1, expected_text="map[int]")
 
 result2 = map(call, [func1, func2])
-reveal_type(result2, expected_text="map[float]")
+reveal_type(result2, expected_text="map[float | int]")

--- a/packages/pyright-internal/src/tests/samples/solver14.py
+++ b/packages/pyright-internal/src/tests/samples/solver14.py
@@ -59,4 +59,4 @@ def min2(__arg1: SupportsLessThanT, __arg2: SupportsLessThanT) -> SupportsLessTh
 
 def func1():
     x = max2(1, min2(1, 4.5))
-    reveal_type(x, expected_text="float")
+    reveal_type(x, expected_text="float | int")

--- a/packages/pyright-internal/src/tests/samples/solverHigherOrder6.py
+++ b/packages/pyright-internal/src/tests/samples/solverHigherOrder6.py
@@ -20,7 +20,7 @@ def test1(x: Literal[2]) -> Literal[2]:
 
 
 v1 = min(1, max(2, 0.5))
-reveal_type(v1, expected_text="float")
+reveal_type(v1, expected_text="float | int")
 
 
 class Future(Generic[_T]):

--- a/packages/pyright-internal/src/tests/samples/typePromotions1.py
+++ b/packages/pyright-internal/src/tests/samples/typePromotions1.py
@@ -48,3 +48,8 @@ def func6(f: complex):
         f.hex()
     else:
         reveal_type(f, expected_text="complex | int")
+
+
+float(11 / 5).is_integer()
+
+(1.2).is_integer()


### PR DESCRIPTION
… `float` or `complex` literals or constructor calls and then accessing a member of the resulting object that is valid on that class but not on `int`. This addresses #6032.