### PR TITLE
Fixed a bug that resulted in incorrect narrowing on assignment when t…

### DIFF
--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -24705,15 +24705,11 @@ export function createTypeEvaluator(importLookup: ImportLookup, evaluatorOptions
         }
         recursionCount++;
 
-        // If this is a tuple with defined tuple type arguments, don't overwrite them.
-        if (assignedType.tupleTypeArguments) {
-            return undefined;
-        }
-
         if (
             assignedType.details.typeParameters.length > 0 &&
             assignedType.typeArguments &&
-            assignedType.typeArguments.length <= assignedType.details.typeParameters.length
+            assignedType.typeArguments.length <= assignedType.details.typeParameters.length &&
+            !assignedType.tupleTypeArguments
         ) {
             const typeVarContext = new TypeVarContext(getTypeVarScopeId(assignedType));
             populateTypeVarContextBasedOnExpectedType(

--- a/packages/pyright-internal/src/tests/samples/assignment10.py
+++ b/packages/pyright-internal/src/tests/samples/assignment10.py
@@ -71,3 +71,14 @@ def func4(y: list[Any]):
 def func5(v1: list[Any | None]):
     x1: list[int | None] = v1
     reveal_type(x1, expected_text="list[int | None]")
+
+
+def func6(v1: tuple[Any], v2: tuple[int, Any], v3: tuple[Any, ...]):
+    x1: tuple[int] = v1
+    reveal_type(x1, expected_text="tuple[int]")
+
+    x2: tuple[int, str] = v2
+    reveal_type(x2, expected_text="tuple[int, str]")
+
+    x3: tuple[str, ...] = v3
+    reveal_type(x3, expected_text="tuple[str, ...]")


### PR DESCRIPTION
…he assigned type is a tuple that includes one or more `Any` type arguments and the declared type is a tuple without an `Any`. This addresses #6208.