### PR TITLE
Fixed recent regression that resulted in a false negative when `type`…

### DIFF
--- a/packages/pyright-internal/src/analyzer/dataClasses.ts
+++ b/packages/pyright-internal/src/analyzer/dataClasses.ts
@@ -62,6 +62,7 @@ import {
     convertToInstance,
     getTypeVarScopeId,
     isLiteralType,
+    isMetaclassInstance,
     populateTypeVarContextForSelfType,
     requiresSpecialization,
     specializeTupleClass,
@@ -931,7 +932,7 @@ function getDescriptorForConverterField(
 // __set__ method, this method transforms the type into the input parameter
 // for the set method.
 function transformDescriptorType(evaluator: TypeEvaluator, type: Type): Type {
-    if (!isClassInstance(type)) {
+    if (!isClassInstance(type) || isMetaclassInstance(type)) {
         return type;
     }
 

--- a/packages/pyright-internal/src/tests/samples/dataclass1.py
+++ b/packages/pyright-internal/src/tests/samples/dataclass1.py
@@ -4,39 +4,39 @@ from dataclasses import dataclass, InitVar
 
 
 @dataclass
-class Bar:
+class DC1:
     bbb: int
     ccc: str
     aaa: str = "string"
     __hash__: None
 
 
-bar1 = Bar(bbb=5, ccc="hello")
-bar2 = Bar(5, "hello")
-bar3 = Bar(5, "hello", "hello2")
+bar1 = DC1(bbb=5, ccc="hello")
+bar2 = DC1(5, "hello")
+bar3 = DC1(5, "hello", "hello2")
 print(bar3.bbb)
 print(bar3.ccc)
 print(bar3.aaa)
 
 # This should generate an error because ddd
 # isn't a declared value.
-bar = Bar(bbb=5, ddd=5, ccc="hello")
+bar = DC1(bbb=5, ddd=5, ccc="hello")
 
 # This should generate an error because the
 # parameter types don't match.
-bar = Bar("hello", "goodbye")
+bar = DC1("hello", "goodbye")
 
 # This should generate an error because a parameter
 # is missing.
-bar = [Bar(2)]
+bar = [DC1(2)]
 
 # This should generate an error because there are
 # too many parameters.
-bar = Bar(2, "hello", "hello", 4)
+bar = DC1(2, "hello", "hello", 4)
 
 
 @dataclass
-class Baz1:
+class DC2:
     bbb: int
     aaa: str = "string"
 
@@ -50,13 +50,13 @@ class Baz1:
 
 
 @dataclass
-class Baz2:
+class DC3:
     aaa: str
     ddd: InitVar[int] = 3
 
 
 @dataclass(init=False)
-class Baz3:
+class DC4:
     bbb: int
     aaa: str = "string"
     # This should not generate an error because
@@ -66,7 +66,18 @@ class Baz3:
 
 
 @dataclass
-class Baz4:
+class DC5:
     # Private names are not allowed, so this should
     # generate an error.
     __private: int
+
+
+@dataclass
+class DC6:
+    x: type
+
+
+DC6(int)
+
+# This should generate an error.
+DC6(1)

--- a/packages/pyright-internal/src/tests/typeEvaluator4.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator4.test.ts
@@ -570,7 +570,7 @@ test('DataClassNamedTuple2', () => {
 test('DataClass1', () => {
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['dataclass1.py']);
 
-    TestUtils.validateResults(analysisResults, 6);
+    TestUtils.validateResults(analysisResults, 7);
 });
 
 test('DataClass2', () => {


### PR DESCRIPTION
… or `type[Any]` was used as a type annotation for a field in a dataclass. This addresses #6596.