### PR TITLE
Fixed bug that results in incorrect type evaluation when a `raise` st…

### DIFF
--- a/packages/pyright-internal/src/analyzer/binder.ts
+++ b/packages/pyright-internal/src/analyzer/binder.ts
@@ -1437,6 +1437,10 @@ export class Binder extends ParseTreeWalker {
     }
 
     override visitRaise(node: RaiseNode): boolean {
+        if (this._currentFlowNode) {
+            this._addExceptTargets(this._currentFlowNode);
+        }
+
         if (this._targetFunctionDeclaration) {
             if (!this._targetFunctionDeclaration.raiseStatements) {
                 this._targetFunctionDeclaration.raiseStatements = [];

--- a/packages/pyright-internal/src/tests/samples/with2.py
+++ b/packages/pyright-internal/src/tests/samples/with2.py
@@ -2,7 +2,8 @@
 # or __aexit__ method.
 
 
-from typing import Any, TypeVar
+from contextlib import AbstractContextManager
+from typing import Any, Literal, TypeVar
 
 _T1 = TypeVar("_T1")
 
@@ -61,3 +62,17 @@ async def test2():
     # needs to be used with async with.
     async with a1 as foo:
         pass
+
+
+class Class5(AbstractContextManager[Any]):
+    def __exit__(self, exc_type: Any, exc_value: Any, tb: Any) -> Literal[True]:
+        return True
+
+
+def test3(val: Exception | None):
+    val = None
+    with Class5():
+        val = Exception("asdf")
+        raise Exception
+
+    reveal_type(val, expected_text="Exception | None")


### PR DESCRIPTION
…atement is used within a context manager that swallows exceptions. This addresses #6620.