### PR TITLE
Fixed a bug that resulted in incorrect type evaluation when an async …

### DIFF
--- a/packages/pyright-internal/src/analyzer/typeUtils.ts
+++ b/packages/pyright-internal/src/analyzer/typeUtils.ts
@@ -2584,7 +2584,10 @@ export function removeParamSpecVariadicsFromFunction(type: FunctionType): Functi
         return type;
     }
 
-    return FunctionType.cloneRemoveParamSpecVariadics(type, argsParam.type);
+    return FunctionType.cloneRemoveParamSpecVariadics(
+        type,
+        TypeVarType.cloneForParamSpecAccess(argsParam.type, /* access */ undefined)
+    );
 }
 
 function _expandVariadicUnpackedUnion(type: Type) {

--- a/packages/pyright-internal/src/analyzer/types.ts
+++ b/packages/pyright-internal/src/analyzer/types.ts
@@ -1848,6 +1848,10 @@ export namespace FunctionType {
             newFunction.details.paramSpec = paramSpec;
         }
 
+        if (type.inferredReturnType) {
+            newFunction.inferredReturnType = type.inferredReturnType;
+        }
+
         return newFunction;
     }
 


### PR DESCRIPTION
…function with an inferred return type is decorated with a class or function that uses a ParamSpec (such as `functools.wraps`). This addresses #6080.