### PR TITLE
Added support for `*args: *Ts` parameter that captures a callable wit…

### DIFF
--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -21950,6 +21950,15 @@ export function createTypeEvaluator(importLookup: ImportLookup, evaluatorOptions
             }
         }
 
+        // Remove any optional parameters from the end of the two lists until the lengths match.
+        while (srcTypeArgs.length > destTypeArgs.length && srcTypeArgs[srcTypeArgs.length - 1].isOptional) {
+            srcTypeArgs.splice(srcTypeArgs.length - 1, 1);
+        }
+
+        while (destTypeArgs.length > srcTypeArgs.length && destTypeArgs[destTypeArgs.length - 1].isOptional) {
+            destTypeArgs.splice(destTypeArgs.length - 1, 1);
+        }
+
         const srcArgsToCapture = srcTypeArgs.length - destTypeArgs.length + 1;
 
         if (destUnboundedIndex >= 0 && srcArgsToCapture >= 0) {
@@ -24042,7 +24051,7 @@ export function createTypeEvaluator(importLookup: ImportLookup, evaluatorOptions
                     srcTupleTypes.push({ type: entry.type, isUnbounded: true });
                 }
             } else {
-                srcTupleTypes.push({ type: entry.type, isUnbounded: false });
+                srcTupleTypes.push({ type: entry.type, isUnbounded: false, isOptional: entry.param.hasDefault });
             }
         });
 

--- a/packages/pyright-internal/src/analyzer/types.ts
+++ b/packages/pyright-internal/src/analyzer/types.ts
@@ -604,6 +604,11 @@ export interface TupleTypeArgument {
     // Does the type argument represent a single value or
     // an "unbounded" (zero or more) arguments?
     isUnbounded: boolean;
+
+    // For tuples captured from a callable, this indicates
+    // the corresponding positional parameter has a default
+    // argument and can therefore be omitted.
+    isOptional?: boolean;
 }
 
 export interface PropertyMethodInfo {

--- a/packages/pyright-internal/src/tests/samples/variadicTypeVar26.py
+++ b/packages/pyright-internal/src/tests/samples/variadicTypeVar26.py
@@ -1,0 +1,45 @@
+# This sample tests the case where a `*args: *Ts` parameter captures
+# a callable with an indeterminate number of parameters because
+# some of them have default arguments.
+
+from typing import Callable, TypeVarTuple
+
+Ts = TypeVarTuple("Ts")
+
+
+def func1(x: int, y: str = "", z: int | None = None) -> None:
+    ...
+
+
+def func2(callback: Callable[[*Ts], None], *args: *Ts) -> tuple[*Ts]:
+    ...
+
+
+v1 = func2(func1, 1)
+reveal_type(v1, expected_text="tuple[int]")
+
+v2 = func2(func1, 1, "")
+reveal_type(v2, expected_text="tuple[int, str]")
+
+v3 = func2(func1, 1, "", 3)
+reveal_type(v3, expected_text="tuple[int, str, int]")
+
+v4 = func2(func1, 1, "", None)
+reveal_type(v4, expected_text="tuple[int, str, None]")
+
+# This should generate an error.
+func2(func1)
+
+# This should generate an error.
+func2(func1, "")
+
+# This should generate an error.
+func2(func1, 3, "", None, None)
+
+
+def func3(callback: Callable[[*Ts], None]) -> tuple[*Ts]:
+    ...
+
+
+v5 = func3(func1)
+reveal_type(v5, expected_text="tuple[int, str, int | None]")

--- a/packages/pyright-internal/src/tests/typeEvaluator3.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator3.test.ts
@@ -1210,6 +1210,14 @@ test('VariadicTypeVar25', () => {
     TestUtils.validateResults(analysisResults, 0);
 });
 
+test('VariadicTypeVar26', () => {
+    const configOptions = new ConfigOptions('.');
+
+    configOptions.defaultPythonVersion = PythonVersion.V3_11;
+    const analysisResults = TestUtils.typeAnalyzeSampleFiles(['variadicTypeVar26.py'], configOptions);
+    TestUtils.validateResults(analysisResults, 3);
+});
+
 test('Match1', () => {
     const configOptions = new ConfigOptions('.');
 


### PR DESCRIPTION
…h an indeterminate number of positional parameters because some of them have default arguments. This addresses #6613.