### PR TITLE
Improved type narrowing in the negative case for `isinstance` when th…

### DIFF
--- a/packages/pyright-internal/src/analyzer/checker.ts
+++ b/packages/pyright-internal/src/analyzer/checker.ts
@@ -3660,6 +3660,7 @@ export class Checker extends ParseTreeWalker {
                 const filterIsSuperclass = isIsinstanceFilterSuperclass(
                     this._evaluator,
                     varType,
+                    varType,
                     filterType,
                     filterType,
                     isInstanceCheck

--- a/packages/pyright-internal/src/tests/samples/typeNarrowingIsinstance16.py
+++ b/packages/pyright-internal/src/tests/samples/typeNarrowingIsinstance16.py
@@ -16,4 +16,4 @@ class ClassA:
             reveal_type(other, expected_text="Self@ClassA")
 
         if isinstance(other, (int, type(self))):
-            reveal_type(other, expected_text="Self@ClassA | int")
+            reveal_type(other, expected_text="ClassA | int | Self@ClassA")

--- a/packages/pyright-internal/src/tests/samples/typeNarrowingIsinstance2.py
+++ b/packages/pyright-internal/src/tests/samples/typeNarrowingIsinstance2.py
@@ -2,13 +2,49 @@
 # on "self" and other bound TypeVars.
 
 
-class Base:
+from typing import Self, TypeVar
+
+
+class ClassA:
     def get_value(self) -> int:
-        if isinstance(self, Derived):
+        if isinstance(self, ChildB):
             return self.calculate()
         return 7
 
 
-class Derived(Base):
+class ChildB(ClassA):
     def calculate(self) -> int:
         return 2 * 2
+
+
+TC = TypeVar("TC")
+
+
+class ClassC:
+    @classmethod
+    def test(cls: type[TC], id: int | TC):
+        if isinstance(id, cls):
+            reveal_type(id, expected_text="TC@test")
+        else:
+            reveal_type(id, expected_text="int")
+
+
+TD = TypeVar("TD", bound="ClassD")
+
+
+class ClassD:
+    @classmethod
+    def test(cls: type[TD], id: int | TD):
+        if isinstance(id, cls):
+            reveal_type(id, expected_text="ClassD*")
+        else:
+            reveal_type(id, expected_text="int")
+
+
+class ClassE:
+    @classmethod
+    def test(cls: type[Self], id: int | Self):
+        if isinstance(id, cls):
+            reveal_type(id, expected_text="ClassE")
+        else:
+            reveal_type(id, expected_text="int")


### PR DESCRIPTION
…e filter type (the second argument) is `type[T]` (where `T` is a type variable) and the first argument is of type `T`. In this case, we can eliminate (filter) `T` in the negative case. This addresses #6088.