### PR TITLE
Potential fix for bind failure during source file check

### DIFF
--- a/packages/pyright-internal/src/analyzer/program.ts
+++ b/packages/pyright-internal/src/analyzer/program.ts
@@ -1890,12 +1890,12 @@ export class Program {
                 return false;
             }
 
-            if (!this._disableChecker) {
+            if (!this._disableChecker && !fileToCheck.sourceFile.isFileDeleted()) {
                 // For ipython, make sure we check all its dependent files first since
                 // their results can affect this file's result.
                 const dependentFiles = this._checkDependentFiles(fileToCheck, chainedByList, token);
 
-                this._bindFile(fileToCheck);
+                this._bindFile(fileToCheck, undefined, /* skipFileNeededCheck */ fileToCheck.sourceFile.isBindingRequired());
                 if (this._preCheckCallback) {
                     const parseResults = fileToCheck.sourceFile.getParseResults();
                     if (parseResults) {

--- a/packages/pyright-internal/src/analyzer/program.ts
+++ b/packages/pyright-internal/src/analyzer/program.ts
@@ -1895,7 +1895,11 @@ export class Program {
                 // their results can affect this file's result.
                 const dependentFiles = this._checkDependentFiles(fileToCheck, chainedByList, token);
 
-                this._bindFile(fileToCheck, undefined, /* skipFileNeededCheck */ fileToCheck.sourceFile.isBindingRequired());
+                this._bindFile(
+                    fileToCheck,
+                    undefined,
+                    /* skipFileNeededCheck */ fileToCheck.sourceFile.isBindingRequired()
+                );
                 if (this._preCheckCallback) {
                     const parseResults = fileToCheck.sourceFile.getParseResults();
                     if (parseResults) {

--- a/packages/pyright-internal/src/analyzer/sourceFile.ts
+++ b/packages/pyright-internal/src/analyzer/sourceFile.ts
@@ -135,6 +135,18 @@ class WriteableData {
     builtinsImport: ImportResult | undefined;
     // True if the file appears to have been deleted.
     isFileDeleted = false;
+
+    dump() {
+        return JSON.stringify(this, (key, value) => {
+            if (typeof value === 'object') {
+                return '<object>';
+            }
+            if (Array.isArray(value)) {
+                return '<array>';
+            }
+            return value;
+        });
+    }
 }
 
 export interface SourceFileEditMode {
@@ -778,7 +790,7 @@ export class SourceFile {
         dependentFiles?: ParseResults[]
     ) {
         assert(!this.isParseRequired(), 'Check called before parsing');
-        assert(!this.isBindingRequired(), 'Check called before binding');
+        assert(!this.isBindingRequired(), `Check called before binding: state=${this._writableData.dump()}`);
         assert(!this._writableData.isBindingInProgress, 'Check called while binding in progress');
         assert(this.isCheckingRequired(), 'Check called unnecessarily');
         assert(this._writableData.parseResults !== undefined, 'Parse results not available');

--- a/packages/pyright-internal/src/analyzer/sourceFile.ts
+++ b/packages/pyright-internal/src/analyzer/sourceFile.ts
@@ -136,16 +136,35 @@ class WriteableData {
     // True if the file appears to have been deleted.
     isFileDeleted = false;
 
-    dump() {
-        return JSON.stringify(this, (key, value) => {
-            if (typeof value === 'object') {
-                return '<object>';
-            }
-            if (Array.isArray(value)) {
-                return '<array>';
-            }
-            return value;
-        });
+    debugPrint() {
+        return `WritableData: 
+ diagnosticVersion=${this.diagnosticVersion}, 
+ noCircularDependencyConfirmed=${this.noCircularDependencyConfirmed}, 
+ isBindingNeeded=${this.isBindingNeeded},
+ isBindingInProgress=${this.isBindingInProgress},
+ isCheckingNeeded=${this.isCheckingNeeded},
+ isFileDeleted=${this.isFileDeleted},
+ hitMaxImportDepth=${this.hitMaxImportDepth},
+ parseTreeNeedsCleaning=${this.parseTreeNeedsCleaning},
+ fileContentsVersion=${this.fileContentsVersion},
+ analyzedFileContentsVersion=${this.analyzedFileContentsVersion},
+ clientDocumentVersion=${this.clientDocumentVersion},
+ lastFileContentLength=${this.lastFileContentLength},
+ lastFileContentHash=${this.lastFileContentHash},
+ typeIgnoreAll=${this.typeIgnoreAll},
+ imports=${this.imports?.length},
+ builtinsImport=${this.builtinsImport?.importName},
+ circularDependencies=${this.circularDependencies?.length},
+ parseDiagnostics=${this.parseDiagnostics?.length},
+ commentDiagnostics=${this.commentDiagnostics?.length},
+ bindDiagnostics=${this.bindDiagnostics?.length},
+ checkerDiagnostics=${this.checkerDiagnostics?.length},
+ accumulatedDiagnostics=${this.accumulatedDiagnostics?.length},
+ typeIgnoreLines=${this.typeIgnoreLines?.size},
+ pyrightIgnoreLines=${this.pyrightIgnoreLines?.size},
+ checkTime=${this.checkTime},
+ clientDocumentContents=${this.clientDocumentContents?.length},
+ parseResults=${this.parseResults?.parseTree.length}`;
     }
 }
 
@@ -790,7 +809,7 @@ export class SourceFile {
         dependentFiles?: ParseResults[]
     ) {
         assert(!this.isParseRequired(), 'Check called before parsing');
-        assert(!this.isBindingRequired(), `Check called before binding: state=${this._writableData.dump()}`);
+        assert(!this.isBindingRequired(), `Check called before binding: state=${this._writableData.debugPrint()}`);
         assert(!this._writableData.isBindingInProgress, 'Check called while binding in progress');
         assert(this.isCheckingRequired(), 'Check called unnecessarily');
         assert(this._writableData.parseResults !== undefined, 'Parse results not available');


### PR DESCRIPTION
Addresses https://github.com/microsoft/pylance-release/issues/5097

Saw a potential spot where this problem might occur:

Binding is required but it doesn't happen because a file is skipped. Check is still called in that situation.
Also added more information when binding is required but the check happens anyway.