### PR TITLE
Fixed regression that results in a false positive when using a value …

### DIFF
--- a/packages/pyright-internal/src/analyzer/checker.ts
+++ b/packages/pyright-internal/src/analyzer/checker.ts
@@ -3677,16 +3677,6 @@ export class Checker extends ParseTreeWalker {
             return;
         }
 
-        // According to PEP 544, protocol classes cannot be used as the right-hand
-        // argument to isinstance or issubclass unless they are annotated as
-        // "runtime checkable".
-        if (classTypeList.some((type) => ClassType.isProtocolClass(type) && !ClassType.isRuntimeCheckable(type))) {
-            this._evaluator.addError(
-                Localizer.Diagnostic.protocolUsedInCall().format({ name: callName }),
-                node.arguments[1].valueExpression
-            );
-        }
-
         if (derivesFromAnyOrUnknown(arg0Type)) {
             return;
         }
@@ -3826,7 +3816,14 @@ export class Checker extends ParseTreeWalker {
                         // type arguments. This will result in a TypeError exception.
                         diag.addMessage(Localizer.DiagnosticAddendum.genericClassNotAllowed());
                         isSupported = false;
-                    } else if (ClassType.isProtocolClass(subtype) && !ClassType.isRuntimeCheckable(subtype)) {
+                    } else if (
+                        ClassType.isProtocolClass(subtype) &&
+                        !ClassType.isRuntimeCheckable(subtype) &&
+                        !subtype.includeSubclasses
+                    ) {
+                        // According to PEP 544, protocol classes cannot be used as the right-hand
+                        // argument to isinstance or issubclass unless they are annotated as
+                        // "runtime checkable".
                         diag.addMessage(Localizer.DiagnosticAddendum.protocolRequiresRuntimeCheckable());
                         isSupported = false;
                     }

--- a/packages/pyright-internal/src/localization/localize.ts
+++ b/packages/pyright-internal/src/localization/localize.ts
@@ -777,8 +777,6 @@ export namespace Localizer {
         export const protocolIllegal = () => getRawString('Diagnostic.protocolIllegal');
         export const protocolNotAllowedInTypeArgument = () =>
             getRawString('Diagnostic.protocolNotAllowedInTypeArgument');
-        export const protocolUsedInCall = () =>
-            new ParameterizedString<{ name: string }>(getRawString('Diagnostic.protocolUsedInCall'));
         export const protocolVarianceContravariant = () =>
             new ParameterizedString<{ variable: string; class: string }>(
                 getRawString('Diagnostic.protocolVarianceContravariant')

--- a/packages/pyright-internal/src/localization/package.nls.cs.json
+++ b/packages/pyright-internal/src/localization/package.nls.cs.json
@@ -377,7 +377,6 @@
         "protocolBaseClassWithTypeArgs": "Argumenty typu nejsou u třídy Protocol povoleny při použití syntaxe parametru typu",
         "protocolIllegal": "Použití protokolu vyžaduje Python 3.7 nebo novější",
         "protocolNotAllowedInTypeArgument": "Protocol není možné použít jako argument typu",
-        "protocolUsedInCall": "Ve volání {name} není možné použít třídu protokolu",
         "protocolVarianceContravariant": "Proměnná typu „{variable}“ použitá v obecném protokolu „{class}“ by měla být kontravariantní",
         "protocolVarianceCovariant": "Proměnná typu „{variable}“ použitá v obecném protokolu „{class}“ by měla být kovariantní",
         "protocolVarianceInvariant": "Proměnná typu „{variable}“ použitá v obecném protokolu „{class}“ by měla být invariantní",

--- a/packages/pyright-internal/src/localization/package.nls.de.json
+++ b/packages/pyright-internal/src/localization/package.nls.de.json
@@ -377,7 +377,6 @@
         "protocolBaseClassWithTypeArgs": "Typargumente sind mit der Protokollklasse nicht zulässig, wenn die Typparametersyntax verwendet wird.",
         "protocolIllegal": "Die Verwendung von \"Protocol\" erfordert Python 3.7 oder höher.",
         "protocolNotAllowedInTypeArgument": "\"Protocol\" kann nicht als Typargument verwendet werden.",
-        "protocolUsedInCall": "Die Protokollklasse kann nicht im Aufruf \"{name}\" verwendet werden.",
         "protocolVarianceContravariant": "Die Typvariable \"{variable}\", die im generischen Protokoll \"{class}\" verwendet wird, muss \"contravariant\" sein.",
         "protocolVarianceCovariant": "Die Typvariable \"{variable}\", die im generischen Protokoll \"{class}\" verwendet wird, muss \"covariant\" sein.",
         "protocolVarianceInvariant": "Die Typvariable \"{variable}\", die im generischen Protokoll \"{class}\" verwendet wird, muss \"invariant\" sein.",

--- a/packages/pyright-internal/src/localization/package.nls.en-us.json
+++ b/packages/pyright-internal/src/localization/package.nls.en-us.json
@@ -363,7 +363,6 @@
         "protocolBaseClassWithTypeArgs": "Type arguments are not allowed with Protocol class when using type parameter syntax",
         "protocolIllegal": "Use of \"Protocol\" requires Python 3.7 or newer",
         "protocolNotAllowedInTypeArgument": "\"Protocol\" cannot be used as a type argument",
-        "protocolUsedInCall": "Protocol class cannot be used in \"{name}\" call",
         "protocolVarianceContravariant": "Type variable \"{variable}\" used in generic protocol \"{class}\" should be contravariant",
         "protocolVarianceCovariant": "Type variable \"{variable}\" used in generic protocol \"{class}\" should be covariant",
         "protocolVarianceInvariant": "Type variable \"{variable}\" used in generic protocol \"{class}\" should be invariant",

--- a/packages/pyright-internal/src/localization/package.nls.es.json
+++ b/packages/pyright-internal/src/localization/package.nls.es.json
@@ -377,7 +377,6 @@
         "protocolBaseClassWithTypeArgs": "No se permiten argumentos de tipo con la clase Protocol cuando se usa la sintaxis de parámetro de tipo",
         "protocolIllegal": "El uso de \"Protocolo\" requiere Python 3.7 o posterior.",
         "protocolNotAllowedInTypeArgument": "\"Protocol\" no puede utilizarse como argumento de tipo",
-        "protocolUsedInCall": "La clase de protocolo no puede utilizarse en la llamada \"{name}\".",
         "protocolVarianceContravariant": "La variable de tipo \"{variable}\" usada en el protocolo genérico \"{class}\" debe ser contravariante.",
         "protocolVarianceCovariant": "La variable de tipo \"{variable}\" usada en el protocolo genérico \"{class}\" debe ser covariante",
         "protocolVarianceInvariant": "La variable de tipo \"{variable}\" usada en el protocolo genérico \"{class}\" debe ser invariable.",

--- a/packages/pyright-internal/src/localization/package.nls.fr.json
+++ b/packages/pyright-internal/src/localization/package.nls.fr.json
@@ -377,7 +377,6 @@
         "protocolBaseClassWithTypeArgs": "Les arguments de type ne sont pas autorisés avec la classe Protocol lors de l'utilisation de la syntaxe des paramètres de type",
         "protocolIllegal": "L’utilisation de « Protocole » nécessite Python 3.7 ou une version plus récente",
         "protocolNotAllowedInTypeArgument": "« Protocol » ne peut pas être utilisé comme argument de type",
-        "protocolUsedInCall": "Impossible d’utiliser la classe de protocole dans l’appel « {name} »",
         "protocolVarianceContravariant": "La variable de type \"{variable}\" utilisée dans le protocole générique \"{class}\" doit être contravariante",
         "protocolVarianceCovariant": "La variable de type \"{variable}\" utilisée dans le protocole générique \"{class}\" doit être covariante",
         "protocolVarianceInvariant": "La variable de type \"{variable}\" utilisée dans le protocole générique \"{class}\" doit être invariante",

--- a/packages/pyright-internal/src/localization/package.nls.it.json
+++ b/packages/pyright-internal/src/localization/package.nls.it.json
@@ -377,7 +377,6 @@
         "protocolBaseClassWithTypeArgs": "Gli argomenti tipo non sono consentiti con la classe Protocollo quando si usa la sintassi dei parametri tipo",
         "protocolIllegal": "L'uso del \"protocollo\" richiede Python 3.7 o versione successiva",
         "protocolNotAllowedInTypeArgument": "Impossibile utilizzare \"Protocol\" come argomento di tipo",
-        "protocolUsedInCall": "Non è possibile usare la classe protocollo nella chiamata \"{name}\"",
         "protocolVarianceContravariant": "La variabile di tipo \"{variable}\" usata nel protocollo generico \"{class}\" deve essere controvariante",
         "protocolVarianceCovariant": "La variabile di tipo \"{variable}\" usata nel protocollo generico \"{class}\" deve essere covariante",
         "protocolVarianceInvariant": "La variabile di tipo \"{variable}\" usata nel protocollo generico \"{class}\" deve essere invariabile",

--- a/packages/pyright-internal/src/localization/package.nls.ja.json
+++ b/packages/pyright-internal/src/localization/package.nls.ja.json
@@ -377,7 +377,6 @@
         "protocolBaseClassWithTypeArgs": "型パラメーター構文を使用する場合、Protocol クラスでは型引数を使用できません",
         "protocolIllegal": "\"Protocol\" を使用するには Python 3.7 以降が必要です",
         "protocolNotAllowedInTypeArgument": "\"Protocol\" は型引数として使用できません",
-        "protocolUsedInCall": "プロトコル クラスは \"{name}\" 呼び出しでは使用できません",
         "protocolVarianceContravariant": "ジェネリック プロトコル \"{class}\" で使用される型変数 \"{variable}\" は反変である必要があります",
         "protocolVarianceCovariant": "ジェネリック プロトコル \"{class}\" で使用される型変数 \"{variable}\" は共変である必要があります",
         "protocolVarianceInvariant": "ジェネリック プロトコル \"{class}\" で使用される型変数 \"{variable}\" は不変である必要があります",

--- a/packages/pyright-internal/src/localization/package.nls.ko.json
+++ b/packages/pyright-internal/src/localization/package.nls.ko.json
@@ -377,7 +377,6 @@
         "protocolBaseClassWithTypeArgs": "형식 매개 변수 구문을 사용할 때는 Protocol 클래스에 형식 인수가 허용되지 않습니다.",
         "protocolIllegal": "\"프로토콜\"을 사용하려면 Python 3.7 이상이 필요합니다.",
         "protocolNotAllowedInTypeArgument": "\"Protocol\"은 형식 인수로 사용할 수 없습니다.",
-        "protocolUsedInCall": "프로토콜 클래스는 \"{name}\" 호출에서 사용할 수 없습니다.",
         "protocolVarianceContravariant": "‘{class}‘ 제네릭 프로토콜에서 사용되는 ’{variable}‘ 형식 변수는 반공변이어야 합니다.",
         "protocolVarianceCovariant": "‘{class}‘ 제네릭 프로토콜에서 사용되는 ’{variable}‘ 형식 변수는 공변이어야 합니다",
         "protocolVarianceInvariant": "‘{class}‘ 제네릭 프로토콜에서 사용되는 ’{variable}‘ 형식 변수는 고정 변수여야 합니다.",

--- a/packages/pyright-internal/src/localization/package.nls.pl.json
+++ b/packages/pyright-internal/src/localization/package.nls.pl.json
@@ -377,7 +377,6 @@
         "protocolBaseClassWithTypeArgs": "Argumenty typu są niedozwolone w przypadku klasy protokołu, gdy jest używana składnia parametru typu",
         "protocolIllegal": "Użycie elementu „Protocol” wymaga języka Python w wersji 3.7 lub nowszej",
         "protocolNotAllowedInTypeArgument": "„Protokół” nie może być użyty jako argument typu",
-        "protocolUsedInCall": "Nie można użyć klasy protokołu w wywołaniu „{name}”.",
         "protocolVarianceContravariant": "Zmienna typu „{variable}” używana w klasie protokołu ogólnego „{class}” powinna być kontrawariantna",
         "protocolVarianceCovariant": "Zmienna typu „{variable}” używana w klasie protokołu ogólnego „{class}” powinna być kowariantna",
         "protocolVarianceInvariant": "Zmienna typu „{variable}” używana w klasie protokołu ogólnego „{class}” powinna być niezmienna",

--- a/packages/pyright-internal/src/localization/package.nls.pt-br.json
+++ b/packages/pyright-internal/src/localization/package.nls.pt-br.json
@@ -377,7 +377,6 @@
         "protocolBaseClassWithTypeArgs": "Argumentos de tipo não são permitidos com a classe Protocol ao usar a sintaxe de parâmetro de tipo",
         "protocolIllegal": "O uso de \"Protocol\" requer o Python 3.7 ou mais recente",
         "protocolNotAllowedInTypeArgument": "\"Protocolo\" não pode ser usado como um argumento de tipo",
-        "protocolUsedInCall": "A classe de protocolo não pode ser usada na chamada \"{name}\"",
         "protocolVarianceContravariant": "A variável de tipo \"{variable}\" usada no protocolo genérico \"{class}\" deve ser contravariante",
         "protocolVarianceCovariant": "A variável de tipo \"{variable}\" usada no protocolo genérico \"{class}\" deve ser covariante",
         "protocolVarianceInvariant": "A variável de tipo \"{variable}\" usada no protocolo genérico \"{class}\" deve ser invariável",

--- a/packages/pyright-internal/src/localization/package.nls.qps-ploc.json
+++ b/packages/pyright-internal/src/localization/package.nls.qps-ploc.json
@@ -377,7 +377,6 @@
         "protocolBaseClassWithTypeArgs": "[tpYEx][นั้Tÿpë ærgµmëñts ærë ñøt ælløwëð wïth Prøtøçøl çlæss whëñ µsïñg tÿpë pæræmëtër sÿñtæxẤğ倪İЂҰक्र्तिृまẤğ倪İЂҰक्र्तिृまẤğ倪İЂนั้ढूँ]",
         "protocolIllegal": "[jYjYe][นั้Üsë øf \"Prøtøçøl\" rëqµïrës Pÿthøñ 3.7 ør ñëwërẤğ倪İЂҰक्र्तिृまẤğ倪İนั้ढूँ]",
         "protocolNotAllowedInTypeArgument": "[W1e5W][นั้\"Prøtøçøl\" çæññøt þë µsëð æs æ tÿpë ærgµmëñtẤğ倪İЂҰक्र्तिृまẤğ倪İนั้ढूँ]",
-        "protocolUsedInCall": "[0gPFH][นั้Prøtøçøl çlæss çæññøt þë µsëð ïñ \"{ñæmë}\" çællẤğ倪İЂҰक्र्तिृまẤğ倪İนั้ढूँ]",
         "protocolVarianceContravariant": "[B4htZ][นั้Tÿpë værïæþlë \"{værïæþlë}\" µsëð ïñ gëñërïç prøtøçøl \"{çlæss}\" shøµlð þë çøñtræværïæñtẤğ倪İЂҰक्र्तिृまẤğ倪İЂҰक्र्तिृまẤğ倪İЂҰนั้ढूँ]",
         "protocolVarianceCovariant": "[Hcnn5][นั้Tÿpë værïæþlë \"{værïæþlë}\" µsëð ïñ gëñërïç prøtøçøl \"{çlæss}\" shøµlð þë çøværïæñtẤğ倪İЂҰक्र्तिृまẤğ倪İЂҰक्र्तिृまẤğ倪İนั้ढूँ]",
         "protocolVarianceInvariant": "[o8oB7][นั้Tÿpë værïæþlë \"{værïæþlë}\" µsëð ïñ gëñërïç prøtøçøl \"{çlæss}\" shøµlð þë ïñværïæñtẤğ倪İЂҰक्र्तिृまẤğ倪İЂҰक्र्तिृまẤğ倪İนั้ढूँ]",

--- a/packages/pyright-internal/src/localization/package.nls.ru.json
+++ b/packages/pyright-internal/src/localization/package.nls.ru.json
@@ -377,7 +377,6 @@
         "protocolBaseClassWithTypeArgs": "Аргументы типа не допускаются с классом протокола при использовании синтаксиса параметра типа",
         "protocolIllegal": "Ключевое слово \"Protocol\" можно использовать в Python версии не ниже 3.7",
         "protocolNotAllowedInTypeArgument": "\"Protocol\" не может использоваться в качестве аргумента типа",
-        "protocolUsedInCall": "Класс протокола нельзя использовать в вызове \"{name}\"",
         "protocolVarianceContravariant": "Переменная типа \"{variable}\", используемая в универсальном протоколе \"{class}\", должна быть контравариантной.",
         "protocolVarianceCovariant": "Переменная типа \"{variable}\", используемая в универсальном протоколе \"{class}\", должна быть ковариантной",
         "protocolVarianceInvariant": "Переменная типа \"{variable}\", используемая в универсальном протоколе \"{class}\", должна быть инвариантной",

--- a/packages/pyright-internal/src/localization/package.nls.tr.json
+++ b/packages/pyright-internal/src/localization/package.nls.tr.json
@@ -377,7 +377,6 @@
         "protocolBaseClassWithTypeArgs": "Tür parametresi söz dizimi kullanılırken, tür bağımsız değişkenlerinin Protokol sınıfıyla kullanılmasına izin verilmez",
         "protocolIllegal": "\"Protocol\" kullanımı için Python 3.7 veya daha yeni bir sürümü gerekiyor",
         "protocolNotAllowedInTypeArgument": "\"Protocol\" tür bağımsız değişkeni olarak kullanılamaz",
-        "protocolUsedInCall": "Protokol sınıfı \"{name}\" çağrısında kullanılamaz",
         "protocolVarianceContravariant": "\"{class}\" genel protokolünde kullanılan \"{variable}\" tür değişkeni, değişken karşıtı olmalıdır",
         "protocolVarianceCovariant": "\"{class}\" genel protokolünde kullanılan \"{variable}\" tür değişkeni birlikte değişen olmalıdır",
         "protocolVarianceInvariant": "\"{class}\" genel protokolünde kullanılan \"{variable}\" tür değişkeni sabit olmalıdır",

--- a/packages/pyright-internal/src/localization/package.nls.zh-cn.json
+++ b/packages/pyright-internal/src/localization/package.nls.zh-cn.json
@@ -377,7 +377,6 @@
         "protocolBaseClassWithTypeArgs": "使用类型参数语法时，协议类不允许使用类型参数",
         "protocolIllegal": "使用 \"Protocol\" 需要 Python 3.7 或更高版本",
         "protocolNotAllowedInTypeArgument": "\"Protocol\"不能用作类型参数",
-        "protocolUsedInCall": "协议类不能在“{name}”调用中使用",
         "protocolVarianceContravariant": "泛型协议“{class}”中使用的类型变量“{variable}”应为逆变",
         "protocolVarianceCovariant": "泛型协议“{class}”中使用的类型变量“{variable}”应为协变",
         "protocolVarianceInvariant": "泛型协议“{class}”中使用的类型变量“{variable}”应为固定变量",

--- a/packages/pyright-internal/src/localization/package.nls.zh-tw.json
+++ b/packages/pyright-internal/src/localization/package.nls.zh-tw.json
@@ -377,7 +377,6 @@
         "protocolBaseClassWithTypeArgs": "使用型別參數語法時，通訊協定類別不允許使用型別引數",
         "protocolIllegal": "使用 \"Protocol\" 需要 Python 3.7 或更新版本",
         "protocolNotAllowedInTypeArgument": "\"Protocol\" 不能作為類型引數使用",
-        "protocolUsedInCall": "通訊協定類別不能用於 \"{name}\" 呼叫",
         "protocolVarianceContravariant": "一般通訊協定 \"{class}\" 中使用的型別變數 \"{variable}\" 必須為逆變數",
         "protocolVarianceCovariant": "一般通訊協定 \"{class}\" 中使用的型別變數 \"{variable}\" 必須為共變數",
         "protocolVarianceInvariant": "一般通訊協定 \"{class}\" 中使用的型別變數 \"{variable}\" 必須為不變數",

--- a/packages/pyright-internal/src/tests/samples/isinstance4.py
+++ b/packages/pyright-internal/src/tests/samples/isinstance4.py
@@ -19,6 +19,10 @@ isinstance(4, MyProtocol1)
 issubclass(str, (str, MyProtocol1))
 
 
+def func1(t: type[MyProtocol1]):
+    isinstance(1, t)
+
+
 @runtime_checkable
 class MyProtocol2(Protocol):
     pass
@@ -50,9 +54,9 @@ def get_type_of_object(object: Union[Callable[..., Any], CustomClass]):
 _T1 = TypeVar("_T1", bound=CustomClass)
 
 
-def func1(cls: Type[_T1], val: _T1):
+def func2(cls: Type[_T1], val: _T1):
     if issubclass(cls, CustomClass):
-        reveal_type(cls, expected_text="type[_T1@func1]")
+        reveal_type(cls, expected_text="type[_T1@func2]")
     else:
         reveal_type(cls, expected_text="Never")
 
@@ -60,7 +64,7 @@ def func1(cls: Type[_T1], val: _T1):
 _T2 = TypeVar("_T2")
 
 
-def func2(x: _T2) -> Union[_T2, int]:
+def func3(x: _T2) -> Union[_T2, int]:
     if callable(x) and isfunction(x):
         return 1
     return x


### PR DESCRIPTION
…of type `type[Protocol]` as the second argument to `isinstance` or `issubclass` if the protocol isn't `@runtime_checkable`. This addresses #6463.