### PR TITLE
Fixed bug that led to an inconsistency between the use of `type` and …

### DIFF
--- a/packages/pyright-internal/src/analyzer/binder.ts
+++ b/packages/pyright-internal/src/analyzer/binder.ts
@@ -644,16 +644,7 @@ export class Binder extends ParseTreeWalker {
         this._disableTrueFalseTargets(() => {
             this.walk(node.leftExpression);
 
-            // Sort all keyword arguments to the end of the parameter list. This is
-            // necessary because all positional arguments (including *args) are evaluated
-            // prior to any keyword arguments at runtime.
-            const positionalArgs = node.arguments.filter(
-                (arg) => !arg.name && arg.argumentCategory !== ArgumentCategory.UnpackedDictionary
-            );
-            const keywordArgs = node.arguments.filter(
-                (arg) => !!arg.name || arg.argumentCategory === ArgumentCategory.UnpackedDictionary
-            );
-            const sortedArgs = positionalArgs.concat(keywordArgs);
+            const sortedArgs = ParseTreeUtils.getArgumentsByRuntimeOrder(node);
 
             sortedArgs.forEach((argNode) => {
                 if (this._currentFlowNode) {

--- a/packages/pyright-internal/src/analyzer/parseTreeUtils.ts
+++ b/packages/pyright-internal/src/analyzer/parseTreeUtils.ts
@@ -965,6 +965,19 @@ export function getTypeAnnotationNode(node: ParseNode): TypeAnnotationNode | und
     return undefined;
 }
 
+// In general, arguments passed to a call are evaluated by the runtime in
+// left-to-right order. There is one exception, however, when an unpacked
+// iterable is used after a keyword argument.
+export function getArgumentsByRuntimeOrder(node: CallNode) {
+    const positionalArgs = node.arguments.filter(
+        (arg) => !arg.name && arg.argumentCategory !== ArgumentCategory.UnpackedDictionary
+    );
+    const keywordArgs = node.arguments.filter(
+        (arg) => !!arg.name || arg.argumentCategory === ArgumentCategory.UnpackedDictionary
+    );
+    return positionalArgs.concat(keywordArgs);
+}
+
 // PEP 591 spells out certain limited cases where an assignment target
 // can be annotated with a "Final" annotation. This function determines
 // whether Final is allowed for the specified node.

--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -8018,7 +8018,7 @@ export function createTypeEvaluator(importLookup: ImportLookup, evaluatorOptions
             );
         }
 
-        const argList = node.arguments.map((arg) => {
+        const argList = ParseTreeUtils.getArgumentsByRuntimeOrder(node).map((arg) => {
             const functionArg: FunctionArgument = {
                 valueExpression: arg.valueExpression,
                 argumentCategory: arg.argumentCategory,

--- a/packages/pyright-internal/src/analyzer/typeUtils.ts
+++ b/packages/pyright-internal/src/analyzer/typeUtils.ts
@@ -2236,7 +2236,9 @@ export function convertToInstance(type: Type, includeSubclasses = true): Type {
                         }
                     } else {
                         if (subtype.typeArguments && subtype.typeArguments.length > 0) {
-                            return convertToInstantiable(subtype.typeArguments[0]);
+                            if (!isAnyOrUnknown(subtype.typeArguments[0])) {
+                                return convertToInstantiable(subtype.typeArguments[0]);
+                            }
                         }
                     }
                 }

--- a/packages/pyright-internal/src/tests/samples/call12.py
+++ b/packages/pyright-internal/src/tests/samples/call12.py
@@ -38,3 +38,10 @@ func1(**A(a=(v5 + 1)), b=(v5 := 1))
 func1(**A(a=(v5 := 1)), b=(v5 + 1))
 
 func1(b=(v6 + 1), *[(v6 := 1)], **C(c=(v6 + 2)))
+
+
+def func2(a: int, b: int):
+    pass
+
+
+func2(b=1, *(2,))


### PR DESCRIPTION
…`Type` when applying `isinstance` type narrowing in some cases. This addresses #6252.