### PR TITLE
Fixed a bug that led to incorrect type narrowing for the `x is None` …

### DIFF
--- a/packages/pyright-internal/src/analyzer/typeGuards.ts
+++ b/packages/pyright-internal/src/analyzer/typeGuards.ts
@@ -1126,6 +1126,11 @@ function narrowTypeForIsNone(evaluator: TypeEvaluator, type: Type, isPositiveTes
             // See if it's a match for None.
             if (isNoneInstance(subtype) === isPositiveTest) {
                 resultIncludesNoneSubtype = true;
+
+                if (isTypeVar(adjustedSubtype) && adjustedSubtype.details.isSynthesizedSelf) {
+                    return adjustedSubtype;
+                }
+
                 return subtype;
             }
 

--- a/packages/pyright-internal/src/tests/samples/literalString3.py
+++ b/packages/pyright-internal/src/tests/samples/literalString3.py
@@ -20,7 +20,7 @@ def func2(x: T_LS | None, default: T_LS) -> ClassA[T_LS]:
     if x is None:
         x = default
 
-    reveal_type(x, expected_text="T_LS@func2 | LiteralString*")
+    reveal_type(x, expected_text="T_LS@func2")
     out = func1(x)
-    reveal_type(out, expected_text="ClassA[T_LS@func2 | str*]")
+    reveal_type(out, expected_text="ClassA[T_LS@func2]")
     return out

--- a/packages/pyright-internal/src/tests/samples/typeNarrowingIsNone1.py
+++ b/packages/pyright-internal/src/tests/samples/typeNarrowingIsNone1.py
@@ -4,7 +4,7 @@
 
 # pyright: strict, reportUnusedVariable=false
 
-from typing import Any, Literal, Protocol, TypeVar
+from typing import Any, Literal, Protocol, Self, TypeVar
 
 
 def func1(x: int | None):
@@ -80,3 +80,27 @@ def func7(x: NoneProto | None):
         reveal_type(x, expected_text="None")
     else:
         reveal_type(x, expected_text="NoneProto")
+
+
+_T3 = TypeVar("_T3", bound=None | int)
+
+
+def func8(x: _T3) -> _T3:
+    if x is None:
+        reveal_type(x, expected_text="None*")
+    else:
+        reveal_type(x, expected_text="int*")
+    return x
+
+
+class A:
+    def __init__(self, parent: Self | None) -> None:
+        self.parent = parent
+
+    def get_depth(self) -> int:
+        current: Self | None = self
+        count = 0
+        while current is not None:
+            count += 1
+            current = current.parent
+        return count - 1


### PR DESCRIPTION
…in the negative (else) case when `x` is a bound TypeVar (or `Self`). This addresses #6361.