### PR TITLE
Added check for the use of contravariant TypeVars in an inferred retu…

### DIFF
--- a/packages/pyright-internal/src/tests/samples/genericType33.py
+++ b/packages/pyright-internal/src/tests/samples/genericType33.py
@@ -14,7 +14,7 @@ class Foo(Protocol[T_contra]):
         ...
 
 
-def t1(x: Foo[T_contra]) -> T_contra | None:
+def t1(x: Foo[T_contra]) -> list[T_contra] | None:
     ...
 
 
@@ -22,7 +22,7 @@ def t2(x: Foo[object]) -> None:
     ...
 
 
-def func1(x: Foo[T_contra]) -> T_contra | None:
+def func1(x: Foo[T_contra]) -> list[T_contra] | None:
     # This should generate an error.
     t2(x)
 

--- a/packages/pyright-internal/src/tests/samples/typeVar4.py
+++ b/packages/pyright-internal/src/tests/samples/typeVar4.py
@@ -41,8 +41,15 @@ class Foo(Generic[_T, _T_co, _T_contra]):
     def func8(self) -> _T_contra:
         ...
 
+    # This should generate an error because contravariant
+    # TypeVars are not allowed for return parameters.
     def func9(self) -> _T_contra | int:
         return 3
 
-    def func10(self) -> list[_T_contra]:
+    # This should generate an error because contravariant
+    # TypeVars are not allowed for return parameters.
+    def func10(self, x: _T_contra):
+        return x
+
+    def func11(self) -> list[_T_contra]:
         return []

--- a/packages/pyright-internal/src/tests/typeEvaluator4.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator4.test.ts
@@ -1140,7 +1140,7 @@ test('TypeVar3', () => {
 test('TypeVar4', () => {
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['typeVar4.py']);
 
-    TestUtils.validateResults(analysisResults, 2);
+    TestUtils.validateResults(analysisResults, 4);
 });
 
 test('TypeVar5', () => {


### PR DESCRIPTION
…rn type. Also fixed an existing bug in the contravariant return type check where a contravariant used in a union was not reported. This addresses #6414.