### PR TITLE
[PylanceBot] Pull Pylance with Pyright 1.1.331

### DIFF
--- a/packages/pyright-internal/src/analyzer/program.ts
+++ b/packages/pyright-internal/src/analyzer/program.ts
@@ -273,6 +273,11 @@ export class Program {
             }
         }
 
+        if (mutatedFiles.length > 0) {
+            // All cache is invalid now.
+            this._createNewEvaluator();
+        }
+
         return edits;
     }
 
@@ -715,7 +720,11 @@ export class Program {
     }
 
     getParseResults(filePath: string): ParseResults | undefined {
-        return this.getBoundSourceFile(filePath)?.getParseResults();
+        return this.getBoundSourceFileInfo(
+            filePath,
+            /* content */ undefined,
+            /* force */ true
+        )?.sourceFile.getParseResults();
     }
 
     handleMemoryHighUsage() {

--- a/packages/pyright-internal/src/analyzer/sourceFileInfo.ts
+++ b/packages/pyright-internal/src/analyzer/sourceFileInfo.ts
@@ -26,6 +26,7 @@ export class SourceFileInfo {
         args: OptionalArguments = {}
     ) {
         this.isCreatedInEditMode = this._editModeTracker.isEditMode;
+
         this._writableData = this._createWriteableData(args);
 
         this._cachePreEditState();
@@ -102,7 +103,7 @@ export class SourceFileInfo {
         this._writableData.chainedSourceFile = value;
     }
 
-    set effectiveFutureImports(value: Set<string> | undefined) {
+    set effectiveFutureImports(value: ReadonlySet<string> | undefined) {
         this._cachePreEditState();
         this._writableData.effectiveFutureImports = value;
     }
@@ -126,6 +127,9 @@ export class SourceFileInfo {
         if (this._preEditData) {
             this._writableData = this._preEditData;
             this._preEditData = undefined;
+
+            // Some states have changed. Force some of info to be re-calcuated.
+            this.sourceFile.dropParseAndBindInfo();
         }
 
         return this.sourceFile.restore();
@@ -187,7 +191,7 @@ interface OptionalArguments {
     builtinsImport?: SourceFileInfo | undefined;
     ipythonDisplayImport?: SourceFileInfo | undefined;
     chainedSourceFile?: SourceFileInfo | undefined;
-    effectiveFutureImports?: Set<string>;
+    effectiveFutureImports?: ReadonlySet<string>;
 }
 
 interface WriteableData {
@@ -205,7 +209,7 @@ interface WriteableData {
     // current file's scope.
     chainedSourceFile?: SourceFileInfo | undefined;
 
-    effectiveFutureImports?: Set<string>;
+    effectiveFutureImports?: ReadonlySet<string>;
 
     // Information about why the file is included in the program
     // and its relation to other source files in the program.

--- a/packages/pyright-internal/src/backgroundThreadBase.ts
+++ b/packages/pyright-internal/src/backgroundThreadBase.ts
@@ -13,7 +13,7 @@ import { ConfigOptions } from './common/configOptions';
 import { ConsoleInterface, LogLevel } from './common/console';
 import * as debug from './common/debug';
 import { FileSpec } from './common/pathUtils';
-import { createFromRealFileSystem } from './common/realFileSystem';
+import { createFromRealFileSystem, RealTempFile } from './common/realFileSystem';
 import { ServiceProvider } from './common/serviceProvider';
 import './common/serviceProviderExtensions';
 import { ServiceKeys } from './common/serviceProviderExtensions';
@@ -59,6 +59,9 @@ export class BackgroundThreadBase {
         if (!this._serviceProvider.tryGet(ServiceKeys.fs)) {
             this._serviceProvider.add(ServiceKeys.fs, createFromRealFileSystem(this.getConsole()));
         }
+        if (!this._serviceProvider.tryGet(ServiceKeys.tempFile)) {
+            this._serviceProvider.add(ServiceKeys.tempFile, new RealTempFile());
+        }
     }
 
     protected get fs() {
@@ -78,7 +81,7 @@ export class BackgroundThreadBase {
     }
 
     protected handleShutdown() {
-        this.fs.dispose();
+        this._serviceProvider.tryGet(ServiceKeys.tempFile)?.dispose();
         parentPort?.close();
     }
 }

--- a/packages/pyright-internal/src/common/configOptions.ts
+++ b/packages/pyright-internal/src/common/configOptions.ts
@@ -13,7 +13,7 @@ import { getPathsFromPthFiles } from '../analyzer/pythonPathUtils';
 import * as pathConsts from '../common/pathConsts';
 import { appendArray } from './collectionUtils';
 import { DiagnosticSeverityOverridesMap } from './commandLineOptions';
-import { ConsoleInterface } from './console';
+import { ConsoleInterface, NullConsole } from './console';
 import { TaskListToken } from './diagnostic';
 import { DiagnosticRule } from './diagnosticRules';
 import { FileSystem } from './fileSystem';
@@ -29,6 +29,8 @@ import {
     resolvePaths,
 } from './pathUtils';
 import { latestStablePythonVersion, PythonVersion, versionFromString, versionToString } from './pythonVersion';
+import { ServiceProvider } from './serviceProvider';
+import { ServiceKeys } from './serviceProviderExtensions';
 
 export enum PythonPlatform {
     Darwin = 'Darwin',
@@ -886,13 +888,13 @@ export class ConfigOptions {
     initializeFromJson(
         configObj: any,
         typeCheckingMode: string | undefined,
-        console: ConsoleInterface,
-        fs: FileSystem,
+        serviceProvider: ServiceProvider,
         host: Host,
         diagnosticOverrides?: DiagnosticSeverityOverridesMap,
         skipIncludeSection = false
     ) {
         this.initializedFromJson = true;
+        const console = serviceProvider.tryGet(ServiceKeys.console) ?? new NullConsole();
 
         // Read the "include" entry.
         if (!skipIncludeSection) {
@@ -908,7 +910,7 @@ export class ConfigOptions {
                         } else if (isAbsolute(fileSpec)) {
                             console.error(`Ignoring path "${fileSpec}" in "include" array because it is not relative.`);
                         } else {
-                            this.include.push(getFileSpec(fs, this.projectRoot, fileSpec));
+                            this.include.push(getFileSpec(serviceProvider, this.projectRoot, fileSpec));
                         }
                     });
                 }
@@ -928,7 +930,7 @@ export class ConfigOptions {
                     } else if (isAbsolute(fileSpec)) {
                         console.error(`Ignoring path "${fileSpec}" in "exclude" array because it is not relative.`);
                     } else {
-                        this.exclude.push(getFileSpec(fs, this.projectRoot, fileSpec));
+                        this.exclude.push(getFileSpec(serviceProvider, this.projectRoot, fileSpec));
                     }
                 });
             }
@@ -947,7 +949,7 @@ export class ConfigOptions {
                     } else if (isAbsolute(fileSpec)) {
                         console.error(`Ignoring path "${fileSpec}" in "ignore" array because it is not relative.`);
                     } else {
-                        this.ignore.push(getFileSpec(fs, this.projectRoot, fileSpec));
+                        this.ignore.push(getFileSpec(serviceProvider, this.projectRoot, fileSpec));
                     }
                 });
             }
@@ -966,7 +968,7 @@ export class ConfigOptions {
                     } else if (isAbsolute(fileSpec)) {
                         console.error(`Ignoring path "${fileSpec}" in "strict" array because it is not relative.`);
                     } else {
-                        this.strict.push(getFileSpec(fs, this.projectRoot, fileSpec));
+                        this.strict.push(getFileSpec(serviceProvider, this.projectRoot, fileSpec));
                     }
                 });
             }

--- a/packages/pyright-internal/src/common/extensibility.ts
+++ b/packages/pyright-internal/src/common/extensibility.ts
@@ -11,7 +11,6 @@ import { CancellationToken } from 'vscode-languageserver';
 import { Declaration } from '../analyzer/declaration';
 import { ImportResolver } from '../analyzer/importResolver';
 import * as prog from '../analyzer/program';
-import * as src from '../analyzer/sourceFileInfo';
 import { SourceMapper } from '../analyzer/sourceMapper';
 import { TypeEvaluator } from '../analyzer/typeEvaluatorTypes';
 import { ServerSettings } from '../languageServerBase';
@@ -99,7 +98,6 @@ export interface ProgramView {
     getDiagnosticsForRange(filePath: string, range: Range): Diagnostic[];
 
     // See whether we can get rid of these methods
-    getBoundSourceFileInfo(file: string, content?: string, force?: boolean): src.SourceFileInfo | undefined;
     handleMemoryHighUsage(): void;
     clone(): prog.Program;
 }

--- a/packages/pyright-internal/src/common/fileSystem.ts
+++ b/packages/pyright-internal/src/common/fileSystem.ts
@@ -32,11 +32,6 @@ export interface MkDirOptions {
     // mode: string | number;
 }
 
-export interface TmpfileOptions {
-    postfix?: string;
-    prefix?: string;
-}
-
 export interface ReadOnlyFileSystem {
     existsSync(path: string): boolean;
     chdir(path: string): void;
@@ -80,7 +75,14 @@ export interface FileSystem extends ReadOnlyFileSystem {
     createReadStream(path: string): fs.ReadStream;
     createWriteStream(path: string): fs.WriteStream;
     copyFileSync(src: string, dst: string): void;
+}
 
+export interface TmpfileOptions {
+    postfix?: string;
+    prefix?: string;
+}
+
+export interface TempFile {
     // The directory returned by tmpdir must exist and be the same each time tmpdir is called.
     tmpdir(): string;
     tmpfile(options?: TmpfileOptions): string;
@@ -90,6 +92,12 @@ export interface FileSystem extends ReadOnlyFileSystem {
 export namespace FileSystem {
     export function is(value: any): value is FileSystem {
         return value.createFileSystemWatcher && value.createReadStream && value.createWriteStream && value.copyFileSync;
+    }
+}
+
+export namespace TempFile {
+    export function is(value: any): value is TempFile {
+        return value.tmpdir && value.tmpfile && value.dispose;
     }
 }
 

--- a/packages/pyright-internal/src/common/serviceProviderExtensions.ts
+++ b/packages/pyright-internal/src/common/serviceProviderExtensions.ts
@@ -15,7 +15,7 @@ import {
     SymbolDefinitionProvider,
     SymbolUsageProviderFactory,
 } from './extensibility';
-import { FileSystem } from './fileSystem';
+import { FileSystem, TempFile } from './fileSystem';
 import { LogTracker } from './logTracker';
 import { GroupServiceKey, ServiceKey, ServiceProvider } from './serviceProvider';
 
@@ -38,6 +38,7 @@ export namespace ServiceKeys {
     export const symbolDefinitionProvider = new GroupServiceKey<SymbolDefinitionProvider>();
     export const symbolUsageProviderFactory = new GroupServiceKey<SymbolUsageProviderFactory>();
     export const stateMutationListeners = new GroupServiceKey<StatusMutationListener>();
+    export const tempFile = new ServiceKey<TempFile>();
 }
 
 export function createServiceProvider(...services: any): ServiceProvider {
@@ -59,6 +60,9 @@ export function createServiceProvider(...services: any): ServiceProvider {
         }
         if (SupportUriToPathMapping.is(service)) {
             sp.add(ServiceKeys.uriMapper, service);
+        }
+        if (TempFile.is(service)) {
+            sp.add(ServiceKeys.tempFile, service);
         }
     });
     return sp;

--- a/packages/pyright-internal/src/languageService/navigationUtils.ts
+++ b/packages/pyright-internal/src/languageService/navigationUtils.ts
@@ -14,8 +14,12 @@ export function canNavigateToFile(fs: ReadOnlyFileSystem, path: string): boolean
     return !fs.isInZip(path);
 }
 
-export function convertDocumentRangesToLocation(fs: ReadOnlyFileSystem, ranges: DocumentRange[]): Location[] {
-    return ranges.map((range) => convertDocumentRangeToLocation(fs, range)).filter((loc) => !!loc) as Location[];
+export function convertDocumentRangesToLocation(
+    fs: ReadOnlyFileSystem,
+    ranges: DocumentRange[],
+    converter: (fs: ReadOnlyFileSystem, range: DocumentRange) => Location | undefined = convertDocumentRangeToLocation
+): Location[] {
+    return ranges.map((range) => converter(fs, range)).filter((loc) => !!loc) as Location[];
 }
 
 export function convertDocumentRangeToLocation(fs: ReadOnlyFileSystem, range: DocumentRange): Location | undefined {

--- a/packages/pyright-internal/src/localization/package.nls.cs.json
+++ b/packages/pyright-internal/src/localization/package.nls.cs.json
@@ -648,6 +648,7 @@
         "newMethodSignature": "Podpis __new__ je {type}",
         "noOverloadAssignable": "Typ {type} neodpovídá žádné přetížené funkci",
         "orPatternMissingName": "Chybějící názvy: {name}",
+        "overloadIndex": "Přetížení {index} je nejbližší shoda.",
         "overloadNotAssignable": "Nejméně jedno přetížení {name} není možné přiřadit",
         "overloadSignature": "Tady je definován podpis přetížení",
         "overriddenMethod": "Přepsaná metoda",

--- a/packages/pyright-internal/src/localization/package.nls.de.json
+++ b/packages/pyright-internal/src/localization/package.nls.de.json
@@ -648,6 +648,7 @@
         "newMethodSignature": "Signatur von __new__ ist \"{type}\"",
         "noOverloadAssignable": "Keine überladene Funktion stimmt mit dem Typ \"{type}\" überein.",
         "orPatternMissingName": "Fehlende Namen: {name}",
+        "overloadIndex": "Überladung \"{index}\" ist die nächste Übereinstimmung.",
         "overloadNotAssignable": "Mindestens eine Überladung von \"{name}\" kann nicht zugewiesen werden.",
         "overloadSignature": "Die Überladungssignatur ist hier definiert.",
         "overriddenMethod": "Überschriebene Methode",

--- a/packages/pyright-internal/src/localization/package.nls.es.json
+++ b/packages/pyright-internal/src/localization/package.nls.es.json
@@ -648,6 +648,7 @@
         "newMethodSignature": "La firma de __new__ es \"{type}\"",
         "noOverloadAssignable": "Ninguna función sobrecargada coincide con el tipo \"{type}\"",
         "orPatternMissingName": "Nombres que faltan: {name}",
+        "overloadIndex": "La sobrecarga {index} es la coincidencia más cercana",
         "overloadNotAssignable": "Una o más sobrecargas de \"{name}\" no es asignable",
         "overloadSignature": "Aquí se define la firma de la sobrecarga",
         "overriddenMethod": "Método reemplazado",

--- a/packages/pyright-internal/src/localization/package.nls.fr.json
+++ b/packages/pyright-internal/src/localization/package.nls.fr.json
@@ -648,6 +648,7 @@
         "newMethodSignature": "La signature de __new__ est « {type} »",
         "noOverloadAssignable": "Aucune fonction surchargée ne correspond au type « {type} »",
         "orPatternMissingName": "Noms manquants : {name}",
+        "overloadIndex": "La surcharge {index} est la correspondance la plus proche",
         "overloadNotAssignable": "Une ou plusieurs surcharges de « {name} » ne sont pas assignables",
         "overloadSignature": "La signature de surcharge est définie ici",
         "overriddenMethod": "Méthode substituée",

--- a/packages/pyright-internal/src/localization/package.nls.it.json
+++ b/packages/pyright-internal/src/localization/package.nls.it.json
@@ -648,6 +648,7 @@
         "newMethodSignature": "La firma del __new__ è \"{type}\"",
         "noOverloadAssignable": "Nessuna funzione di overload corrisponde al tipo \"{type}\"",
         "orPatternMissingName": "Nomi mancanti: {name}",
+        "overloadIndex": "L'overload {index} è la corrispondenza più vicina",
         "overloadNotAssignable": "Uno o più overload di \"{name}\" non sono assegnabili",
         "overloadSignature": "La firma di overload è definita qui",
         "overriddenMethod": "Metodo sottoposto a override",

--- a/packages/pyright-internal/src/localization/package.nls.ja.json
+++ b/packages/pyright-internal/src/localization/package.nls.ja.json
@@ -648,6 +648,7 @@
         "newMethodSignature": "__new__の署名は \"{type}\" です",
         "noOverloadAssignable": "型 \"{type}\" に一致するオーバーロードされた関数はありません",
         "orPatternMissingName": "名前がありません: {name}",
+        "overloadIndex": "オーバーロード {index} が最も近い一致です",
         "overloadNotAssignable": "\"{name}\" の 1 つ以上のオーバーロードが割り当て可能ではありません",
         "overloadSignature": "オーバーロードシグネチャはここで定義されています",
         "overriddenMethod": "オーバーライドされたメソッド",

--- a/packages/pyright-internal/src/localization/package.nls.ko.json
+++ b/packages/pyright-internal/src/localization/package.nls.ko.json
@@ -648,6 +648,7 @@
         "newMethodSignature": "__new__ 의 서명은 \"{type}\"입니다.",
         "noOverloadAssignable": "\"{type}\" 형식과 일치하는 오버로드된 함수가 없습니다.",
         "orPatternMissingName": "누락된 이름: {name}",
+        "overloadIndex": "오버로드 {index}이(가) 가장 가까운 일치 항목입니다.",
         "overloadNotAssignable": "\"{name}\"의 오버로드를 하나 이상 할당할 수 없습니다.",
         "overloadSignature": "오버로드 서명은 여기에 정의되어 있습니다.",
         "overriddenMethod": "재정의된 메서드",

--- a/packages/pyright-internal/src/localization/package.nls.pl.json
+++ b/packages/pyright-internal/src/localization/package.nls.pl.json
@@ -648,6 +648,7 @@
         "newMethodSignature": "Sygnatura __new__ to typ „{type}”",
         "noOverloadAssignable": "Żadna przeciążona funkcja nie pasuje do typu „{type}”",
         "orPatternMissingName": "Brak nazw: {name}",
+        "overloadIndex": "Przeciążenie {index} jest najbardziej zbliżonym dopasowaniem",
         "overloadNotAssignable": "Nie można przypisać jednego lub więcej przeciążeń „{name}”.",
         "overloadSignature": "Sygnatura przeciążenia jest zdefiniowana tutaj",
         "overriddenMethod": "Przesłonięta metoda",

--- a/packages/pyright-internal/src/localization/package.nls.pt-br.json
+++ b/packages/pyright-internal/src/localization/package.nls.pt-br.json
@@ -648,6 +648,7 @@
         "newMethodSignature": "A assinatura de__new__ é \"{type}\"",
         "noOverloadAssignable": "Nenhuma função sobrecarregada corresponde ao tipo \"{type}\"",
         "orPatternMissingName": "Nomes ausentes: {name}",
+        "overloadIndex": "Sobrecarga {index} é a correspondência mais próxima",
         "overloadNotAssignable": "Uma ou mais sobrecargas de \"{name}\" não podem ser atribuídas",
         "overloadSignature": "A assinatura de sobrecarga é definida aqui",
         "overriddenMethod": "Método substituído",

--- a/packages/pyright-internal/src/localization/package.nls.qps-ploc.json
+++ b/packages/pyright-internal/src/localization/package.nls.qps-ploc.json
@@ -648,6 +648,7 @@
         "newMethodSignature": "[NeWKO][นั้§ïgñætµrë øf __ñëw__ ïs \"{tÿpë}\"Ấğ倪İЂҰक्र्तिृนั้ढूँ]",
         "noOverloadAssignable": "[FJ88c][นั้Ñø øvërløæðëð fµñçtïøñ mætçhës tÿpë \"{tÿpë}\"Ấğ倪İЂҰक्र्तिृまẤğ倪İนั้ढूँ]",
         "orPatternMissingName": "[kgiPM][นั้Mïssïñg ñæmës: {ñæmë}Ấğ倪İЂҰक्นั้ढूँ]",
+        "overloadIndex": "[vNPxL][นั้Øvërløæð {ïñðëx} ïs thë çløsëst mætçhẤğ倪İЂҰक्र्तिृまẤนั้ढूँ]",
         "overloadNotAssignable": "[BA2kK][นั้Øñë ør mørë øvërløæðs øf \"{ñæmë}\" ïs ñøt æssïgñæþlëẤğ倪İЂҰक्र्तिृまẤğ倪İЂҰนั้ढूँ]",
         "overloadSignature": "[NPzwf][นั้Øvërløæð sïgñætµrë ïs ðëfïñëð hërëẤğ倪İЂҰक्र्तिृまนั้ढूँ]",
         "overriddenMethod": "[CcUB2][นั้Øvërrïððëñ mëthøðẤğ倪İЂҰक्นั้ढूँ]",

--- a/packages/pyright-internal/src/localization/package.nls.ru.json
+++ b/packages/pyright-internal/src/localization/package.nls.ru.json
@@ -648,6 +648,7 @@
         "newMethodSignature": "Сигнатура метода __new__ требует \"{type}\"",
         "noOverloadAssignable": "Нет перегруженной функции, соответствующей типу \"{type}\"",
         "orPatternMissingName": "Отсутствуют имена: {name}",
+        "overloadIndex": "Наилучшее совпадение: {index} перегрузки",
         "overloadNotAssignable": "Одна или несколько перегрузок \"{name}\" не подлежат присвоению",
         "overloadSignature": "Здесь определена сигнатура перегрузки",
         "overriddenMethod": "Переопределенный метод",

--- a/packages/pyright-internal/src/localization/package.nls.tr.json
+++ b/packages/pyright-internal/src/localization/package.nls.tr.json
@@ -648,6 +648,7 @@
         "newMethodSignature": "__new__ imzası \"{type}\"",
         "noOverloadAssignable": "Aşırı yüklenmiş işlevlerden hiçbiri \"{type}\" türüyle uyuşmuyor",
         "orPatternMissingName": "Eksik adlar: {name}",
+        "overloadIndex": "Aşırı yükleme {index} en yakın eşleşmedir",
         "overloadNotAssignable": "Bir veya daha fazla \"{name}\" aşırı yüklemesi atanabilir değil",
         "overloadSignature": "Aşırı yükleme imzası burada tanımlı",
         "overriddenMethod": "Geçersiz kılınan metot",

--- a/packages/pyright-internal/src/localization/package.nls.zh-cn.json
+++ b/packages/pyright-internal/src/localization/package.nls.zh-cn.json
@@ -648,6 +648,7 @@
         "newMethodSignature": "__new__的签名为“{type}”",
         "noOverloadAssignable": "没有重载函数与类型“{type}”匹配",
         "orPatternMissingName": "缺少名称: {name}",
+        "overloadIndex": "重载 {index} 是最接近的匹配项",
         "overloadNotAssignable": "无法分配“{name}”的一个或多个重载",
         "overloadSignature": "此处定义了重载签名",
         "overriddenMethod": "替代的方法",

--- a/packages/pyright-internal/src/localization/package.nls.zh-tw.json
+++ b/packages/pyright-internal/src/localization/package.nls.zh-tw.json
@@ -648,6 +648,7 @@
         "newMethodSignature": "__new__ 的簽章為 \"{type}\"",
         "noOverloadAssignable": "沒有任何多載函式符合類型 \"{type}\"",
         "orPatternMissingName": "遺失名稱: {name}",
+        "overloadIndex": "多載 {index} 是最接近的相符項目",
         "overloadNotAssignable": "\"{name}\" 的一或多個多載無法指派",
         "overloadSignature": "多載簽章在這裡定義",
         "overriddenMethod": "覆寫方法",

--- a/packages/pyright-internal/src/pyright.ts
+++ b/packages/pyright-internal/src/pyright.ts
@@ -30,7 +30,7 @@ import { FileDiagnostics } from './common/diagnosticSink';
 import { FullAccessHost } from './common/fullAccessHost';
 import { combinePaths, normalizePath } from './common/pathUtils';
 import { versionFromString } from './common/pythonVersion';
-import { createFromRealFileSystem } from './common/realFileSystem';
+import { RealTempFile, createFromRealFileSystem } from './common/realFileSystem';
 import { Range, isEmptyRange } from './common/textRange';
 import { PyrightFileSystem } from './pyrightFileSystem';
 import { createServiceProvider } from './common/serviceProviderExtensions';
@@ -346,7 +346,8 @@ async function processArgs(): Promise<ExitStatus> {
     // up the JSON output, which goes to stdout.
     const output = args.outputjson ? new StderrConsole(logLevel) : new StandardConsole(logLevel);
     const fileSystem = new PyrightFileSystem(createFromRealFileSystem(output, new ChokidarFileWatcherProvider(output)));
-    const serviceProvider = createServiceProvider(fileSystem, output);
+    const tempFile = new RealTempFile();
+    const serviceProvider = createServiceProvider(fileSystem, output, tempFile);
 
     // The package type verification uses a different path.
     if (args['verifytypes'] !== undefined) {

--- a/packages/pyright-internal/src/pyrightFileSystem.ts
+++ b/packages/pyright-internal/src/pyrightFileSystem.ts
@@ -237,10 +237,6 @@ export class PyrightFileSystem extends ReadOnlyAugmentedFileSystem implements IP
         }
     }
 
-    override dispose(): void {
-        this.realFS.dispose();
-    }
-
     clearPartialStubs(): void {
         super.clear();
 

--- a/packages/pyright-internal/src/readonlyAugmentedFileSystem.ts
+++ b/packages/pyright-internal/src/readonlyAugmentedFileSystem.ts
@@ -10,7 +10,7 @@
 import type * as fs from 'fs';
 
 import { appendArray, getOrAdd } from './common/collectionUtils';
-import { FileSystem, MkDirOptions, Stats, TmpfileOptions, VirtualDirent } from './common/fileSystem';
+import { FileSystem, MkDirOptions, Stats, VirtualDirent } from './common/fileSystem';
 import { FileWatcher, FileWatcherEventHandler } from './common/fileWatcher';
 import { combinePaths, ensureTrailingDirectorySeparator, getDirectoryPath, getFileName } from './common/pathUtils';
 
@@ -133,15 +133,6 @@ export class ReadOnlyAugmentedFileSystem implements FileSystem {
         return this.realFS.readFileText(this.getOriginalPath(path), encoding);
     }
 
-    // The directory returned by tmpdir must exist and be the same each time tmpdir is called.
-    tmpdir(): string {
-        return this.realFS.tmpdir();
-    }
-
-    tmpfile(options?: TmpfileOptions): string {
-        return this.realFS.tmpfile(options);
-    }
-
     realCasePath(path: string): string {
         return this.realFS.realCasePath(path);
     }
@@ -168,10 +159,6 @@ export class ReadOnlyAugmentedFileSystem implements FileSystem {
 
     isInZip(path: string): boolean {
         return this.realFS.isInZip(path);
-    }
-
-    dispose(): void {
-        this.realFS.dispose();
     }
 
     protected recordMovedEntry(mappedPath: string, originalPath: string, reversible = true, isFile = true) {

--- a/packages/pyright-internal/src/server.ts
+++ b/packages/pyright-internal/src/server.ts
@@ -31,7 +31,7 @@ import { FullAccessHost } from './common/fullAccessHost';
 import { Host } from './common/host';
 import { realCasePath, resolvePaths } from './common/pathUtils';
 import { ProgressReporter } from './common/progressReporter';
-import { WorkspaceFileWatcherProvider, createFromRealFileSystem } from './common/realFileSystem';
+import { RealTempFile, WorkspaceFileWatcherProvider, createFromRealFileSystem } from './common/realFileSystem';
 import { ServiceProvider } from './common/serviceProvider';
 import { createServiceProvider } from './common/serviceProviderExtensions';
 import { LanguageServerBase, ServerSettings } from './languageServerBase';
@@ -57,7 +57,9 @@ export class PyrightServer extends LanguageServerBase {
         const fileWatcherProvider = new WorkspaceFileWatcherProvider();
         const fileSystem = createFromRealFileSystem(console, fileWatcherProvider);
         const pyrightFs = new PyrightFileSystem(fileSystem);
-        const serviceProvider = createServiceProvider(pyrightFs, console);
+        const tempFile = new RealTempFile();
+
+        const serviceProvider = createServiceProvider(pyrightFs, tempFile, console);
         const realPathRoot = realCasePath(rootDirectory, pyrightFs);
 
         super(

--- a/packages/pyright-internal/src/tests/config.test.ts
+++ b/packages/pyright-internal/src/tests/config.test.ts
@@ -193,7 +193,7 @@ test('FindExecEnv1', () => {
 
 test('PythonPlatform', () => {
     const cwd = normalizePath(process.cwd());
-    const nullConsole = new NullConsole();
+
     const configOptions = new ConfigOptions(cwd);
 
     const json = JSON.parse(`{
@@ -206,7 +206,10 @@ test('PythonPlatform', () => {
     }]}`);
 
     const fs = new TestFileSystem(/* ignoreCase */ false);
-    configOptions.initializeFromJson(json, undefined, nullConsole, fs, new NoAccessHost());
+    const nullConsole = new NullConsole();
+
+    const sp = createServiceProvider(fs, nullConsole);
+    configOptions.initializeFromJson(json, undefined, sp, new NoAccessHost());
 
     const env = configOptions.executionEnvironments[0];
     assert.strictEqual(env.pythonPlatform, 'platform');
@@ -323,7 +326,8 @@ test('verify config fileSpecs after cloning', () => {
     };
 
     const config = new ConfigOptions(process.cwd());
-    config.initializeFromJson(configFile, undefined, new NullConsole(), fs, new TestAccessHost());
+    const sp = createServiceProvider(fs, new NullConsole());
+    config.initializeFromJson(configFile, undefined, sp, new TestAccessHost());
     const cloned = createConfigOptionsFrom(config);
 
     assert.deepEqual(config.ignore, cloned.ignore);

--- a/packages/pyright-internal/src/tests/harness/vfs/filesystem.ts
+++ b/packages/pyright-internal/src/tests/harness/vfs/filesystem.ts
@@ -10,7 +10,7 @@
 import { Dirent, ReadStream, WriteStream } from 'fs';
 import { URI } from 'vscode-uri';
 
-import { FileSystem, MkDirOptions, TmpfileOptions } from '../../../common/fileSystem';
+import { FileSystem, MkDirOptions, TempFile, TmpfileOptions } from '../../../common/fileSystem';
 import { FileWatcher, FileWatcherEventHandler, FileWatcherEventType } from '../../../common/fileWatcher';
 import * as pathUtil from '../../../common/pathUtils';
 import { bufferFrom, createIOError } from '../utils';
@@ -49,7 +49,7 @@ export class TestFileSystemWatcher implements FileWatcher {
 /**
  * Represents a virtual POSIX-like file system.
  */
-export class TestFileSystem implements FileSystem {
+export class TestFileSystem implements FileSystem, TempFile {
     /** Indicates whether the file system is case-sensitive (`false`) or case-insensitive (`true`). */
     readonly ignoreCase: boolean;
 

--- a/packages/pyright-internal/src/tests/importResolver.test.ts
+++ b/packages/pyright-internal/src/tests/importResolver.test.ts
@@ -9,7 +9,7 @@ import assert from 'assert';
 import { Dirent, ReadStream, WriteStream } from 'fs';
 import { ImportResolver } from '../analyzer/importResolver';
 import { ConfigOptions } from '../common/configOptions';
-import { FileSystem, MkDirOptions, Stats, TmpfileOptions } from '../common/fileSystem';
+import { FileSystem, MkDirOptions, Stats } from '../common/fileSystem';
 import { FileWatcher, FileWatcherEventHandler } from '../common/fileWatcher';
 import { FullAccessHost } from '../common/fullAccessHost';
 import { Host } from '../common/host';
@@ -760,18 +760,6 @@ class CombinedFileSystem implements FileSystem {
 
     copyFileSync(src: string, dst: string): void {
         this._testFS.copyFileSync(src, dst);
-    }
-
-    tmpdir(): string {
-        return this._testFS.tmpdir();
-    }
-
-    tmpfile(options?: TmpfileOptions | undefined): string {
-        return this._testFS.tmpfile(options);
-    }
-
-    dispose(): void {
-        this._testFS.dispose();
     }
 
     existsSync(path: string): boolean {

--- a/packages/pyright-internal/src/tests/pathUtils.test.ts
+++ b/packages/pyright-internal/src/tests/pathUtils.test.ts
@@ -400,10 +400,10 @@ test('CaseSensitivity', () => {
     const cwd = normalizeSlashes('/');
 
     const fsCaseInsensitive = new vfs.TestFileSystem(/*ignoreCase*/ true, { cwd });
-    assert.equal(isFileSystemCaseSensitiveInternal(fsCaseInsensitive), false);
+    assert.equal(isFileSystemCaseSensitiveInternal(fsCaseInsensitive, fsCaseInsensitive), false);
 
     const fsCaseSensitive = new vfs.TestFileSystem(/*ignoreCase*/ false, { cwd });
-    assert.equal(isFileSystemCaseSensitiveInternal(fsCaseSensitive), true);
+    assert.equal(isFileSystemCaseSensitiveInternal(fsCaseSensitive, fsCaseSensitive), true);
 });
 
 test('deduplicateFolders', () => {


### PR DESCRIPTION
Rollup of the following changes:

1. pylance loc update 20231010.1 https://github.com/microsoft/pyrx/pull/4171
2. extracted out temp file from FileSystem https://github.com/microsoft/pyrx/pull/4168
3. got rid of `getBoundSourceInfo` from `extensibility` and make `stringDefinition` to support multiple indirect references. https://github.com/microsoft/pyrx/pull/4164
4. Fixed pyTest sometimes fail to find fixtures https://github.com/microsoft/pyrx/pull/4161
5. Add `kind` (read/write) metadata to Find All References response https://github.com/microsoft/pyrx/pull/4160

  Co-authored-by: Bill Schnurr <bschnurr@microsoft.com>
  Co-authored-by: HeeJae Chang <hechang@microsoft.com>
  Co-authored-by: Erik De Bonte <erikd@microsoft.com>
  Co-authored-by: Rich Chiodo <rchiodo@microsoft.com>
  Co-authored-by: Stella Huang <stellahuang@microsoft.com>
    