### PR TITLE
Modified recent bug fix in `isinstance` and `issubclass` type narrowi…

### DIFF
--- a/packages/pyright-internal/src/analyzer/typeGuards.ts
+++ b/packages/pyright-internal/src/analyzer/typeGuards.ts
@@ -1395,11 +1395,12 @@ function narrowTypeForIsInstance(
                         // If the variable type is a subclass of the isinstance filter,
                         // we haven't learned anything new about the variable type.
 
-                        // If the varType is a constrained TypeVar, narrow to the specific
-                        // constraint. Otherwise retain the varType.
-                        const unnarrowedType =
-                            isTypeVar(varType) && varType.details.constraints.length > 0 ? concreteVarType : varType;
-                        filteredTypes.push(addConditionToType(unnarrowedType, conditions));
+                        // If the varType is a Self or type[Self], retain the unnarrowedType.
+                        if (isTypeVar(varType) && varType.details.isSynthesizedSelf) {
+                            filteredTypes.push(addConditionToType(varType, conditions));
+                        } else {
+                            filteredTypes.push(addConditionToType(concreteVarType, conditions));
+                        }
                     } else if (filterIsSubclass) {
                         if (
                             evaluator.assignType(

--- a/packages/pyright-internal/src/tests/samples/isinstance4.py
+++ b/packages/pyright-internal/src/tests/samples/isinstance4.py
@@ -56,7 +56,7 @@ _T1 = TypeVar("_T1", bound=CustomClass)
 
 def func2(cls: Type[_T1], val: _T1):
     if issubclass(cls, CustomClass):
-        reveal_type(cls, expected_text="type[_T1@func2]")
+        reveal_type(cls, expected_text="type[CustomClass]*")
     else:
         reveal_type(cls, expected_text="Never")
 

--- a/packages/pyright-internal/src/tests/samples/typeNarrowingIsinstance1.py
+++ b/packages/pyright-internal/src/tests/samples/typeNarrowingIsinstance1.py
@@ -206,6 +206,6 @@ TA2 = str | TA1
 
 def func12(x: TA2) -> None:
     if isinstance(x, dict):
-        reveal_type(x, expected_text="dict[str, str | list[TA2] | ...]")
+        reveal_type(x, expected_text="dict[str, str | list[TA2] | dict[str, TA2]]")
     else:
         reveal_type(x, expected_text="str | list[str | ... | dict[str, TA2]]")

--- a/packages/pyright-internal/src/tests/samples/typeNarrowingIsinstance14.py
+++ b/packages/pyright-internal/src/tests/samples/typeNarrowingIsinstance14.py
@@ -18,7 +18,7 @@ reveal_type(v1, expected_text="int")
 
 def func2(klass: type[T], obj: T | int) -> T:
     assert isinstance(obj, klass)
-    reveal_type(obj, expected_text="T@func2")
+    reveal_type(obj, expected_text="object*")
     return obj
 
 

--- a/packages/pyright-internal/src/tests/samples/typeNarrowingIsinstance2.py
+++ b/packages/pyright-internal/src/tests/samples/typeNarrowingIsinstance2.py
@@ -24,7 +24,7 @@ class ClassC:
     @classmethod
     def test(cls: type[TC], id: int | TC):
         if isinstance(id, cls):
-            reveal_type(id, expected_text="TC@test")
+            reveal_type(id, expected_text="object*")
         else:
             reveal_type(id, expected_text="int")
 
@@ -36,7 +36,7 @@ class ClassD:
     @classmethod
     def test(cls: type[TD], id: int | TD):
         if isinstance(id, cls):
-            reveal_type(id, expected_text="TD@test")
+            reveal_type(id, expected_text="ClassD*")
         else:
             reveal_type(id, expected_text="int")
 


### PR DESCRIPTION
…ng logic so it better handles type variables with bounds that are unions. This addresses #6475.