### PR TITLE
Fixed a bug in the type guard logic for simple truthy/falsy checks. I…

### DIFF
--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -1800,7 +1800,7 @@ export function createTypeEvaluator(importLookup: ImportLookup, evaluatorOptions
                     return true;
                 }
 
-                return false;
+                return !ClassType.isFinal(type);
             }
         }
     }
@@ -1948,6 +1948,18 @@ export function createTypeEvaluator(importLookup: ImportLookup, evaluatorOptions
                 // "false" is a falsy value.
                 if (ClassType.isBuiltIn(concreteSubtype, 'bool')) {
                     return ClassType.cloneWithLiteral(concreteSubtype, /* value */ true);
+                }
+
+                // If the object is a "None" instance, we can eliminate it.
+                if (isNoneInstance(concreteSubtype)) {
+                    return undefined;
+                }
+
+                // If this is an instance of a class that cannot be subclassed,
+                // we cannot say definitively that it's not falsy because a subclass
+                // could override `__bool__`.
+                if (!ClassType.isFinal(concreteSubtype)) {
+                    return subtype;
                 }
             }
 

--- a/packages/pyright-internal/src/tests/samples/typeNarrowing1.py
+++ b/packages/pyright-internal/src/tests/samples/typeNarrowing1.py
@@ -4,8 +4,10 @@
 # pyright: reportOptionalMemberAccess=false
 
 from random import random
+from typing import final
 
 
+@final
 class ClassA:
     def x(self):
         return

--- a/packages/pyright-internal/src/tests/samples/typeNarrowingFalsy1.py
+++ b/packages/pyright-internal/src/tests/samples/typeNarrowingFalsy1.py
@@ -1,9 +1,14 @@
 # This sample tests type narrowing for falsey and truthy values.
 
-from typing import AnyStr, Iterable, Literal, NamedTuple, Union
+from typing import AnyStr, Iterable, Literal, NamedTuple, TypeVar, Union, final
 
 
 class A:
+    ...
+
+
+@final
+class AFinal:
     ...
 
 
@@ -22,11 +27,11 @@ class D:
         ...
 
 
-def func1(x: Union[int, list[int], A, B, C, D, None]) -> None:
+def func1(x: int | list[int] | A | AFinal | B | C | D | None) -> None:
     if x:
-        reveal_type(x, expected_text="int | list[int] | A | B | D")
+        reveal_type(x, expected_text="int | list[int] | A | AFinal | B | D")
     else:
-        reveal_type(x, expected_text="list[int] | B | C | Literal[0] | None")
+        reveal_type(x, expected_text="list[int] | A | B | C | Literal[0] | None")
 
 
 def func2(maybe_int: int | None):
@@ -36,61 +41,68 @@ def func2(maybe_int: int | None):
         reveal_type(maybe_int, expected_text="Literal[0] | None")
 
 
-def func3(maybe_a: A | None):
+def func3_1(maybe_a: A | None):
     if bool(maybe_a):
         reveal_type(maybe_a, expected_text="A")
+    else:
+        reveal_type(maybe_a, expected_text="A | None")
+
+
+def func3_2(maybe_a: AFinal | None):
+    if bool(maybe_a):
+        reveal_type(maybe_a, expected_text="AFinal")
     else:
         reveal_type(maybe_a, expected_text="None")
 
 
-def func4(foo: Iterable[int]) -> None:
-    if foo:
-        reveal_type(foo, expected_text="Iterable[int]")
+def func4(val: Iterable[int]) -> None:
+    if val:
+        reveal_type(val, expected_text="Iterable[int]")
     else:
-        reveal_type(foo, expected_text="Iterable[int]")
+        reveal_type(val, expected_text="Iterable[int]")
 
 
-def func5(foo: tuple[int]) -> None:
-    if foo:
-        reveal_type(foo, expected_text="tuple[int]")
+def func5(val: tuple[int]) -> None:
+    if val:
+        reveal_type(val, expected_text="tuple[int]")
     else:
-        reveal_type(foo, expected_text="Never")
+        reveal_type(val, expected_text="Never")
 
 
-def func6(foo: tuple[int, ...]) -> None:
-    if foo:
-        reveal_type(foo, expected_text="tuple[int, ...]")
+def func6(val: tuple[int, ...]) -> None:
+    if val:
+        reveal_type(val, expected_text="tuple[int, ...]")
     else:
-        reveal_type(foo, expected_text="tuple[int, ...]")
+        reveal_type(val, expected_text="tuple[int, ...]")
 
 
-def func7(foo: tuple[()]) -> None:
-    if foo:
-        reveal_type(foo, expected_text="Never")
+def func7(val: tuple[()]) -> None:
+    if val:
+        reveal_type(val, expected_text="Never")
     else:
-        reveal_type(foo, expected_text="tuple[()]")
+        reveal_type(val, expected_text="tuple[()]")
 
 
 class NT1(NamedTuple):
-    foo: int
+    val: int
 
 
-def func8(foo: NT1) -> None:
-    if foo:
-        reveal_type(foo, expected_text="NT1")
+def func8(val: NT1) -> None:
+    if val:
+        reveal_type(val, expected_text="NT1")
     else:
-        reveal_type(foo, expected_text="Never")
+        reveal_type(val, expected_text="Never")
 
 
 class NT2(NT1):
     pass
 
 
-def func9(foo: NT2) -> None:
-    if foo:
-        reveal_type(foo, expected_text="NT2")
+def func9(val: NT2) -> None:
+    if val:
+        reveal_type(val, expected_text="NT2")
     else:
-        reveal_type(foo, expected_text="Never")
+        reveal_type(val, expected_text="Never")
 
 
 class E:
@@ -113,3 +125,15 @@ def func10(val: AnyStr | None):
 def func11(val: AnyStr | None):
     assert val
     reveal_type(val, expected_text="AnyStr@func11")
+
+
+T = TypeVar("T")
+
+
+def func12(val: T) -> T:
+    if val:
+        reveal_type(val, expected_text="T@func12")
+    else:
+        reveal_type(val, expected_text="T@func12")
+
+    return val

--- a/packages/pyright-internal/src/tests/samples/typeNarrowingLocalConst1.py
+++ b/packages/pyright-internal/src/tests/samples/typeNarrowingLocalConst1.py
@@ -4,12 +4,15 @@
 
 
 import random
+from typing import final
 
 
+@final
 class A:
     a: int
 
 
+@final
 class B:
     b: int
 


### PR DESCRIPTION
…f a class doesn't provide an explicit `__bool__` method and is not final, we cannot assume that it will always be evaluated as truthy because a subclass may override `__bool__` and return false. This addresses #6266.