### PR TITLE
Added check for the use of a bare `Literal` (with no type arguments) …

### DIFF
--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -19256,7 +19256,7 @@ export function createTypeEvaluator(importLookup: ImportLookup, evaluatorOptions
                 case 'Protocol': {
                     if (
                         (flags &
-                            (EvaluatorFlags.DisallowProtocolAndTypedDict | EvaluatorFlags.ExpectingTypeAnnotation)) !==
+                            (EvaluatorFlags.DisallowNonTypeSpecialForms | EvaluatorFlags.ExpectingTypeAnnotation)) !==
                         0
                     ) {
                         addError(Localizer.Diagnostic.protocolNotAllowed(), errorNode);
@@ -19275,10 +19275,21 @@ export function createTypeEvaluator(importLookup: ImportLookup, evaluatorOptions
                 case 'TypedDict': {
                     if (
                         (flags &
-                            (EvaluatorFlags.DisallowProtocolAndTypedDict | EvaluatorFlags.ExpectingTypeAnnotation)) !==
+                            (EvaluatorFlags.DisallowNonTypeSpecialForms | EvaluatorFlags.ExpectingTypeAnnotation)) !==
                         0
                     ) {
                         addError(Localizer.Diagnostic.typedDictNotAllowed(), errorNode);
+                    }
+                    break;
+                }
+
+                case 'Literal': {
+                    if (
+                        (flags &
+                            (EvaluatorFlags.DisallowNonTypeSpecialForms | EvaluatorFlags.ExpectingTypeAnnotation)) !==
+                        0
+                    ) {
+                        addError(Localizer.Diagnostic.literalNotAllowed(), errorNode);
                     }
                     break;
                 }
@@ -19745,7 +19756,7 @@ export function createTypeEvaluator(importLookup: ImportLookup, evaluatorOptions
         }
 
         if (options?.disallowProtocolAndTypedDict) {
-            flags |= EvaluatorFlags.DisallowProtocolAndTypedDict;
+            flags |= EvaluatorFlags.DisallowNonTypeSpecialForms;
         }
 
         return getTypeOfExpression(node, flags);

--- a/packages/pyright-internal/src/analyzer/typeEvaluatorTypes.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluatorTypes.ts
@@ -150,7 +150,7 @@ export const enum EvaluatorFlags {
     SkipConvertParamSpecToRuntimeObject = 1 << 25,
 
     // Protocol and TypedDict are not allowed in this context.
-    DisallowProtocolAndTypedDict = 1 << 26,
+    DisallowNonTypeSpecialForms = 1 << 26,
 
     // Defaults used for evaluating the LHS of a call expression.
     CallBaseDefaults = DoNotSpecialize | DisallowPep695TypeAlias,

--- a/packages/pyright-internal/src/localization/localize.ts
+++ b/packages/pyright-internal/src/localization/localize.ts
@@ -597,6 +597,7 @@ export namespace Localizer {
         export const listInAnnotation = () => getRawString('Diagnostic.listInAnnotation');
         export const literalUnsupportedType = () => getRawString('Diagnostic.literalUnsupportedType');
         export const literalEmptyArgs = () => getRawString('Diagnostic.literalEmptyArgs');
+        export const literalNotAllowed = () => getRawString('Diagnostic.literalNotAllowed');
         export const literalNotCallable = () => getRawString('Diagnostic.literalNotCallable');
         export const matchIncompatible = () => getRawString('Diagnostic.matchIncompatible');
         export const matchIsNotExhaustive = () => getRawString('Diagnostic.matchIsNotExhaustive');

--- a/packages/pyright-internal/src/localization/package.nls.en-us.json
+++ b/packages/pyright-internal/src/localization/package.nls.en-us.json
@@ -253,6 +253,7 @@
         "listInAnnotation": "List expression not allowed in type annotation",
         "literalUnsupportedType": "Type arguments for \"Literal\" must be None, a literal value (int, bool, str, or bytes), or an enum value",
         "literalEmptyArgs": "Expected one or more type arguments after \"Literal\"",
+        "literalNotAllowed": "\"Literal\" cannot be used in this context without a type argument",
         "literalNotCallable": "Literal type cannot be instantiated",
         "matchIncompatible": "Match statements require Python 3.10 or newer",
         "matchIsNotExhaustive": "Cases within match statement do not exhaustively handle all values",


### PR DESCRIPTION
…in places where it's not allowed. This addresses https://github.com/python/mypy/issues/16535.