### PR TITLE
Fixed regression that resulted in false positive errors when a magic …

### DIFF
--- a/packages/pyright-internal/src/tests/samples/operator11.py
+++ b/packages/pyright-internal/src/tests/samples/operator11.py
@@ -1,0 +1,24 @@
+# This sample tests the case where an operator overload method is
+# defined as a callable protocol object.
+
+from typing import Protocol
+
+
+class ComparisonOp(Protocol):
+    def __call__(self, other: object, /) -> bool:
+        ...
+
+
+class Number:
+    __lt__: ComparisonOp
+    __le__: ComparisonOp
+    __gt__: ComparisonOp
+    __ge__: ComparisonOp
+
+
+n1 = Number()
+n2 = Number()
+
+v1 = n1 < n2
+v2 = n1 >= n2
+v2 = n1 > n2

--- a/packages/pyright-internal/src/tests/typeEvaluator1.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator1.test.ts
@@ -1194,6 +1194,12 @@ test('Operator10', () => {
     TestUtils.validateResults(analysisResults, 1);
 });
 
+test('Operator11', () => {
+    const analysisResults = TestUtils.typeAnalyzeSampleFiles(['operator11.py']);
+
+    TestUtils.validateResults(analysisResults, 0);
+});
+
 test('Optional1', () => {
     const configOptions = new ConfigOptions('.');
 


### PR DESCRIPTION
…method (e.g. `__lt__` or `__add__`) are implemented with a callable protocol object. This addresses #6466.