### PR TITLE
Fixed bug that led to a false negative when assigning type `Class` to…

### DIFF
--- a/packages/pyright-internal/src/analyzer/constraintSolver.ts
+++ b/packages/pyright-internal/src/analyzer/constraintSolver.ts
@@ -140,7 +140,10 @@ export function assignTypeToTypeVar(
         }
 
         isTypeVarInScope = false;
-        if (!destType.details.isSynthesized) {
+
+        // Emit an error unless this is a synthesized type variable used
+        // for pseudo-generic classes.
+        if (!destType.details.isSynthesized && !destType.details.isSynthesizedSelf) {
             diag?.addMessage(
                 Localizer.DiagnosticAddendum.typeAssignmentMismatch().format(
                     evaluator.printSrcDestTypes(srcType, destType)


### PR DESCRIPTION
… `Self@Class`. This should not be permitted, but it was. This addresses #6261.