### PR TITLE
[PylanceBot] Pull Pylance with Pyright 1.1.333

### DIFF
--- a/packages/pyright-internal/src/analyzer/backgroundAnalysisProgram.ts
+++ b/packages/pyright-internal/src/analyzer/backgroundAnalysisProgram.ts
@@ -15,7 +15,6 @@ import { Diagnostic } from '../common/diagnostic';
 import { FileDiagnostics } from '../common/diagnosticSink';
 import { Range } from '../common/textRange';
 import { AnalysisCompleteCallback, analyzeProgram } from './analysis';
-import { CacheManager } from './cacheManager';
 import { ImportResolver } from './importResolver';
 import { MaxAnalysisTime, OpenFileOptions, Program } from './program';
 import { ServiceProvider } from '../common/serviceProvider';
@@ -41,8 +40,7 @@ export class BackgroundAnalysisProgram {
         private _importResolver: ImportResolver,
         private _backgroundAnalysis?: BackgroundAnalysisBase,
         private readonly _maxAnalysisTime?: MaxAnalysisTime,
-        private readonly _disableChecker?: boolean,
-        cacheManager?: CacheManager
+        private readonly _disableChecker?: boolean
     ) {
         this._program = new Program(
             this.importResolver,
@@ -50,7 +48,6 @@ export class BackgroundAnalysisProgram {
             this._serviceProvider,
             undefined,
             this._disableChecker,
-            cacheManager,
             serviceId
         );
     }
@@ -166,7 +163,11 @@ export class BackgroundAnalysisProgram {
         );
     }
 
-    analyzeFile(filePath: string, token: CancellationToken): boolean {
+    async analyzeFile(filePath: string, token: CancellationToken): Promise<boolean> {
+        if (this._backgroundAnalysis) {
+            return this._backgroundAnalysis.analyzeFile(filePath, token);
+        }
+
         return this._program.analyzeFile(filePath, token);
     }
 
@@ -276,6 +277,5 @@ export type BackgroundAnalysisProgramFactory = (
     configOptions: ConfigOptions,
     importResolver: ImportResolver,
     backgroundAnalysis?: BackgroundAnalysisBase,
-    maxAnalysisTime?: MaxAnalysisTime,
-    cacheManager?: CacheManager
+    maxAnalysisTime?: MaxAnalysisTime
 ) => BackgroundAnalysisProgram;

--- a/packages/pyright-internal/src/analyzer/cacheManager.ts
+++ b/packages/pyright-internal/src/analyzer/cacheManager.ts
@@ -100,3 +100,16 @@ export class CacheManager {
         return `${Math.round(bytes / (1024 * 1024))}MB`;
     }
 }
+
+export namespace CacheManager {
+    export function is(obj: any): obj is CacheManager {
+        return (
+            obj.registerCacheOwner !== undefined &&
+            obj.unregisterCacheOwner !== undefined &&
+            obj.pauseTracking !== undefined &&
+            obj.getCacheUsage !== undefined &&
+            obj.emptyCache !== undefined &&
+            obj.getUsedHeapRatio !== undefined
+        );
+    }
+}

--- a/packages/pyright-internal/src/analyzer/service.ts
+++ b/packages/pyright-internal/src/analyzer/service.ts
@@ -57,7 +57,6 @@ import {
     BackgroundAnalysisProgramFactory,
     InvalidatedReason,
 } from './backgroundAnalysisProgram';
-import { CacheManager } from './cacheManager';
 import {
     ImportResolver,
     ImportResolverFactory,
@@ -88,7 +87,6 @@ export interface AnalyzerServiceOptions {
     backgroundAnalysisProgramFactory?: BackgroundAnalysisProgramFactory;
     cancellationProvider?: CancellationProvider;
     libraryReanalysisTimeProvider?: () => number;
-    cacheManager?: CacheManager;
     serviceId?: string;
     skipScanningUserFiles?: boolean;
     fileSystem?: FileSystem;
@@ -166,8 +164,7 @@ export class AnalyzerService {
                       this._options.configOptions,
                       importResolver,
                       this._options.backgroundAnalysis,
-                      this._options.maxAnalysisTime,
-                      this._options.cacheManager
+                      this._options.maxAnalysisTime
                   )
                 : new BackgroundAnalysisProgram(
                       this._options.serviceId,
@@ -176,8 +173,7 @@ export class AnalyzerService {
                       importResolver,
                       this._options.backgroundAnalysis,
                       this._options.maxAnalysisTime,
-                      /* disableChecker */ undefined,
-                      this._options.cacheManager
+                      /* disableChecker */ undefined
                   );
     }
 
@@ -412,6 +408,10 @@ export class AnalyzerService {
 
     printDependencies(verbose: boolean) {
         this._program.printDependencies(this._executionRootPath, verbose);
+    }
+
+    analyzeFile(filePath: string, token: CancellationToken): Promise<boolean> {
+        return this._backgroundAnalysisProgram.analyzeFile(filePath, token);
     }
 
     getDiagnosticsForRange(filePath: string, range: Range, token: CancellationToken): Promise<Diagnostic[]> {

--- a/packages/pyright-internal/src/analyzer/sourceFile.ts
+++ b/packages/pyright-internal/src/analyzer/sourceFile.ts
@@ -57,7 +57,6 @@ const _maxSourceFileSize = 50 * 1024 * 1024;
 interface ResolveImportResult {
     imports: ImportResult[];
     builtinsImportResult?: ImportResult | undefined;
-    ipythonDisplayImportResult?: ImportResult | undefined;
 }
 
 // Indicates whether IPython syntax is supported and if so, what
@@ -134,8 +133,6 @@ class WriteableData {
     // Information about implicit and explicit imports from this file.
     imports: ImportResult[] | undefined;
     builtinsImport: ImportResult | undefined;
-    ipythonDisplayImport: ImportResult | undefined;
-
     // True if the file appears to have been deleted.
     isFileDeleted = false;
 }
@@ -302,10 +299,6 @@ export class SourceFile {
 
     getBuiltinsImport(): ImportResult | undefined {
         return this._writableData.builtinsImport;
-    }
-
-    getIPythonDisplayImport(): ImportResult | undefined {
-        return this._writableData.ipythonDisplayImport;
     }
 
     getModuleSymbolTable(): SymbolTable | undefined {
@@ -612,7 +605,6 @@ export class SourceFile {
 
                     this._writableData.imports = importResult.imports;
                     this._writableData.builtinsImport = importResult.builtinsImportResult;
-                    this._writableData.ipythonDisplayImport = importResult.ipythonDisplayImportResult;
 
                     this._writableData.parseDiagnostics = diagSink.fetchAndClear();
                 });
@@ -676,7 +668,6 @@ export class SourceFile {
                 };
                 this._writableData.imports = undefined;
                 this._writableData.builtinsImport = undefined;
-                this._writableData.ipythonDisplayImport = undefined;
 
                 const diagSink = this.createDiagnosticSink();
                 diagSink.addError(
@@ -1284,10 +1275,6 @@ export class SourceFile {
             builtinsImportResult = resolveAndAddIfNotSelf(['builtins']);
         }
 
-        const ipythonDisplayImportResult = this._ipythonMode
-            ? resolveAndAddIfNotSelf(['IPython', 'display'])
-            : undefined;
-
         for (const moduleImport of moduleImports) {
             const importResult = importResolver.resolveImport(this._filePath, execEnv, {
                 leadingDots: moduleImport.leadingDots,
@@ -1319,7 +1306,6 @@ export class SourceFile {
         return {
             imports,
             builtinsImportResult,
-            ipythonDisplayImportResult,
         };
     }
 

--- a/packages/pyright-internal/src/analyzer/sourceFileInfo.ts
+++ b/packages/pyright-internal/src/analyzer/sourceFileInfo.ts
@@ -40,10 +40,6 @@ export class SourceFileInfo {
         return this._writableData.builtinsImport;
     }
 
-    get ipythonDisplayImport() {
-        return this._writableData.ipythonDisplayImport;
-    }
-
     // Information about the chained source file
     // Chained source file is not supposed to exist on file system but
     // must exist in the program's source file list. Module level
@@ -91,11 +87,6 @@ export class SourceFileInfo {
     set builtinsImport(value: SourceFileInfo | undefined) {
         this._cachePreEditState();
         this._writableData.builtinsImport = value;
-    }
-
-    set ipythonDisplayImport(value: SourceFileInfo | undefined) {
-        this._cachePreEditState();
-        this._writableData.ipythonDisplayImport = value;
     }
 
     set chainedSourceFile(value: SourceFileInfo | undefined) {
@@ -154,7 +145,6 @@ export class SourceFileInfo {
             chainedSourceFile: args.chainedSourceFile,
             diagnosticsVersion: args.diagnosticsVersion,
             effectiveFutureImports: args.effectiveFutureImports,
-            ipythonDisplayImport: args.ipythonDisplayImport,
             imports: [],
             importedBy: [],
             shadows: [],
@@ -170,7 +160,6 @@ export class SourceFileInfo {
             chainedSourceFile: data.chainedSourceFile,
             diagnosticsVersion: data.diagnosticsVersion,
             effectiveFutureImports: data.effectiveFutureImports,
-            ipythonDisplayImport: data.ipythonDisplayImport,
             imports: data.imports.slice(),
             importedBy: data.importedBy.slice(),
             shadows: data.shadows.slice(),
@@ -189,7 +178,6 @@ interface OptionalArguments {
     isOpenByClient?: boolean;
     diagnosticsVersion?: number | undefined;
     builtinsImport?: SourceFileInfo | undefined;
-    ipythonDisplayImport?: SourceFileInfo | undefined;
     chainedSourceFile?: SourceFileInfo | undefined;
     effectiveFutureImports?: ReadonlySet<string>;
 }
@@ -200,7 +188,6 @@ interface WriteableData {
     diagnosticsVersion?: number | undefined;
 
     builtinsImport?: SourceFileInfo | undefined;
-    ipythonDisplayImport?: SourceFileInfo | undefined;
 
     // Information about the chained source file
     // Chained source file is not supposed to exist on file system but

--- a/packages/pyright-internal/src/common/serviceProviderExtensions.ts
+++ b/packages/pyright-internal/src/common/serviceProviderExtensions.ts
@@ -5,6 +5,7 @@
  *
  * Shortcuts to common services.
  */
+import { CacheManager } from '../analyzer/cacheManager';
 import { ISourceFileFactory } from '../analyzer/program';
 import { IPythonMode, SourceFile, SourceFileEditMode } from '../analyzer/sourceFile';
 import { SupportPartialStubs } from '../pyrightFileSystem';
@@ -37,6 +38,7 @@ export namespace ServiceKeys {
     export const symbolUsageProviderFactory = new GroupServiceKey<SymbolUsageProviderFactory>();
     export const stateMutationListeners = new GroupServiceKey<StatusMutationListener>();
     export const tempFile = new ServiceKey<TempFile>();
+    export const cacheManager = new ServiceKey<CacheManager>();
 }
 
 export function createServiceProvider(...services: any): ServiceProvider {
@@ -58,6 +60,9 @@ export function createServiceProvider(...services: any): ServiceProvider {
         }
         if (TempFile.is(service)) {
             sp.add(ServiceKeys.tempFile, service);
+        }
+        if (CacheManager.is(service)) {
+            sp.add(ServiceKeys.cacheManager, service);
         }
     });
     return sp;

--- a/packages/pyright-internal/src/languageServerBase.ts
+++ b/packages/pyright-internal/src/languageServerBase.ts
@@ -75,7 +75,6 @@ import { ResultProgressReporter, attachWorkDone } from 'vscode-languageserver/li
 import { TextDocument } from 'vscode-languageserver-textdocument';
 import { AnalysisResults } from './analyzer/analysis';
 import { BackgroundAnalysisProgram, InvalidatedReason } from './analyzer/backgroundAnalysisProgram';
-import { CacheManager } from './analyzer/cacheManager';
 import { ImportResolver } from './analyzer/importResolver';
 import { MaxAnalysisTime } from './analyzer/program';
 import { AnalyzerService, configFileNames, getNextServiceId } from './analyzer/service';
@@ -349,7 +348,6 @@ export abstract class LanguageServerBase implements LanguageServerInterface, Dis
 
     protected readonly workspaceFactory: WorkspaceFactory;
     protected readonly openFileMap = new Map<string, TextDocument>();
-    protected readonly cacheManager: CacheManager;
     protected readonly fs: FileSystem;
 
     // The URIs for which diagnostics are reported
@@ -373,8 +371,6 @@ export abstract class LanguageServerBase implements LanguageServerInterface, Dis
         );
 
         this.console.info(`Server root directory: ${serverOptions.rootDirectory}`);
-
-        this.cacheManager = new CacheManager();
 
         this.fs = this.serverOptions.serviceProvider.fs();
 
@@ -454,7 +450,6 @@ export abstract class LanguageServerBase implements LanguageServerInterface, Dis
             backgroundAnalysisProgramFactory: this.createBackgroundAnalysisProgram.bind(this),
             cancellationProvider: this.serverOptions.cancellationProvider,
             libraryReanalysisTimeProvider,
-            cacheManager: this.cacheManager,
             serviceId,
             fileSystem: services?.fs ?? this.serverOptions.serviceProvider.fs(),
         });
@@ -614,8 +609,7 @@ export abstract class LanguageServerBase implements LanguageServerInterface, Dis
         configOptions: ConfigOptions,
         importResolver: ImportResolver,
         backgroundAnalysis?: BackgroundAnalysisBase,
-        maxAnalysisTime?: MaxAnalysisTime,
-        cacheManager?: CacheManager
+        maxAnalysisTime?: MaxAnalysisTime
     ): BackgroundAnalysisProgram {
         return new BackgroundAnalysisProgram(
             serviceId,
@@ -624,8 +618,7 @@ export abstract class LanguageServerBase implements LanguageServerInterface, Dis
             importResolver,
             backgroundAnalysis,
             maxAnalysisTime,
-            /* disableChecker */ undefined,
-            cacheManager
+            /* disableChecker */ undefined
         );
     }
 

--- a/packages/pyright-internal/src/localization/package.nls.cs.json
+++ b/packages/pyright-internal/src/localization/package.nls.cs.json
@@ -642,6 +642,7 @@
         "memberSetClassVar": "Člen „{name}“ nelze přiřadit prostřednictvím instance třídy, protože se jedná o třídu ClassVar",
         "memberTypeMismatch": "{name} je nekompatibilní typ",
         "memberUnknown": "Člen {name} je neznámý",
+        "metaclassConflict": "Metaclass \"{metaclass1}\" conflicts with \"{metaclass2}\"",
         "missingDeleter": "Chybí metoda odstranění vlastnosti",
         "missingGetter": "Chybí metoda getter vlastnosti",
         "missingProtocolMember": "Člen {name} je deklarován ve třídě protokolu {classType}",

--- a/packages/pyright-internal/src/localization/package.nls.de.json
+++ b/packages/pyright-internal/src/localization/package.nls.de.json
@@ -642,6 +642,7 @@
         "memberSetClassVar": "Der Member \"{name}\" kann nicht über eine Klasseninstanz zugewiesen werden, da es sich um eine ClassVar handelt.",
         "memberTypeMismatch": "\"{name}\" ist ein inkompatibler Typ.",
         "memberUnknown": "Das Member \"{name}\" ist unbekannt.",
+        "metaclassConflict": "Metaclass \"{metaclass1}\" conflicts with \"{metaclass2}\"",
         "missingDeleter": "Die Eigenschaft-Deleter-Methode fehlt.",
         "missingGetter": "Die Eigenschaft-Getter-Methode fehlt.",
         "missingProtocolMember": "Member \"{name}\" ist in Protokollklasse \"{classType}\" deklariert.",

--- a/packages/pyright-internal/src/localization/package.nls.es.json
+++ b/packages/pyright-internal/src/localization/package.nls.es.json
@@ -642,6 +642,7 @@
         "memberSetClassVar": "El miembro \"{name}\" no se puede asignar a través de una instancia de clase porque es un ClassVar.",
         "memberTypeMismatch": "\"{name}\" es un tipo incompatible",
         "memberUnknown": "El miembro \"{name}\" es desconocido",
+        "metaclassConflict": "Metaclass \"{metaclass1}\" conflicts with \"{metaclass2}\"",
         "missingDeleter": "Falta el método de eliminación de propiedades",
         "missingGetter": "Falta el método Getter de la propiedad",
         "missingProtocolMember": "El miembro \"{name}\" está declarado en la clase de protocolo \"{classType}\"",

--- a/packages/pyright-internal/src/localization/package.nls.fr.json
+++ b/packages/pyright-internal/src/localization/package.nls.fr.json
@@ -642,6 +642,7 @@
         "memberSetClassVar": "Le membre \"{name}\" ne peut pas être attribué via une instance de classe car il s'agit d'une ClassVar",
         "memberTypeMismatch": "« {name} » est un type incompatible",
         "memberUnknown": "Le membre « {name} » est inconnu",
+        "metaclassConflict": "Metaclass \"{metaclass1}\" conflicts with \"{metaclass2}\"",
         "missingDeleter": "La méthode de suppression de propriétés est manquante",
         "missingGetter": "La méthode getter de propriété est manquante",
         "missingProtocolMember": "Le membre « {name} » est déclaré dans la classe de protocole « {classType} »",

--- a/packages/pyright-internal/src/localization/package.nls.it.json
+++ b/packages/pyright-internal/src/localization/package.nls.it.json
@@ -642,6 +642,7 @@
         "memberSetClassVar": "Non è possibile assegnare il membro \"{name}\" tramite un'istanza di classe perché è una ClassVar",
         "memberTypeMismatch": "\"{name}\" è un tipo non compatibile",
         "memberUnknown": "Il membro \"{name}\" è sconosciuto",
+        "metaclassConflict": "Metaclass \"{metaclass1}\" conflicts with \"{metaclass2}\"",
         "missingDeleter": "Manca il metodo di eliminazione delle proprietà",
         "missingGetter": "Metodo getter proprietà mancante",
         "missingProtocolMember": "Il \"{name}\" membro è dichiarato nella classe di protocollo \"{classType}\"",

--- a/packages/pyright-internal/src/localization/package.nls.ja.json
+++ b/packages/pyright-internal/src/localization/package.nls.ja.json
@@ -642,6 +642,7 @@
         "memberSetClassVar": "メンバー \"{name}\" は ClassVar であるため、クラス インスタンスを介して割り当てることはできません",
         "memberTypeMismatch": "\"{name}\" は互換性のない型です",
         "memberUnknown": "メンバー \"{name}\" が不明です",
+        "metaclassConflict": "Metaclass \"{metaclass1}\" conflicts with \"{metaclass2}\"",
         "missingDeleter": "プロパティ削除メソッドがありません",
         "missingGetter": "プロパティ getter メソッドがありません",
         "missingProtocolMember": "メンバー \"{name}\" はプロトコル クラス \"{classType}\" で宣言されています",

--- a/packages/pyright-internal/src/localization/package.nls.ko.json
+++ b/packages/pyright-internal/src/localization/package.nls.ko.json
@@ -642,6 +642,7 @@
         "memberSetClassVar": "‘{name}’ 멤버는 ClassVar이므로 클래스 인스턴스를 통해 할당할 수 없습니다.",
         "memberTypeMismatch": "\"{name}\"은(는) 호환되지 않는 형식입니다.",
         "memberUnknown": "멤버 \"{name}\"을(를) 알 수 없습니다.",
+        "metaclassConflict": "Metaclass \"{metaclass1}\" conflicts with \"{metaclass2}\"",
         "missingDeleter": "속성 삭제자 메서드가 없습니다.",
         "missingGetter": "속성 getter 메서드가 없습니다.",
         "missingProtocolMember": "\"{name}\" 멤버가 프로토콜 클래스 \"{classType}\"로 선언되었습니다.",

--- a/packages/pyright-internal/src/localization/package.nls.pl.json
+++ b/packages/pyright-internal/src/localization/package.nls.pl.json
@@ -642,6 +642,7 @@
         "memberSetClassVar": "Nie można przypisać składowej „{name}” przez wystąpienie klasy, ponieważ jest to element ClassVar",
         "memberTypeMismatch": "Nazwa „{name}” jest niezgodnym typem",
         "memberUnknown": "Składowa „{name}” jest nieznana",
+        "metaclassConflict": "Metaclass \"{metaclass1}\" conflicts with \"{metaclass2}\"",
         "missingDeleter": "Brak metody usuwania właściwości",
         "missingGetter": "Brak metody pobierającej właściwości",
         "missingProtocolMember": "Składowa „{name}” jest zadeklarowana w klasie protokołu „{classType}”",

--- a/packages/pyright-internal/src/localization/package.nls.pt-br.json
+++ b/packages/pyright-internal/src/localization/package.nls.pt-br.json
@@ -642,6 +642,7 @@
         "memberSetClassVar": "O membro \"{name}\" não pode ser atribuído por meio de uma instância de classe porque é um ClassVar",
         "memberTypeMismatch": "\"{name}\" é um tipo incompatível",
         "memberUnknown": "O membro \"{name}\" é desconhecido",
+        "metaclassConflict": "Metaclass \"{metaclass1}\" conflicts with \"{metaclass2}\"",
         "missingDeleter": "O método de exclusão de propriedade está ausente",
         "missingGetter": "O método getter da propriedade está ausente",
         "missingProtocolMember": "O membro \"{name}\" está declarado na classe de protocolo \"{classType}\"",

--- a/packages/pyright-internal/src/localization/package.nls.qps-ploc.json
+++ b/packages/pyright-internal/src/localization/package.nls.qps-ploc.json
@@ -642,6 +642,7 @@
         "memberSetClassVar": "[2pVfQ][นั้Mëmþër \"{ñæmë}\" çæññøt þë æssïgñëð thrøµgh æ çlæss ïñstæñçë þëçæµsë ït ïs æ ÇlæssVærẤğ倪İЂҰक्र्तिृまẤğ倪İЂҰक्र्तिृまẤğ倪İЂҰนั้ढूँ]",
         "memberTypeMismatch": "[IHN4x][นั้\"{ñæmë}\" ïs æñ ïñçømpætïþlë tÿpëẤğ倪İЂҰक्र्तिृนั้ढूँ]",
         "memberUnknown": "[7kDIF][นั้Mëmþër \"{ñæmë}\" ïs µñkñøwñẤğ倪İЂҰक्र्นั้ढूँ]",
+        "metaclassConflict": "[fjWW1][นั้Mëtæçlæss \"{mëtæçlæss1}\" çøñflïçts wïth \"{mëtæçlæss2}\"Ấğ倪İЂҰक्र्तिृまẤğ倪İЂҰक्นั้ढूँ]",
         "missingDeleter": "[5IVNI][นั้Prøpërtÿ ðëlëtër mëthøð ïs mïssïñgẤğ倪İЂҰक्र्तिृまนั้ढूँ]",
         "missingGetter": "[Mzn4K][นั้Prøpërtÿ gëttër mëthøð ïs mïssïñgẤğ倪İЂҰक्र्तिृนั้ढूँ]",
         "missingProtocolMember": "[ZIqwL][นั้Mëmþër \"{ñæmë}\" ïs ðëçlærëð ïñ prøtøçøl çlæss \"{çlæssTÿpë}\"Ấğ倪İЂҰक्र्तिृまẤğ倪İЂҰक्र्นั้ढूँ]",

--- a/packages/pyright-internal/src/localization/package.nls.ru.json
+++ b/packages/pyright-internal/src/localization/package.nls.ru.json
@@ -642,6 +642,7 @@
         "memberSetClassVar": "Элемент \"{name}\" не может быть назначен через экземпляр класса, так как это ClassVar",
         "memberTypeMismatch": "\"{name}\" является несовместимым типом",
         "memberUnknown": "Элемент \"{name}\" неизвестен",
+        "metaclassConflict": "Metaclass \"{metaclass1}\" conflicts with \"{metaclass2}\"",
         "missingDeleter": "Отсутствует метод удаления свойства",
         "missingGetter": "Отсутствует метод получения свойства",
         "missingProtocolMember": "Элемент \"{name}\" объявлен в классе протокола \"{classType}\"",

--- a/packages/pyright-internal/src/localization/package.nls.tr.json
+++ b/packages/pyright-internal/src/localization/package.nls.tr.json
@@ -642,6 +642,7 @@
         "memberSetClassVar": "\"{name}\" üyesi bir ClassVar olduğundan sınıf örneği aracılığıyla atanamaz",
         "memberTypeMismatch": "\"{name}\" uyumsuz bir tür",
         "memberUnknown": "\"{name}\" üyesi bilinmiyor",
+        "metaclassConflict": "Metaclass \"{metaclass1}\" conflicts with \"{metaclass2}\"",
         "missingDeleter": "Özellik silici metodu eksik",
         "missingGetter": "Özellik alıcı metodu eksik",
         "missingProtocolMember": "\"{name}\" üyesi \"{classType}\" protokol sınıfında bildirildi",

--- a/packages/pyright-internal/src/localization/package.nls.zh-cn.json
+++ b/packages/pyright-internal/src/localization/package.nls.zh-cn.json
@@ -642,6 +642,7 @@
         "memberSetClassVar": "无法通过类实例分配成员“{name}”，因为它是 ClassVar",
         "memberTypeMismatch": "\"{name}\"是不兼容的类型",
         "memberUnknown": "成员\"{name}\"未知",
+        "metaclassConflict": "Metaclass \"{metaclass1}\" conflicts with \"{metaclass2}\"",
         "missingDeleter": "缺少属性 deleter方法",
         "missingGetter": "缺少属性 getter 方法",
         "missingProtocolMember": "成员\"{name}\"已在协议类\"{classType}\"中声明",

--- a/packages/pyright-internal/src/localization/package.nls.zh-tw.json
+++ b/packages/pyright-internal/src/localization/package.nls.zh-tw.json
@@ -642,6 +642,7 @@
         "memberSetClassVar": "無法透過類別執行個體指派成員 \"{name}\"，因為它是 ClassVar",
         "memberTypeMismatch": "\"{name}\" 是不相容的類型",
         "memberUnknown": "成員 \"{name}\" 未知",
+        "metaclassConflict": "Metaclass \"{metaclass1}\" conflicts with \"{metaclass2}\"",
         "missingDeleter": "屬性 deleter 方法遺失",
         "missingGetter": "屬性 getter 方法遺失",
         "missingProtocolMember": "成員 \"{name}\" 已在通訊協定類別 \"{classType}\" 中宣告",

--- a/packages/pyright-internal/src/server.ts
+++ b/packages/pyright-internal/src/server.ts
@@ -38,6 +38,7 @@ import { LanguageServerBase, ServerSettings } from './languageServerBase';
 import { CodeActionProvider } from './languageService/codeActionProvider';
 import { PyrightFileSystem } from './pyrightFileSystem';
 import { Workspace } from './workspaceFactory';
+import { CacheManager } from './analyzer/cacheManager';
 
 const maxAnalysisTimeInForeground = { openFilesTimeInMs: 50, noOpenFilesTimeInMs: 200 };
 
@@ -58,8 +59,9 @@ export class PyrightServer extends LanguageServerBase {
         const fileSystem = createFromRealFileSystem(console, fileWatcherProvider);
         const pyrightFs = new PyrightFileSystem(fileSystem);
         const tempFile = new RealTempFile();
+        const cacheManager = new CacheManager();
 
-        const serviceProvider = createServiceProvider(pyrightFs, tempFile, console);
+        const serviceProvider = createServiceProvider(pyrightFs, tempFile, console, cacheManager);
         const realPathRoot = realCasePath(rootDirectory, pyrightFs);
 
         super(

--- a/packages/pyright-internal/src/tests/harness/fourslash/testLanguageService.ts
+++ b/packages/pyright-internal/src/tests/harness/fourslash/testLanguageService.ts
@@ -13,7 +13,6 @@ import {
     BackgroundAnalysisProgram,
     BackgroundAnalysisProgramFactory,
 } from '../../../analyzer/backgroundAnalysisProgram';
-import { CacheManager } from '../../../analyzer/cacheManager';
 import { ImportResolver, ImportResolverFactory } from '../../../analyzer/importResolver';
 import { MaxAnalysisTime } from '../../../analyzer/program';
 import { AnalyzerService } from '../../../analyzer/service';
@@ -45,8 +44,7 @@ export class TestFeatures implements HostSpecificFeatures {
         configOptions: ConfigOptions,
         importResolver: ImportResolver,
         backgroundAnalysis?: BackgroundAnalysisBase,
-        maxAnalysisTime?: MaxAnalysisTime,
-        cacheManager?: CacheManager
+        maxAnalysisTime?: MaxAnalysisTime
     ) =>
         new BackgroundAnalysisProgram(
             serviceId,
@@ -55,8 +53,7 @@ export class TestFeatures implements HostSpecificFeatures {
             importResolver,
             backgroundAnalysis,
             maxAnalysisTime,
-            /* disableChecker */ undefined,
-            cacheManager
+            /* disableChecker */ undefined
         );
 
     runIndexer(workspace: Workspace, noStdLib: boolean, options?: string): void {

--- a/packages/pyright-internal/src/tests/harness/fourslash/testState.ts
+++ b/packages/pyright-internal/src/tests/harness/fourslash/testState.ts
@@ -692,7 +692,7 @@ export class TestState {
         verifyMode: _.FourSlashVerificationMode,
         map: {
             [marker: string]: {
-                codeActions: { title: string; kind: string; command?: Command; edit?: WorkspaceEdit[] }[];
+                codeActions: { title: string; kind: string; command?: Command; edit?: WorkspaceEdit }[];
             };
         }
     ): Promise<any> {

--- a/packages/pyright-internal/src/tests/ipythonMode.test.ts
+++ b/packages/pyright-internal/src/tests/ipythonMode.test.ts
@@ -441,40 +441,6 @@ test('try implicitly load ipython display module but fail', async () => {
     });
 });
 
-test('implicitly load ipython display module', async () => {
-    const code = `
-// @filename: pyrightconfig.json
-//// {
-////   "useLibraryCodeForTypes": true
-//// }
-
-// @filename: test.py
-// @ipythonMode: true
-//// [|display/*marker*/|]
-
-// @filename: IPython/__init__.py
-// @library: true
-//// 
-
-// @filename: IPython/display.py
-// @library: true
-//// def display(): pass
-    `;
-
-    const state = parseAndGetTestState(code).state;
-
-    await state.verifyCompletion('included', MarkupKind.Markdown, {
-        marker: {
-            completions: [
-                {
-                    label: 'display',
-                    kind: CompletionItemKind.Function,
-                },
-            ],
-        },
-    });
-});
-
 test('magics at the end', async () => {
     const code = `
 // @filename: test.py

--- a/packages/pyright-internal/src/tests/pathUtils.test.ts
+++ b/packages/pyright-internal/src/tests/pathUtils.test.ts
@@ -475,3 +475,23 @@ test('Realcase use cwd implicitly', () => {
     const fspaths = fsentries.map((entry) => fs.realCasePath(path.join(dir, entry)));
     assert.deepStrictEqual(paths, fspaths);
 });
+
+test('Realcase drive letter', () => {
+    const fs = createFromRealFileSystem();
+
+    const cwd = process.cwd();
+
+    assert.strictEqual(
+        getDriveLetter(fs.realCasePath(cwd)),
+        getDriveLetter(fs.realCasePath(combinePaths(cwd.toLowerCase(), 'notExist.txt')))
+    );
+
+    function getDriveLetter(path: string) {
+        const driveLetter = getRootLength(path);
+        if (driveLetter === 0) {
+            return '';
+        }
+
+        return path.substring(0, driveLetter);
+    }
+});


### PR DESCRIPTION
Rollup of the following changes:

1. Fix user defined __builtins__.pyi for notebooks https://github.com/microsoft/pyrx/pull/4236
2. Don't show pyTest code action when it can't generate fixture types. https://github.com/microsoft/pyrx/pull/4233
3. Moved more stuff to service provider https://github.com/microsoft/pyrx/pull/4225
4. added resolve alias cache https://github.com/microsoft/pyrx/pull/4223
5. Potentially fix crash when opening notebooks https://github.com/microsoft/pyrx/pull/4210
6. make sure we are up to date when code action is invoked explicitly. https://github.com/microsoft/pyrx/pull/4209
7. Support pyright ignore in code action https://github.com/microsoft/pyrx/pull/4207
8. pylance loc update 20231018.1 https://github.com/microsoft/pyrx/pull/4205
9. fix rename module regression https://github.com/microsoft/pyrx/pull/4192
10. git subrepo clone --force https://github.com/microsoft/pyright.git packages/pyright
11. git subrepo pull (merge) packages/pyright
12. fixed `FAR` on `__init__` not working in multiple files scenario https://github.com/microsoft/pyrx/pull/4194
13. pylance loc update 20231017.1 https://github.com/microsoft/pyrx/pull/4193
14. Support hover on string definition provider https://github.com/microsoft/pyrx/pull/4188
15. Support virtual workspaces in sync https://github.com/microsoft/pyrx/pull/4157
    