### PR TITLE
Support unpacked TypedDict in parameter hover

### DIFF
--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -19953,6 +19953,19 @@ export function createTypeEvaluator(importLookup: ImportLookup, evaluatorOptions
                                 .getDeclarations()
                                 .find((decl) => decl.type === DeclarationType.Parameter);
                         }
+
+                        const parameterDetails = getParameterListDetails(type);
+                        if (parameterDetails.unpackedKwargsTypedDictType) {
+                            const lookupResults = lookUpClassMember(
+                                parameterDetails.unpackedKwargsTypedDictType,
+                                paramName
+                            );
+                            if (lookupResults) {
+                                return lookupResults.symbol
+                                    .getDeclarations()
+                                    .find((decl) => decl.type === DeclarationType.Variable);
+                            }
+                        }
                     }
                 }
             }

--- a/packages/pyright-internal/src/tests/fourslash/hover.unpackedTypedDict.key.fourslash.ts
+++ b/packages/pyright-internal/src/tests/fourslash/hover.unpackedTypedDict.key.fourslash.ts
@@ -1,0 +1,24 @@
+/// <reference path="fourslash.ts" />
+
+// @filename: test.py
+//// from typing import TypedDict, Unpack
+////
+//// class User(TypedDict):
+////     name: str
+////     """The fullname of the User"""
+////
+////     age: int
+////     """The age of the User, will not be over 200"""
+////
+//// def foo(**user: Unpack[User]) -> None:
+////     ...
+////
+//// foo(name='Robert', [|/*marker1*/age|]=100)
+//// foo(name='Robert', [|/*marker2*/age|]=)
+//// foo([|/*marker3*/name|]='Robert')
+
+helper.verifyHover('markdown', {
+    marker1: '```python\n(variable) age: int\n```\n---\nThe age of the User, will not be over 200',
+    marker2: '```python\n(variable) age: int\n```\n---\nThe age of the User, will not be over 200',
+    marker3: '```python\n(variable) name: str\n```\n---\nThe fullname of the User',
+});


### PR DESCRIPTION
Fixes: https://github.com/microsoft/pylance-release/issues/5015

## Before:
Parameter has no docstring
<img width="476" alt="image" src="https://github.com/microsoft/pylance-release/assets/99349468/0cf2155a-ef2b-4446-846f-31c5a04194b0">

## After
Doc string is now included when hovering over the parameter:
<img width="476" alt="image" src="https://github.com/microsoft/pylance-release/assets/99349468/16d3ab00-675b-47f4-83c7-3f06fe1c3e7b">

You can also navigate to key definition.