### PR TITLE
Fixed a bug that resulted in a false positive error when a higher-ord…

### DIFF
--- a/packages/pyright-internal/src/analyzer/constraintSolver.ts
+++ b/packages/pyright-internal/src/analyzer/constraintSolver.ts
@@ -404,6 +404,23 @@ export function assignTypeToTypeVar(
                 } else {
                     newNarrowTypeBound = applySolvedTypeVars(curNarrowTypeBound, typeVarContext);
                 }
+            } else if (
+                isTypeVar(curNarrowTypeBound) &&
+                !isTypeVar(adjSrcType) &&
+                evaluator.assignType(
+                    evaluator.makeTopLevelTypeVarsConcrete(curNarrowTypeBound),
+                    adjSrcType,
+                    diagAddendum,
+                    /* destTypeVarContext */ undefined,
+                    /* srcTypeVarContext */ undefined,
+                    flags,
+                    recursionCount
+                )
+            ) {
+                // If the existing narrow type bound was a TypeVar that is not
+                // part of the current context we can replace it with the new
+                // source type.
+                newNarrowTypeBound = adjSrcType;
             } else {
                 // We need to widen the type.
                 if (typeVarContext.isLocked()) {

--- a/packages/pyright-internal/src/tests/samples/solverHigherOrder11.py
+++ b/packages/pyright-internal/src/tests/samples/solverHigherOrder11.py
@@ -1,0 +1,38 @@
+# This sample tests the case where a higher-order function receives
+# a generic function as an argument, and the type of the generic
+# function depends on one of the other arguments passed to the
+# higher-order function. This shouldn't depend on the order the
+# arguments are passed.
+
+
+from typing import Protocol, TypeVar
+
+
+T = TypeVar("T")
+
+
+class Proto1(Protocol[T]):
+    def method(self, v: T) -> T:
+        ...
+
+
+class Impl1:
+    def method(self, v: T) -> T:
+        ...
+
+
+def func1(a: Proto1[T], b: T) -> T:
+    ...
+
+
+v1 = func1(a=Impl1(), b="abc")
+reveal_type(v1, expected_text="str")
+
+v2 = func1(b="abc", a=Impl1())
+reveal_type(v2, expected_text="str")
+
+v3 = func1(a=Impl1(), b=1)
+reveal_type(v3, expected_text="int")
+
+v4 = func1(b=1, a=Impl1())
+reveal_type(v4, expected_text="int")

--- a/packages/pyright-internal/src/tests/typeEvaluator2.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator2.test.ts
@@ -782,6 +782,12 @@ test('SolverHigherOrder10', () => {
     TestUtils.validateResults(analysisResults, 0);
 });
 
+test('SolverHigherOrder11', () => {
+    const analysisResults = TestUtils.typeAnalyzeSampleFiles(['solverHigherOrder11.py']);
+
+    TestUtils.validateResults(analysisResults, 0);
+});
+
 test('SolverLiteral1', () => {
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['solverLiteral1.py']);
 


### PR DESCRIPTION
…er generic function is passed another generic function as an argument along with another argument that dictates the type of the first argument's type variable(s). This shouldn't depend on the order in which the arguments are passed. This addresses #6461.