### PR TITLE
Removed the `NoneType` which has historically been used to track `Non…

### DIFF
--- a/packages/pyright-internal/src/analyzer/analyzerFileInfo.ts
+++ b/packages/pyright-internal/src/analyzer/analyzerFileInfo.ts
@@ -57,6 +57,7 @@ export interface AnalyzerFileInfo {
     isStubFile: boolean;
     isTypingStubFile: boolean;
     isTypingExtensionsStubFile: boolean;
+    isTypeshedStubFile: boolean;
     isBuiltInStubFile: boolean;
     isInPyTypedPackage: boolean;
     ipythonMode: IPythonMode;

--- a/packages/pyright-internal/src/analyzer/checker.ts
+++ b/packages/pyright-internal/src/analyzer/checker.ts
@@ -1052,7 +1052,7 @@ export class Checker extends ParseTreeWalker {
                 doForEachSubtype(exceptionType, (subtype) => {
                     subtype = this._evaluator.makeTopLevelTypeVarsConcrete(subtype);
 
-                    if (!isAnyOrUnknown(subtype) && !isNoneInstance(subtype)) {
+                    if (!isAnyOrUnknown(subtype)) {
                         if (isClass(subtype)) {
                             if (!derivesFromClassRecursive(subtype, baseExceptionType, /* ignoreUnknown */ false)) {
                                 diagAddendum.addMessage(
@@ -3786,15 +3786,13 @@ export class Checker extends ParseTreeWalker {
                     break;
 
                 case TypeCategory.Class:
-                    // If it's a class, make sure that it has not been given explicit
-                    // type arguments. This will result in a TypeError exception.
-                    if (subtype.isTypeArgumentExplicit && !subtype.includeSubclasses) {
+                    if (isNoneInstance(subtype)) {
+                        isSupported = false;
+                    } else if (subtype.isTypeArgumentExplicit && !subtype.includeSubclasses) {
+                        // If it's a class, make sure that it has not been given explicit
+                        // type arguments. This will result in a TypeError exception.
                         isSupported = false;
                     }
-                    break;
-
-                case TypeCategory.None:
-                    isSupported = TypeBase.isInstantiable(subtype);
                     break;
 
                 case TypeCategory.Function:

--- a/packages/pyright-internal/src/analyzer/packageTypeVerifier.ts
+++ b/packages/pyright-internal/src/analyzer/packageTypeVerifier.ts
@@ -710,7 +710,6 @@ export class PackageTypeVerifier {
         switch (type.category) {
             case TypeCategory.Unbound:
             case TypeCategory.Any:
-            case TypeCategory.None:
             case TypeCategory.Never:
             case TypeCategory.TypeVar:
                 break;
@@ -1293,7 +1292,6 @@ export class PackageTypeVerifier {
         switch (type.category) {
             case TypeCategory.Unbound:
             case TypeCategory.Any:
-            case TypeCategory.None:
             case TypeCategory.Never:
             case TypeCategory.TypeVar:
                 break;

--- a/packages/pyright-internal/src/analyzer/sourceFile.ts
+++ b/packages/pyright-internal/src/analyzer/sourceFile.ts
@@ -173,6 +173,10 @@ export class SourceFile {
     // special-case handling.
     private readonly _isTypingExtensionsStubFile: boolean;
 
+    // True if the file is the "_typeshed.pyi" file, which needs special-
+    // case handling.
+    private readonly _isTypeshedStubFile: boolean;
+
     // True if the file one of the other built-in stub files
     // that require special-case handling: "collections.pyi",
     // "dataclasses.pyi", "abc.pyi", "asyncio/coroutines.pyi".
@@ -221,6 +225,8 @@ export class SourceFile {
             this._isStubFile &&
             (this._filePath.endsWith(normalizeSlashes('stdlib/typing.pyi')) || fileName === 'typing_extensions.pyi');
         this._isTypingExtensionsStubFile = this._isStubFile && fileName === 'typing_extensions.pyi';
+        this._isTypeshedStubFile =
+            this._isStubFile && this._filePath.endsWith(normalizeSlashes('stdlib/_typeshed/__init__.pyi'));
 
         this._isBuiltInStubFile = false;
         if (this._isStubFile) {
@@ -1217,6 +1223,7 @@ export class SourceFile {
             isStubFile: this._isStubFile,
             isTypingStubFile: this._isTypingStubFile,
             isTypingExtensionsStubFile: this._isTypingExtensionsStubFile,
+            isTypeshedStubFile: this._isTypeshedStubFile,
             isBuiltInStubFile: this._isBuiltInStubFile,
             isInPyTypedPackage: this._isThirdPartyPyTypedPresent,
             ipythonMode: this._ipythonMode,

--- a/packages/pyright-internal/src/analyzer/tracePrinter.ts
+++ b/packages/pyright-internal/src/analyzer/tracePrinter.ts
@@ -79,9 +79,6 @@ export function createTracePrinter(roots: string[]): TracePrinter {
                 case TypeCategory.Never:
                     return `Never ${wrap(type.typeAliasInfo?.fullName)}`;
 
-                case TypeCategory.None:
-                    return `None ${wrap(type.typeAliasInfo?.fullName)}`;
-
                 case TypeCategory.OverloadedFunction:
                     return `OverloadedFunction [${type.overloads.map((o) => wrap(printType(o), '"')).join(',')}]`;
 

--- a/packages/pyright-internal/src/analyzer/typePrinter.ts
+++ b/packages/pyright-internal/src/analyzer/typePrinter.ts
@@ -713,12 +713,6 @@ function printTypeInternal(
                 return typeVarName;
             }
 
-            case TypeCategory.None: {
-                return `${
-                    TypeBase.isInstantiable(type) ? `${_printNestedInstantiable(type, 'None')}` : 'None'
-                }${getConditionalIndicator(type)}`;
-            }
-
             case TypeCategory.Never: {
                 return type.isNoReturn ? 'NoReturn' : 'Never';
             }
@@ -850,6 +844,11 @@ function printObjectTypeForClassInternal(
     if (!objName) {
         objName =
             (printTypeFlags & PrintTypeFlags.UseFullyQualifiedNames) !== 0 ? type.details.fullName : type.details.name;
+    }
+
+    // Special-case NoneType to convert it to None.
+    if (ClassType.isBuiltIn(type, 'NoneType')) {
+        objName = 'None';
     }
 
     // Use the fully-qualified name if the name isn't unique.

--- a/packages/pyright-internal/src/analyzer/typeVarContext.ts
+++ b/packages/pyright-internal/src/analyzer/typeVarContext.ts
@@ -206,7 +206,6 @@ export class TypeVarSignatureContext {
         switch (type.category) {
             case TypeCategory.Unknown:
             case TypeCategory.Any:
-            case TypeCategory.None:
             case TypeCategory.TypeVar: {
                 return 0.5;
             }

--- a/packages/pyright-internal/src/analyzer/typeWalker.ts
+++ b/packages/pyright-internal/src/analyzer/typeWalker.ts
@@ -15,7 +15,6 @@ import {
     FunctionType,
     ModuleType,
     NeverType,
-    NoneType,
     OverloadedFunctionType,
     Type,
     TypeCategory,
@@ -66,10 +65,6 @@ export class TypeWalker {
 
             case TypeCategory.Unknown:
                 this.visitUnknown(type);
-                break;
-
-            case TypeCategory.None:
-                this.visitNone(type);
                 break;
 
             case TypeCategory.Never:
@@ -133,10 +128,6 @@ export class TypeWalker {
     }
 
     visitUnknown(type: UnknownType): void {
-        // Nothing to do.
-    }
-
-    visitNone(type: NoneType): void {
         // Nothing to do.
     }
 

--- a/packages/pyright-internal/src/analyzer/typedDicts.ts
+++ b/packages/pyright-internal/src/analyzer/typedDicts.ts
@@ -930,7 +930,7 @@ export function assignTypedDictToTypedDict(
                 // so we need to make sure the dest entry is compatible with that.
                 const objType = evaluator.getObjectType();
 
-                if (objType && isClassInstance(objType)) {
+                if (isClassInstance(objType)) {
                     const subDiag = diag?.createAddendum();
                     if (
                         !evaluator.assignType(

--- a/packages/pyright-internal/src/analyzer/types.ts
+++ b/packages/pyright-internal/src/analyzer/types.ts
@@ -24,9 +24,6 @@ export const enum TypeCategory {
     // Type can be anything.
     Any,
 
-    // Special "None" type defined in Python.
-    None,
-
     // Used in type narrowing to indicate that all possible
     // subtypes in a union have been eliminated, and execution
     // should never get to this point.
@@ -74,7 +71,6 @@ export type UnionableType =
     | UnboundType
     | UnknownType
     | AnyType
-    | NoneType
     | FunctionType
     | OverloadedFunctionType
     | ClassType
@@ -2069,30 +2065,6 @@ export namespace OverloadedFunctionType {
 
     export function getImplementation(type: OverloadedFunctionType): FunctionType | undefined {
         return type.overloads.find((func) => !FunctionType.isOverloaded(func));
-    }
-}
-
-export interface NoneType extends TypeBase {
-    category: TypeCategory.None;
-}
-
-export namespace NoneType {
-    const _noneInstance: NoneType = {
-        category: TypeCategory.None,
-        flags: TypeFlags.Instance,
-    };
-
-    const _noneType: NoneType = {
-        category: TypeCategory.None,
-        flags: TypeFlags.Instantiable,
-    };
-
-    export function createInstance() {
-        return _noneInstance;
-    }
-
-    export function createType() {
-        return _noneType;
     }
 }
 

--- a/packages/pyright-internal/src/commands/dumpFileDebugInfoCommand.ts
+++ b/packages/pyright-internal/src/commands/dumpFileDebugInfoCommand.ts
@@ -522,8 +522,6 @@ function getTypeCategoryString(typeCategory: TypeCategory, type: any) {
             return 'Unknown';
         case TypeCategory.Any:
             return 'Any';
-        case TypeCategory.None:
-            return 'None';
         case TypeCategory.Never:
             return 'Never';
         case TypeCategory.Function:

--- a/packages/pyright-internal/src/tests/testUtils.ts
+++ b/packages/pyright-internal/src/tests/testUtils.ts
@@ -122,6 +122,7 @@ export function buildAnalyzerFileInfo(
         isTypingStubFile: false,
         isInPyTypedPackage: false,
         isTypingExtensionsStubFile: false,
+        isTypeshedStubFile: false,
         isBuiltInStubFile: false,
         ipythonMode: IPythonMode.None,
         accessedSymbolSet: new Set<number>(),


### PR DESCRIPTION
…e` and `type[None]` within pyright's logic. The new logic now models `None` like any other class and simply uses `ClassType` to track values of this type. This eliminates a bunch of special-case logic and edge-case bugs.