### PR TITLE
Fixed a false positive due to incorrect type narrowing logic when a `…

### DIFF
--- a/packages/pyright-internal/src/analyzer/codeFlowEngine.ts
+++ b/packages/pyright-internal/src/analyzer/codeFlowEngine.ts
@@ -454,6 +454,14 @@ export function getCodeFlowEngine(
                                 // Is this a special "unbind" assignment? If so,
                                 // we can handle it immediately without any further evaluation.
                                 if (curFlowNode.flags & FlowFlags.Unbind) {
+                                    // Don't treat unbound assignments to indexed expressions (i.e. "del x[0]")
+                                    // as true deletions. The most common use case for "del x[0]" is in a list,
+                                    // and the list class treats this as an element deletion, not an assignment.
+                                    if (reference.nodeType === ParseNodeType.Index) {
+                                        // No need to explore further.
+                                        return setCacheEntry(curFlowNode, undefined, /* isIncomplete */ false);
+                                    }
+
                                     return setCacheEntry(curFlowNode, UnboundType.create(), /* isIncomplete */ false);
                                 }
 

--- a/packages/pyright-internal/src/tests/samples/del1.py
+++ b/packages/pyright-internal/src/tests/samples/del1.py
@@ -27,3 +27,22 @@ class ClassA:
 
     z1 = 1
     del z1
+
+
+class ClassB:
+    x: int
+
+
+b = ClassB()
+b.x = 3
+reveal_type(b.x, expected_text="Literal[3]")
+del b.x
+reveal_type(b.x, expected_text="Unbound")
+
+x2: list[str | int] = ["a", 1, "b", 2]
+reveal_type(x2[0], expected_text="str | int")
+x2[0] = 0
+reveal_type(x2[0], expected_text="Literal[0]")
+reveal_type(x2[1], expected_text="str | int")
+del x2[0]
+reveal_type(x2[0], expected_text="str | int")


### PR DESCRIPTION
…del` statement targets a specific element within a list (e.g. `del my_list[1]`). This addresses #6026.