### PR TITLE
Changed behavior of `reportUnknownMemberType` (and other checks in th…

### DIFF
--- a/packages/pyright-internal/src/analyzer/constructors.ts
+++ b/packages/pyright-internal/src/analyzer/constructors.ts
@@ -30,7 +30,6 @@ import {
     doForEachSubtype,
     ensureFunctionSignaturesAreUnique,
     getTypeVarScopeId,
-    isPartlyUnknown,
     isTupleClass,
     lookUpClassMember,
     mapSubtypes,
@@ -295,7 +294,10 @@ function validateNewAndInitMethods(
         // but didn't supply solved type arguments, we'll ignore its specialized return
         // type and rely on the __init__ method to supply the type arguments instead.
         let initMethodBindToType = newMethodReturnType;
-        if (isPartlyUnknown(initMethodBindToType)) {
+        if (
+            initMethodBindToType.typeArguments &&
+            initMethodBindToType.typeArguments.some((typeArg) => isUnknown(typeArg))
+        ) {
             initMethodBindToType = ClassType.cloneAsInstance(type);
         }
 

--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -11993,24 +11993,11 @@ export function createTypeEvaluator(importLookup: ImportLookup, evaluatorOptions
                         Localizer.Diagnostic.argTypeUnknown() + diagAddendum.getString(),
                         argParam.errorNode
                     );
-                } else if (isPartlyUnknown(simplifiedType, /* allowUnknownTypeArgsForClasses */ true)) {
-                    let suppressPartialUnknown = false;
-
-                    // Don't report an error if the type is a partially-specialized
-                    // class. This comes up frequently in cases where a type is passed
-                    // as an argument (e.g. "defaultdict(list)").
-                    if (isInstantiableClass(simplifiedType)) {
-                        suppressPartialUnknown = true;
-                    }
-
+                } else if (isPartlyUnknown(simplifiedType)) {
                     // If the parameter type is also partially unknown, don't report
                     // the error because it's likely that the partially-unknown type
                     // arose due to bidirectional type matching.
-                    if (isPartlyUnknown(argParam.paramType)) {
-                        suppressPartialUnknown = true;
-                    }
-
-                    if (!suppressPartialUnknown) {
+                    if (!isPartlyUnknown(argParam.paramType)) {
                         const diagAddendum = getDiagAddendum();
                         diagAddendum.addMessage(
                             Localizer.DiagnosticAddendum.argumentType().format({

--- a/packages/pyright-internal/src/analyzer/typeUtils.ts
+++ b/packages/pyright-internal/src/analyzer/typeUtils.ts
@@ -2546,7 +2546,7 @@ export function containsAnyOrUnknown(type: Type, recurse: boolean): AnyType | Un
 // This function does not use the TypeWalker because it is called very frequently,
 // and allocating a memory walker object for every call significantly increases
 // peak memory usage.
-export function isPartlyUnknown(type: Type, allowUnknownTypeArgsForClasses = false, recursionCount = 0): boolean {
+export function isPartlyUnknown(type: Type, recursionCount = 0): boolean {
     if (recursionCount > maxTypeRecursionCount) {
         return false;
     }
@@ -2559,34 +2559,30 @@ export function isPartlyUnknown(type: Type, allowUnknownTypeArgsForClasses = fal
     // If this is a generic type alias, see if any of its type arguments
     // are either unspecified or are partially known.
     if (type.typeAliasInfo?.typeArguments) {
-        if (
-            type.typeAliasInfo.typeArguments.some((typeArg) =>
-                isPartlyUnknown(typeArg, allowUnknownTypeArgsForClasses, recursionCount)
-            )
-        ) {
+        if (type.typeAliasInfo.typeArguments.some((typeArg) => isPartlyUnknown(typeArg, recursionCount))) {
             return true;
         }
     }
 
     // See if a union contains an unknown type.
     if (isUnion(type)) {
-        return (
-            findSubtype(type, (subtype) => isPartlyUnknown(subtype, allowUnknownTypeArgsForClasses, recursionCount)) !==
-            undefined
-        );
+        return findSubtype(type, (subtype) => isPartlyUnknown(subtype, recursionCount)) !== undefined;
     }
 
     // See if an object or class has an unknown type argument.
     if (isClass(type)) {
-        if (TypeBase.isInstance(type)) {
-            allowUnknownTypeArgsForClasses = false;
+        // If this is a reference to the class itself, as opposed to a reference
+        // to a type that represents the class and its subclasses, don't flag
+        // the type as partially unknown.
+        if (!type.includeSubclasses) {
+            return false;
         }
 
-        if (!allowUnknownTypeArgsForClasses && !ClassType.isPseudoGenericClass(type)) {
+        if (!ClassType.isPseudoGenericClass(type)) {
             const typeArgs = type.tupleTypeArguments?.map((t) => t.type) || type.typeArguments;
             if (typeArgs) {
                 for (const argType of typeArgs) {
-                    if (isPartlyUnknown(argType, allowUnknownTypeArgsForClasses, recursionCount)) {
+                    if (isPartlyUnknown(argType, recursionCount)) {
                         return true;
                     }
                 }
@@ -2599,7 +2595,7 @@ export function isPartlyUnknown(type: Type, allowUnknownTypeArgsForClasses = fal
     // See if a function has an unknown type.
     if (isOverloadedFunction(type)) {
         return OverloadedFunctionType.getOverloads(type).some((overload) => {
-            return isPartlyUnknown(overload, /* allowUnknownTypeArgsForClasses */ false, recursionCount);
+            return isPartlyUnknown(overload, recursionCount);
         });
     }
 
@@ -2608,7 +2604,7 @@ export function isPartlyUnknown(type: Type, allowUnknownTypeArgsForClasses = fal
             // Ignore parameters such as "*" that have no name.
             if (type.details.parameters[i].name) {
                 const paramType = FunctionType.getEffectiveParameterType(type, i);
-                if (isPartlyUnknown(paramType, /* allowUnknownTypeArgsForClasses */ false, recursionCount)) {
+                if (isPartlyUnknown(paramType, recursionCount)) {
                     return true;
                 }
             }
@@ -2617,7 +2613,7 @@ export function isPartlyUnknown(type: Type, allowUnknownTypeArgsForClasses = fal
         if (
             type.details.declaredReturnType &&
             !FunctionType.isParamSpecValue(type) &&
-            isPartlyUnknown(type.details.declaredReturnType, /* allowUnknownTypeArgsForClasses */ false, recursionCount)
+            isPartlyUnknown(type.details.declaredReturnType, recursionCount)
         ) {
             return true;
         }


### PR DESCRIPTION
…e `reportUnknown...` family) to not report a partially-unknown type if it refers to an unspecialized class. This addresses #6582.