### PR TITLE
[PylanceBot] Pull Pylance with Pyright 1.1.334

### DIFF
--- a/packages/pyright-internal/src/common/pathUtils.ts
+++ b/packages/pyright-internal/src/common/pathUtils.ts
@@ -144,7 +144,7 @@ export function getPathSeparator(pathString: string) {
 
 export function getPathComponents(pathString: string) {
     const normalizedPath = normalizeSlashes(pathString);
-    const rootLength = getRootLength(normalizedPath, /*checkUri*/ isUri(normalizedPath));
+    const rootLength = getRootLength(normalizedPath, /* checkUri */ isUri(normalizedPath));
     const root = normalizedPath.substring(0, rootLength);
     const sep = getPathSeparator(pathString);
     const rest = normalizedPath.substring(rootLength).split(sep);

--- a/packages/pyright-internal/src/common/pathUtils.ts
+++ b/packages/pyright-internal/src/common/pathUtils.ts
@@ -92,19 +92,21 @@ export function forEachAncestorDirectory(
 
 export function getDirectoryPath(pathString: string): string {
     if (isUri(pathString)) {
-        return Utils.dirname(URI.parse(pathString).with({ fragment: '' })).toString();
+        return Utils.dirname(URI.parse(pathString).with({ fragment: '', query: '' })).toString();
     }
     return pathString.substr(0, Math.max(getRootLength(pathString), pathString.lastIndexOf(path.sep)));
 }
 
+const _schemePattern = /^\w[\w\d+.-]*$/;
+
 export function isUri(pathString: string) {
-    return pathString.indexOf(':') > 1;
+    return pathString.indexOf(':') > 1 && _schemePattern.test(pathString.split(':')[0]);
 }
 
 /**
  * Returns length of the root part of a path or URL (i.e. length of "/", "x:/", "//server/").
  */
-export function getRootLength(pathString: string): number {
+export function getRootLength(pathString: string, checkUri = true): number {
     if (pathString.charAt(0) === path.sep) {
         if (pathString.charAt(1) !== path.sep) {
             return 1; // POSIX: "/" (or non-normalized "\")
@@ -124,12 +126,12 @@ export function getRootLength(pathString: string): number {
         }
     }
 
-    if (isUri(pathString)) {
+    if (checkUri && isUri(pathString)) {
         const uri = URI.parse(pathString);
         if (uri.authority) {
             return uri.scheme.length + 3; // URI: "file://"
         } else {
-            return uri.scheme.length + 2; // URI: "untitled:/"
+            return uri.scheme.length + 1; // URI: "untitled:"
         }
     }
 
@@ -142,7 +144,7 @@ export function getPathSeparator(pathString: string) {
 
 export function getPathComponents(pathString: string) {
     const normalizedPath = normalizeSlashes(pathString);
-    const rootLength = getRootLength(normalizedPath);
+    const rootLength = getRootLength(normalizedPath, /*checkUri*/ isUri(normalizedPath));
     const root = normalizedPath.substring(0, rootLength);
     const sep = getPathSeparator(pathString);
     const rest = normalizedPath.substring(rootLength).split(sep);
@@ -282,7 +284,7 @@ function combineFilePaths(pathString: string, ...paths: (string | undefined)[]):
 
         relativePath = normalizeSlashes(relativePath);
 
-        if (!pathString || getRootLength(relativePath) !== 0) {
+        if (!pathString || getRootLength(relativePath, /* checkUri */ false) !== 0) {
             pathString = relativePath;
         } else {
             pathString = ensureTrailingDirectorySeparator(pathString) + relativePath;
@@ -300,7 +302,7 @@ export function combinePaths(pathString: string, ...paths: (string | undefined)[
 
     // Go through the paths to see if any are rooted. If so, treat as
     // a file path. On linux this might be wrong if a path starts with '/'.
-    if (some(paths, (p) => !!p && getRootLength(p) !== 0)) {
+    if (some(paths, (p) => !!p && getRootLength(p, /* checkUri */ false) !== 0)) {
         return combineFilePaths(pathString, ...paths);
     }
 
@@ -312,7 +314,7 @@ export function combinePaths(pathString: string, ...paths: (string | undefined)[
     if (uri.path === '' || uri.path === undefined) {
         nonEmptyPaths.unshift('/');
     }
-    return Utils.joinPath(uri.with({ fragment: '' }), ...nonEmptyPaths).toString();
+    return Utils.joinPath(uri.with({ fragment: '', query: '' }), ...nonEmptyPaths).toString();
 }
 
 /**
@@ -485,7 +487,7 @@ export function getBaseFileName(pathString: string, extensions?: string | readon
     // separator but not including any trailing directory separator.
     pathString = stripTrailingDirectorySeparator(pathString);
     const name = isUri(pathString)
-        ? Utils.basename(URI.parse(pathString))
+        ? Utils.basename(URI.parse(pathString).with({ fragment: '', query: '' }))
         : pathString.slice(Math.max(getRootLength(pathString), pathString.lastIndexOf(path.sep) + 1));
     const extension =
         extensions !== undefined && ignoreCase !== undefined

--- a/packages/pyright-internal/src/common/pathUtils.ts
+++ b/packages/pyright-internal/src/common/pathUtils.ts
@@ -23,6 +23,7 @@ import { equateStringsCaseInsensitive, equateStringsCaseSensitive } from './stri
 
 let _fsCaseSensitivity: boolean | undefined = undefined;
 let _underTest: boolean = false;
+const _uriSchemePattern = /^\w[\w\d+.-]*$/;
 
 export interface FileSpec {
     // File specs can contain wildcard characters (**, *, ?). This
@@ -97,10 +98,8 @@ export function getDirectoryPath(pathString: string): string {
     return pathString.substr(0, Math.max(getRootLength(pathString), pathString.lastIndexOf(path.sep)));
 }
 
-const _schemePattern = /^\w[\w\d+.-]*$/;
-
 export function isUri(pathString: string) {
-    return pathString.indexOf(':') > 1 && _schemePattern.test(pathString.split(':')[0]);
+    return pathString.indexOf(':') > 1 && _uriSchemePattern.test(pathString.split(':')[0]);
 }
 
 /**

--- a/packages/pyright-internal/src/common/realFileSystem.ts
+++ b/packages/pyright-internal/src/common/realFileSystem.ts
@@ -277,12 +277,10 @@ class RealFileSystem implements FileSystem {
         // See: https://github.com/yarnpkg/berry/blob/master/packages/vscode-zipfs/sources/ZipFSProvider.ts
         if (hasZipExtension(path)) {
             if (stat.isFile() && yarnFS.isZip(path)) {
-                return {
-                    ...stat,
-                    isFile: () => false,
-                    isDirectory: () => true,
-                    isZipDirectory: () => true,
-                };
+                stat.isFile = () => false;
+                stat.isDirectory = () => true;
+                (stat as any).isZipDirectory = () => true;
+                return stat;
             }
         }
         return stat;

--- a/packages/pyright-internal/src/languageServerBase.ts
+++ b/packages/pyright-internal/src/languageServerBase.ts
@@ -1312,7 +1312,7 @@ export abstract class LanguageServerBase implements LanguageServerInterface, Dis
                 return;
             }
 
-            this._sendDiagnostics(this.convertDiagnostics(fs, fileDiag));
+            this.sendDiagnostics(this.convertDiagnostics(fs, fileDiag));
         });
 
         if (!this._progressReporter.isEnabled(results)) {
@@ -1360,7 +1360,7 @@ export abstract class LanguageServerBase implements LanguageServerInterface, Dis
                 if (otherWorkspaces.some((w) => w.service.isTracked(filePath))) {
                     continue;
                 }
-                this._sendDiagnostics([
+                this.sendDiagnostics([
                     {
                         uri: uri,
                         diagnostics: [],
@@ -1441,6 +1441,17 @@ export abstract class LanguageServerBase implements LanguageServerInterface, Dis
         };
     }
 
+    protected sendDiagnostics(params: PublishDiagnosticsParams[]) {
+        for (const param of params) {
+            if (param.diagnostics.length === 0) {
+                this.documentsWithDiagnostics.delete(param.uri);
+            } else {
+                this.documentsWithDiagnostics.add(param.uri);
+            }
+            this.connection.sendDiagnostics(param);
+        }
+    }
+
     private _setupFileWatcher() {
         if (!this.client.hasWatchFileCapability) {
             return;
@@ -1482,17 +1493,6 @@ export abstract class LanguageServerBase implements LanguageServerInterface, Dis
 
             this._lastFileWatcherRegistration = d;
         });
-    }
-
-    private _sendDiagnostics(params: PublishDiagnosticsParams[]) {
-        for (const param of params) {
-            if (param.diagnostics.length === 0) {
-                this.documentsWithDiagnostics.delete(param.uri);
-            } else {
-                this.documentsWithDiagnostics.add(param.uri);
-            }
-            this.connection.sendDiagnostics(param);
-        }
     }
 
     private _getCompatibleMarkupKind(clientSupportedFormats: MarkupKind[] | undefined) {

--- a/packages/pyright-internal/src/localization/package.nls.cs.json
+++ b/packages/pyright-internal/src/localization/package.nls.cs.json
@@ -642,7 +642,7 @@
         "memberSetClassVar": "Člen „{name}“ nelze přiřadit prostřednictvím instance třídy, protože se jedná o třídu ClassVar",
         "memberTypeMismatch": "{name} je nekompatibilní typ",
         "memberUnknown": "Člen {name} je neznámý",
-        "metaclassConflict": "Metaclass \"{metaclass1}\" conflicts with \"{metaclass2}\"",
+        "metaclassConflict": "Metatřída {metaclass1} je v konfliktu s metatřídou {metaclass2}.",
         "missingDeleter": "Chybí metoda odstranění vlastnosti",
         "missingGetter": "Chybí metoda getter vlastnosti",
         "missingProtocolMember": "Člen {name} je deklarován ve třídě protokolu {classType}",

--- a/packages/pyright-internal/src/localization/package.nls.de.json
+++ b/packages/pyright-internal/src/localization/package.nls.de.json
@@ -642,7 +642,7 @@
         "memberSetClassVar": "Der Member \"{name}\" kann nicht über eine Klasseninstanz zugewiesen werden, da es sich um eine ClassVar handelt.",
         "memberTypeMismatch": "\"{name}\" ist ein inkompatibler Typ.",
         "memberUnknown": "Das Member \"{name}\" ist unbekannt.",
-        "metaclassConflict": "Metaclass \"{metaclass1}\" conflicts with \"{metaclass2}\"",
+        "metaclassConflict": "Die Metaklasse \"{metaclass1}\" verursacht einen Konflikt mit \"{metaclass2}\"",
         "missingDeleter": "Die Eigenschaft-Deleter-Methode fehlt.",
         "missingGetter": "Die Eigenschaft-Getter-Methode fehlt.",
         "missingProtocolMember": "Member \"{name}\" ist in Protokollklasse \"{classType}\" deklariert.",

--- a/packages/pyright-internal/src/localization/package.nls.es.json
+++ b/packages/pyright-internal/src/localization/package.nls.es.json
@@ -642,7 +642,7 @@
         "memberSetClassVar": "El miembro \"{name}\" no se puede asignar a través de una instancia de clase porque es un ClassVar.",
         "memberTypeMismatch": "\"{name}\" es un tipo incompatible",
         "memberUnknown": "El miembro \"{name}\" es desconocido",
-        "metaclassConflict": "Metaclass \"{metaclass1}\" conflicts with \"{metaclass2}\"",
+        "metaclassConflict": "La metaclase \"{metaclass1}\" entra en conflicto con \"{metaclass2}\"",
         "missingDeleter": "Falta el método de eliminación de propiedades",
         "missingGetter": "Falta el método Getter de la propiedad",
         "missingProtocolMember": "El miembro \"{name}\" está declarado en la clase de protocolo \"{classType}\"",

--- a/packages/pyright-internal/src/localization/package.nls.fr.json
+++ b/packages/pyright-internal/src/localization/package.nls.fr.json
@@ -642,7 +642,7 @@
         "memberSetClassVar": "Le membre \"{name}\" ne peut pas être attribué via une instance de classe car il s'agit d'une ClassVar",
         "memberTypeMismatch": "« {name} » est un type incompatible",
         "memberUnknown": "Le membre « {name} » est inconnu",
-        "metaclassConflict": "Metaclass \"{metaclass1}\" conflicts with \"{metaclass2}\"",
+        "metaclassConflict": "La métaclasse « {metaclass1} » est en conflit avec « {metaclass2} »",
         "missingDeleter": "La méthode de suppression de propriétés est manquante",
         "missingGetter": "La méthode getter de propriété est manquante",
         "missingProtocolMember": "Le membre « {name} » est déclaré dans la classe de protocole « {classType} »",

--- a/packages/pyright-internal/src/localization/package.nls.it.json
+++ b/packages/pyright-internal/src/localization/package.nls.it.json
@@ -642,7 +642,7 @@
         "memberSetClassVar": "Non è possibile assegnare il membro \"{name}\" tramite un'istanza di classe perché è una ClassVar",
         "memberTypeMismatch": "\"{name}\" è un tipo non compatibile",
         "memberUnknown": "Il membro \"{name}\" è sconosciuto",
-        "metaclassConflict": "Metaclass \"{metaclass1}\" conflicts with \"{metaclass2}\"",
+        "metaclassConflict": "La metaclasse \"{metaclass1}\" è in conflitto con \"{metaclass2}\"",
         "missingDeleter": "Manca il metodo di eliminazione delle proprietà",
         "missingGetter": "Metodo getter proprietà mancante",
         "missingProtocolMember": "Il \"{name}\" membro è dichiarato nella classe di protocollo \"{classType}\"",

--- a/packages/pyright-internal/src/localization/package.nls.ja.json
+++ b/packages/pyright-internal/src/localization/package.nls.ja.json
@@ -642,7 +642,7 @@
         "memberSetClassVar": "メンバー \"{name}\" は ClassVar であるため、クラス インスタンスを介して割り当てることはできません",
         "memberTypeMismatch": "\"{name}\" は互換性のない型です",
         "memberUnknown": "メンバー \"{name}\" が不明です",
-        "metaclassConflict": "Metaclass \"{metaclass1}\" conflicts with \"{metaclass2}\"",
+        "metaclassConflict": "メタクラス \"{metaclass1}\" が \"{metaclass2}\" と競合しています",
         "missingDeleter": "プロパティ削除メソッドがありません",
         "missingGetter": "プロパティ getter メソッドがありません",
         "missingProtocolMember": "メンバー \"{name}\" はプロトコル クラス \"{classType}\" で宣言されています",

--- a/packages/pyright-internal/src/localization/package.nls.ko.json
+++ b/packages/pyright-internal/src/localization/package.nls.ko.json
@@ -642,7 +642,7 @@
         "memberSetClassVar": "‘{name}’ 멤버는 ClassVar이므로 클래스 인스턴스를 통해 할당할 수 없습니다.",
         "memberTypeMismatch": "\"{name}\"은(는) 호환되지 않는 형식입니다.",
         "memberUnknown": "멤버 \"{name}\"을(를) 알 수 없습니다.",
-        "metaclassConflict": "Metaclass \"{metaclass1}\" conflicts with \"{metaclass2}\"",
+        "metaclassConflict": "메타클래스 \"{metaclass1}\"이(가) \"{metaclass2}\"과(와) 충돌합니다.",
         "missingDeleter": "속성 삭제자 메서드가 없습니다.",
         "missingGetter": "속성 getter 메서드가 없습니다.",
         "missingProtocolMember": "\"{name}\" 멤버가 프로토콜 클래스 \"{classType}\"로 선언되었습니다.",

--- a/packages/pyright-internal/src/localization/package.nls.pl.json
+++ b/packages/pyright-internal/src/localization/package.nls.pl.json
@@ -642,7 +642,7 @@
         "memberSetClassVar": "Nie można przypisać składowej „{name}” przez wystąpienie klasy, ponieważ jest to element ClassVar",
         "memberTypeMismatch": "Nazwa „{name}” jest niezgodnym typem",
         "memberUnknown": "Składowa „{name}” jest nieznana",
-        "metaclassConflict": "Metaclass \"{metaclass1}\" conflicts with \"{metaclass2}\"",
+        "metaclassConflict": "Metaklasa „{metaclass1}” powoduje konflikt z „{metaclass2}”",
         "missingDeleter": "Brak metody usuwania właściwości",
         "missingGetter": "Brak metody pobierającej właściwości",
         "missingProtocolMember": "Składowa „{name}” jest zadeklarowana w klasie protokołu „{classType}”",

--- a/packages/pyright-internal/src/localization/package.nls.pt-br.json
+++ b/packages/pyright-internal/src/localization/package.nls.pt-br.json
@@ -642,7 +642,7 @@
         "memberSetClassVar": "O membro \"{name}\" não pode ser atribuído por meio de uma instância de classe porque é um ClassVar",
         "memberTypeMismatch": "\"{name}\" é um tipo incompatível",
         "memberUnknown": "O membro \"{name}\" é desconhecido",
-        "metaclassConflict": "Metaclass \"{metaclass1}\" conflicts with \"{metaclass2}\"",
+        "metaclassConflict": "A metaclasse \"{metaclass1}\" entra em conflito com \"{metaclass2}\"",
         "missingDeleter": "O método de exclusão de propriedade está ausente",
         "missingGetter": "O método getter da propriedade está ausente",
         "missingProtocolMember": "O membro \"{name}\" está declarado na classe de protocolo \"{classType}\"",

--- a/packages/pyright-internal/src/localization/package.nls.ru.json
+++ b/packages/pyright-internal/src/localization/package.nls.ru.json
@@ -642,7 +642,7 @@
         "memberSetClassVar": "Элемент \"{name}\" не может быть назначен через экземпляр класса, так как это ClassVar",
         "memberTypeMismatch": "\"{name}\" является несовместимым типом",
         "memberUnknown": "Элемент \"{name}\" неизвестен",
-        "metaclassConflict": "Metaclass \"{metaclass1}\" conflicts with \"{metaclass2}\"",
+        "metaclassConflict": "Метакласс \"{metaclass1}\" конфликтует с \"{metaclass2}\"",
         "missingDeleter": "Отсутствует метод удаления свойства",
         "missingGetter": "Отсутствует метод получения свойства",
         "missingProtocolMember": "Элемент \"{name}\" объявлен в классе протокола \"{classType}\"",

--- a/packages/pyright-internal/src/localization/package.nls.tr.json
+++ b/packages/pyright-internal/src/localization/package.nls.tr.json
@@ -642,7 +642,7 @@
         "memberSetClassVar": "\"{name}\" üyesi bir ClassVar olduğundan sınıf örneği aracılığıyla atanamaz",
         "memberTypeMismatch": "\"{name}\" uyumsuz bir tür",
         "memberUnknown": "\"{name}\" üyesi bilinmiyor",
-        "metaclassConflict": "Metaclass \"{metaclass1}\" conflicts with \"{metaclass2}\"",
+        "metaclassConflict": "Metaclass \"{metaclass1}\", \"{metaclass2}\" ile çakışıyor",
         "missingDeleter": "Özellik silici metodu eksik",
         "missingGetter": "Özellik alıcı metodu eksik",
         "missingProtocolMember": "\"{name}\" üyesi \"{classType}\" protokol sınıfında bildirildi",

--- a/packages/pyright-internal/src/localization/package.nls.zh-cn.json
+++ b/packages/pyright-internal/src/localization/package.nls.zh-cn.json
@@ -642,7 +642,7 @@
         "memberSetClassVar": "无法通过类实例分配成员“{name}”，因为它是 ClassVar",
         "memberTypeMismatch": "\"{name}\"是不兼容的类型",
         "memberUnknown": "成员\"{name}\"未知",
-        "metaclassConflict": "Metaclass \"{metaclass1}\" conflicts with \"{metaclass2}\"",
+        "metaclassConflict": "元类“{metaclass1}”与“{metaclass2}”存在冲突",
         "missingDeleter": "缺少属性 deleter方法",
         "missingGetter": "缺少属性 getter 方法",
         "missingProtocolMember": "成员\"{name}\"已在协议类\"{classType}\"中声明",

--- a/packages/pyright-internal/src/localization/package.nls.zh-tw.json
+++ b/packages/pyright-internal/src/localization/package.nls.zh-tw.json
@@ -642,7 +642,7 @@
         "memberSetClassVar": "無法透過類別執行個體指派成員 \"{name}\"，因為它是 ClassVar",
         "memberTypeMismatch": "\"{name}\" 是不相容的類型",
         "memberUnknown": "成員 \"{name}\" 未知",
-        "metaclassConflict": "Metaclass \"{metaclass1}\" conflicts with \"{metaclass2}\"",
+        "metaclassConflict": "Metaclass「{metaclass1}」與「{metaclass2}」衝突",
         "missingDeleter": "屬性 deleter 方法遺失",
         "missingGetter": "屬性 getter 方法遺失",
         "missingProtocolMember": "成員 \"{name}\" 已在通訊協定類別 \"{classType}\" 中宣告",

--- a/packages/pyright-internal/src/tests/fourslash/completions.importInterimFile.fourslash.disabled.ts
+++ b/packages/pyright-internal/src/tests/fourslash/completions.importInterimFile.fourslash.disabled.ts
@@ -34,7 +34,7 @@
         },
     });
 
-    helper.replace(helper.BOF, helper.getPosition('marker1'), 'import altair as alt\n\nalt.');
+    helper.replace(helper.BOF, helper.getMarkerByName('marker1').position, 'import altair as alt\n\nalt.');
 
     // @ts-ignore
     await helper.verifyCompletion('included', 'markdown', {

--- a/packages/pyright-internal/src/tests/fourslash/fourslash.ts
+++ b/packages/pyright-internal/src/tests/fourslash/fourslash.ts
@@ -233,7 +233,7 @@ declare namespace _ {
             predicate: (m: Marker | undefined, d: T | undefined, text: string) => boolean
         ): Range[];
         getPositionRange(markerString: string): PositionRange;
-        getPosition(markerString: string): number;
+        getPosition(markerString: string): Position;
         get BOF(): number;
         get EOF(): number;
         expandPositionRange(range: PositionRange, start: number, end: number): PositionRange;

--- a/packages/pyright-internal/src/tests/harness/fourslash/testState.ts
+++ b/packages/pyright-internal/src/tests/harness/fourslash/testState.ts
@@ -326,13 +326,13 @@ export class TestState {
         return this.convertPositionRange(range);
     }
 
-    getPosition(markerString: string): number {
+    getPosition(markerString: string): Position {
         const marker = this.getMarkerByName(markerString);
         const ranges = this.getRanges().filter((r) => r.marker === marker);
         if (ranges.length !== 1) {
             this.raiseError(`no matching range for ${markerString}`);
         }
-        return marker.position;
+        return this.convertOffsetToPosition(marker.fileName, marker.position);
     }
 
     expandPositionRange(range: PositionRange, start: number, end: number) {

--- a/packages/pyright-internal/src/tests/harness/vfs/filesystem.ts
+++ b/packages/pyright-internal/src/tests/harness/vfs/filesystem.ts
@@ -90,7 +90,7 @@ export class TestFileSystem implements FileSystem, TempFile {
         }
 
         let cwd = options.cwd;
-        if ((!cwd || !pathUtil.isDiskPathRoot(cwd)) && this._lazy.links) {
+        if ((!cwd || (!pathUtil.isDiskPathRoot(cwd) && !pathUtil.isUri(cwd))) && this._lazy.links) {
             const iterator = getIterator(this._lazy.links.keys());
             try {
                 for (let i = nextResult(iterator); i; i = nextResult(iterator)) {

--- a/packages/pyright-internal/src/tests/pathUtils.test.ts
+++ b/packages/pyright-internal/src/tests/pathUtils.test.ts
@@ -23,6 +23,7 @@ import {
     ensureTrailingDirectorySeparator,
     getAnyExtensionFromPath,
     getBaseFileName,
+    getDirectoryPath,
     getFileExtension,
     getFileName,
     getPathComponents,
@@ -35,6 +36,7 @@ import {
     isDirectoryWildcardPatternPresent,
     isFileSystemCaseSensitiveInternal,
     isRootedDiskPath,
+    isUri,
     normalizeSlashes,
     realCasePath,
     reducePathComponents,
@@ -89,9 +91,27 @@ test('getPathComponents6', () => {
     assert.equal(components[3], 'file.py');
 });
 
+test('getPathComponents7', () => {
+    const components = getPathComponents('ab:cdef/test');
+    assert.equal(components.length, 3);
+    assert.equal(components[0], 'ab:');
+    assert.equal(components[1], 'cdef');
+    assert.equal(components[2], 'test');
+});
+
 test('combinePaths1', () => {
     const p = combinePaths('/user', '1', '2', '3');
     assert.equal(p, normalizeSlashes('/user/1/2/3'));
+});
+
+test('combinePaths2', () => {
+    const p = combinePaths('/foo', 'ab:c');
+    assert.equal(p, normalizeSlashes('/foo/ab:c'));
+});
+
+test('combinePaths3', () => {
+    const p = combinePaths('untitled:foo', 'ab:c');
+    assert.equal(p, normalizeSlashes('untitled:foo/ab%3Ac'));
 });
 
 test('ensureTrailingDirectorySeparator1', () => {
@@ -362,7 +382,7 @@ test('getRootLength7', () => {
 });
 
 test('getRootLength8', () => {
-    assert.equal(getRootLength('scheme:/no/authority'), 8);
+    assert.equal(getRootLength('scheme:/no/authority'), 7);
 });
 
 test('getRootLength9', () => {
@@ -404,6 +424,24 @@ test('getRelativePath', () => {
     );
 });
 
+test('getDirectoryPath', () => {
+    assert.equal(getDirectoryPath(normalizeSlashes('/a/b/c/d/e/f')), normalizeSlashes('/a/b/c/d/e'));
+    assert.equal(
+        getDirectoryPath(normalizeSlashes('untitled:/a/b/c/d/e/f?query#frag')),
+        normalizeSlashes('untitled:/a/b/c/d/e')
+    );
+});
+
+test('isUri', () => {
+    assert.ok(isUri('untitled:/a/b/c/d/e/f?query#frag'));
+    assert.ok(isUri('untitled:/a/b/c/d/e/f'));
+    assert.ok(isUri('untitled:a/b/c/d/e/f'));
+    assert.ok(isUri('untitled:/a/b/c/d/e/f?query'));
+    assert.ok(isUri('untitled:/a/b/c/d/e/f#frag'));
+    assert.ok(!isUri('c:/foo/bar'));
+    assert.ok(!isUri('c:/foo#/bar'));
+    assert.ok(!isUri('222/dd:/foo/bar'));
+});
 test('CaseSensitivity', () => {
     const cwd = normalizeSlashes('/');
 

--- a/packages/pyright-internal/src/tests/zipfs.test.ts
+++ b/packages/pyright-internal/src/tests/zipfs.test.ts
@@ -19,6 +19,8 @@ function runTests(p: string): void {
         const stats = fs.statSync(zipRoot);
         assert.strictEqual(stats.isDirectory(), true);
         assert.strictEqual(stats.isFile(), false);
+        assert.strictEqual((stats as any).isZipDirectory(), true);
+        assert.strictEqual(stats.isSymbolicLink(), false);
     });
 
     test('readdirEntriesSync root', () => {


### PR DESCRIPTION
rollup of the following changes:
    1. pylance loc update 20231031.1 https://github.com/microsoft/pyrx/pull/4266
    2. Fix URI mapping for wsl https://github.com/microsoft/pyrx/pull/4255
    3. Fix crash when calling `isSymbolicLink` on `stat` of zip/egg https://github.com/microsoft/pyrx/pull/4254
    4. Fix potential issue with query parameters in a URI https://github.com/microsoft/pyrx/pull/4245
    5. don't always look for pyTyped since it is expensive
    6. fixed build failures
  
    Co-authored-by: Bill Schnurr <bschnurr@microsoft.com>
    Co-authored-by: HeeJae Chang <hechang@microsoft.com>
    Co-authored-by: Erik De Bonte <erikd@microsoft.com>
    Co-authored-by: Rich Chiodo <rchiodo@microsoft.com>
    Co-authored-by: Stella Huang <stellahuang@microsoft.com>
    