### PR TITLE
Support boolean values in settings.json's diagnosticSeverityOverrides

### DIFF
--- a/packages/pyright-internal/src/common/configOptions.ts
+++ b/packages/pyright-internal/src/common/configOptions.ts
@@ -12,7 +12,7 @@ import { isAbsolute } from 'path';
 import { getPathsFromPthFiles } from '../analyzer/pythonPathUtils';
 import * as pathConsts from '../common/pathConsts';
 import { appendArray } from './collectionUtils';
-import { DiagnosticSeverityOverridesMap } from './commandLineOptions';
+import { DiagnosticSeverityOverrides, DiagnosticSeverityOverridesMap } from './commandLineOptions';
 import { ConsoleInterface, NullConsole } from './console';
 import { TaskListToken } from './diagnostic';
 import { DiagnosticRule } from './diagnosticRules';
@@ -1403,5 +1403,26 @@ export class ConfigOptions {
         }
 
         return undefined;
+    }
+}
+
+export function parseDiagLevel(value: string | boolean): DiagnosticSeverityOverrides | undefined {
+    switch (value) {
+        case false:
+        case 'none':
+            return DiagnosticSeverityOverrides.None;
+
+        case true:
+        case 'error':
+            return DiagnosticSeverityOverrides.Error;
+
+        case 'warning':
+            return DiagnosticSeverityOverrides.Warning;
+
+        case 'information':
+            return DiagnosticSeverityOverrides.Information;
+
+        default:
+            return undefined;
     }
 }

--- a/packages/pyright-internal/src/languageServerBase.ts
+++ b/packages/pyright-internal/src/languageServerBase.ts
@@ -88,7 +88,12 @@ import {
     DiagnosticSeverityOverridesMap,
     getDiagnosticSeverityOverrides,
 } from './common/commandLineOptions';
-import { ConfigOptions, SignatureDisplayType, getDiagLevelDiagnosticRules } from './common/configOptions';
+import {
+    ConfigOptions,
+    SignatureDisplayType,
+    getDiagLevelDiagnosticRules,
+    parseDiagLevel,
+} from './common/configOptions';
 import { ConsoleInterface, ConsoleWithLogLevel, LogLevel } from './common/console';
 import {
     Diagnostic as AnalyzerDiagnostic,
@@ -578,8 +583,11 @@ export abstract class LanguageServerBase implements LanguageServerInterface, Dis
         return diagnosticMode !== 'workspace';
     }
 
-    protected getSeverityOverrides(value: string): DiagnosticSeverityOverrides | undefined {
-        const enumValue = value as DiagnosticSeverityOverrides;
+    protected getSeverityOverrides(value: string | boolean): DiagnosticSeverityOverrides | undefined {
+        const enumValue = parseDiagLevel(value);
+        if (!enumValue) {
+            return undefined;
+        }
         if (getDiagnosticSeverityOverrides().includes(enumValue)) {
             return enumValue;
         }

--- a/packages/pyright-internal/src/server.ts
+++ b/packages/pyright-internal/src/server.ts
@@ -143,7 +143,7 @@ export class PyrightServer extends LanguageServerBase {
                 if (diagnosticSeverityOverrides) {
                     for (const [name, value] of Object.entries(diagnosticSeverityOverrides)) {
                         const ruleName = this.getDiagnosticRuleName(name);
-                        const severity = this.getSeverityOverrides(value as string);
+                        const severity = this.getSeverityOverrides(value as string | boolean);
                         if (ruleName && severity) {
                             serverSettings.diagnosticSeverityOverrides![ruleName] = severity!;
                         }

--- a/packages/pyright-internal/src/tests/diagnosticOverrides.test.ts
+++ b/packages/pyright-internal/src/tests/diagnosticOverrides.test.ts
@@ -75,19 +75,21 @@ describe('Diagnostic overrides', () => {
         for (const propName of overrideNamesInJson) {
             const p = props[propName];
 
-            expect(p.type).toEqual('string');
+            expect(p.type).toEqual(['string', 'boolean']);
             expect(p.description).toBeDefined();
             expect(p.description.length).toBeGreaterThan(0);
             expect(p.default).toBeDefined();
 
             expect(p.enum).toBeDefined();
             expect(Array.isArray(p.enum));
-            expect(p.enum).toHaveLength(4);
+            expect(p.enum).toHaveLength(6);
 
             expect(p.enum[0]).toEqual('none');
             expect(p.enum[1]).toEqual('information');
             expect(p.enum[2]).toEqual('warning');
             expect(p.enum[3]).toEqual('error');
+            expect(p.enum[4]).toEqual(true);
+            expect(p.enum[5]).toEqual(false);
 
             expect(p.enum).toContain(p.default);
         }

--- a/packages/vscode-pyright/package.json
+++ b/packages/vscode-pyright/package.json
@@ -188,711 +188,1031 @@
                 },
                 "python.analysis.diagnosticSeverityOverrides": {
                     "type": "object",
-                    "description": "Allows a user to override the severity levels for individual diagnostics.",
+                    "description": "Allows a user to override the severity levels for individual diagnostics. Use the rule name as a key and one of \"error\", \"warning\", \"information\", \"none\", `true` (alias for \"error\") or `false` (alias for \"none\") as value. The default value shown for each diagnostic is the default when \"python.analysis.typeCheckingMode\" is set to \"basic\". See [here](https://github.com/microsoft/pyright/blob/main/docs/configuration.md#diagnostic-rule-defaults) for defaults for each type checking mode (\"off\", \"basic\" and \"strict\").",
                     "scope": "resource",
                     "properties": {
                         "reportGeneralTypeIssues": {
-                            "type": "string",
+                            "type": [
+                                "string",
+                                "boolean"
+                            ],
                             "description": "Diagnostics for general type inconsistencies, unsupported operations, argument/parameter mismatches, etc. Covers all of the basic type-checking rules not covered by other rules. Does not include syntax errors.",
                             "default": "error",
                             "enum": [
                                 "none",
                                 "information",
                                 "warning",
-                                "error"
+                                "error",
+                                true,
+                                false
                             ]
                         },
                         "reportPropertyTypeMismatch": {
-                            "type": "string",
+                            "type": [
+                                "string",
+                                "boolean"
+                            ],
                             "description": "Diagnostics for property whose setter and getter have mismatched types.",
                             "default": "none",
                             "enum": [
                                 "none",
                                 "information",
                                 "warning",
-                                "error"
+                                "error",
+                                true,
+                                false
                             ]
                         },
                         "reportFunctionMemberAccess": {
-                            "type": "string",
+                            "type": [
+                                "string",
+                                "boolean"
+                            ],
                             "description": "Diagnostics for member accesses on functions.",
                             "default": "none",
                             "enum": [
                                 "none",
                                 "information",
                                 "warning",
-                                "error"
+                                "error",
+                                true,
+                                false
                             ]
                         },
                         "reportMissingImports": {
-                            "type": "string",
+                            "type": [
+                                "string",
+                                "boolean"
+                            ],
                             "description": "Diagnostics for imports that have no corresponding imported python file or type stub file.",
                             "default": "error",
                             "enum": [
                                 "none",
                                 "information",
                                 "warning",
-                                "error"
+                                "error",
+                                true,
+                                false
                             ]
                         },
                         "reportMissingModuleSource": {
-                            "type": "string",
+                            "type": [
+                                "string",
+                                "boolean"
+                            ],
                             "description": "Diagnostics for imports that have no corresponding source file. This happens when a type stub is found, but the module source file was not found, indicating that the code may fail at runtime when using this execution environment. Type checking will be done using the type stub.",
                             "default": "warning",
                             "enum": [
                                 "none",
                                 "information",
                                 "warning",
-                                "error"
+                                "error",
+                                true,
+                                false
                             ]
                         },
                         "reportMissingTypeStubs": {
-                            "type": "string",
+                            "type": [
+                                "string",
+                                "boolean"
+                            ],
                             "description": "Diagnostics for imports that have no corresponding type stub file (either a typeshed file or a custom type stub). The type checker requires type stubs to do its best job at analysis.",
                             "default": "none",
                             "enum": [
                                 "none",
                                 "information",
                                 "warning",
-                                "error"
+                                "error",
+                                true,
+                                false
                             ]
                         },
                         "reportImportCycles": {
-                            "type": "string",
+                            "type": [
+                                "string",
+                                "boolean"
+                            ],
                             "description": "Diagnostics for cyclical import chains. These are not errors in Python, but they do slow down type analysis and often hint at architectural layering issues. Generally, they should be avoided.",
                             "default": "none",
                             "enum": [
                                 "none",
                                 "information",
                                 "warning",
-                                "error"
+                                "error",
+                                true,
+                                false
                             ]
                         },
                         "reportUnusedImport": {
-                            "type": "string",
+                            "type": [
+                                "string",
+                                "boolean"
+                            ],
                             "description": "Diagnostics for an imported symbol that is not referenced within that file.",
                             "default": "none",
                             "enum": [
                                 "none",
                                 "information",
                                 "warning",
-                                "error"
+                                "error",
+                                true,
+                                false
                             ]
                         },
                         "reportUnusedClass": {
-                            "type": "string",
+                            "type": [
+                                "string",
+                                "boolean"
+                            ],
                             "description": "Diagnostics for a class with a private name (starting with an underscore) that is not accessed.",
                             "default": "none",
                             "enum": [
                                 "none",
                                 "information",
                                 "warning",
-                                "error"
+                                "error",
+                                true,
+                                false
                             ]
                         },
                         "reportUnusedFunction": {
-                            "type": "string",
+                            "type": [
+                                "string",
+                                "boolean"
+                            ],
                             "description": "Diagnostics for a function or method with a private name (starting with an underscore) that is not accessed.",
                             "default": "none",
                             "enum": [
                                 "none",
                                 "information",
                                 "warning",
-                                "error"
+                                "error",
+                                true,
+                                false
                             ]
                         },
                         "reportUnusedVariable": {
-                            "type": "string",
+                            "type": [
+                                "string",
+                                "boolean"
+                            ],
                             "description": "Diagnostics for a variable that is not accessed.",
                             "default": "none",
                             "enum": [
                                 "none",
                                 "information",
                                 "warning",
-                                "error"
+                                "error",
+                                true,
+                                false
                             ]
                         },
                         "reportDuplicateImport": {
-                            "type": "string",
+                            "type": [
+                                "string",
+                                "boolean"
+                            ],
                             "description": "Diagnostics for an imported symbol or module that is imported more than once.",
                             "default": "none",
                             "enum": [
                                 "none",
                                 "information",
                                 "warning",
-                                "error"
+                                "error",
+                                true,
+                                false
                             ]
                         },
                         "reportWildcardImportFromLibrary": {
-                            "type": "string",
+                            "type": [
+                                "string",
+                                "boolean"
+                            ],
                             "description": "Diagnostics for an wildcard import from an external library.",
                             "default": "warning",
                             "enum": [
                                 "none",
                                 "information",
                                 "warning",
-                                "error"
+                                "error",
+                                true,
+                                false
                             ]
                         },
                         "reportOptionalSubscript": {
-                            "type": "string",
+                            "type": [
+                                "string",
+                                "boolean"
+                            ],
                             "description": "Diagnostics for an attempt to subscript (index) a variable with an Optional type.",
                             "default": "error",
                             "enum": [
                                 "none",
                                 "information",
                                 "warning",
-                                "error"
+                                "error",
+                                true,
+                                false
                             ]
                         },
                         "reportOptionalMemberAccess": {
-                            "type": "string",
+                            "type": [
+                                "string",
+                                "boolean"
+                            ],
                             "description": "Diagnostics for an attempt to access a member of a variable with an Optional type.",
                             "default": "error",
                             "enum": [
                                 "none",
                                 "information",
                                 "warning",
-                                "error"
+                                "error",
+                                true,
+                                false
                             ]
                         },
                         "reportOptionalCall": {
-                            "type": "string",
+                            "type": [
+                                "string",
+                                "boolean"
+                            ],
                             "description": "Diagnostics for an attempt to call a variable with an Optional type.",
                             "default": "error",
                             "enum": [
                                 "none",
                                 "information",
                                 "warning",
-                                "error"
+                                "error",
+                                true,
+                                false
                             ]
                         },
                         "reportOptionalIterable": {
-                            "type": "string",
+                            "type": [
+                                "string",
+                                "boolean"
+                            ],
                             "description": "Diagnostics for an attempt to use an Optional type as an iterable value (e.g. within a for statement).",
                             "default": "error",
                             "enum": [
                                 "none",
                                 "information",
                                 "warning",
-                                "error"
+                                "error",
+                                true,
+                                false
                             ]
                         },
                         "reportOptionalContextManager": {
-                            "type": "string",
+                            "type": [
+                                "string",
+                                "boolean"
+                            ],
                             "description": "Diagnostics for an attempt to use an Optional type as a context manager (as a parameter to a with statement).",
                             "default": "error",
                             "enum": [
                                 "none",
                                 "information",
                                 "warning",
-                                "error"
+                                "error",
+                                true,
+                                false
                             ]
                         },
                         "reportOptionalOperand": {
-                            "type": "string",
+                            "type": [
+                                "string",
+                                "boolean"
+                            ],
                             "description": "Diagnostics for an attempt to use an Optional type as an operand to a binary or unary operator (like '+', '==', 'or', 'not').",
                             "default": "error",
                             "enum": [
                                 "none",
                                 "information",
                                 "warning",
-                                "error"
+                                "error",
+                                true,
+                                false
                             ]
                         },
                         "reportTypedDictNotRequiredAccess": {
-                            "type": "string",
+                            "type": [
+                                "string",
+                                "boolean"
+                            ],
                             "description": "Diagnostics for an attempt to access a non-required key within a TypedDict without a check for its presence.",
                             "default": "error",
                             "enum": [
                                 "none",
                                 "information",
                                 "warning",
-                                "error"
+                                "error",
+                                true,
+                                false
                             ]
                         },
                         "reportUntypedFunctionDecorator": {
-                            "type": "string",
+                            "type": [
+                                "string",
+                                "boolean"
+                            ],
                             "description": "Diagnostics for function decorators that have no type annotations. These obscure the function type, defeating many type analysis features.",
                             "default": "none",
                             "enum": [
                                 "none",
                                 "information",
                                 "warning",
-                                "error"
+                                "error",
+                                true,
+                                false
                             ]
                         },
                         "reportUntypedClassDecorator": {
-                            "type": "string",
+                            "type": [
+                                "string",
+                                "boolean"
+                            ],
                             "description": "Diagnostics for class decorators that have no type annotations. These obscure the class type, defeating many type analysis features.",
                             "default": "none",
                             "enum": [
                                 "none",
                                 "information",
                                 "warning",
-                                "error"
+                                "error",
+                                true,
+                                false
                             ]
                         },
                         "reportUntypedBaseClass": {
-                            "type": "string",
+                            "type": [
+                                "string",
+                                "boolean"
+                            ],
                             "description": "Diagnostics for base classes whose type cannot be determined statically. These obscure the class type, defeating many type analysis features.",
                             "default": "none",
                             "enum": [
                                 "none",
                                 "information",
                                 "warning",
-                                "error"
+                                "error",
+                                true,
+                                false
                             ]
                         },
                         "reportUntypedNamedTuple": {
-                            "type": "string",
+                            "type": [
+                                "string",
+                                "boolean"
+                            ],
                             "description": "Diagnostics when “namedtuple” is used rather than “NamedTuple”. The former contains no type information, whereas the latter does.",
                             "default": "none",
                             "enum": [
                                 "none",
                                 "information",
                                 "warning",
-                                "error"
+                                "error",
+                                true,
+                                false
                             ]
                         },
                         "reportPrivateUsage": {
-                            "type": "string",
+                            "type": [
+                                "string",
+                                "boolean"
+                            ],
                             "description": "Diagnostics for incorrect usage of private or protected variables or functions. Protected class members begin with a single underscore _ and can be accessed only by subclasses. Private class members begin with a double underscore but do not end in a double underscore and can be accessed only within the declaring class. Variables and functions declared outside of a class are considered private if their names start with either a single or double underscore, and they cannot be accessed outside of the declaring module.",
                             "default": "none",
                             "enum": [
                                 "none",
                                 "information",
                                 "warning",
-                                "error"
+                                "error",
+                                true,
+                                false
                             ]
                         },
                         "reportTypeCommentUsage": {
-                            "type": "string",
+                            "type": [
+                                "string",
+                                "boolean"
+                            ],
                             "description": "Diagnostics for usage of deprecated type comments.",
                             "default": "none",
                             "enum": [
                                 "none",
                                 "information",
                                 "warning",
-                                "error"
+                                "error",
+                                true,
+                                false
                             ]
                         },
                         "reportPrivateImportUsage": {
-                            "type": "string",
+                            "type": [
+                                "string",
+                                "boolean"
+                            ],
                             "description": "Diagnostics for incorrect usage of symbol imported from a \"py.typed\" module that is not re-exported from that module.",
                             "default": "error",
                             "enum": [
                                 "none",
                                 "information",
                                 "warning",
-                                "error"
+                                "error",
+                                true,
+                                false
                             ]
                         },
                         "reportConstantRedefinition": {
-                            "type": "string",
+                            "type": [
+                                "string",
+                                "boolean"
+                            ],
                             "description": "Diagnostics for attempts to redefine variables whose names are all-caps with underscores and numerals.",
                             "default": "none",
                             "enum": [
                                 "none",
                                 "information",
                                 "warning",
-                                "error"
+                                "error",
+                                true,
+                                false
                             ]
                         },
                         "reportDeprecated": {
-                            "type": "string",
+                            "type": [
+                                "string",
+                                "boolean"
+                            ],
                             "description": "Diagnostics for use of deprecated classes or functions.",
                             "default": "none",
                             "enum": [
                                 "none",
                                 "information",
                                 "warning",
-                                "error"
+                                "error",
+                                true,
+                                false
                             ]
                         },
                         "reportIncompatibleMethodOverride": {
-                            "type": "string",
+                            "type": [
+                                "string",
+                                "boolean"
+                            ],
                             "description": "Diagnostics for methods that override a method of the same name in a base class in an incompatible manner (wrong number of parameters, incompatible parameter types, or incompatible return type).",
                             "default": "none",
                             "enum": [
                                 "none",
                                 "information",
                                 "warning",
-                                "error"
+                                "error",
+                                true,
+                                false
                             ]
                         },
                         "reportIncompatibleVariableOverride": {
-                            "type": "string",
+                            "type": [
+                                "string",
+                                "boolean"
+                            ],
                             "description": "Diagnostics for overrides in subclasses that redefine a variable in an incompatible way.",
                             "default": "none",
                             "enum": [
                                 "none",
                                 "information",
                                 "warning",
-                                "error"
+                                "error",
+                                true,
+                                false
                             ]
                         },
                         "reportInconsistentConstructor": {
-                            "type": "string",
+                            "type": [
+                                "string",
+                                "boolean"
+                            ],
                             "description": "Diagnostics for __init__ and __new__ methods whose signatures are inconsistent.",
                             "default": "none",
                             "enum": [
                                 "none",
                                 "information",
                                 "warning",
-                                "error"
+                                "error",
+                                true,
+                                false
                             ]
                         },
                         "reportOverlappingOverload": {
-                            "type": "string",
+                            "type": [
+                                "string",
+                                "boolean"
+                            ],
                             "description": "Diagnostics for function overloads that overlap in signature and obscure each other or have incompatible return types.",
                             "default": "none",
                             "enum": [
                                 "none",
                                 "information",
                                 "warning",
-                                "error"
+                                "error",
+                                true,
+                                false
                             ]
                         },
                         "reportMissingSuperCall": {
-                            "type": "string",
+                            "type": [
+                                "string",
+                                "boolean"
+                            ],
                             "description": "Diagnostics for missing call to parent class for inherited `__init__` methods.",
                             "default": "none",
                             "enum": [
                                 "none",
                                 "information",
                                 "warning",
-                                "error"
+                                "error",
+                                true,
+                                false
                             ]
                         },
                         "reportUninitializedInstanceVariable": {
-                            "type": "string",
+                            "type": [
+                                "string",
+                                "boolean"
+                            ],
                             "description": "Diagnostics for instance variables that are not declared or initialized within class body or `__init__` method.",
                             "default": "none",
                             "enum": [
                                 "none",
                                 "information",
                                 "warning",
-                                "error"
+                                "error",
+                                true,
+                                false
                             ]
                         },
                         "reportInvalidStringEscapeSequence": {
-                            "type": "string",
+                            "type": [
+                                "string",
+                                "boolean"
+                            ],
                             "description": "Diagnostics for invalid escape sequences used within string literals. The Python specification indicates that such sequences will generate a syntax error in future versions.",
                             "default": "warning",
                             "enum": [
                                 "none",
                                 "information",
                                 "warning",
-                                "error"
+                                "error",
+                                true,
+                                false
                             ]
                         },
                         "reportUnknownParameterType": {
-                            "type": "string",
+                            "type": [
+                                "string",
+                                "boolean"
+                            ],
                             "description": "Diagnostics for input or return parameters for functions or methods that have an unknown type.",
                             "default": "none",
                             "enum": [
                                 "none",
                                 "information",
                                 "warning",
-                                "error"
+                                "error",
+                                true,
+                                false
                             ]
                         },
                         "reportUnknownArgumentType": {
-                            "type": "string",
+                            "type": [
+                                "string",
+                                "boolean"
+                            ],
                             "description": "Diagnostics for call arguments for functions or methods that have an unknown type.",
                             "default": "none",
                             "enum": [
                                 "none",
                                 "information",
                                 "warning",
-                                "error"
+                                "error",
+                                true,
+                                false
                             ]
                         },
                         "reportUnknownLambdaType": {
-                            "type": "string",
+                            "type": [
+                                "string",
+                                "boolean"
+                            ],
                             "description": "Diagnostics for input or return parameters for lambdas that have an unknown type.",
                             "default": "none",
                             "enum": [
                                 "none",
                                 "information",
                                 "warning",
-                                "error"
+                                "error",
+                                true,
+                                false
                             ]
                         },
                         "reportUnknownVariableType": {
-                            "type": "string",
+                            "type": [
+                                "string",
+                                "boolean"
+                            ],
                             "description": "Diagnostics for variables that have an unknown type..",
                             "default": "none",
                             "enum": [
                                 "none",
                                 "information",
                                 "warning",
-                                "error"
+                                "error",
+                                true,
+                                false
                             ]
                         },
                         "reportUnknownMemberType": {
-                            "type": "string",
+                            "type": [
+                                "string",
+                                "boolean"
+                            ],
                             "description": "Diagnostics for class or instance variables that have an unknown type.",
                             "default": "none",
                             "enum": [
                                 "none",
                                 "information",
                                 "warning",
-                                "error"
+                                "error",
+                                true,
+                                false
                             ]
                         },
                         "reportMissingParameterType": {
-                            "type": "string",
+                            "type": [
+                                "string",
+                                "boolean"
+                            ],
                             "description": "Diagnostics for parameters that are missing a type annotation.",
                             "default": "none",
                             "enum": [
                                 "none",
                                 "information",
                                 "warning",
-                                "error"
+                                "error",
+                                true,
+                                false
                             ]
                         },
                         "reportMissingTypeArgument": {
-                            "type": "string",
+                            "type": [
+                                "string",
+                                "boolean"
+                            ],
                             "description": "Diagnostics for generic class reference with missing type arguments.",
                             "default": "none",
                             "enum": [
                                 "none",
                                 "information",
                                 "warning",
-                                "error"
+                                "error",
+                                true,
+                                false
                             ]
                         },
                         "reportInvalidTypeVarUse": {
-                            "type": "string",
+                            "type": [
+                                "string",
+                                "boolean"
+                            ],
                             "description": "Diagnostics for improper use of type variables in a function signature.",
                             "default": "warning",
                             "enum": [
                                 "none",
                                 "information",
                                 "warning",
-                                "error"
+                                "error",
+                                true,
+                                false
                             ]
                         },
                         "reportCallInDefaultInitializer": {
-                            "type": "string",
+                            "type": [
+                                "string",
+                                "boolean"
+                            ],
                             "description": "Diagnostics for function calls within a default value initialization expression. Such calls can mask expensive operations that are performed at module initialization time.",
                             "default": "none",
                             "enum": [
                                 "none",
                                 "information",
                                 "warning",
-                                "error"
+                                "error",
+                                true,
+                                false
                             ]
                         },
                         "reportUnnecessaryIsInstance": {
-                            "type": "string",
+                            "type": [
+                                "string",
+                                "boolean"
+                            ],
                             "description": "Diagnostics for 'isinstance' or 'issubclass' calls where the result is statically determined to be always true. Such calls are often indicative of a programming error.",
                             "default": "none",
                             "enum": [
                                 "none",
                                 "information",
                                 "warning",
-                                "error"
+                                "error",
+                                true,
+                                false
                             ]
                         },
                         "reportUnnecessaryCast": {
-                            "type": "string",
+                            "type": [
+                                "string",
+                                "boolean"
+                            ],
                             "description": "Diagnostics for 'cast' calls that are statically determined to be unnecessary. Such calls are sometimes indicative of a programming error.",
                             "default": "none",
                             "enum": [
                                 "none",
                                 "information",
                                 "warning",
-                                "error"
+                                "error",
+                                true,
+                                false
                             ]
                         },
                         "reportUnnecessaryComparison": {
-                            "type": "string",
+                            "type": [
+                                "string",
+                                "boolean"
+                            ],
                             "description": "Diagnostics for '==' and '!=' comparisons that are statically determined to be unnecessary. Such calls are sometimes indicative of a programming error.",
                             "default": "none",
                             "enum": [
                                 "none",
                                 "information",
                                 "warning",
-                                "error"
+                                "error",
+                                true,
+                                false
                             ]
                         },
                         "reportUnnecessaryContains": {
-                            "type": "string",
+                            "type": [
+                                "string",
+                                "boolean"
+                            ],
                             "description": "Diagnostics for 'in' operation that is statically determined to be unnecessary. Such operations are sometimes indicative of a programming error.",
                             "default": "none",
                             "enum": [
                                 "none",
                                 "information",
                                 "warning",
-                                "error"
+                                "error",
+                                true,
+                                false
                             ]
                         },
                         "reportAssertAlwaysTrue": {
-                            "type": "string",
+                            "type": [
+                                "string",
+                                "boolean"
+                            ],
                             "description": "Diagnostics for 'assert' statement that will provably always assert. This can be indicative of a programming error.",
                             "default": "warning",
                             "enum": [
                                 "none",
                                 "information",
                                 "warning",
-                                "error"
+                                "error",
+                                true,
+                                false
                             ]
                         },
                         "reportSelfClsParameterName": {
-                            "type": "string",
+                            "type": [
+                                "string",
+                                "boolean"
+                            ],
                             "description": "Diagnostics for a missing or misnamed “self” parameter in instance methods and “cls” parameter in class methods. Instance methods in metaclasses (classes that derive from “type”) are allowed to use “cls” for instance methods.",
                             "default": "warning",
                             "enum": [
                                 "none",
                                 "information",
                                 "warning",
-                                "error"
+                                "error",
+                                true,
+                                false
                             ]
                         },
                         "reportImplicitStringConcatenation": {
-                            "type": "string",
+                            "type": [
+                                "string",
+                                "boolean"
+                            ],
                             "description": "Diagnostics for two or more string literals that follow each other, indicating an implicit concatenation. This is considered a bad practice and often masks bugs such as missing commas.",
                             "default": "none",
                             "enum": [
                                 "none",
                                 "information",
                                 "warning",
-                                "error"
+                                "error",
+                                true,
+                                false
                             ]
                         },
                         "reportInvalidStubStatement": {
-                            "type": "string",
+                            "type": [
+                                "string",
+                                "boolean"
+                            ],
                             "description": "Diagnostics for type stub statements that do not conform to PEP 484.",
                             "default": "none",
                             "enum": [
                                 "none",
                                 "information",
                                 "warning",
-                                "error"
+                                "error",
+                                true,
+                                false
                             ]
                         },
                         "reportIncompleteStub": {
-                            "type": "string",
+                            "type": [
+                                "string",
+                                "boolean"
+                            ],
                             "description": "Diagnostics for the use of a module-level “__getattr__” function, indicating that the stub is incomplete.",
                             "default": "none",
                             "enum": [
                                 "none",
                                 "information",
                                 "warning",
-                                "error"
+                                "error",
+                                true,
+                                false
                             ]
                         },
                         "reportUndefinedVariable": {
-                            "type": "string",
+                            "type": [
+                                "string",
+                                "boolean"
+                            ],
                             "description": "Diagnostics for undefined variables.",
                             "default": "error",
                             "enum": [
                                 "none",
                                 "information",
                                 "warning",
-                                "error"
+                                "error",
+                                true,
+                                false
                             ]
                         },
                         "reportUnboundVariable": {
-                            "type": "string",
+                            "type": [
+                                "string",
+                                "boolean"
+                            ],
                             "description": "Diagnostics for unbound and possibly unbound variables.",
                             "default": "error",
                             "enum": [
                                 "none",
                                 "information",
                                 "warning",
-                                "error"
+                                "error",
+                                true,
+                                false
                             ]
                         },
                         "reportUnsupportedDunderAll": {
-                            "type": "string",
+                            "type": [
+                                "string",
+                                "boolean"
+                            ],
                             "description": "Diagnostics for unsupported operations performed on __all__.",
                             "default": "warning",
                             "enum": [
                                 "none",
                                 "information",
                                 "warning",
-                                "error"
+                                "error",
+                                true,
+                                false
                             ]
                         },
                         "reportUnusedCallResult": {
-                            "type": "string",
+                            "type": [
+                                "string",
+                                "boolean"
+                            ],
                             "description": "Diagnostics for call expressions whose results are not consumed and are not None.",
                             "default": "none",
                             "enum": [
                                 "none",
                                 "information",
                                 "warning",
-                                "error"
+                                "error",
+                                true,
+                                false
                             ]
                         },
                         "reportUnusedCoroutine": {
-                            "type": "string",
+                            "type": [
+                                "string",
+                                "boolean"
+                            ],
                             "description": "Diagnostics for call expressions that return a Coroutine and whose results are not consumed.",
                             "default": "error",
                             "enum": [
                                 "none",
                                 "information",
                                 "warning",
-                                "error"
+                                "error",
+                                true,
+                                false
                             ]
                         },
                         "reportUnusedExpression": {
-                            "type": "string",
+                            "type": [
+                                "string",
+                                "boolean"
+                            ],
                             "description": "Diagnostics for simple expressions whose value is not used in any way.",
                             "default": "warning",
                             "enum": [
                                 "none",
                                 "information",
                                 "warning",
-                                "error"
+                                "error",
+                                true,
+                                false
                             ]
                         },
                         "reportUnnecessaryTypeIgnoreComment": {
-                            "type": "string",
+                            "type": [
+                                "string",
+                                "boolean"
+                            ],
                             "description": "Diagnostics for '# type: ignore' comments that have no effect.",
                             "default": "none",
                             "enum": [
                                 "none",
                                 "information",
                                 "warning",
-                                "error"
+                                "error",
+                                true,
+                                false
                             ]
                         },
                         "reportMatchNotExhaustive": {
-                            "type": "string",
+                            "type": [
+                                "string",
+                                "boolean"
+                            ],
                             "description": "Diagnostics for 'match' statements that do not exhaustively match all possible values.",
                             "default": "none",
                             "enum": [
                                 "none",
                                 "information",
                                 "warning",
-                                "error"
+                                "error",
+                                true,
+                                false
                             ]
                         },
                         "reportShadowedImports": {
-                            "type": "string",
+                            "type": [
+                                "string",
+                                "boolean"
+                            ],
                             "description": "Diagnostics for files that are overriding a module in the stdlib.",
                             "default": "none",
                             "enum": [
                                 "none",
                                 "information",
                                 "warning",
-                                "error"
+                                "error",
+                                true,
+                                false
                             ]
                         },
                         "reportImplicitOverride": {
-                            "type": "string",
+                            "type": [
+                                "string",
+                                "boolean"
+                            ],
                             "description": "Diagnostics for overridden methods that do not include an `@override` decorator.",
                             "default": "none",
                             "enum": [
                                 "none",
                                 "information",
                                 "warning",
-                                "error"
+                                "error",
+                                true,
+                                false
                             ]
                         }
                     }


### PR DESCRIPTION
This PR adds support for accepting `true` and `false` in `settings.json`'s `diagnosticSeverityOverrides`.

It makes the `diagnosticSeverityOverrides` work the same as the corresponding config file options and the `# pyright` comment overrides, which already support `true` and `false` for all the `reportXXX` rules. The value `true`  will be treated as "error" and `false` will be treated as "none".