### PR TITLE
Fixed a bug in the `reportIncompatibleMethodOverride` check that lead…

### DIFF
--- a/packages/pyright-internal/src/tests/samples/methodOverride2.py
+++ b/packages/pyright-internal/src/tests/samples/methodOverride2.py
@@ -2,7 +2,7 @@
 # diagnostic check.
 
 
-from typing import Any, Generic, ParamSpec, TypeVar
+from typing import Any, Generic, ParamSpec, Self, TypeVar
 
 
 class Base1:
@@ -94,4 +94,24 @@ class Derived2(Base2[P, R]):
         ...
 
     def method2(self, *args: Any, **kwargs: Any) -> R:
+        ...
+
+
+T = TypeVar("T")
+
+
+class Base3:
+    def method1(self, x: Self) -> Self:
+        ...
+
+    def method2(self, x: Self) -> Self:
+        ...
+
+
+class Derived3(Generic[T], Base3):
+    def method1(self, x: "Derived3[T]") -> "Derived3[T]":
+        ...
+
+    # This should generate an error.
+    def method2(self, x: "Derived3[int]") -> "Derived3[int]":
         ...

--- a/packages/pyright-internal/src/tests/typeEvaluator3.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator3.test.ts
@@ -840,7 +840,7 @@ test('MethodOverride2', () => {
     // Turn on errors.
     configOptions.diagnosticRuleSet.reportIncompatibleMethodOverride = 'error';
     analysisResults = TestUtils.typeAnalyzeSampleFiles(['methodOverride2.py'], configOptions);
-    TestUtils.validateResults(analysisResults, 5);
+    TestUtils.validateResults(analysisResults, 6);
 });
 
 test('MethodOverride3', () => {


### PR DESCRIPTION
…s to a false negative if the base class uses a `Self` type and the override uses an incompatible specialized type. This addresses #6010.