### PR TITLE
Fixed a bug that resulted in an incorrect type evaluation when access…

### DIFF
--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -5904,7 +5904,11 @@ export function createTypeEvaluator(importLookup: ImportLookup, evaluatorOptions
             // generic but are not defined that way. Because of this, we use type variables
             // in the synthesized methods (e.g. __get__) for the property class that are
             // defined in the class that declares the fget method.
-            const specializedType = partiallySpecializeType(methodType, memberInfo.classType, classType);
+            const specializedType = partiallySpecializeType(
+                methodType,
+                memberInfo.classType,
+                selfType ? (convertToInstantiable(selfType) as ClassType | TypeVarType) : classType
+            );
             if (isFunction(specializedType) || isOverloadedFunction(specializedType)) {
                 methodType = specializedType;
             }

--- a/packages/pyright-internal/src/tests/samples/property1.py
+++ b/packages/pyright-internal/src/tests/samples/property1.py
@@ -2,6 +2,9 @@
 # properties.
 
 
+from typing import Self
+
+
 class ClassA:
     @property
     def read_only_prop(self):
@@ -66,7 +69,7 @@ a.deletable_prop = val
 del a.deletable_prop
 
 
-class ClassWithProperty:
+class ClassB:
     @property
     def name(self) -> str:
         return "bar"
@@ -75,3 +78,17 @@ class ClassWithProperty:
 p1: property = ClassA.read_only_prop
 p2: property = ClassA.read_write_prop
 p3: property = ClassA.deletable_prop
+
+
+class ClassC:
+    @property
+    def prop1(self) -> type[Self]:
+        ...
+
+    def method1(self) -> None:
+        reveal_type(self.prop1, expected_text="type[Self@ClassC]")
+
+
+class ClassD(ClassC):
+    def method1(self) -> None:
+        reveal_type(self.prop1, expected_text="type[Self@ClassD]")


### PR DESCRIPTION
…ing a property that returns `Self` or `type[Self]`.