### PR TITLE
Fixed a bug that resulted in a false positive error when using a walr…

### DIFF
--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -1135,7 +1135,7 @@ export function createTypeEvaluator(importLookup: ImportLookup, evaluatorOptions
             }
 
             case ParseNodeType.AssignmentExpression: {
-                typeResult = getTypeOfExpression(node.rightExpression);
+                typeResult = getTypeOfExpression(node.rightExpression, flags, inferenceContext);
                 assignTypeToExpression(
                     node.name,
                     typeResult.type,

--- a/packages/pyright-internal/src/tests/samples/assignmentExpr9.py
+++ b/packages/pyright-internal/src/tests/samples/assignmentExpr9.py
@@ -1,7 +1,7 @@
 # This sample tests the case where an assignment expression target
 # is found within a function decorator or a function default value expression.
 
-from typing import Any, Callable, TypeVar
+from typing import Any, Callable, TypeVar, overload
 
 
 _T = TypeVar("_T")
@@ -26,3 +26,20 @@ def decorated(
 
 reveal_type(walrus_target_1, expected_text="set[int]")
 reveal_type(walrus_target_2, expected_text="list[str]")
+
+
+@overload
+def func1(value: None = None) -> None:
+    ...
+
+
+@overload
+def func1(value: str) -> str:
+    ...
+
+
+def func1(value: str | None = None) -> str | None:
+    return value
+
+
+func1(value=(param_value := "test"))


### PR DESCRIPTION
…us operator in a call expression that targets an overloaded function. This addresses #6470.