### PR TITLE
Fixed bug that resulted in a false positive under certain circumstanc…

### DIFF
--- a/packages/pyright-internal/src/analyzer/types.ts
+++ b/packages/pyright-internal/src/analyzer/types.ts
@@ -103,8 +103,10 @@ export type TypeSourceId = number;
 // This constant controls the maximum number of nested types (i.e. types
 // used as type arguments or parameter types in other types) before we
 // give up. This constant was previously set to 32, but there were certain
-// pathological recursive types where this resulted in a hang.
-export const maxTypeRecursionCount = 10;
+// pathological recursive types where this resulted in a hang. It was also
+// previously lowered to 10, but this caused some legitimate failures in
+// code that used numpy.
+export const maxTypeRecursionCount = 12;
 
 export type InheritanceChain = (ClassType | UnknownType)[];
 


### PR DESCRIPTION
…es where a recursive type alias was used and hit an internal recursion limit. This addresses #6511.