### PR TITLE
Fixed bug that led to a false positive when assigning a lambda with `…

### DIFF
--- a/packages/pyright-internal/src/tests/samples/lambda1.py
+++ b/packages/pyright-internal/src/tests/samples/lambda1.py
@@ -80,12 +80,12 @@ a: object = reduce((lambda x, y: x * y), [1, 2, 3, 4])
 #------------------------------------------------------
 # Test lambdas with *args
 
-b1: Callable[[int, int, int], Any] = lambda _, *b: reveal_type(
-    b, expected_text="tuple[int, ...]"
+b1: Callable[[int, int, str], Any] = lambda _, *b: reveal_type(
+    b, expected_text="tuple[Unknown, ...]"
 )
 
 b2: Callable[[str, str], Any] = lambda *b: reveal_type(
-    b, expected_text="tuple[str, ...]"
+    b, expected_text="tuple[Unknown, ...]"
 )
 
 b3: Callable[[int], Any] = lambda _, *b: reveal_type(

--- a/packages/pyright-internal/src/tests/samples/lambda2.py
+++ b/packages/pyright-internal/src/tests/samples/lambda2.py
@@ -24,3 +24,9 @@ foo5: Callable[[int, int, int], int] = lambda x, *, y: x + y + 1
 # This should generate an error because there are too many
 # parameters provided by the lambda.
 foo6: Callable[[int], int] = lambda x, *, y: x + y + 1
+
+foo7: Callable[[int, str], int] = lambda *args: 1
+
+# This should generate an error because there are too many
+# parameters provided by the lambda.
+foo8: Callable[[int, str], int] = lambda a, b, c, *args: 1

--- a/packages/pyright-internal/src/tests/typeEvaluator1.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator1.test.ts
@@ -672,7 +672,7 @@ test('Lambda1', () => {
 test('Lambda2', () => {
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['lambda2.py']);
 
-    TestUtils.validateResults(analysisResults, 5);
+    TestUtils.validateResults(analysisResults, 6);
 });
 
 test('Lambda3', () => {


### PR DESCRIPTION
…*args` to a callable type that doesn't contain `*args`. This addresses #6308.