### PR TITLE
Fixed bug that led to a false negative when `Never` is used as an exp…

### DIFF
--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -25621,7 +25621,8 @@ export function createTypeEvaluator(importLookup: ImportLookup, evaluatorOptions
 
             // Try to find the best (narrowest) match among the constraints.
             for (const constraint of constraints) {
-                if (assignType(constraint, effectiveSrcType)) {
+                // Don't allow Never as a type argument.
+                if (assignType(constraint, effectiveSrcType) && !isNever(effectiveSrcType)) {
                     if (!bestConstraintSoFar || assignType(bestConstraintSoFar, constraint)) {
                         bestConstraintSoFar = constraint;
                     }

--- a/packages/pyright-internal/src/tests/samples/constrainedTypeVar1.py
+++ b/packages/pyright-internal/src/tests/samples/constrainedTypeVar1.py
@@ -13,24 +13,34 @@ def constrained(first: S, second: S) -> S:
 # cannot satisfy the 'str' or 'bytes' constraint.
 result = constrained("a", b"abc")
 
-U = TypeVar("U", int, str)
+U = TypeVar("U", float, str)
 
 
-class Foo(Generic[U]):
+class ClassA(Generic[U]):
     def generic_func1(self, a: U, b: str = "", **kwargs: U) -> U:
         return a
 
 
-foo = Foo[str]()
-r1 = foo.generic_func1("hi")
+a1 = ClassA[str]()
+r1 = a1.generic_func1("hi")
 reveal_type(r1, expected_text="str")
-r2 = foo.generic_func1("hi", test="hi")
+r2 = a1.generic_func1("hi", test="hi")
 reveal_type(r2, expected_text="str")
 
 # This should generate an error.
-r3 = foo.generic_func1("hi", test=3)
+r3 = a1.generic_func1("hi", test=3)
 reveal_type(r3, expected_text="str")
 
 # This should generate an error.
-r4 = foo.generic_func1("hi", 3)
+r4 = a1.generic_func1("hi", 3)
 reveal_type(r4, expected_text="str")
+
+a2: ClassA[int]
+
+# This should generate an error.
+a3: ClassA[Never]
+
+ClassAAlias = ClassA[U]
+
+# This should generate an error.
+a4: ClassAAlias[Never]

--- a/packages/pyright-internal/src/tests/typeEvaluator2.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator2.test.ts
@@ -397,7 +397,7 @@ test('NameBinding5', () => {
 test('ConstrainedTypeVar1', () => {
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['constrainedTypeVar1.py']);
 
-    TestUtils.validateResults(analysisResults, 3);
+    TestUtils.validateResults(analysisResults, 5);
 });
 
 test('ConstrainedTypeVar2', () => {


### PR DESCRIPTION
…licit type argument for a generic class or type alias if the corresponding type parameter is a constrained TypeVar. This addresses #6557.