### PR TITLE
Fix infinite loop in `isThirdPartyPyTypedPresent` logic of `_getModuleNameForImport`

### DIFF
--- a/packages/pyright-internal/src/common/pathUtils.ts
+++ b/packages/pyright-internal/src/common/pathUtils.ts
@@ -126,8 +126,13 @@ export function getRootLength(pathString: string): number {
 
     if (isUri(pathString)) {
         const uri = URI.parse(pathString);
-        return Math.min(pathString.length, uri.scheme.length + 3);
+        if (uri.authority) {
+            return uri.scheme.length + 3; // URI: "file://"
+        } else {
+            return uri.scheme.length + 2; // URI: "untitled:/"
+        }
     }
+
     return 0;
 }
 

--- a/packages/pyright-internal/src/common/pathUtils.ts
+++ b/packages/pyright-internal/src/common/pathUtils.ts
@@ -16,10 +16,10 @@ import { some } from './collectionUtils';
 import { GetCanonicalFileName, identity } from './core';
 import { randomBytesHex } from './crypto';
 import * as debug from './debug';
-import { FileSystem, ReadOnlyFileSystem, Stats, TempFile } from './fileSystem';
-import { equateStringsCaseInsensitive, equateStringsCaseSensitive } from './stringUtils';
 import { ServiceProvider } from './extensibility';
+import { FileSystem, ReadOnlyFileSystem, Stats, TempFile } from './fileSystem';
 import { ServiceKeys } from './serviceProviderExtensions';
+import { equateStringsCaseInsensitive, equateStringsCaseSensitive } from './stringUtils';
 
 let _fsCaseSensitivity: boolean | undefined = undefined;
 let _underTest: boolean = false;
@@ -125,7 +125,8 @@ export function getRootLength(pathString: string): number {
     }
 
     if (isUri(pathString)) {
-        return URI.parse(pathString).scheme.length + 3;
+        const uri = URI.parse(pathString);
+        return Math.min(pathString.length, uri.scheme.length + 3);
     }
     return 0;
 }

--- a/packages/pyright-internal/src/tests/pathUtils.test.ts
+++ b/packages/pyright-internal/src/tests/pathUtils.test.ts
@@ -361,6 +361,14 @@ test('getRootLength7', () => {
     assert.equal(getRootLength(fixSeparators('//server/share')), 9);
 });
 
+test('getRootLength8', () => {
+    assert.equal(getRootLength('scheme:/no/authority'), 8);
+});
+
+test('getRootLength9', () => {
+    assert.equal(getRootLength('scheme://with/authority'), 9);
+});
+
 test('isRootedDiskPath1', () => {
     assert(isRootedDiskPath(normalizeSlashes('C:/a/b')));
 });


### PR DESCRIPTION
Addresses https://github.com/microsoft/pyright/issues/6232

`getRootLength` wasn't handling URIs without `authority` (single slash after colon) correctly. In the case of `untitled:/` (length 10) it was returning 11 under the assumption that there were two trailing slashes. This caused `isDiskPathRoot` to incorrectly return `false`. If `isDiskPathRoot` returns `true` instead, `_tryWalkUp` will return `false` thus causing the `_shouldWalkUp` loop to exit.