### PR TITLE
Fixed a bug that led to a confusing error message when assigning a va…

### DIFF
--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -2000,7 +2000,7 @@ export function createTypeEvaluator(importLookup: ImportLookup, evaluatorOptions
             }
         }
 
-        if (memberInfo) {
+        if (memberInfo && !memberInfo.isSetTypeError) {
             return {
                 type: memberInfo.type,
                 classType: memberInfo.classType,
@@ -2102,7 +2102,7 @@ export function createTypeEvaluator(importLookup: ImportLookup, evaluatorOptions
             }
         }
 
-        if (memberInfo) {
+        if (memberInfo && !memberInfo.isSetTypeError) {
             return {
                 type: memberInfo.type,
                 isIncomplete: !!memberInfo.isTypeIncomplete,
@@ -5776,6 +5776,7 @@ export function createTypeEvaluator(importLookup: ImportLookup, evaluatorOptions
                 return undefined;
             }
             type = descriptorResult.type;
+            let isSetTypeError = false;
 
             if (usage.method === 'set' && usage.setType) {
                 // Verify that the assigned type is compatible.
@@ -5789,7 +5790,7 @@ export function createTypeEvaluator(importLookup: ImportLookup, evaluatorOptions
                             })
                         );
                     }
-                    return undefined;
+                    isSetTypeError = true;
                 }
 
                 if (
@@ -5802,7 +5803,7 @@ export function createTypeEvaluator(importLookup: ImportLookup, evaluatorOptions
                             name: printType(ClassType.cloneAsInstance(memberInfo.classType)),
                         })
                     );
-                    return undefined;
+                    isSetTypeError = true;
                 }
             }
 
@@ -5810,6 +5811,7 @@ export function createTypeEvaluator(importLookup: ImportLookup, evaluatorOptions
                 symbol: memberInfo.symbol,
                 type,
                 isTypeIncomplete,
+                isSetTypeError,
                 isClassMember: !memberInfo.isInstanceMember,
                 isClassVar: memberInfo.isClassVar,
                 classType: memberInfo.classType,
@@ -5831,6 +5833,7 @@ export function createTypeEvaluator(importLookup: ImportLookup, evaluatorOptions
                     symbol: undefined,
                     type: generalAttrType.type,
                     isTypeIncomplete: false,
+                    isSetTypeError: false,
                     isClassMember: false,
                     isClassVar: false,
                     isAsymmetricAccessor: generalAttrType.isAsymmetricAccessor,

--- a/packages/pyright-internal/src/analyzer/typeEvaluatorTypes.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluatorTypes.ts
@@ -383,6 +383,9 @@ export interface ClassMemberLookup {
     type: Type;
     isTypeIncomplete: boolean;
 
+    // True if access violates the type (used only for 'set' usage).
+    isSetTypeError: boolean;
+
     // True if class member, false otherwise.
     isClassMember: boolean;
 

--- a/packages/pyright-internal/src/tests/samples/metaclass11.py
+++ b/packages/pyright-internal/src/tests/samples/metaclass11.py
@@ -37,6 +37,7 @@ class ClassB(metaclass=MetaB):
     var0: int
 
 
+# This should generate an error
 ClassB.var0 = ""
 ClassB.var1 = ""
 

--- a/packages/pyright-internal/src/tests/typeEvaluator4.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator4.test.ts
@@ -93,7 +93,7 @@ test('Metaclass10', () => {
 
 test('Metaclass11', () => {
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['metaclass11.py']);
-    TestUtils.validateResults(analysisResults, 3);
+    TestUtils.validateResults(analysisResults, 4);
 });
 
 test('AssignmentExpr1', () => {


### PR DESCRIPTION
…lue with an incompatible type to a class variable that has no explicit type declaration. This addresses #6106.