### PR TITLE
Fixed a bug in the `issubclass` type narrowing logic when the first a…

### DIFF
--- a/packages/pyright-internal/src/tests/samples/typeNarrowingIsinstance19.py
+++ b/packages/pyright-internal/src/tests/samples/typeNarrowingIsinstance19.py
@@ -1,0 +1,67 @@
+# This sample tests the logic for narrowing a metaclass using an
+# issubclass call.
+
+from abc import ABC, ABCMeta
+from typing import Any, ClassVar
+from typing_extensions import reveal_type
+
+
+class Meta1(ABCMeta):
+    pass
+
+
+class Parent1(ABC, metaclass=Meta1):
+    pass
+
+
+class Child1(Parent1):
+    x: ClassVar[tuple[int, int]] = (0, 1)
+
+
+def func1(m: Meta1) -> None:
+    if issubclass(m, Parent1):
+        reveal_type(m, expected_text="type[Parent1]")
+    else:
+        reveal_type(m, expected_text="Meta1")
+
+
+def func2(m: Meta1) -> None:
+    if issubclass(m, Child1):
+        reveal_type(m, expected_text="type[Child1]")
+    else:
+        reveal_type(m, expected_text="Meta1")
+
+
+def func3(m: ABCMeta) -> None:
+    if issubclass(m, Child1):
+        reveal_type(m, expected_text="type[Child1]")
+    else:
+        reveal_type(m, expected_text="ABCMeta")
+
+
+def func4(m: ABCMeta) -> None:
+    if issubclass(m, (Parent1, Child1, int)):
+        reveal_type(m, expected_text="type[Parent1] | type[Child1]")
+    else:
+        reveal_type(m, expected_text="ABCMeta")
+
+
+def func5(m: Meta1) -> None:
+    if issubclass(m, (Parent1, Child1)):
+        reveal_type(m, expected_text="type[Parent1] | type[Child1]")
+    else:
+        reveal_type(m, expected_text="Meta1")
+
+
+def func6(m: Meta1, x: type[Any]) -> None:
+    if issubclass(m, x):
+        reveal_type(m, expected_text="Meta1")
+    else:
+        reveal_type(m, expected_text="Meta1")
+
+
+def func7(m: Meta1, x: type[Parent1] | type[Child1]) -> None:
+    if issubclass(m, x):
+        reveal_type(m, expected_text="type[Parent1] | type[Child1]")
+    else:
+        reveal_type(m, expected_text="Meta1")

--- a/packages/pyright-internal/src/tests/samples/typeNarrowingIsinstance8.py
+++ b/packages/pyright-internal/src/tests/samples/typeNarrowingIsinstance8.py
@@ -16,10 +16,13 @@ class Base(ABC):
 
 def func1(cls: Any):
     assert issubclass(cls, Base)
+    reveal_type(cls, expected_text="type[Base]")
     _ = cls()
 
 
 def func2(cls: Any):
     assert isinstance(cls, type)
+    reveal_type(cls, expected_text="type")
     assert issubclass(cls, Base)
+    reveal_type(cls, expected_text="type[Base]")
     _ = cls()

--- a/packages/pyright-internal/src/tests/typeEvaluator1.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator1.test.ts
@@ -459,6 +459,12 @@ test('TypeNarrowingIsinstance18', () => {
     TestUtils.validateResults(analysisResults, 0);
 });
 
+test('TypeNarrowingIsinstance19', () => {
+    const analysisResults = TestUtils.typeAnalyzeSampleFiles(['typeNarrowingIsinstance19.py']);
+
+    TestUtils.validateResults(analysisResults, 0);
+});
+
 test('TypeNarrowingTupleLength1', () => {
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['typeNarrowingTupleLength1.py']);
 


### PR DESCRIPTION
…rgument is a metaclass (a subclass of `type`). This addresses #6152.