### PR TITLE
Fixed a bug that led to incorrect type narrowing in the `type(x) is T…

### DIFF
--- a/packages/pyright-internal/src/analyzer/typeGuards.ts
+++ b/packages/pyright-internal/src/analyzer/typeGuards.ts
@@ -2217,7 +2217,7 @@ function narrowTypeForTypeIs(evaluator: TypeEvaluator, type: Type, classType: Cl
         type,
         /* conditionFilter */ undefined,
         (subtype: Type, unexpandedSubtype: Type) => {
-            if (isClassInstance(subtype)) {
+            if (isClassInstance(subtype) && !classType.includeSubclasses) {
                 const matches = ClassType.isDerivedFrom(classType, ClassType.cloneAsInstantiable(subtype));
                 if (isPositiveTest) {
                     if (matches) {

--- a/packages/pyright-internal/src/tests/samples/typeNarrowingTypeIs1.py
+++ b/packages/pyright-internal/src/tests/samples/typeNarrowingTypeIs1.py
@@ -110,3 +110,11 @@ def func8(a: _TC, b: _TC) -> _TC:
         return a
     reveal_type(a, expected_text="CParent*")
     return a
+
+
+class F:
+    def method1(self, other: object):
+        if type(self) == type(other):
+            reveal_type(self, expected_text="Self@F")
+        else:
+            reveal_type(self, expected_text="Self@F")


### PR DESCRIPTION
…` and `type(x) == T` type guards when `T` is a dynamic type rather than a specific class. This addresses https://github.com/microsoft/pylance-release/issues/4942.