### PR TITLE
Fix docs/configuration.md missing default value for `reportImplicitOverride`

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -186,7 +186,7 @@ The following settings control pyright’s diagnostic output (warnings or errors
 
 <a name="reportMatchNotExhaustive"></a> **reportMatchNotExhaustive** [boolean or string, optional]: Generate or suppress diagnostics for a `match` statement that does not provide cases that exhaustively match against all potential types of the target expression. The default value for this setting is `"none"`.
 
-<a name="reportImplicitOverride"></a> **reportImplicitOverride** [boolean or string, optional]: Generate or suppress diagnostics for overridden methods in a class that are missing an explicit `@override` decorator.
+<a name="reportImplicitOverride"></a> **reportImplicitOverride** [boolean or string, optional]: Generate or suppress diagnostics for overridden methods in a class that are missing an explicit `@override` decorator. The default value for this setting is `"none"`.
 
 <a name="reportShadowedImports"></a> **reportShadowedImports** [boolean or string, optional]: Generate or suppress diagnostics for files that are overriding a module in the stdlib. The default value for this setting is `"none"`.
 


### PR DESCRIPTION
The [documentation](https://microsoft.github.io/pyright/#/configuration) is missing the default value for `reportImplicitOverride` in the type check diagnostics settings.
The default value is `none` as defined in [`getBasicDiagnosticRuleSet`](https://github.com/microsoft/pyright/blob/cfefc8255c99cba12ec7752243bf6b7c42db04d1/packages/pyright-internal/src/common/configOptions.ts#L605).