### PR TITLE
Fixed a bug that led to a false negative when a subclass overrides a …

### DIFF
--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -24878,7 +24878,7 @@ export function createTypeEvaluator(importLookup: ImportLookup, evaluatorOptions
             }
 
             if (matchIndex < 0) {
-                continue;
+                break;
             }
 
             if (matchIndex < previousMatchIndex) {

--- a/packages/pyright-internal/src/tests/samples/methodOverride6.py
+++ b/packages/pyright-internal/src/tests/samples/methodOverride6.py
@@ -263,3 +263,31 @@ class Child4_1(Parent4[int]):
 
     def function(self, a: int | None = None) -> float:
         return 0.0
+
+
+class Parent5:
+    @overload
+    def m1(self, x: int) -> int:
+        ...
+
+    @overload
+    def m1(self, x: str) -> str:
+        ...
+
+    def m1(self, x: int | str) -> int | str:
+        ...
+
+
+class Parent5_1(Parent5):
+    @overload
+    def m1(self, x: bytes) -> bytes:
+        ...
+
+    @overload
+    def m1(self, x: str) -> str:
+        ...
+
+    # This should generate an error because the overloads are
+    # incompatible
+    def m1(self, x: bytes | str) -> bytes | str:
+        ...

--- a/packages/pyright-internal/src/tests/typeEvaluator3.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator3.test.ts
@@ -877,7 +877,7 @@ test('MethodOverride6', () => {
 
     configOptions.diagnosticRuleSet.reportIncompatibleMethodOverride = 'error';
     const analysisResults2 = TestUtils.typeAnalyzeSampleFiles(['methodOverride6.py'], configOptions);
-    TestUtils.validateResults(analysisResults2, 2);
+    TestUtils.validateResults(analysisResults2, 3);
 });
 
 test('Enum1', () => {


### PR DESCRIPTION
…parent class with an overloaded method in an incompatible manner. This addresses #6382.