### PR TITLE
Enhanced the handling of zero-argument form of `super()` to support t…

### DIFF
--- a/packages/pyright-internal/src/tests/samples/super11.py
+++ b/packages/pyright-internal/src/tests/samples/super11.py
@@ -1,0 +1,15 @@
+# This sample tests the case where a protocol class is used within a mixin
+# class method that calls super().
+
+from typing import Protocol
+
+
+class MixinProt(Protocol):
+    def method1(self) -> int:
+        ...
+
+
+class MyMixin:
+    def get(self: MixinProt) -> None:
+        x = super().method1()
+        reveal_type(x, expected_text="int")

--- a/packages/pyright-internal/src/tests/typeEvaluator2.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator2.test.ts
@@ -221,6 +221,12 @@ test('Super10', () => {
     TestUtils.validateResults(analysisResults, 0);
 });
 
+test('Super11', () => {
+    const analysisResults = TestUtils.typeAnalyzeSampleFiles(['super11.py']);
+
+    TestUtils.validateResults(analysisResults, 0);
+});
+
 test('MissingSuper1', () => {
     const configOptions = new ConfigOptions('.');
 


### PR DESCRIPTION
…he case where the containing method's `self` or `cls` parameter is annotated using a protocol. This can be used to handle mixin methods that call `super()`. This addresses #6347.