### PR TITLE
Another round of simplifying member accesses — and in particular, met…

### DIFF
--- a/packages/pyright-internal/src/analyzer/checker.ts
+++ b/packages/pyright-internal/src/analyzer/checker.ts
@@ -1678,10 +1678,10 @@ export class Checker extends ParseTreeWalker {
             }
 
             // Invoke the __bool__ method on the type.
-            const boolReturnType = this._evaluator.getTypeOfMagicMethodReturn(
+            const boolReturnType = this._evaluator.getTypeOfMagicMethodCall(
                 expandedSubtype,
-                [],
                 '__bool__',
+                [],
                 node,
                 /* inferenceContext */ undefined
             );
@@ -6553,7 +6553,8 @@ export class Checker extends ParseTreeWalker {
                     this._evaluator.getTypeOfIterator(
                         { type: exceptionType },
                         /* isAsync */ false,
-                        /* errorNode */ undefined
+                        /* errorNode */ except.typeExpression,
+                        /* emitNotIterableError */ false
                     )?.type ?? UnknownType.create();
 
                 doForEachSubtype(iterableType, (subtype) => {

--- a/packages/pyright-internal/src/analyzer/enums.ts
+++ b/packages/pyright-internal/src/analyzer/enums.ts
@@ -345,8 +345,12 @@ export function transformTypeForPossibleEnumClass(
         // a special case.
         if (isUnpackedTuple) {
             valueType =
-                evaluator.getTypeOfIterator({ type: valueType }, /* isAsync */ false, /* errorNode */ undefined)
-                    ?.type ?? UnknownType.create();
+                evaluator.getTypeOfIterator(
+                    { type: valueType },
+                    /* isAsync */ false,
+                    node,
+                    /* emitNotIterableError */ false
+                )?.type ?? UnknownType.create();
         }
     }
 

--- a/packages/pyright-internal/src/analyzer/operations.ts
+++ b/packages/pyright-internal/src/analyzer/operations.ts
@@ -177,10 +177,10 @@ export function validateBinaryOperation(
                                 return preserveUnknown(leftSubtype, rightSubtypeExpanded);
                             }
 
-                            let returnType = evaluator.getTypeOfMagicMethodReturn(
+                            let returnType = evaluator.getTypeOfMagicMethodCall(
                                 rightSubtypeExpanded,
-                                [{ type: leftSubtype, isIncomplete: leftTypeResult.isIncomplete }],
                                 '__contains__',
+                                [{ type: leftSubtype, isIncomplete: leftTypeResult.isIncomplete }],
                                 errorNode,
                                 /* inferenceContext */ undefined
                             );
@@ -191,7 +191,8 @@ export function validateBinaryOperation(
                                 const iteratorType = evaluator.getTypeOfIterator(
                                     { type: rightSubtypeExpanded, isIncomplete: rightTypeResult.isIncomplete },
                                     /* isAsync */ false,
-                                    /* errorNode */ undefined
+                                    errorNode,
+                                    /* emitNotIterableError */ false
                                 )?.type;
 
                                 if (iteratorType && evaluator.assignType(iteratorType, leftSubtype)) {
@@ -384,20 +385,20 @@ export function validateBinaryOperation(
                             }
 
                             const magicMethodName = binaryOperatorMap[operator][0];
-                            let resultType = evaluator.getTypeOfMagicMethodReturn(
+                            let resultType = evaluator.getTypeOfMagicMethodCall(
                                 convertFunctionToObject(evaluator, leftSubtypeUnexpanded),
-                                [{ type: rightSubtypeUnexpanded, isIncomplete: rightTypeResult.isIncomplete }],
                                 magicMethodName,
+                                [{ type: rightSubtypeUnexpanded, isIncomplete: rightTypeResult.isIncomplete }],
                                 errorNode,
                                 inferenceContext
                             );
 
                             if (!resultType && leftSubtypeUnexpanded !== leftSubtypeExpanded) {
                                 // Try the expanded left type.
-                                resultType = evaluator.getTypeOfMagicMethodReturn(
+                                resultType = evaluator.getTypeOfMagicMethodCall(
                                     convertFunctionToObject(evaluator, leftSubtypeExpanded),
-                                    [{ type: rightSubtypeUnexpanded, isIncomplete: rightTypeResult.isIncomplete }],
                                     magicMethodName,
+                                    [{ type: rightSubtypeUnexpanded, isIncomplete: rightTypeResult.isIncomplete }],
                                     errorNode,
                                     inferenceContext
                                 );
@@ -405,10 +406,10 @@ export function validateBinaryOperation(
 
                             if (!resultType && rightSubtypeUnexpanded !== rightSubtypeExpanded) {
                                 // Try the expanded left and right type.
-                                resultType = evaluator.getTypeOfMagicMethodReturn(
+                                resultType = evaluator.getTypeOfMagicMethodCall(
                                     convertFunctionToObject(evaluator, leftSubtypeExpanded),
-                                    [{ type: rightSubtypeExpanded, isIncomplete: rightTypeResult.isIncomplete }],
                                     magicMethodName,
+                                    [{ type: rightSubtypeExpanded, isIncomplete: rightTypeResult.isIncomplete }],
                                     errorNode,
                                     inferenceContext
                                 );
@@ -417,25 +418,25 @@ export function validateBinaryOperation(
                             if (!resultType) {
                                 // Try the alternate form (swapping right and left).
                                 const altMagicMethodName = binaryOperatorMap[operator][1];
-                                resultType = evaluator.getTypeOfMagicMethodReturn(
+                                resultType = evaluator.getTypeOfMagicMethodCall(
                                     convertFunctionToObject(evaluator, rightSubtypeUnexpanded),
-                                    [{ type: leftSubtypeUnexpanded, isIncomplete: leftTypeResult.isIncomplete }],
                                     altMagicMethodName,
+                                    [{ type: leftSubtypeUnexpanded, isIncomplete: leftTypeResult.isIncomplete }],
                                     errorNode,
                                     inferenceContext
                                 );
 
                                 if (!resultType && rightSubtypeUnexpanded !== rightSubtypeExpanded) {
                                     // Try the expanded right type.
-                                    resultType = evaluator.getTypeOfMagicMethodReturn(
+                                    resultType = evaluator.getTypeOfMagicMethodCall(
                                         convertFunctionToObject(evaluator, rightSubtypeExpanded),
+                                        altMagicMethodName,
                                         [
                                             {
                                                 type: leftSubtypeUnexpanded,
                                                 isIncomplete: leftTypeResult.isIncomplete,
                                             },
                                         ],
-                                        altMagicMethodName,
                                         errorNode,
                                         inferenceContext
                                     );
@@ -443,10 +444,10 @@ export function validateBinaryOperation(
 
                                 if (!resultType && leftSubtypeUnexpanded !== leftSubtypeExpanded) {
                                     // Try the expanded right and left type.
-                                    resultType = evaluator.getTypeOfMagicMethodReturn(
+                                    resultType = evaluator.getTypeOfMagicMethodCall(
                                         convertFunctionToObject(evaluator, rightSubtypeExpanded),
-                                        [{ type: leftSubtypeExpanded, isIncomplete: leftTypeResult.isIncomplete }],
                                         altMagicMethodName,
+                                        [{ type: leftSubtypeExpanded, isIncomplete: leftTypeResult.isIncomplete }],
                                         errorNode,
                                         inferenceContext
                                     );
@@ -825,20 +826,20 @@ export function getTypeOfAugmentedAssignment(
                         }
 
                         const magicMethodName = operatorMap[node.operator][0];
-                        let returnType = evaluator.getTypeOfMagicMethodReturn(
+                        let returnType = evaluator.getTypeOfMagicMethodCall(
                             leftSubtypeUnexpanded,
-                            [{ type: rightSubtypeUnexpanded, isIncomplete: rightTypeResult.isIncomplete }],
                             magicMethodName,
+                            [{ type: rightSubtypeUnexpanded, isIncomplete: rightTypeResult.isIncomplete }],
                             node,
                             inferenceContext
                         );
 
                         if (!returnType && leftSubtypeUnexpanded !== leftSubtypeExpanded) {
                             // Try with the expanded left type.
-                            returnType = evaluator.getTypeOfMagicMethodReturn(
+                            returnType = evaluator.getTypeOfMagicMethodCall(
                                 leftSubtypeExpanded,
-                                [{ type: rightSubtypeUnexpanded, isIncomplete: rightTypeResult.isIncomplete }],
                                 magicMethodName,
+                                [{ type: rightSubtypeUnexpanded, isIncomplete: rightTypeResult.isIncomplete }],
                                 node,
                                 inferenceContext
                             );
@@ -846,10 +847,10 @@ export function getTypeOfAugmentedAssignment(
 
                         if (!returnType && rightSubtypeUnexpanded !== rightSubtypeExpanded) {
                             // Try with the expanded left and right type.
-                            returnType = evaluator.getTypeOfMagicMethodReturn(
+                            returnType = evaluator.getTypeOfMagicMethodCall(
                                 leftSubtypeExpanded,
-                                [{ type: rightSubtypeExpanded, isIncomplete: rightTypeResult.isIncomplete }],
                                 magicMethodName,
+                                [{ type: rightSubtypeExpanded, isIncomplete: rightTypeResult.isIncomplete }],
                                 node,
                                 inferenceContext
                             );
@@ -997,7 +998,7 @@ export function getTypeOfUnaryOperation(
                 type = exprType;
             } else {
                 const magicMethodName = unaryOperatorMap[node.operator];
-                type = evaluator.getTypeOfMagicMethodReturn(exprType, [], magicMethodName, node, inferenceContext);
+                type = evaluator.getTypeOfMagicMethodCall(exprType, magicMethodName, [], node, inferenceContext);
             }
 
             if (!type) {

--- a/packages/pyright-internal/src/analyzer/patternMatching.ts
+++ b/packages/pyright-internal/src/analyzer/patternMatching.ts
@@ -1080,10 +1080,10 @@ function narrowTypeBasedOnValuePattern(
                         // Determine if assignment is supported for this combination of
                         // value subtype and matching subtype.
                         const returnType = evaluator.useSpeculativeMode(pattern.expression, () =>
-                            evaluator.getTypeOfMagicMethodReturn(
+                            evaluator.getTypeOfMagicMethodCall(
                                 valueSubtypeExpanded,
-                                [{ type: subjectSubtypeExpanded }],
                                 '__eq__',
+                                [{ type: subjectSubtypeExpanded }],
                                 pattern.expression,
                                 /* expectedType */ undefined
                             )

--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -2115,8 +2115,7 @@ export function createTypeEvaluator(importLookup: ImportLookup, evaluatorOptions
     function getBoundMethod(
         classType: ClassType,
         memberName: string,
-        recursionCount = 0,
-        treatConstructorAsClassMember = false
+        recursionCount = 0
     ): FunctionType | OverloadedFunctionType | undefined {
         const memberInfo = lookUpClassMember(classType, memberName, ClassMemberLookupFlags.SkipInstanceVariables);
 
@@ -2127,7 +2126,7 @@ export function createTypeEvaluator(importLookup: ImportLookup, evaluatorOptions
                     ClassType.cloneAsInstance(classType),
                     unboundMethodType,
                     /* memberClass */ undefined,
-                    treatConstructorAsClassMember,
+                    /* treatConstructorAsClassMember */ true,
                     /* selfType */ undefined,
                     /* diag */ undefined,
                     recursionCount
@@ -2261,12 +2260,7 @@ export function createTypeEvaluator(importLookup: ImportLookup, evaluatorOptions
                         // the `object` class or accepts only default parameters(* args, ** kwargs),
                         // see if we can find a better signature from the `__new__` method.
                         if (!methodType || isObjectInit || isDefaultParams) {
-                            const constructorType = getBoundMethod(
-                                subtype,
-                                '__new__',
-                                /* recursionCount */ undefined,
-                                /* treatConstructorAsClassMember */ true
-                            );
+                            const constructorType = getBoundMethod(subtype, '__new__');
 
                             if (constructorType) {
                                 // Is this the __new__ method provided by the object class?
@@ -2552,7 +2546,8 @@ export function createTypeEvaluator(importLookup: ImportLookup, evaluatorOptions
     function getTypeOfIterator(
         typeResult: TypeResult,
         isAsync: boolean,
-        errorNode: ExpressionNode | undefined
+        errorNode: ExpressionNode,
+        emitNotIterableError = true
     ): TypeResult | undefined {
         const iterMethodName = isAsync ? '__aiter__' : '__iter__';
         const nextMethodName = isAsync ? '__anext__' : '__next__';
@@ -2582,49 +2577,31 @@ export function createTypeEvaluator(importLookup: ImportLookup, evaluatorOptions
 
             const diag = new DiagnosticAddendum();
             if (isClass(subtype)) {
-                let iterReturnType: Type | undefined;
-
-                if (TypeBase.isInstance(subtype)) {
-                    // Handle an empty tuple specially.
-                    if (
-                        isTupleClass(subtype) &&
-                        subtype.tupleTypeArguments &&
-                        subtype.tupleTypeArguments.length === 0
-                    ) {
-                        return NeverType.createNever();
-                    }
-
-                    iterReturnType = getSpecializedReturnType(subtype, iterMethodName, [], errorNode);
-                } else if (
-                    TypeBase.isInstantiable(subtype) &&
-                    subtype.details.effectiveMetaclass &&
-                    isInstantiableClass(subtype.details.effectiveMetaclass)
+                // Handle an empty tuple specially.
+                if (
+                    TypeBase.isInstance(subtype) &&
+                    isTupleClass(subtype) &&
+                    subtype.tupleTypeArguments &&
+                    subtype.tupleTypeArguments.length === 0
                 ) {
-                    iterReturnType = getSpecializedReturnType(
-                        ClassType.cloneAsInstance(subtype.details.effectiveMetaclass),
-                        iterMethodName,
-                        [],
-                        errorNode,
-                        subtype
-                    );
+                    return NeverType.createNever();
                 }
+
+                const iterReturnType = getTypeOfMagicMethodCall(subtype, iterMethodName, [], errorNode);
 
                 if (!iterReturnType) {
                     // There was no __iter__. See if we can fall back to
                     // the __getitem__ method instead.
                     if (!isAsync && isClassInstance(subtype)) {
-                        const getItemReturnType = getSpecializedReturnType(
+                        const getItemReturnType = getTypeOfMagicMethodCall(
                             subtype,
                             '__getitem__',
                             [
                                 {
-                                    argumentCategory: ArgumentCategory.Simple,
-                                    typeResult: {
-                                        type:
-                                            intClassType && isInstantiableClass(intClassType)
-                                                ? ClassType.cloneAsInstance(intClassType)
-                                                : UnknownType.create(),
-                                    },
+                                    type:
+                                        intClassType && isInstantiableClass(intClassType)
+                                            ? ClassType.cloneAsInstance(intClassType)
+                                            : UnknownType.create(),
                                 },
                             ],
                             errorNode
@@ -2647,7 +2624,7 @@ export function createTypeEvaluator(importLookup: ImportLookup, evaluatorOptions
                             }
 
                             if (isClassInstance(subtype)) {
-                                let nextReturnType = getSpecializedReturnType(subtype, nextMethodName, [], errorNode);
+                                let nextReturnType = getTypeOfMagicMethodCall(subtype, nextMethodName, [], errorNode);
 
                                 if (!nextReturnType) {
                                     iterReturnTypeDiag.addMessage(
@@ -2693,7 +2670,7 @@ export function createTypeEvaluator(importLookup: ImportLookup, evaluatorOptions
                 }
             }
 
-            if (errorNode && !typeResult.isIncomplete) {
+            if (!typeResult.isIncomplete && emitNotIterableError) {
                 addDiagnostic(
                     AnalyzerNodeInfo.getFileInfo(errorNode).diagnosticRuleSet.reportGeneralTypeIssues,
                     DiagnosticRule.reportGeneralTypeIssues,
@@ -2713,7 +2690,8 @@ export function createTypeEvaluator(importLookup: ImportLookup, evaluatorOptions
     function getTypeOfIterable(
         typeResult: TypeResult,
         isAsync: boolean,
-        errorNode: ExpressionNode | undefined
+        errorNode: ExpressionNode,
+        emitNotIterableError = true
     ): TypeResult | undefined {
         const iterMethodName = isAsync ? '__aiter__' : '__iter__';
         let isValidIterable = true;
@@ -2738,30 +2716,14 @@ export function createTypeEvaluator(importLookup: ImportLookup, evaluatorOptions
             }
 
             if (isClass(subtype)) {
-                let iterReturnType: Type | undefined;
-
-                if (TypeBase.isInstance(subtype)) {
-                    iterReturnType = getSpecializedReturnType(subtype, iterMethodName, [], errorNode);
-                } else if (
-                    TypeBase.isInstantiable(subtype) &&
-                    subtype.details.effectiveMetaclass &&
-                    isInstantiableClass(subtype.details.effectiveMetaclass)
-                ) {
-                    iterReturnType = getSpecializedReturnType(
-                        ClassType.cloneAsInstance(subtype.details.effectiveMetaclass),
-                        iterMethodName,
-                        [],
-                        errorNode,
-                        subtype
-                    );
-                }
+                const iterReturnType = getTypeOfMagicMethodCall(subtype, iterMethodName, [], errorNode);
 
                 if (iterReturnType) {
                     return makeTopLevelTypeVarsConcrete(iterReturnType);
                 }
             }
 
-            if (errorNode) {
+            if (emitNotIterableError) {
                 addDiagnostic(
                     AnalyzerNodeInfo.getFileInfo(errorNode).diagnosticRuleSet.reportGeneralTypeIssues,
                     DiagnosticRule.reportGeneralTypeIssues,
@@ -4248,60 +4210,6 @@ export function createTypeEvaluator(importLookup: ImportLookup, evaluatorOptions
         if (!isSpeculativeModeInUse(node)) {
             fileInfo.accessedSymbolSet.add(symbol.id);
         }
-    }
-
-    function getSpecializedReturnType(
-        objType: ClassType,
-        memberName: string,
-        argList: FunctionArgument[],
-        errorNode: ExpressionNode | undefined,
-        bindToClass?: ClassType
-    ) {
-        const classMember = lookUpObjectMember(objType, memberName, ClassMemberLookupFlags.SkipInstanceVariables);
-        if (!classMember) {
-            return undefined;
-        }
-
-        const memberTypeResult = getTypeOfMemberInternal(classMember, objType);
-        if (!memberTypeResult) {
-            return undefined;
-        }
-
-        const memberType = memberTypeResult.type;
-        if (isAnyOrUnknown(memberType)) {
-            return memberType;
-        }
-
-        if (isFunction(memberType) || isOverloadedFunction(memberType)) {
-            const methodType = bindFunctionToClassOrObjectWithErrors(
-                bindToClass ?? objType,
-                memberType,
-                classMember && isInstantiableClass(classMember.classType) ? classMember.classType : undefined,
-                errorNode,
-                /* treatConstructorAsClassMember */ false,
-                /* selfType */ bindToClass
-            );
-
-            if (methodType) {
-                if (isOverloadedFunction(methodType)) {
-                    if (errorNode) {
-                        const bestOverload = getBestOverloadForArguments(
-                            errorNode,
-                            { type: methodType, isIncomplete: memberTypeResult.isIncomplete },
-                            argList
-                        );
-
-                        if (bestOverload) {
-                            return getFunctionEffectiveReturnType(bestOverload);
-                        }
-                    }
-                } else {
-                    return getFunctionEffectiveReturnType(methodType);
-                }
-            }
-        }
-
-        return undefined;
     }
 
     function getTypeOfName(node: NameNode, flags: EvaluatorFlags): TypeResult {
@@ -12680,12 +12588,12 @@ export function createTypeEvaluator(importLookup: ImportLookup, evaluatorOptions
         return { type: type ?? UnknownType.create() };
     }
 
-    function getTypeOfMagicMethodReturn(
+    function getTypeOfMagicMethodCall(
         objType: Type,
-        args: TypeResult[],
-        magicMethodName: string,
+        methodName: string,
+        argList: TypeResult[],
         errorNode: ExpressionNode,
-        inferenceContext: InferenceContext | undefined
+        inferenceContext?: InferenceContext
     ): Type | undefined {
         let magicMethodSupported = true;
 
@@ -12698,7 +12606,7 @@ export function createTypeEvaluator(importLookup: ImportLookup, evaluatorOptions
                 magicMethodType = getTypeOfObjectMember(
                     errorNode,
                     concreteSubtype,
-                    magicMethodName,
+                    methodName,
                     /* usage */ undefined,
                     /* diag */ undefined,
                     MemberAccessFlags.AccessClassMembersOnly | MemberAccessFlags.SkipAttributeAccessOverride
@@ -12706,7 +12614,7 @@ export function createTypeEvaluator(importLookup: ImportLookup, evaluatorOptions
             }
 
             if (magicMethodType) {
-                const functionArgs: FunctionArgument[] = args.map((arg) => {
+                const functionArgs: FunctionArgument[] = argList.map((arg) => {
                     return {
                         argumentCategory: ArgumentCategory.Simple,
                         typeResult: arg,
@@ -13907,7 +13815,8 @@ export function createTypeEvaluator(importLookup: ImportLookup, evaluatorOptions
             expectedElementType = getTypeOfIterator(
                 { type: inferenceContext.expectedType },
                 isAsync,
-                /* errorNode */ undefined
+                node,
+                /* emitNotIterableError */ false
             )?.type;
         }
 
@@ -18071,10 +17980,10 @@ export function createTypeEvaluator(importLookup: ImportLookup, evaluatorOptions
             const additionalHelp = new DiagnosticAddendum();
 
             if (isClass(subtype)) {
-                let enterType = getTypeOfMagicMethodReturn(
+                let enterType = getTypeOfMagicMethodCall(
                     subtype,
-                    [],
                     enterMethodName,
+                    [],
                     node.expression,
                     /* inferenceContext */ undefined
                 );
@@ -18090,10 +17999,10 @@ export function createTypeEvaluator(importLookup: ImportLookup, evaluatorOptions
 
                 if (!isAsync) {
                     if (
-                        getTypeOfMagicMethodReturn(
+                        getTypeOfMagicMethodCall(
                             subtype,
-                            [],
                             '__aenter__',
+                            [],
                             node.expression,
                             /* inferenceContext */ undefined
                         )
@@ -18125,10 +18034,10 @@ export function createTypeEvaluator(importLookup: ImportLookup, evaluatorOptions
 
             if (isClass(subtype)) {
                 const anyArg: TypeResult = { type: AnyType.create() };
-                const exitType = getTypeOfMagicMethodReturn(
+                const exitType = getTypeOfMagicMethodCall(
                     subtype,
-                    [anyArg, anyArg, anyArg],
                     exitMethodName,
+                    [anyArg, anyArg, anyArg],
                     node.expression,
                     /* inferenceContext */ undefined
                 );
@@ -26064,7 +25973,7 @@ export function createTypeEvaluator(importLookup: ImportLookup, evaluatorOptions
         getTypeOfObjectMember,
         getTypeOfClassMemberName,
         getBoundMethod,
-        getTypeOfMagicMethodReturn,
+        getTypeOfMagicMethodCall,
         bindFunctionToClassOrObject,
         getCallSignatureInfo,
         getAbstractMethods,

--- a/packages/pyright-internal/src/analyzer/typeEvaluatorTypes.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluatorTypes.ts
@@ -534,12 +534,14 @@ export interface TypeEvaluator {
     getTypeOfIterable: (
         typeResult: TypeResult,
         isAsync: boolean,
-        errorNode: ExpressionNode | undefined
+        errorNode: ExpressionNode,
+        emitNotIterableError?: boolean
     ) => TypeResult | undefined;
     getTypeOfIterator: (
         typeResult: TypeResult,
         isAsync: boolean,
-        errorNode: ExpressionNode | undefined
+        errorNode: ExpressionNode,
+        emitNotIterableError?: boolean
     ) => TypeResult | undefined;
     getGetterTypeFromProperty: (propertyClass: ClassType, inferTypeIfNeeded: boolean) => Type | undefined;
     getTypeOfArgument: (arg: FunctionArgument) => TypeResult;
@@ -595,10 +597,10 @@ export interface TypeEvaluator {
         recursionCount?: number,
         treatConstructorAsClassMember?: boolean
     ) => FunctionType | OverloadedFunctionType | undefined;
-    getTypeOfMagicMethodReturn: (
+    getTypeOfMagicMethodCall: (
         objType: Type,
-        args: TypeResult[],
-        magicMethodName: string,
+        methodName: string,
+        argList: TypeResult[],
         errorNode: ExpressionNode,
         inferenceContext: InferenceContext | undefined
     ) => Type | undefined;


### PR DESCRIPTION
…hod accesses for magic methods. The previous code had redundant (and partially incomplete) methods for evaluating calls to magic methods. This change consolidates the code and eliminates various holes.