### PR TITLE
Fixed a bug that led to a false positive error when attempting to ins…

### DIFF
--- a/packages/pyright-internal/src/analyzer/types.ts
+++ b/packages/pyright-internal/src/analyzer/types.ts
@@ -793,6 +793,16 @@ export namespace ClassType {
         return newClassType;
     }
 
+    export function cloneIncludeSubclasses(classType: ClassType) {
+        if (classType.includeSubclasses) {
+            return classType;
+        }
+
+        const newClassType = TypeBase.cloneType(classType);
+        newClassType.includeSubclasses = true;
+        return newClassType;
+    }
+
     export function cloneWithLiteral(classType: ClassType, value: LiteralValue | undefined): ClassType {
         const newClassType = TypeBase.cloneType(classType);
         newClassType.literalValue = value;

--- a/packages/pyright-internal/src/tests/samples/abstractClass1.py
+++ b/packages/pyright-internal/src/tests/samples/abstractClass1.py
@@ -4,7 +4,7 @@
 from abc import ABC, abstractmethod
 
 
-class AbstractFoo(ABC):
+class AbstractClassA(ABC):
     @abstractmethod
     def foo1(self):
         pass
@@ -26,26 +26,30 @@ class AbstractFoo(ABC):
         return cls()
 
 
+v1 = [subclass() for subclass in AbstractClassA.__subclasses__()]
+reveal_type(v1, expected_text="list[AbstractClassA]")
+
+
 # This should generate an error because AbstractFoo
 # is an abstract class.
-a = AbstractFoo()
+a = AbstractClassA()
 
 
-class AbstractBar1(AbstractFoo):
+class AbstractClassB(AbstractClassA):
     def foo1(self):
         pass
 
 
 # This should generate an error because AbstractBar1
 # is an abstract class.
-b = AbstractBar1()
+b = AbstractClassB()
 
 
-class AbstractBar2(AbstractBar1):
+class AbstractClassC(AbstractClassB):
     def foo2(self):
         pass
 
 
 # This should not generate an error because AbstractBar2
 # overrides all of the abstract methods it inherits.
-c = AbstractBar2()
+c = AbstractClassC()


### PR DESCRIPTION
…tantiate a value of type `type[Self]` when `Self` refers to an abstract class. This addresses #6184.