### PR TITLE
Fixed a recent regression that led to a false positive error when a c…

### DIFF
--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -1990,7 +1990,9 @@ export function createTypeEvaluator(importLookup: ImportLookup, evaluatorOptions
                     memberName,
                     usage,
                     /* diag */ undefined,
-                    memberAccessFlags | MemberAccessFlags.AccessInstanceMembersOnly,
+                    memberAccessFlags |
+                        MemberAccessFlags.AccessInstanceMembersOnly |
+                        MemberAccessFlags.SkipAttributeAccessOverride,
                     ClassType.cloneAsInstantiable(objectType)
                 );
             }

--- a/packages/pyright-internal/src/tests/samples/metaclass11.py
+++ b/packages/pyright-internal/src/tests/samples/metaclass11.py
@@ -1,29 +1,49 @@
 # This sample verifies that the type checker allows access
 # to instance variables provided by a metaclass.
 
-from enum import Enum
-from typing import Mapping
+from typing import Any
 
 
-class Meta(type):
+class MetaA(type):
     var0 = 3
 
     def __init__(cls, name, bases, dct):
         cls.var1 = "hi"
 
 
-class MyClass(metaclass=Meta):
+class ClassA(metaclass=MetaA):
     pass
 
 
 # This should generate an error because var0 isn't
 # accessible via an instance of this class.
-MyClass().var0
-reveal_type(MyClass.var0, expected_text="int")
-MyClass.var0 = 1
+ClassA().var0
+reveal_type(ClassA.var0, expected_text="int")
+ClassA.var0 = 1
 
-reveal_type(MyClass().var1, expected_text="str")
-reveal_type(MyClass.var1, expected_text="str")
+reveal_type(ClassA().var1, expected_text="str")
+reveal_type(ClassA.var1, expected_text="str")
 
-MyClass.var1 = "hi"
-MyClass().var1 = "hi"
+ClassA.var1 = "hi"
+ClassA().var1 = "hi"
+
+
+class MetaB(type):
+    def __setattr__(cls, key: str, value: Any) -> None:
+        ...
+
+
+class ClassB(metaclass=MetaB):
+    var0: int
+
+
+ClassB.var0 = ""
+ClassB.var1 = ""
+
+ClassB().var0 = 1
+
+# This should generate an error
+ClassB().var0 = ""
+
+# This should generate an error
+ClassB().var1 = ""

--- a/packages/pyright-internal/src/tests/typeEvaluator4.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator4.test.ts
@@ -93,7 +93,7 @@ test('Metaclass10', () => {
 
 test('Metaclass11', () => {
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['metaclass11.py']);
-    TestUtils.validateResults(analysisResults, 1);
+    TestUtils.validateResults(analysisResults, 3);
 });
 
 test('AssignmentExpr1', () => {


### PR DESCRIPTION
…lass uses a custom metaclass that supplies a `__setattr__` method. This addresses #6089.