### PR TITLE
Fixed a bug that resulted in a false negative when assigning one Type…

### DIFF
--- a/packages/pyright-internal/src/analyzer/typedDicts.ts
+++ b/packages/pyright-internal/src/analyzer/typedDicts.ts
@@ -879,6 +879,13 @@ export function assignTypedDictToTypedDict(
             }
 
             const subDiag = diag?.createAddendum();
+            let adjustedFlags = flags;
+
+            // If either of the fields is not read-only, we need to enforce invariance.
+            if (!destEntry.isReadOnly || !srcEntry.isReadOnly) {
+                adjustedFlags |= AssignTypeFlags.EnforceInvariance;
+            }
+
             if (
                 !evaluator.assignType(
                     destEntry.valueType,
@@ -886,7 +893,7 @@ export function assignTypedDictToTypedDict(
                     subDiag?.createAddendum(),
                     typeVarContext,
                     /* srcTypeVarContext */ undefined,
-                    flags,
+                    adjustedFlags,
                     recursionCount
                 )
             ) {

--- a/packages/pyright-internal/src/tests/samples/typedDict5.py
+++ b/packages/pyright-internal/src/tests/samples/typedDict5.py
@@ -24,6 +24,11 @@ class Movie4(TypedDict, total=True):
     earnings: float
 
 
+class Movie5(TypedDict, total=True):
+    name: str
+    year: float
+
+
 movie1: Movie1 = Movie2(name="hello", year=1971)
 
 # This should generate an error because
@@ -34,7 +39,7 @@ movie2: Movie2 = Movie3(name="hello", year=1971)
 # items are required in Movie3 but not Movie2.
 movie3: Movie3 = Movie2(name="hello", year=1971)
 
-# This should generate an error
+# This should generate an error.
 movie4: Movie4 = Movie3(name="hello", year=1971)
 
 movie5: Movie3 = Movie4(name="hello", year=1971, earnings=23)
@@ -48,3 +53,9 @@ movie7["name"] = "goodbye"
 
 movie8: Movie2 = {"year": 1981, "name": "test"}
 movie8["year"] = 1982
+
+movie9 = Movie3(name="", year=1971)
+
+# This should generate an error because "year" is mutable,
+# so its type must match exactly.
+movie10: Movie5 = movie9

--- a/packages/pyright-internal/src/tests/samples/typedDictReadOnly2.py
+++ b/packages/pyright-internal/src/tests/samples/typedDictReadOnly2.py
@@ -120,3 +120,23 @@ n1: TD8 = td10
 # and required in TD10 but writable and not required in
 # TD9, which means it can be deleted.
 n2: TD9 = td10
+
+
+class TD11(TypedDict, readonly=True):
+    a: int
+
+
+class TD12(TypedDict, readonly=True):
+    a: float
+
+
+class TD13(TypedDict):
+    a: float
+
+
+v1 = TD11(a=2)
+v2: TD12 = v1
+
+# This should generate an error becuase "a" is writable
+# and is therefore invariant.
+v3: TD13 = v1

--- a/packages/pyright-internal/src/tests/typeEvaluator2.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator2.test.ts
@@ -1359,7 +1359,7 @@ test('TypedDict4', () => {
 test('TypedDict5', () => {
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['typedDict5.py']);
 
-    TestUtils.validateResults(analysisResults, 3);
+    TestUtils.validateResults(analysisResults, 4);
 });
 
 test('TypedDict6', () => {

--- a/packages/pyright-internal/src/tests/typeEvaluator5.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator5.test.ts
@@ -326,7 +326,7 @@ test('TypedDictReadOnly2', () => {
     configOptions.diagnosticRuleSet.enableExperimentalFeatures = true;
 
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['typedDictReadOnly2.py'], configOptions);
-    TestUtils.validateResults(analysisResults, 8);
+    TestUtils.validateResults(analysisResults, 9);
 });
 
 test('DataclassTransform1', () => {


### PR DESCRIPTION
…dDict to another TypedDict. Field types should be treated as invariant rather than covariant because they are mutable (unless marked readonly).