### PR TITLE
Fixed a bug that results in incorrect type evaluation of an index exp…

### DIFF
--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -6985,7 +6985,7 @@ export function createTypeEvaluator(importLookup: ImportLookup, evaluatorOptions
                     return typeResult.type;
                 }
 
-                if (isNever(concreteSubtype) || isUnbound(concreteSubtype)) {
+                if (isNever(concreteSubtype)) {
                     return NeverType.createNever();
                 }
 

--- a/packages/pyright-internal/src/tests/samples/index1.py
+++ b/packages/pyright-internal/src/tests/samples/index1.py
@@ -104,3 +104,12 @@ class ClassF(Generic[T]):
     def get(self, index: int) -> Self:
         reveal_type(self[index], expected_text="Self@ClassF[T@ClassF]")
         return self[index]
+
+
+class ClassG:
+    __slots__ = ["x"]
+
+
+def func3(g: ClassG):
+    reveal_type(g.x, expected_text="Unbound")
+    reveal_type(g.x[0], expected_text="Unknown")


### PR DESCRIPTION
…ression when the LHS is unbound. It should produce `Unknown` rather than `Never`. This addresses #6512.