### PR TITLE
Fixed bug in `x is <Literal>` and `x == <Literal>` type guard logic. …

### DIFF
--- a/packages/pyright-internal/src/analyzer/typeGuards.ts
+++ b/packages/pyright-internal/src/analyzer/typeGuards.ts
@@ -2315,7 +2315,14 @@ function narrowTypeForLiteralComparison(
 ): Type {
     return mapSubtypes(referenceType, (subtype) => {
         subtype = evaluator.makeTopLevelTypeVarsConcrete(subtype);
-        if (isClassInstance(subtype) && ClassType.isSameGenericClass(literalType, subtype)) {
+
+        if (isAnyOrUnknown(subtype)) {
+            if (isPositiveTest) {
+                return literalType;
+            }
+
+            return subtype;
+        } else if (isClassInstance(subtype) && ClassType.isSameGenericClass(literalType, subtype)) {
             if (subtype.literalValue !== undefined) {
                 const literalValueMatches = ClassType.isLiteralValueSame(subtype, literalType);
                 if ((literalValueMatches && !isPositiveTest) || (!literalValueMatches && isPositiveTest)) {

--- a/packages/pyright-internal/src/tests/samples/typeNarrowingLiteral2.py
+++ b/packages/pyright-internal/src/tests/samples/typeNarrowingLiteral2.py
@@ -2,7 +2,7 @@
 # types that have enumerated literals (bool and enums).
 
 from enum import Enum
-from typing import Literal, Union
+from typing import Any, Literal, Union
 
 
 class SomeEnum(Enum):
@@ -61,3 +61,17 @@ def func5(x: Union[MyEnum, str]):
         reveal_type(x, expected_text="Literal[MyEnum.ONE]")
     else:
         reveal_type(x, expected_text="str")
+
+
+def func6(x: Any):
+    if x is MyEnum.ZERO:
+        reveal_type(x, expected_text="Literal[MyEnum.ZERO]")
+    else:
+        reveal_type(x, expected_text="Any")
+
+
+def func7(x: Any):
+    if x == MyEnum.ZERO:
+        reveal_type(x, expected_text="Literal[MyEnum.ZERO]")
+    else:
+        reveal_type(x, expected_text="Any")


### PR DESCRIPTION
…It was not properly handling the case where `x` is `Any` or `Unknown`. This addresses #6109.