### PR TITLE
Improved inference logic for lambdas so it handles a wider variety of…

### DIFF
--- a/packages/pyright-internal/src/tests/samples/lambda1.py
+++ b/packages/pyright-internal/src/tests/samples/lambda1.py
@@ -1,5 +1,5 @@
 # This sample tests type checking for lambdas and their parameters.
-from typing import Callable, Iterable, TypeVar
+from typing import Any, Callable, Iterable, TypeVar
 
 #------------------------------------------------------
 # Test basic lambda matching
@@ -75,3 +75,19 @@ def reduce(function: Callable[[_T1, _T1], _T1], sequence: Iterable[_T1]) -> _T1:
 
 
 a: object = reduce((lambda x, y: x * y), [1, 2, 3, 4])
+
+
+#------------------------------------------------------
+# Test lambdas with *args
+
+b1: Callable[[int, int, int], Any] = lambda _, *b: reveal_type(
+    b, expected_text="tuple[int, ...]"
+)
+
+b2: Callable[[str, str], Any] = lambda *b: reveal_type(
+    b, expected_text="tuple[str, ...]"
+)
+
+b3: Callable[[int], Any] = lambda _, *b: reveal_type(
+    b, expected_text="tuple[Unknown, ...]"
+)


### PR DESCRIPTION
… cases including lambas with `*args` parameters and cases where the expected type is a union of multiple subtypes that might be matches. This addresses #6222.