### PR TITLE
Fixed bug that results in an incorrect type evaluation when `functool…

### DIFF
--- a/packages/pyright-internal/src/analyzer/constructorTransform.ts
+++ b/packages/pyright-internal/src/analyzer/constructorTransform.ts
@@ -95,13 +95,15 @@ function applyPartialTransform(
 
     const origFunctionTypeResult = evaluator.getTypeOfArgument(argList[0]);
     let origFunctionType = origFunctionTypeResult.type;
+    const origFunctionTypeConcrete = evaluator.makeTopLevelTypeVarsConcrete(origFunctionType);
 
-    if (isTypeVar(origFunctionType)) {
-        origFunctionType = evaluator.makeTopLevelTypeVarsConcrete(origFunctionType);
-    }
+    if (isInstantiableClass(origFunctionTypeConcrete)) {
+        const constructor = createFunctionFromConstructor(
+            evaluator,
+            origFunctionTypeConcrete,
+            isTypeVar(origFunctionType) ? convertToInstance(origFunctionType) : undefined
+        );
 
-    if (isInstantiableClass(origFunctionType)) {
-        const constructor = createFunctionFromConstructor(evaluator, origFunctionType);
         if (constructor) {
             origFunctionType = constructor;
         }

--- a/packages/pyright-internal/src/analyzer/constructors.ts
+++ b/packages/pyright-internal/src/analyzer/constructors.ts
@@ -45,6 +45,7 @@ import {
     InheritanceChain,
     OverloadedFunctionType,
     Type,
+    TypeVarType,
     UnknownType,
     isAny,
     isAnyOrUnknown,
@@ -783,6 +784,7 @@ function applyExpectedTypeForTupleConstructor(type: ClassType, inferenceContext:
 export function createFunctionFromConstructor(
     evaluator: TypeEvaluator,
     classType: ClassType,
+    selfType: ClassType | TypeVarType | undefined = undefined,
     recursionCount = 0
 ): FunctionType | OverloadedFunctionType | undefined {
     // Use the __init__ method if available. It's usually more detailed.
@@ -804,19 +806,19 @@ export function createFunctionFromConstructor(
                 initSubtype,
                 /* memberClass */ undefined,
                 /* treatConstructorAsClassMember */ undefined,
-                /* selfType */ undefined,
+                selfType,
                 /* diag */ undefined,
                 recursionCount
             ) as FunctionType | undefined;
 
             if (constructorFunction) {
                 constructorFunction = FunctionType.clone(constructorFunction);
-                constructorFunction.details.declaredReturnType = objectType;
+                constructorFunction.details.declaredReturnType = selfType ?? objectType;
                 constructorFunction.details.name = '';
                 constructorFunction.details.fullName = '';
 
                 if (constructorFunction.specializedTypes) {
-                    constructorFunction.specializedTypes.returnType = objectType;
+                    constructorFunction.specializedTypes.returnType = selfType ?? objectType;
                 }
 
                 if (!constructorFunction.details.docString && classType.details.docString) {
@@ -869,7 +871,7 @@ export function createFunctionFromConstructor(
                 newSubtype,
                 /* memberClass */ undefined,
                 /* treatConstructorAsClassMember */ true,
-                /* selfType */ undefined,
+                selfType,
                 /* diag */ undefined,
                 recursionCount
             ) as FunctionType | undefined;

--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -22917,7 +22917,12 @@ export function createTypeEvaluator(importLookup: ImportLookup, evaluatorOptions
 
             // If it's a class, use the constructor for type compatibility checking.
             if (isInstantiableClass(concreteSrcType) && concreteSrcType.literalValue === undefined) {
-                const constructor = createFunctionFromConstructor(evaluatorInterface, concreteSrcType, recursionCount);
+                const constructor = createFunctionFromConstructor(
+                    evaluatorInterface,
+                    concreteSrcType,
+                    isTypeVar(srcType) ? convertToInstance(srcType) : undefined,
+                    recursionCount
+                );
                 if (constructor) {
                     concreteSrcType = constructor;
                 }

--- a/packages/pyright-internal/src/tests/samples/partial5.py
+++ b/packages/pyright-internal/src/tests/samples/partial5.py
@@ -1,8 +1,9 @@
 # This sample tests the case where a class is passed as the first argument
 # to functools.partial.
 
+from dataclasses import dataclass
 from functools import partial
-from typing import TypeVar
+from typing import Self, TypeVar
 
 
 class A:
@@ -32,3 +33,19 @@ def func1(x: type[T]):
     v2()
 
     v2(x=1)
+
+
+@dataclass
+class B:
+    x: int
+    y: str
+
+    @classmethod
+    def from_x(cls, x: int) -> Self:
+        make_b = partial(cls, x=x)
+        reveal_type(make_b, expected_text="partial[Self@B]")
+
+        self = make_b(y="")
+        reveal_type(self, expected_text="Self@B")
+
+        return self


### PR DESCRIPTION
…s.partial` is used with a constructor where `type[Self]` is passed as the first argument. This addresses #6378.