### PR TITLE
Fixed recent regression that results in false positive error where `t…

### DIFF
--- a/packages/pyright-internal/src/analyzer/constraintSolver.ts
+++ b/packages/pyright-internal/src/analyzer/constraintSolver.ts
@@ -112,8 +112,22 @@ export function assignTypeToTypeVar(
     // Verify that we are solving for the scope associated with this
     // type variable.
     if (!typeVarContext.hasSolveForScope(destType.scopeId)) {
+        // Handle Any as a source.
         if (isAnyOrUnknown(srcType) || (isClass(srcType) && ClassType.derivesFromAnyOrUnknown(srcType))) {
             return true;
+        }
+
+        // Handle a type[Any] as a source.
+        if (isClassInstance(srcType) && ClassType.isBuiltIn(srcType, 'type')) {
+            if (
+                !srcType.typeArguments ||
+                srcType.typeArguments.length < 1 ||
+                isAnyOrUnknown(srcType.typeArguments[0])
+            ) {
+                if (TypeBase.isInstantiable(destType)) {
+                    return true;
+                }
+            }
         }
 
         // Is this the equivalent of an "Unknown" for a ParamSpec?

--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -22801,19 +22801,14 @@ export function createTypeEvaluator(importLookup: ImportLookup, evaluatorOptions
             }
 
             if (isAnyOrUnknown(typeTypeArg)) {
-                if (isClassInstance(destType) && ClassType.isBuiltIn(expandedSrcType, 'type')) {
+                if (isEffectivelyInstantiable(destType)) {
                     return true;
                 }
-                return TypeBase.isInstantiable(destType);
-            }
-
-            const instantiableType = convertToInstantiable(typeTypeArg);
-
-            if (isClassInstance(typeTypeArg) || isTypeVar(typeTypeArg)) {
+            } else if (isClassInstance(typeTypeArg) || isTypeVar(typeTypeArg)) {
                 if (
                     assignType(
                         destType,
-                        instantiableType,
+                        convertToInstantiable(typeTypeArg),
                         diag?.createAddendum(),
                         destTypeVarContext,
                         srcTypeVarContext,

--- a/packages/pyright-internal/src/tests/samples/type1.py
+++ b/packages/pyright-internal/src/tests/samples/type1.py
@@ -1,6 +1,6 @@
 # This sample tests the handling of type[T] and Type[T].
 
-from typing import Any, Type, TypeVar
+from typing import Any, Callable, Generic, Type, TypeVar
 
 
 def func1(t1: Type, t2: Type[Any], t3: type, t4: type[Any]):
@@ -110,3 +110,17 @@ def func6(t1: TA8[T]) -> T:
 
 reveal_type(func5(int), expected_text="int")
 reveal_type(func6(int), expected_text="int")
+
+
+def func7(v: type):
+    x1: Callable[..., Any] = v
+    x2: Callable[[int, int], int] = v
+    x3: object = v
+    x4: type = v
+    x5: type[int] = v
+    x6: type[Any] = v
+
+
+class Class1(Generic[T]):
+    def method1(self, v: type) -> type[T]:
+        return v


### PR DESCRIPTION
…ype` or `type[Any]` is not considered type compatible with `Callable`. This addresses #6600.