### PR TITLE
Fixed a bug in protocol matching logic that resulted in a false posit…

### DIFF
--- a/packages/pyright-internal/src/tests/samples/protocol6.py
+++ b/packages/pyright-internal/src/tests/samples/protocol6.py
@@ -52,7 +52,7 @@ class Cow:
 
 a: Mammal[str] = Sloth()
 
-# This should generage an error because Armadillo
+# This should generate an error because Armadillo
 # uses bytes for its attributes, not str.
 b: Mammal[str] = Armadillo()
 

--- a/packages/pyright-internal/src/tests/samples/protocol9.py
+++ b/packages/pyright-internal/src/tests/samples/protocol9.py
@@ -1,4 +1,5 @@
-# This sample tests a protocol class that refers to itself.
+# This sample tests a recursive protocol class (i.e. a protocol
+# that refers to itself).
 
 from typing import Protocol
 
@@ -33,3 +34,19 @@ class SimpleTree:
 
 
 root: TreeLike = SimpleTree(0)
+
+
+class ProtoA(Protocol):
+    def method1(self) -> "ProtoA":
+        ...
+
+
+class ImplA:
+    class CallableClass:
+        def __call__(self) -> "ImplA":
+            return ImplA()
+
+    method1 = CallableClass()
+
+
+v1: ProtoA = ImplA()


### PR DESCRIPTION
…ive error when a class implementation used a callback protocol rather than a `def` statement to define an instance variable defined in a protocol. This addresses #6127.