### PR TITLE
Fixed a bug that results in a false positive when `anext` is passed a…

### DIFF
--- a/packages/pyright-internal/src/tests/samples/await1.py
+++ b/packages/pyright-internal/src/tests/samples/await1.py
@@ -1,7 +1,7 @@
 # This sample validates that the await keyword participates in
 # bidirectional type inference.
 
-from typing import Callable, TypeVar, Generic
+from typing import AsyncIterator, Callable, TypeVar, Generic
 
 T = TypeVar("T")
 AnyMsg = TypeVar("AnyMsg", bound="Msg")
@@ -19,5 +19,13 @@ async def func1(check: "Callable[[AnyMsg], bool]") -> AnyMsg:
     ...
 
 
-async def main():
+async def func2():
     _: Msg[Request] = await func1(check=lambda msg: (msg.body.id == 12345))
+
+
+async def func3() -> AsyncIterator[int]:
+    yield 1
+
+
+async def func4() -> int:
+    return await anext(func3())


### PR DESCRIPTION
… value of type `AsyncIterator`. This addresses #6598.