### PR TITLE
Fixed a regression in overload matching that resulted in false positi…

### DIFF
--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -246,7 +246,6 @@ import {
     preserveUnknown,
     removeParamSpecVariadicsFromFunction,
     removeParamSpecVariadicsFromSignature,
-    replaceTypeVarsWithAny,
     requiresSpecialization,
     requiresTypeArguments,
     selfSpecializeClass,
@@ -8874,25 +8873,6 @@ export function createTypeEvaluator(importLookup: ImportLookup, evaluatorOptions
                 );
 
                 if (!matchResults.argumentErrors) {
-                    // If there is an expected return type, see if it's potentially compatible
-                    // with this overload's return type. If not, we'll de-emphasize this overload.
-                    if (inferenceContext?.expectedType) {
-                        const returnType = getFunctionEffectiveReturnType(matchResults.overload);
-
-                        if (
-                            !assignType(
-                                replaceTypeVarsWithAny(inferenceContext.expectedType),
-                                replaceTypeVarsWithAny(returnType),
-                                /* diag */ undefined,
-                                /* destTypeVarContext */ undefined,
-                                /* srcTypeVarContext */ undefined,
-                                AssignTypeFlags.SkipSolveTypeVars
-                            )
-                        ) {
-                            matchResults.relevance += -0.5;
-                        }
-                    }
-
                     filteredMatchResults.push(matchResults);
                 }
 

--- a/packages/pyright-internal/src/tests/samples/literalString1.py
+++ b/packages/pyright-internal/src/tests/samples/literalString1.py
@@ -72,7 +72,7 @@ def func6(a: LiteralString):
 
     a = "hi"
 
-    v3: list[str] = "1 2 3".split(" ")
+    v3: list[LiteralString] = "1 2 3".split(" ")
 
 
 def func7(a: Literal["a", "b"], b: Literal["a", 1]):

--- a/packages/pyright-internal/src/tests/samples/overload16.py
+++ b/packages/pyright-internal/src/tests/samples/overload16.py
@@ -23,6 +23,8 @@ class A(Generic[T]):
 
 def func2(a: A[bool], b: A[str]):
     v1: list[LiteralString] = a.func1(a)
+
+    # This should generate an error.
     v2: list[str] = a.func1(a)
 
     # This should generate an error.

--- a/packages/pyright-internal/src/tests/typeEvaluator4.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator4.test.ts
@@ -346,7 +346,7 @@ test('Overload15', () => {
 
 test('Overload16', () => {
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['overload16.py']);
-    TestUtils.validateResults(analysisResults, 1);
+    TestUtils.validateResults(analysisResults, 2);
 });
 
 test('Final1', () => {


### PR DESCRIPTION
…ve errors in hydra-zen. This change involves removing a heuristic from overload matching that attempted to eliminate a false positive error for `x: list[str] = "a,b".split(",")`. This addresses #6160.