### PR TITLE
Restored previous behavior (prior to 1.1.334) where an instance of a …

### DIFF
--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -21949,9 +21949,13 @@ export function createTypeEvaluator(importLookup: ImportLookup, evaluatorOptions
             const ancestorType = inheritanceChain[ancestorIndex];
 
             // If we've hit an "unknown", all bets are off, and we need to assume
-            // that the type is assignable.
+            // that the type is assignable. If the destType is marked "@final",
+            // we should be able to assume that it's not assignable, but we can't do
+            // this in the general case because it breaks assumptions with the
+            // NotImplemented symbol exported by typeshed's builtins.pyi. Instead,
+            // we'll special-case only None.
             if (isUnknown(ancestorType)) {
-                return true;
+                return !isNoneTypeClass(destType);
             }
 
             // If this isn't the first time through the loop, specialize

--- a/packages/pyright-internal/src/tests/samples/memberAccess24.py
+++ b/packages/pyright-internal/src/tests/samples/memberAccess24.py
@@ -1,16 +1,29 @@
 # This sample tests the case where an attribute is accessed from a
 # class that derives from an unknown type or Any.
 
-from typing import Any
+from typing import Any, overload
 from dummy import UnknownX  # type: ignore
 
 
+class Desc:
+    @overload
+    def __get__(self, instance: None, owner: Any) -> "Desc":
+        ...
+
+    @overload
+    def __get__(self, instance: object, owner: Any) -> int:
+        ...
+
+    def __get__(self, instance: object | None, owner: Any) -> "Desc | int":
+        ...
+
+
 class DerivesFromUnknown(UnknownX):
-    pass
+    y: Desc
 
 
 class DerivesFromAny(Any):
-    pass
+    y: Desc
 
 
 v1 = DerivesFromUnknown().x
@@ -18,3 +31,6 @@ reveal_type(v1, expected_text="Unknown")
 
 v2 = DerivesFromAny().x
 reveal_type(v2, expected_text="Any")
+
+reveal_type(DerivesFromUnknown().y, expected_text="int")
+reveal_type(DerivesFromAny().y, expected_text="int")


### PR DESCRIPTION
…class that derives from `Any` will not be considered type compatible with `None`. This addresses #6325.