### PR TITLE
Fixed a bug that causes a false positive `reportUnnecessaryContains` …

### DIFF
--- a/packages/pyright-internal/src/analyzer/typeGuards.ts
+++ b/packages/pyright-internal/src/analyzer/typeGuards.ts
@@ -2020,7 +2020,10 @@ export function narrowTypeForContainerElementType(evaluator: TypeEvaluator, refe
 
         if (evaluator.assignType(elementTypeWithoutLiteral, concreteReferenceType)) {
             return mapSubtypes(elementType, (elementSubtype) => {
-                if (isClassInstance(elementSubtype) && isSameWithoutLiteralValue(referenceSubtype, elementSubtype)) {
+                if (
+                    isClassInstance(elementSubtype) &&
+                    isSameWithoutLiteralValue(concreteReferenceType, elementSubtype)
+                ) {
                     return elementSubtype;
                 }
                 return undefined;

--- a/packages/pyright-internal/src/tests/samples/unnecessaryContains1.py
+++ b/packages/pyright-internal/src/tests/samples/unnecessaryContains1.py
@@ -1,5 +1,6 @@
 # This sample tests the "reportUnnecessaryContains" diagnostic rule.
 
+from enum import Enum
 from typing import Literal, TypeVar
 
 T1 = TypeVar("T1")
@@ -48,3 +49,17 @@ def func5(x: list[T2]) -> T2:
     if 0 not in x:
         pass
     return x[0]
+
+
+class Enum1(Enum):
+    a = "a"
+    b = "b"
+    c = "c"
+
+    @property
+    def is_ab(self):
+        return self in (Enum1.a, Enum1.b)
+
+    @property
+    def is_c(self):
+        return self not in (Enum1.a, Enum1.b)


### PR DESCRIPTION
…error when `self` is used on the LHS of the `in` operator within an enum class. This addresses #6329.