### PR TITLE
Fixed a bug that led to incorrect type evaluation when two lists with…

### DIFF
--- a/packages/pyright-internal/src/analyzer/constraintSolver.ts
+++ b/packages/pyright-internal/src/analyzer/constraintSolver.ts
@@ -384,7 +384,7 @@ export function assignTypeToTypeVar(
                     curNarrowTypeBound,
                     adjSrcType,
                     diagAddendum,
-                    /* destTypeVarContext */ undefined,
+                    typeVarContext,
                     /* srcTypeVarContext */ undefined,
                     flags,
                     recursionCount
@@ -400,7 +400,7 @@ export function assignTypeToTypeVar(
                         adjSrcType,
                         curNarrowTypeBound,
                         /* diag */ undefined,
-                        /* destTypeVarContext */ undefined,
+                        typeVarContext,
                         /* srcTypeVarContext */ undefined,
                         flags & AssignTypeFlags.IgnoreTypeVarScope,
                         recursionCount
@@ -417,7 +417,7 @@ export function assignTypeToTypeVar(
                     evaluator.makeTopLevelTypeVarsConcrete(curNarrowTypeBound),
                     adjSrcType,
                     diagAddendum,
-                    /* destTypeVarContext */ undefined,
+                    typeVarContext,
                     /* srcTypeVarContext */ undefined,
                     flags,
                     recursionCount
@@ -443,7 +443,7 @@ export function assignTypeToTypeVar(
                         adjSrcType,
                         curNarrowTypeBound,
                         /* diag */ undefined,
-                        /* destTypeVarContext */ undefined,
+                        typeVarContext,
                         /* srcTypeVarContext */ undefined,
                         flags & AssignTypeFlags.IgnoreTypeVarScope,
                         recursionCount
@@ -519,7 +519,7 @@ export function assignTypeToTypeVar(
                         adjWideTypeBound,
                         newNarrowTypeBound,
                         diag?.createAddendum(),
-                        /* destTypeVarContext */ undefined,
+                        typeVarContext,
                         /* srcTypeVarContext */ undefined,
                         AssignTypeFlags.IgnoreTypeVarScope,
                         recursionCount

--- a/packages/pyright-internal/src/tests/samples/solver31.py
+++ b/packages/pyright-internal/src/tests/samples/solver31.py
@@ -1,0 +1,20 @@
+# This sample tests the case where an expected type contains a union,
+# as in the case where the list.__add__ method returns the type
+# list[_T | _S].
+
+from typing import Generic, Iterable, TypeVar
+
+T = TypeVar("T")
+
+
+class A(Generic[T]):
+    def __init__(self, i: Iterable[T]):
+        ...
+
+
+def func1(i: Iterable[T]) -> T:
+    ...
+
+
+reveal_type(func1([0] + [""]), expected_text="str | int")
+reveal_type(A([0] + [""]), expected_text="A[str | int]")

--- a/packages/pyright-internal/src/tests/typeEvaluator2.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator2.test.ts
@@ -698,6 +698,12 @@ test('Solver30', () => {
     TestUtils.validateResults(analysisResults, 0);
 });
 
+test('Solver31', () => {
+    const analysisResults = TestUtils.typeAnalyzeSampleFiles(['solver31.py']);
+
+    TestUtils.validateResults(analysisResults, 0);
+});
+
 test('SolverScoring1', () => {
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['solverScoring1.py']);
 


### PR DESCRIPTION
… different types were concatenated using a `+` operator in a bidirectional inference context. This addresses #6273.