### PR TITLE
Fixed bug that led to incorrect type narrowing for `isinstance` when …

### DIFF
--- a/packages/pyright-internal/src/analyzer/typeGuards.ts
+++ b/packages/pyright-internal/src/analyzer/typeGuards.ts
@@ -1552,6 +1552,10 @@ function narrowTypeForIsInstance(
                         } else {
                             foundSuperclass = true;
                         }
+                    } else if (evaluator.assignType(concreteVarType, filterType)) {
+                        if (isPositiveTest) {
+                            filteredTypes.push(filterType);
+                        }
                     }
                 }
             }

--- a/packages/pyright-internal/src/tests/samples/typeNarrowingIsinstance4.py
+++ b/packages/pyright-internal/src/tests/samples/typeNarrowingIsinstance4.py
@@ -57,3 +57,10 @@ def check_callable5(fn: Callable[P, None]) -> None:
         reveal_type(fn, expected_text="ClassA")
     else:
         reveal_type(fn, expected_text="(**P@check_callable5) -> None")
+
+
+def check_callable6(o: object | Callable[[int], int]):
+    if isinstance(o, Callable):
+        reveal_type(o, expected_text="((...) -> Unknown) | ((int) -> int)")
+    else:
+        reveal_type(o, expected_text="object")


### PR DESCRIPTION
…using `Callable` and the pre-narrowed type is `object`. This addresses #6100.