### PR TITLE
Changed behavior when converting a class to a callable. If the class …

### DIFF
--- a/packages/pyright-internal/src/analyzer/constructors.ts
+++ b/packages/pyright-internal/src/analyzer/constructors.ts
@@ -922,10 +922,15 @@ export function createFunctionFromConstructor(
         }
     }
 
-    // Return a generic constructor.
+    // Return a fallback constructor based on the object.__new__ method.
     const constructorFunction = FunctionType.createSynthesizedInstance('__new__', FunctionTypeFlags.None);
     constructorFunction.details.declaredReturnType = ClassType.cloneAsInstance(classType);
-    FunctionType.addDefaultParameters(constructorFunction);
+
+    // If this is type[T] or a protocol, we don't know what parameters are accepted
+    // by the constructor, so add the default parameters.
+    if (classType.includeSubclasses || ClassType.isProtocolClass(classType)) {
+        FunctionType.addDefaultParameters(constructorFunction);
+    }
 
     if (!constructorFunction.details.docString && classType.details.docString) {
         constructorFunction.details.docString = classType.details.docString;

--- a/packages/pyright-internal/src/tests/samples/constructor8.py
+++ b/packages/pyright-internal/src/tests/samples/constructor8.py
@@ -2,7 +2,17 @@
 # type if its constructor conforms to that type.
 
 from dataclasses import dataclass
-from typing import Any, Callable, Generic, Literal, ParamSpec, TypeVar, Union, overload
+from typing import (
+    Any,
+    Callable,
+    Generic,
+    Literal,
+    ParamSpec,
+    Sized,
+    TypeVar,
+    Union,
+    overload,
+)
 
 T1 = TypeVar("T1")
 T2 = TypeVar("T2")
@@ -115,3 +125,23 @@ def func2(x: T1) -> E[T1]:
 
 
 e2: Callable[[int], E[int]] = func2
+
+
+def cast_to_callable(cls: Callable[P, T1]) -> Callable[P, T1]:
+    return cls
+
+
+class F:
+    pass
+
+
+reveal_type(cast_to_callable(F), expected_text="() -> F")
+reveal_type(
+    cast_to_callable(Sized), expected_text="(*args: Any, **kwargs: Any) -> Sized"
+)
+
+
+def func3(t: type[object]):
+    reveal_type(
+        cast_to_callable(t), expected_text="(*args: Any, **kwargs: Any) -> object"
+    )


### PR DESCRIPTION
…has no `__init__` or `__new__` method in its class hierarchy (other than those provided by `object`), pyright previously converted the constructor to a signature of `(*args: Any, **kwargs: Any)`. It now converts it to a signature of `()` (i.e. no params) unless it's a `type[T]` or a protocol class. This addresses #6426.