### PR TITLE
Fixed a bug that led to the loss of type narrowing for a captured var…

### DIFF
--- a/packages/pyright-internal/src/analyzer/scopeUtils.ts
+++ b/packages/pyright-internal/src/analyzer/scopeUtils.ts
@@ -39,7 +39,8 @@ export function getScopeHierarchy(node: ParseNode, stopScope?: Scope): Scope[] |
     let curNode: ParseNode | undefined = node;
 
     while (curNode) {
-        const curScope = getScopeForNode(curNode);
+        const scopeNode = getEvaluationScopeNode(curNode);
+        const curScope = getScope(scopeNode);
 
         if (!curScope) {
             return undefined;
@@ -53,7 +54,7 @@ export function getScopeHierarchy(node: ParseNode, stopScope?: Scope): Scope[] |
             return scopeHierarchy;
         }
 
-        curNode = curNode.parent;
+        curNode = scopeNode.parent;
     }
 
     return stopScope ? undefined : scopeHierarchy;

--- a/packages/pyright-internal/src/tests/samples/capturedVariable1.py
+++ b/packages/pyright-internal/src/tests/samples/capturedVariable1.py
@@ -119,3 +119,10 @@ def func10(cond: bool, val: str):
         def inner2():
             reveal_type(x, expected_text="str | None")
             reveal_type(y, expected_text="str")
+
+
+def func11(foo: list[int] | None):
+    if isinstance(foo, list):
+
+        def inner() -> list[int]:
+            return [x for x in foo]


### PR DESCRIPTION
…iable used within an inner scope if used in a comprehension expression. This addresses #6067.