### PR TITLE
Fixed issue that led to false positive error when calling a `NoReturn…

### DIFF
--- a/packages/pyright-internal/src/analyzer/codeFlowEngine.ts
+++ b/packages/pyright-internal/src/analyzer/codeFlowEngine.ts
@@ -83,7 +83,6 @@ export interface FlowNodeTypeResult {
 
 export interface FlowNodeTypeOptions {
     isTypeAtStartIncomplete?: boolean;
-    skipNoReturnCallAnalysis?: boolean;
     skipConditionalNarrowing?: boolean;
 }
 
@@ -431,7 +430,7 @@ export function getCodeFlowEngine(
                         // If this function returns a "NoReturn" type, that means
                         // it always raises an exception or otherwise doesn't return,
                         // so we can assume that the code before this is unreachable.
-                        if (!options?.skipNoReturnCallAnalysis && isCallNoReturn(evaluator, callFlowNode)) {
+                        if (isCallNoReturn(evaluator, callFlowNode)) {
                             return setCacheEntry(curFlowNode, /* type */ undefined, /* isIncomplete */ false);
                         }
 

--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -2952,10 +2952,7 @@ export function createTypeEvaluator(importLookup: ImportLookup, evaluatorOptions
             flowNode,
             /* reference */ undefined,
             /* targetSymbolId */ undefined,
-            /* typeAtStart */ UnboundType.create(),
-            {
-                skipNoReturnCallAnalysis: true,
-            }
+            /* typeAtStart */ UnboundType.create()
         );
 
         return codeFlowResult.type !== undefined && !isNever(codeFlowResult.type);


### PR DESCRIPTION
…` function within a `case` block or within an `if`/`elif` chain. This addresses #6234.