### PR TITLE
Fixed an inconsistency in how a constructor (an `__init__` method) is…

### DIFF
--- a/packages/pyright-internal/src/analyzer/checker.ts
+++ b/packages/pyright-internal/src/analyzer/checker.ts
@@ -146,6 +146,7 @@ import {
     lookUpClassMember,
     mapSubtypes,
     partiallySpecializeType,
+    selfSpecializeClass,
     transformPossibleRecursiveTypeAlias,
 } from './typeUtils';
 import { TypeVarContext } from './typeVarContext';
@@ -5781,13 +5782,7 @@ export class Checker extends ParseTreeWalker {
         }
 
         const baseClass = baseClassAndSymbol.classType;
-
-        // Self specialize the class.
-        const childClassSelf = ClassType.cloneForSpecialization(
-            childClassType,
-            childClassType.details.typeParameters,
-            /* isTypeArgumentExplicit */ true
-        );
+        const childClassSelf = selfSpecializeClass(childClassType);
 
         const baseType = partiallySpecializeType(
             this._evaluator.getEffectiveTypeOfSymbol(baseClassAndSymbol.symbol),

--- a/packages/pyright-internal/src/analyzer/constructors.ts
+++ b/packages/pyright-internal/src/analyzer/constructors.ts
@@ -41,6 +41,7 @@ import {
     isTupleClass,
     lookUpClassMember,
     mapSubtypes,
+    selfSpecializeClass,
     specializeTupleClass,
     transformPossibleRecursiveTypeAlias,
 } from './typeUtils';
@@ -809,7 +810,7 @@ export function createFunctionFromConstructor(
                 constructorFunction.details.typeVarScopeId = initSubtype.details.typeVarScopeId;
 
                 if (constructorFunction.specializedTypes) {
-                    constructorFunction.specializedTypes.returnType = objectType;
+                    constructorFunction.specializedTypes.returnType = selfSpecializeClass(objectType);
                 }
 
                 if (!constructorFunction.details.docString && classType.details.docString) {

--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -249,6 +249,7 @@ import {
     replaceTypeVarsWithAny,
     requiresSpecialization,
     requiresTypeArguments,
+    selfSpecializeClass,
     setTypeArgumentsRecursive,
     sortTypes,
     specializeClassType,
@@ -13315,12 +13316,7 @@ export function createTypeEvaluator(importLookup: ImportLookup, evaluatorOptions
                 } else if (mappingType && isInstantiableClass(mappingType)) {
                     const mappingTypeVarContext = new TypeVarContext(getTypeVarScopeId(mappingType));
 
-                    // Self-specialize the class.
-                    mappingType = ClassType.cloneForSpecialization(
-                        mappingType,
-                        mappingType.details.typeParameters,
-                        /* isTypeArgumentExplicit */ true
-                    );
+                    mappingType = selfSpecializeClass(mappingType);
 
                     if (
                         assignType(

--- a/packages/pyright-internal/src/analyzer/typeUtils.ts
+++ b/packages/pyright-internal/src/analyzer/typeUtils.ts
@@ -926,6 +926,17 @@ export function specializeWithDefaultTypeArgs(type: ClassType): ClassType {
     );
 }
 
+// If the class is generic and not already specialized, this function
+// "self specializes" the class, filling in its own type parameters
+// as type arguments.
+export function selfSpecializeClass(type: ClassType): ClassType {
+    if (type.details.typeParameters.length === 0 || type.typeArguments) {
+        return type;
+    }
+
+    return ClassType.cloneForSpecialization(type, type.details.typeParameters, /* isTypeArgumentExplicit */ true);
+}
+
 // Determines whether the type derives from tuple. If so, it returns
 // the specialized tuple type.
 export function getSpecializedTupleType(type: Type): ClassType | undefined {

--- a/packages/pyright-internal/src/tests/samples/constructor8.py
+++ b/packages/pyright-internal/src/tests/samples/constructor8.py
@@ -2,18 +2,20 @@
 # type if its constructor conforms to that type.
 
 from dataclasses import dataclass
-from typing import Any, Callable, Generic, Literal, TypeVar, Union, overload
+from typing import Any, Callable, Generic, Literal, ParamSpec, TypeVar, Union, overload
 
-_T1 = TypeVar("_T1")
-_S = TypeVar("_S")
+T1 = TypeVar("T1")
+T2 = TypeVar("T2")
+P = ParamSpec("P")
+R = TypeVar("R")
 
 
-def func1(callback: Callable[[_T1], _S], val: _T1) -> _S:
+def func1(callback: Callable[[T1], T2], val: T1) -> T2:
     ...
 
 
-class A(Generic[_T1]):
-    def __new__(cls, x: _T1) -> "A[_T1]":
+class A(Generic[T1]):
+    def __new__(cls, x: T1) -> "A[T1]":
         ...
 
 
@@ -27,16 +29,16 @@ a3 = func1(A[int], 3)
 reveal_type(a3, expected_text="A[int]")
 
 
-class B(Generic[_T1]):
+class B(Generic[T1]):
     @overload
     def __new__(cls, x: int, y: Literal[True]) -> "B[None]":
         ...
 
     @overload
-    def __new__(cls, x: _T1, y: bool = ...) -> "B[_T1]":
+    def __new__(cls, x: T1, y: bool = ...) -> "B[T1]":
         ...
 
-    def __new__(cls, x: Union[_T1, int], y: bool = False) -> "B[Any]":
+    def __new__(cls, x: Union[T1, int], y: bool = False) -> "B[Any]":
         ...
 
 
@@ -56,8 +58,8 @@ b5 = func1(B[Union[int, str]], "3")
 reveal_type(b5, expected_text="B[int | str]")
 
 
-class C(Generic[_T1]):
-    def __init__(self: "C[_T1]", x: _T1) -> None:
+class C(Generic[T1]):
+    def __init__(self: "C[T1]", x: T1) -> None:
         ...
 
 
@@ -71,13 +73,13 @@ c3 = func1(C[int], 3)
 reveal_type(c3, expected_text="C[int]")
 
 
-class D(Generic[_T1]):
+class D(Generic[T1]):
     @overload
     def __init__(self: "D[None]", x: int, y: Literal[True]) -> None:
         ...
 
     @overload
-    def __init__(self: "D[_T1]", x: _T1, y: bool = ...) -> None:
+    def __init__(self: "D[T1]", x: T1, y: bool = ...) -> None:
         ...
 
     def __init__(self, x: Any, y: bool = False) -> None:
@@ -101,15 +103,31 @@ reveal_type(d5, expected_text="D[int | str]")
 
 
 @dataclass(frozen=True, slots=True)
-class E(Generic[_T1]):
-    x: _T1
+class E(Generic[T1]):
+    x: T1
 
 
 e1: Callable[[int], E[int]] = E
 
 
-def func2(x: _T1) -> E[_T1]:
+def func2(x: T1) -> E[T1]:
     ...
 
 
 e2: Callable[[int], E[int]] = func2
+
+
+P = ParamSpec("P")
+R = TypeVar("R")
+
+
+def deco1(func: Callable[P, R]) -> Callable[P, R]:
+    return func
+
+
+class F(Generic[T1]):
+    def __init__(self, t: T1) -> None:
+        pass
+
+
+reveal_type(deco1(F)(""), expected_text="F[str]")


### PR DESCRIPTION
… converted to a callable for a generic class. This addresses #6139.