### PR TITLE
Updated heuristics for constructor evaluation to accommodate a wider …

### DIFF
--- a/packages/pyright-internal/src/analyzer/constructors.ts
+++ b/packages/pyright-internal/src/analyzer/constructors.ts
@@ -234,10 +234,9 @@ function validateNewAndInitMethods(
         // (cls, *args, **kwargs) -> Self, allow the __init__ method to
         // determine the specialized type of the class.
         newMethodReturnType = ClassType.cloneAsInstance(type);
-    } else if (!isNever(newMethodReturnType) && !isClassInstance(newMethodReturnType)) {
-        // If the __new__ method returns something other than an object or
-        // NoReturn, we'll ignore its return type and assume that it
-        // returns Self.
+    } else if (isAnyOrUnknown(newMethodReturnType)) {
+        // If the __new__ method returns Any or Unknown, we'll ignore its return
+        // type and assume that it returns Self.
         newMethodReturnType = applySolvedTypeVars(
             ClassType.cloneAsInstance(type),
             new TypeVarContext(getTypeVarScopeId(type)),
@@ -251,7 +250,8 @@ function validateNewAndInitMethods(
     if (
         !argumentErrors &&
         !isNever(newMethodReturnType) &&
-        !shouldSkipInitEvaluation(evaluator, type, newMethodReturnType)
+        !shouldSkipInitEvaluation(evaluator, type, newMethodReturnType) &&
+        isClassInstance(newMethodReturnType)
     ) {
         // If the __new__ method returned the same type as the class it's constructing
         // but didn't supply solved type arguments, we'll ignore its specialized return

--- a/packages/pyright-internal/src/tests/samples/constructor7.py
+++ b/packages/pyright-internal/src/tests/samples/constructor7.py
@@ -2,10 +2,30 @@
 # a type that differs from the class that contains it.
 
 
-class HelloWorld:
+from typing import Callable, ParamSpec, TypeVar
+
+
+class ClassA:
     def __new__(cls) -> str:
         return "Hello World"
 
 
-v1 = HelloWorld()
+v1 = ClassA()
 reveal_type(v1, expected_text="str")
+
+
+_P = ParamSpec("_P")
+_R = TypeVar("_R")
+
+
+def func1(a: int) -> int:
+    return a + 1
+
+
+class ClassB:
+    def __new__(cls, func: Callable[_P, _R]) -> Callable[_P, _R]:
+        return func
+
+
+v2 = ClassB(func1)
+reveal_type(v2, expected_text="(a: int) -> int")


### PR DESCRIPTION
…range of types returned by the `__new__` method. Previously, if the `__new__` return type was anything other than a class instance, the heuristics assumed it wasn't intended and assumed that `__new__` returned an instance of its class, as is usually the case. This addresses #6303.