### PR TITLE
Changed override-related checks (`reportIncompatibleMethodOverride`, …

### DIFF
--- a/packages/pyright-internal/src/analyzer/checker.ts
+++ b/packages/pyright-internal/src/analyzer/checker.ts
@@ -332,14 +332,13 @@ export class Checker extends ParseTreeWalker {
                 this._validateProtocolTypeParamVariance(node, classTypeResult.classType);
             }
 
-            // Skip the overrides check for stub files. Many of the built-in
-            // typeshed stub files trigger this diagnostic. Also skip the slots
-            // check because class variables declared in a stub file are
-            // interpreted as instance variables.
+            // Skip the slots check because class variables declared in a stub
+            // file are interpreted as instance variables.
             if (!this._fileInfo.isStubFile) {
-                this._validateBaseClassOverrides(classTypeResult.classType);
                 this._validateSlotsClassVarConflict(classTypeResult.classType);
             }
+
+            this._validateBaseClassOverrides(classTypeResult.classType);
 
             this._validateMultipleInheritanceBaseClasses(classTypeResult.classType, node.name);
 


### PR DESCRIPTION
…`reportIncompatibleVariableOverride` and `reportImplicitOverride`) so they apply to stub files. Previously, these were skipped for stubs. This addresses #6158.