### PR TITLE
Enhanced the handling of zero-argument form of `super()` to support t…

### DIFF
--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -8314,7 +8314,12 @@ export function createTypeEvaluator(importLookup: ImportLookup, evaluatorOptions
             }
 
             if (bindToType && implicitBindToType) {
-                bindToType = addConditionToType(bindToType, getTypeCondition(implicitBindToType)) as ClassType;
+                const typeCondition = getTypeCondition(implicitBindToType);
+                if (typeCondition) {
+                    bindToType = addConditionToType(bindToType, typeCondition) as ClassType;
+                } else if (isClass(implicitBindToType)) {
+                    bindToType = implicitBindToType;
+                }
             }
         }
 
@@ -8343,7 +8348,19 @@ export function createTypeEvaluator(importLookup: ImportLookup, evaluatorOptions
         const parentNode = node.parent!;
         if (parentNode.nodeType === ParseNodeType.MemberAccess) {
             const memberName = parentNode.memberName.value;
-            const effectiveTargetClass = isClass(targetClassType) ? targetClassType : undefined;
+            let effectiveTargetClass = isClass(targetClassType) ? targetClassType : undefined;
+
+            // If the bind-to type is a protocol, don't use the effective target class.
+            // This pattern is used for mixins, where the mixin type is a protocol class
+            // that is used to decorate the "self" or "cls" parameter.
+            if (
+                bindToType &&
+                ClassType.isProtocolClass(bindToType) &&
+                effectiveTargetClass &&
+                !ClassType.isSameGenericClass(bindToType, effectiveTargetClass)
+            ) {
+                effectiveTargetClass = undefined;
+            }
 
             const lookupResults = bindToType
                 ? lookUpClassMember(bindToType, memberName, MemberAccessFlags.Default, effectiveTargetClass)

--- a/packages/pyright-internal/src/tests/samples/super11.py
+++ b/packages/pyright-internal/src/tests/samples/super11.py
@@ -1,0 +1,15 @@
+# This sample tests the case where a protocol class is used within a mixin
+# class method that calls super().
+
+from typing import Protocol
+
+
+class MixinProt(Protocol):
+    def method1(self) -> int:
+        ...
+
+
+class MyMixin:
+    def get(self: MixinProt) -> None:
+        x = super().method1()
+        reveal_type(x, expected_text="int")

--- a/packages/pyright-internal/src/tests/typeEvaluator2.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator2.test.ts
@@ -221,6 +221,12 @@ test('Super10', () => {
     TestUtils.validateResults(analysisResults, 0);
 });
 
+test('Super11', () => {
+    const analysisResults = TestUtils.typeAnalyzeSampleFiles(['super11.py']);
+
+    TestUtils.validateResults(analysisResults, 0);
+});
+
 test('MissingSuper1', () => {
     const configOptions = new ConfigOptions('.');
 


### PR DESCRIPTION
…he case where the containing method's `self` or `cls` parameter is annotated using a protocol. This can be used to handle mixin methods that call `super()`. This addresses #6347.