### PR TITLE
Fixed a bug that resulted in a false positive in certain circumstance…

### DIFF
--- a/packages/pyright-internal/src/analyzer/operations.ts
+++ b/packages/pyright-internal/src/analyzer/operations.ts
@@ -22,7 +22,7 @@ import {
 } from '../parser/parseNodes';
 import { OperatorType } from '../parser/tokenizerTypes';
 import { getFileInfo } from './analyzerNodeInfo';
-import { isWithinLoop, operatorSupportsChaining, printOperator } from './parseTreeUtils';
+import { getEnclosingLambda, isWithinLoop, operatorSupportsChaining, printOperator } from './parseTreeUtils';
 import { evaluateStaticBoolExpression } from './staticExpressions';
 import { EvaluatorFlags, TypeEvaluator, TypeResult } from './typeEvaluatorTypes';
 import {
@@ -695,8 +695,10 @@ export function getTypeOfBinaryOperation(
     const diag = new DiagnosticAddendum();
 
     // Don't use literal math if either of the operation is within a loop
-    // because the literal values may change each time.
-    const isLiteralMathAllowed = !isWithinLoop(node);
+    // because the literal values may change each time. We also don't want to
+    // apply literal math within the body of a lambda because they are often
+    // used as callbacks where the value changes each time they are called.
+    const isLiteralMathAllowed = !isWithinLoop(node) && !getEnclosingLambda(node);
 
     // Don't special-case tuple __add__ if the left type is a union. This
     // can result in an infinite loop if we keep creating new tuple types

--- a/packages/pyright-internal/src/tests/samples/lambda10.py
+++ b/packages/pyright-internal/src/tests/samples/lambda10.py
@@ -16,11 +16,11 @@ reveal_type(v1, expected_text="int")
 
 
 v2 = (lambda a, b: a + b)(3, 4)
-reveal_type(v2, expected_text="Literal[7]")
+reveal_type(v2, expected_text="int")
 
 
 v3 = (lambda a, b: a + b)("foo", "bar")
-reveal_type(v3, expected_text="Literal['foobar']")
+reveal_type(v3, expected_text="LiteralString")
 
 v4 = (lambda a, b: a + b)("foo", (lambda c, d: c + d)("b", "ar"))
-reveal_type(v4, expected_text="Literal['foobar']")
+reveal_type(v4, expected_text="LiteralString")

--- a/packages/pyright-internal/src/tests/samples/operator8.py
+++ b/packages/pyright-internal/src/tests/samples/operator8.py
@@ -2,7 +2,8 @@
 # are applied when all operands are literal types with the same associated
 # class.
 
-from typing import Literal
+from functools import reduce
+from typing import Iterable, Literal
 
 
 def func1(a: Literal[1, 2], b: Literal[0, 4], c: Literal[3, 4]):
@@ -123,3 +124,23 @@ def func6(x: Literal[1, 3, 5, 7, 11, 13]):
 
     y *= x
     reveal_type(y, expected_text="int")
+
+
+def func7(values: Iterable[str]) -> tuple[str, int]:
+    return reduce(
+        lambda x, value: (x[0] + value, x[1] + 1),
+        values,
+        ("", 0),
+    )
+
+
+def func8(values: Iterable[float]) -> float:
+    total, num_of_values = reduce(
+        lambda total_and_count, value: (
+            total_and_count[0] + value,
+            total_and_count[1] + 1,
+        ),
+        values,
+        (0, 0),
+    )
+    return total / num_of_values


### PR DESCRIPTION
…s where a lambda included simple math operations with integer literals. The fix requires disabling literal math within lambdas, since they are often used as callbacks that are called repeatedly in a loop. This addresses #6031.