### PR TITLE
Improved support for runtime `TypeVar`, `TypeVarTuple` and `ParamSpec…

### DIFF
--- a/packages/pyright-internal/src/analyzer/typeEvaluatorTypes.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluatorTypes.ts
@@ -145,6 +145,10 @@ export const enum EvaluatorFlags {
     // Disallow a type alias defined with a "type" statement.
     DisallowPep695TypeAlias = 1 << 24,
 
+    // If evaluation is a TypeVarType that is a ParamSpec, do
+    // not convert it to its corresponding ParamSpec runtime object.
+    SkipConvertParamSpecToRuntimeObject = 1 << 25,
+
     // Defaults used for evaluating the LHS of a call expression.
     CallBaseDefaults = DoNotSpecialize | DisallowPep695TypeAlias,
 

--- a/packages/pyright-internal/src/analyzer/types.ts
+++ b/packages/pyright-internal/src/analyzer/types.ts
@@ -2389,6 +2389,7 @@ export interface TypeVarDetails {
     constraints: Type[];
     boundType?: Type | undefined;
     defaultType?: Type | undefined;
+    runtimeClass?: ClassType | undefined;
 
     isParamSpec: boolean;
     isVariadic: boolean;
@@ -2465,8 +2466,8 @@ export namespace TypeVarType {
         return create(name, /* isParamSpec */ false, TypeFlags.Instance);
     }
 
-    export function createInstantiable(name: string, isParamSpec = false) {
-        return create(name, isParamSpec, TypeFlags.Instantiable);
+    export function createInstantiable(name: string, isParamSpec = false, runtimeClass?: ClassType) {
+        return create(name, isParamSpec, TypeFlags.Instantiable, runtimeClass);
     }
 
     export function cloneAsInstance(type: TypeVarType): TypeVarType {
@@ -2598,7 +2599,7 @@ export namespace TypeVarType {
         return `${name}.${scopeId}`;
     }
 
-    function create(name: string, isParamSpec: boolean, typeFlags: TypeFlags): TypeVarType {
+    function create(name: string, isParamSpec: boolean, typeFlags: TypeFlags, runtimeClass?: ClassType): TypeVarType {
         const newTypeVarType: TypeVarType = {
             category: TypeCategory.TypeVar,
             details: {
@@ -2608,6 +2609,7 @@ export namespace TypeVarType {
                 isParamSpec,
                 isVariadic: false,
                 isSynthesized: false,
+                runtimeClass,
             },
             flags: typeFlags,
         };

--- a/packages/pyright-internal/src/tests/samples/typeVar8.py
+++ b/packages/pyright-internal/src/tests/samples/typeVar8.py
@@ -1,22 +1,29 @@
-# This sample tests the handling of a TypeVar symbol that is
-# not representing another type.
+# This sample tests the handling of a TypeVar symbol when it is
+# used as a runtime object rather than a special form.
 
-from typing import TypeVar
+import typing as t
+import typing_extensions as te
 
 
-T = TypeVar("T")
-S = TypeVar("S", bound=str)
+T1 = t.TypeVar("T1")
+S1 = t.TypeVar("S1", bound=str)
+Ts1 = t.TypeVarTuple("Ts1")
+P1 = t.ParamSpec("P1")
 
 # In these cases, the TypeVar symbol simply represents the TypeVar
 # object itself, rather than representing a type variable.
-T.__name__
-S.__name__
-S.__bound__
+T1.__name__
+S1.__name__
+S1.__bound__
+Ts1.__name__
+P1.__name__
 
 
-def func1(x: bool, a: T, b: S) -> T | S:
-    reveal_type(T.__name__, expected_text="str")
-    reveal_type(S.__name__, expected_text="str")
+def func1(x: bool, a: T1, b: S1) -> T1 | S1:
+    reveal_type(T1.__name__, expected_text="str")
+    reveal_type(S1.__name__, expected_text="str")
+    reveal_type(Ts1.__name__, expected_text="str")
+    reveal_type(P1.__name__, expected_text="str")
 
     # This should generate an error
     a.__name__
@@ -28,3 +35,50 @@ def func1(x: bool, a: T, b: S) -> T | S:
         return a
     else:
         return b
+
+
+T2 = te.TypeVar("T2")
+S2 = te.TypeVar("S2", bound=str)
+Ts2 = te.TypeVarTuple("Ts2")
+P2 = te.ParamSpec("P2")
+
+T2.__name__
+S2.__name__
+S2.__bound__
+Ts2.__name__
+P2.__name__
+
+
+def func2(x: bool, a: T2, b: S2) -> T2 | S2:
+    reveal_type(T2.__name__, expected_text="str")
+    reveal_type(S2.__name__, expected_text="str")
+    reveal_type(Ts2.__name__, expected_text="str")
+    reveal_type(P2.__name__, expected_text="str")
+
+    if x:
+        return a
+    else:
+        return b
+
+
+def func3(t: t.TypeVar, ts: t.TypeVarTuple = ..., p: t.ParamSpec = ...) -> None:
+    ...
+
+
+func3(T1, Ts1, P1)
+
+# This should generate an error because the runtime object typing.TypeVar
+# is not the same as typing_extensions.TypeVar.
+func3(T2)
+
+
+def func4(t: te.TypeVar, ts: te.TypeVarTuple = ..., p: te.ParamSpec = ...) -> None:
+    ...
+
+
+func4(T2, Ts2, P2)
+
+
+# This should generate an error because the runtime object typing.TypeVar
+# is not the same as typing_extensions.TypeVar.
+func4(T1)

--- a/packages/pyright-internal/src/tests/typeEvaluator4.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator4.test.ts
@@ -1159,7 +1159,7 @@ test('TypeVar7', () => {
 test('TypeVar8', () => {
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['typeVar8.py']);
 
-    TestUtils.validateResults(analysisResults, 2);
+    TestUtils.validateResults(analysisResults, 4);
 });
 
 test('TypeVar9', () => {


### PR DESCRIPTION
…` objects, including when they are instantiated from `typing_extensions` classes. This addresses #6241.