### PR TITLE
Fixed bug in "type printer", the code that converts a type to text fo…

### DIFF
--- a/packages/pyright-internal/src/analyzer/typePrinter.ts
+++ b/packages/pyright-internal/src/analyzer/typePrinter.ts
@@ -33,6 +33,7 @@ import {
     Type,
     TypeBase,
     TypeCategory,
+    TypeFlags,
     TypeVarType,
     Variance,
 } from './types';
@@ -501,9 +502,14 @@ function printTypeInternal(
                         for (const sourceSubtype of typeAliasSource.subtypes) {
                             let unionSubtypeIndex = 0;
                             let foundMatch = false;
+                            const sourceSubtypeInstance = convertToInstance(sourceSubtype);
 
                             for (const unionSubtype of type.subtypes) {
-                                if (isTypeSame(sourceSubtype, unionSubtype, { ignoreTypeFlags: true })) {
+                                if (
+                                    isTypeSame(sourceSubtypeInstance, unionSubtype, {
+                                        typeFlagsToHonor: TypeFlags.Instance | TypeFlags.Instantiable,
+                                    })
+                                ) {
                                     if (!subtypeHandledSet.has(unionSubtypeIndex)) {
                                         allSubtypesPreviouslyHandled = false;
                                     }

--- a/packages/pyright-internal/src/analyzer/types.ts
+++ b/packages/pyright-internal/src/analyzer/types.ts
@@ -115,6 +115,7 @@ export type InheritanceChain = (ClassType | UnknownType)[];
 export interface TypeSameOptions {
     ignorePseudoGeneric?: boolean;
     ignoreTypeFlags?: boolean;
+    typeFlagsToHonor?: TypeFlags;
     ignoreTypedDictNarrowEntries?: boolean;
     treatAnySameAsUnknown?: boolean;
 }
@@ -2792,9 +2793,18 @@ export function isTypeSame(type1: Type, type2: Type, options: TypeSameOptions = 
     }
 
     if (!options.ignoreTypeFlags) {
-        // The Annotated flag should never be considered for type compatibility.
-        const type1Flags = type1.flags & ~TypeFlags.Annotated;
-        const type2Flags = type2.flags & ~TypeFlags.Annotated;
+        let type1Flags = type1.flags;
+        let type2Flags = type2.flags;
+
+        // Mask out the flags that we don't care about.
+        if (options.typeFlagsToHonor !== undefined) {
+            type1Flags &= options.typeFlagsToHonor;
+            type2Flags &= options.typeFlagsToHonor;
+        } else {
+            // By default, we don't care about the Annotated flag.
+            type1Flags &= ~TypeFlags.Annotated;
+            type2Flags &= ~TypeFlags.Annotated;
+        }
 
         if (type1Flags !== type2Flags) {
             return false;

--- a/packages/pyright-internal/src/tests/samples/typeAlias1.py
+++ b/packages/pyright-internal/src/tests/samples/typeAlias1.py
@@ -5,16 +5,16 @@ from typing import Any, Literal
 # Make sure it works with and without forward references.
 TupleAlias = tuple["int", int]
 
-foo1: tuple[int, int]
-bar1: TupleAlias
+v1: tuple[int, int]
+v2: TupleAlias
 
-foo1 = (1, 2)
-bar1 = (1, 2)
+v1 = (1, 2)
+v2 = (1, 2)
 
 
 AnyAlias = Any
 
-baz1: AnyAlias = 3
+v3: AnyAlias = 3
 
 
 class A:
@@ -29,9 +29,16 @@ reveal_type(A.Value2, expected_text="int")
 
 Alias1 = Literal[0, 1]
 
-foo2: dict[Alias1, Any] = {}
+v4: dict[Alias1, Any] = {}
 
-if foo2:
+if v4:
     pass
 
-baz2: list[Alias1] = []
+v5: list[Alias1] = []
+
+
+Alias2 = int | str
+
+
+def func1(x: Alias2):
+    reveal_type(type(x), expected_text="type[int] | type[str]")


### PR DESCRIPTION
…r error messages. It wasn't properly handling `type(t)` where `t` is defined using a type alias. This addresses #6173.