### PR TITLE
Fixed bug that led to an incorrect type evaluation when a list compre…

### DIFF
--- a/packages/pyright-internal/src/tests/samples/comprehension11.py
+++ b/packages/pyright-internal/src/tests/samples/comprehension11.py
@@ -1,0 +1,18 @@
+# This sample tests the case where bidirectional type inference is used
+# in a nested manner with list comprehensions.
+
+# pyright: strict
+
+from itertools import chain
+
+times = [
+    (hour, minute, meridian)
+    for hour, minute, meridian in chain.from_iterable(
+        chain.from_iterable(
+            ((hour, minute, meridian) for minute in range(0, 60, 15))
+            for hour in range(12)
+        )
+        for meridian in ("am", "pm")
+    )
+]
+reveal_type(times, expected_text="list[tuple[int, int, Literal['am', 'pm']]]")

--- a/packages/pyright-internal/src/tests/typeEvaluator3.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator3.test.ts
@@ -478,6 +478,12 @@ test('Comprehension10', () => {
     TestUtils.validateResults(analysisResults, 1);
 });
 
+test('Comprehension11', () => {
+    const analysisResults = TestUtils.typeAnalyzeSampleFiles(['comprehension11.py']);
+
+    TestUtils.validateResults(analysisResults, 0);
+});
+
 test('Literals1', () => {
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['literals1.py']);
 


### PR DESCRIPTION
…hension expression is used with bidirectional type inference and the expected type includes a type variable. This addresses #6455.