### PR TITLE
Changed the behavior for empty dict or list expressions. Previously, …

### DIFF
--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -11974,12 +11974,6 @@ export function createTypeEvaluator(importLookup: ImportLookup, evaluatorOptions
                         suppressPartialUnknown = true;
                     }
 
-                    // If the argument type comes from a `[]` or `{}` expression,
-                    // don't bother reporting it.
-                    if (isClassInstance(simplifiedType) && simplifiedType.isEmptyContainer) {
-                        suppressPartialUnknown = true;
-                    }
-
                     if (!suppressPartialUnknown) {
                         const diagAddendum = getDiagAddendum();
                         diagAddendum.addMessage(

--- a/packages/pyright-internal/src/tests/samples/emptyContainers1.py
+++ b/packages/pyright-internal/src/tests/samples/emptyContainers1.py
@@ -23,8 +23,7 @@ def func1(a: bool):
 
     val3 = val2
 
-    # This would normally generate an error, but because it comes from
-    # a [] expression, it's allowed.
+    # This should generate an error because val3 is partially unknown.
     print(val3)
     reveal_type(val3, expected_text="list[Unknown]")
 
@@ -55,8 +54,7 @@ def func2(a: bool):
 
     val3 = val2
 
-    # This would normally generate an error, but because it comes from
-    # a {} expression, it's allowed.
+    # This should generate an error because val3 is partially unknown.
     print(val3)
     reveal_type(val3, expected_text="dict[Unknown, Unknown]")
 

--- a/packages/pyright-internal/src/tests/typeEvaluator3.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator3.test.ts
@@ -1370,7 +1370,7 @@ test('Comparison2', () => {
 
 test('EmptyContainers1', () => {
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['emptyContainers1.py']);
-    TestUtils.validateResults(analysisResults, 3);
+    TestUtils.validateResults(analysisResults, 5);
 });
 
 test('InitSubclass1', () => {


### PR DESCRIPTION
…a variable initialized with `{}` or `[]` was not flagged as "partially unknown" by the `reportUnknownArgument` check when used as an argument to a call. This resulted in a small type hole. This addresses #6514.