### PR TITLE
Another round of simplifying member accesses — and in particular, met…

### DIFF
--- a/packages/pyright-internal/src/analyzer/checker.ts
+++ b/packages/pyright-internal/src/analyzer/checker.ts
@@ -1678,10 +1678,10 @@ export class Checker extends ParseTreeWalker {
             }
 
             // Invoke the __bool__ method on the type.
-            const boolReturnType = this._evaluator.getTypeOfMagicMethodReturn(
+            const boolReturnType = this._evaluator.getTypeOfMagicMethodCall(
                 expandedSubtype,
-                [],
                 '__bool__',
+                [],
                 node,
                 /* inferenceContext */ undefined
             );
@@ -6553,7 +6553,8 @@ export class Checker extends ParseTreeWalker {
                     this._evaluator.getTypeOfIterator(
                         { type: exceptionType },
                         /* isAsync */ false,
-                        /* errorNode */ undefined
+                        /* errorNode */ except.typeExpression,
+                        /* emitNotIterableError */ false
                     )?.type ?? UnknownType.create();
 
                 doForEachSubtype(iterableType, (subtype) => {

--- a/packages/pyright-internal/src/analyzer/enums.ts
+++ b/packages/pyright-internal/src/analyzer/enums.ts
@@ -345,8 +345,12 @@ export function transformTypeForPossibleEnumClass(
         // a special case.
         if (isUnpackedTuple) {
             valueType =
-                evaluator.getTypeOfIterator({ type: valueType }, /* isAsync */ false, /* errorNode */ undefined)
-                    ?.type ?? UnknownType.create();
+                evaluator.getTypeOfIterator(
+                    { type: valueType },
+                    /* isAsync */ false,
+                    node,
+                    /* emitNotIterableError */ false
+                )?.type ?? UnknownType.create();
         }
     }
 

--- a/packages/pyright-internal/src/analyzer/operations.ts
+++ b/packages/pyright-internal/src/analyzer/operations.ts
@@ -177,10 +177,10 @@ export function validateBinaryOperation(
                                 return preserveUnknown(leftSubtype, rightSubtypeExpanded);
                             }
 
-                            let returnType = evaluator.getTypeOfMagicMethodReturn(
+                            let returnType = evaluator.getTypeOfMagicMethodCall(
                                 rightSubtypeExpanded,
-                                [{ type: leftSubtype, isIncomplete: leftTypeResult.isIncomplete }],
                                 '__contains__',
+                                [{ type: leftSubtype, isIncomplete: leftTypeResult.isIncomplete }],
                                 errorNode,
                                 /* inferenceContext */ undefined
                             );
@@ -191,7 +191,8 @@ export function validateBinaryOperation(
                                 const iteratorType = evaluator.getTypeOfIterator(
                                     { type: rightSubtypeExpanded, isIncomplete: rightTypeResult.isIncomplete },
                                     /* isAsync */ false,
-                                    /* errorNode */ undefined
+                                    errorNode,
+                                    /* emitNotIterableError */ false
                                 )?.type;
 
                                 if (iteratorType && evaluator.assignType(iteratorType, leftSubtype)) {
@@ -384,20 +385,20 @@ export function validateBinaryOperation(
                             }
 
                             const magicMethodName = binaryOperatorMap[operator][0];
-                            let resultType = evaluator.getTypeOfMagicMethodReturn(
+                            let resultType = evaluator.getTypeOfMagicMethodCall(
                                 convertFunctionToObject(evaluator, leftSubtypeUnexpanded),
-                                [{ type: rightSubtypeUnexpanded, isIncomplete: rightTypeResult.isIncomplete }],
                                 magicMethodName,
+                                [{ type: rightSubtypeUnexpanded, isIncomplete: rightTypeResult.isIncomplete }],
                                 errorNode,
                                 inferenceContext
                             );
 
                             if (!resultType && leftSubtypeUnexpanded !== leftSubtypeExpanded) {
                                 // Try the expanded left type.
-                                resultType = evaluator.getTypeOfMagicMethodReturn(
+                                resultType = evaluator.getTypeOfMagicMethodCall(
                                     convertFunctionToObject(evaluator, leftSubtypeExpanded),
-                                    [{ type: rightSubtypeUnexpanded, isIncomplete: rightTypeResult.isIncomplete }],
                                     magicMethodName,
+                                    [{ type: rightSubtypeUnexpanded, isIncomplete: rightTypeResult.isIncomplete }],
                                     errorNode,
                                     inferenceContext
                                 );
@@ -405,10 +406,10 @@ export function validateBinaryOperation(
 
                             if (!resultType && rightSubtypeUnexpanded !== rightSubtypeExpanded) {
                                 // Try the expanded left and right type.
-                                resultType = evaluator.getTypeOfMagicMethodReturn(
+                                resultType = evaluator.getTypeOfMagicMethodCall(
                                     convertFunctionToObject(evaluator, leftSubtypeExpanded),
-                                    [{ type: rightSubtypeExpanded, isIncomplete: rightTypeResult.isIncomplete }],
                                     magicMethodName,
+                                    [{ type: rightSubtypeExpanded, isIncomplete: rightTypeResult.isIncomplete }],
                                     errorNode,
                                     inferenceContext
                                 );
@@ -417,25 +418,25 @@ export function validateBinaryOperation(
                             if (!resultType) {
                                 // Try the alternate form (swapping right and left).
                                 const altMagicMethodName = binaryOperatorMap[operator][1];
-                                resultType = evaluator.getTypeOfMagicMethodReturn(
+                                resultType = evaluator.getTypeOfMagicMethodCall(
                                     convertFunctionToObject(evaluator, rightSubtypeUnexpanded),
-                                    [{ type: leftSubtypeUnexpanded, isIncomplete: leftTypeResult.isIncomplete }],
                                     altMagicMethodName,
+                                    [{ type: leftSubtypeUnexpanded, isIncomplete: leftTypeResult.isIncomplete }],
                                     errorNode,
                                     inferenceContext
                                 );
 
                                 if (!resultType && rightSubtypeUnexpanded !== rightSubtypeExpanded) {
                                     // Try the expanded right type.
-                                    resultType = evaluator.getTypeOfMagicMethodReturn(
+                                    resultType = evaluator.getTypeOfMagicMethodCall(
                                         convertFunctionToObject(evaluator, rightSubtypeExpanded),
+                                        altMagicMethodName,
                                         [
                                             {
                                                 type: leftSubtypeUnexpanded,
                                                 isIncomplete: leftTypeResult.isIncomplete,
                                             },
                                         ],
-                                        altMagicMethodName,
                                         errorNode,
                                         inferenceContext
                                     );
@@ -443,10 +444,10 @@ export function validateBinaryOperation(
 
                                 if (!resultType && leftSubtypeUnexpanded !== leftSubtypeExpanded) {
                                     // Try the expanded right and left type.
-                                    resultType = evaluator.getTypeOfMagicMethodReturn(
+                                    resultType = evaluator.getTypeOfMagicMethodCall(
                                         convertFunctionToObject(evaluator, rightSubtypeExpanded),
-                                        [{ type: leftSubtypeExpanded, isIncomplete: leftTypeResult.isIncomplete }],
                                         altMagicMethodName,
+                                        [{ type: leftSubtypeExpanded, isIncomplete: leftTypeResult.isIncomplete }],
                                         errorNode,
                                         inferenceContext
                                     );
@@ -825,20 +826,20 @@ export function getTypeOfAugmentedAssignment(
                         }
 
                         const magicMethodName = operatorMap[node.operator][0];
-                        let returnType = evaluator.getTypeOfMagicMethodReturn(
+                        let returnType = evaluator.getTypeOfMagicMethodCall(
                             leftSubtypeUnexpanded,
-                            [{ type: rightSubtypeUnexpanded, isIncomplete: rightTypeResult.isIncomplete }],
                             magicMethodName,
+                            [{ type: rightSubtypeUnexpanded, isIncomplete: rightTypeResult.isIncomplete }],
                             node,
                             inferenceContext
                         );
 
                         if (!returnType && leftSubtypeUnexpanded !== leftSubtypeExpanded) {
                             // Try with the expanded left type.
-                            returnType = evaluator.getTypeOfMagicMethodReturn(
+                            returnType = evaluator.getTypeOfMagicMethodCall(
                                 leftSubtypeExpanded,
-                                [{ type: rightSubtypeUnexpanded, isIncomplete: rightTypeResult.isIncomplete }],
                                 magicMethodName,
+                                [{ type: rightSubtypeUnexpanded, isIncomplete: rightTypeResult.isIncomplete }],
                                 node,
                                 inferenceContext
                             );
@@ -846,10 +847,10 @@ export function getTypeOfAugmentedAssignment(
 
                         if (!returnType && rightSubtypeUnexpanded !== rightSubtypeExpanded) {
                             // Try with the expanded left and right type.
-                            returnType = evaluator.getTypeOfMagicMethodReturn(
+                            returnType = evaluator.getTypeOfMagicMethodCall(
                                 leftSubtypeExpanded,
-                                [{ type: rightSubtypeExpanded, isIncomplete: rightTypeResult.isIncomplete }],
                                 magicMethodName,
+                                [{ type: rightSubtypeExpanded, isIncomplete: rightTypeResult.isIncomplete }],
                                 node,
                                 inferenceContext
                             );
@@ -997,7 +998,7 @@ export function getTypeOfUnaryOperation(
                 type = exprType;
             } else {
                 const magicMethodName = unaryOperatorMap[node.operator];
-                type = evaluator.getTypeOfMagicMethodReturn(exprType, [], magicMethodName, node, inferenceContext);
+                type = evaluator.getTypeOfMagicMethodCall(exprType, magicMethodName, [], node, inferenceContext);
             }
 
             if (!type) {

--- a/packages/pyright-internal/src/analyzer/patternMatching.ts
+++ b/packages/pyright-internal/src/analyzer/patternMatching.ts
@@ -1080,10 +1080,10 @@ function narrowTypeBasedOnValuePattern(
                         // Determine if assignment is supported for this combination of
                         // value subtype and matching subtype.
                         const returnType = evaluator.useSpeculativeMode(pattern.expression, () =>
-                            evaluator.getTypeOfMagicMethodReturn(
+                            evaluator.getTypeOfMagicMethodCall(
                                 valueSubtypeExpanded,
-                                [{ type: subjectSubtypeExpanded }],
                                 '__eq__',
+                                [{ type: subjectSubtypeExpanded }],
                                 pattern.expression,
                                 /* expectedType */ undefined
                             )

--- a/packages/pyright-internal/src/analyzer/typeEvaluatorTypes.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluatorTypes.ts
@@ -534,12 +534,14 @@ export interface TypeEvaluator {
     getTypeOfIterable: (
         typeResult: TypeResult,
         isAsync: boolean,
-        errorNode: ExpressionNode | undefined
+        errorNode: ExpressionNode,
+        emitNotIterableError?: boolean
     ) => TypeResult | undefined;
     getTypeOfIterator: (
         typeResult: TypeResult,
         isAsync: boolean,
-        errorNode: ExpressionNode | undefined
+        errorNode: ExpressionNode,
+        emitNotIterableError?: boolean
     ) => TypeResult | undefined;
     getGetterTypeFromProperty: (propertyClass: ClassType, inferTypeIfNeeded: boolean) => Type | undefined;
     getTypeOfArgument: (arg: FunctionArgument) => TypeResult;
@@ -595,10 +597,10 @@ export interface TypeEvaluator {
         recursionCount?: number,
         treatConstructorAsClassMember?: boolean
     ) => FunctionType | OverloadedFunctionType | undefined;
-    getTypeOfMagicMethodReturn: (
+    getTypeOfMagicMethodCall: (
         objType: Type,
-        args: TypeResult[],
-        magicMethodName: string,
+        methodName: string,
+        argList: TypeResult[],
         errorNode: ExpressionNode,
         inferenceContext: InferenceContext | undefined
     ) => Type | undefined;


### PR DESCRIPTION
…hod accesses for magic methods. The previous code had redundant (and partially incomplete) methods for evaluating calls to magic methods. This change consolidates the code and eliminates various holes.