### PR TITLE
Fixed a bug that resulted in incorrect type evaluation when using a `…

### DIFF
--- a/packages/pyright-internal/src/tests/samples/variadicTypeVar25.py
+++ b/packages/pyright-internal/src/tests/samples/variadicTypeVar25.py
@@ -1,0 +1,17 @@
+# This sample tests the case where a TypeVarTuple is used in a
+# nested callable type.
+
+from typing import Callable, TypeVarTuple
+
+Ts = TypeVarTuple("Ts")
+
+
+def func1(g: Callable[[Callable[[*Ts], None]], None]) -> tuple[*Ts]:
+    ...
+
+
+def func2(cb: Callable[[bytes, int], None]) -> None:
+    ...
+
+
+reveal_type(func1(func2), expected_text="tuple[bytes, int]")

--- a/packages/pyright-internal/src/tests/typeEvaluator3.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator3.test.ts
@@ -1196,6 +1196,14 @@ test('VariadicTypeVar24', () => {
     TestUtils.validateResults(analysisResults, 0);
 });
 
+test('VariadicTypeVar25', () => {
+    const configOptions = new ConfigOptions('.');
+
+    configOptions.defaultPythonVersion = PythonVersion.V3_11;
+    const analysisResults = TestUtils.typeAnalyzeSampleFiles(['variadicTypeVar25.py'], configOptions);
+    TestUtils.validateResults(analysisResults, 0);
+});
+
 test('Match1', () => {
     const configOptions = new ConfigOptions('.');
 


### PR DESCRIPTION
…TypeVarTuple` within a nested `Callable` type (i.e. a `Callable` that takes a `Callable` as a parameter). This addresses #6316.