### PR TITLE
add `importStrategy` option to vscode extension to allow using the version of pyright installed in the project

### DIFF
--- a/packages/vscode-pyright/package-lock.json
+++ b/packages/vscode-pyright/package-lock.json
@@ -9,6 +9,7 @@
             "version": "1.1.338",
             "license": "MIT",
             "dependencies": {
+                "@vscode/python-extension": "^1.0.5",
                 "vscode-jsonrpc": "8.1.0",
                 "vscode-languageclient": "8.1.0",
                 "vscode-languageserver": "8.1.0",
@@ -192,6 +193,16 @@
             "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.78.1.tgz",
             "integrity": "sha512-wEA+54axejHu7DhcUfnFBan1IqFD1gBDxAFz8LoX06NbNDMRJv/T6OGthOs52yZccasKfN588EyffHWABkR0fg==",
             "dev": true
+        },
+        "node_modules/@vscode/python-extension": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/@vscode/python-extension/-/python-extension-1.0.5.tgz",
+            "integrity": "sha512-uYhXUrL/gn92mfqhjAwH2+yGOpjloBxj9ekoL4BhUsKcyJMpEg6WlNf3S3si+5x9zlbHHe7FYQNjZEbz1ymI9Q==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=16.17.1",
+                "vscode": "^1.78.0"
+            }
         },
         "node_modules/@webassemblyjs/ast": {
             "version": "1.11.6",
@@ -3512,6 +3523,11 @@
             "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.78.1.tgz",
             "integrity": "sha512-wEA+54axejHu7DhcUfnFBan1IqFD1gBDxAFz8LoX06NbNDMRJv/T6OGthOs52yZccasKfN588EyffHWABkR0fg==",
             "dev": true
+        },
+        "@vscode/python-extension": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/@vscode/python-extension/-/python-extension-1.0.5.tgz",
+            "integrity": "sha512-uYhXUrL/gn92mfqhjAwH2+yGOpjloBxj9ekoL4BhUsKcyJMpEg6WlNf3S3si+5x9zlbHHe7FYQNjZEbz1ymI9Q=="
         },
         "@webassemblyjs/ast": {
             "version": "1.11.6",

--- a/packages/vscode-pyright/package.json
+++ b/packages/vscode-pyright/package.json
@@ -1277,6 +1277,16 @@
                     "default": "",
                     "description": "Path to folder with a list of Virtual Environments.",
                     "scope": "resource"
+                },
+                "pyright.importStrategy": {
+                    "type": "string",
+                    "default": "fromEnvironment",
+                    "enum": [
+                        "fromEnvironment",
+                        "useBundled"
+                    ],
+                    "description": "Whether to use the version of pyright installed in the project (recommended) or the one bundled with the extension (not recommended).",
+                    "scope": "resource"
                 }
             }
         },
@@ -1297,6 +1307,7 @@
         "webpack-dev": "npm run clean && webpack --mode development --watch --progress"
     },
     "dependencies": {
+        "@vscode/python-extension": "^1.0.5",
         "vscode-jsonrpc": "8.1.0",
         "vscode-languageclient": "8.1.0",
         "vscode-languageserver": "8.1.0",


### PR DESCRIPTION
after the discussion in https://github.com/microsoft/pyright/issues/6633#issuecomment-1837113310 about adding this option to pylance, i decided to try adding it to the pyright extension instead.

specifically, it looks for the [pyright pipi package](https://pypi.org/project/pyright/) in the project and falls back to the bundled one if it can't be found.

currently there are a couple issues however:

- [ ] the setting currently requires the vscode window to be reloaded to take effect (`Developer: Reload Window`)
- [ ] when i try to use my new `fromEnvironment` option, errors are not displayed, even though the language server from the pypi package seems to be running, and other language server commands such as organize imports seem to work:
  ![image](https://github.com/microsoft/pyright/assets/57028336/9a6c4d1d-1c74-4913-9c22-05a3593c1c3f)
  ![image](https://github.com/microsoft/pyright/assets/57028336/20ba4208-46e5-4b24-ab78-22795aeb1dfd)
  
  i can't see any errors in the log either:
  ```
  [Info  - 6:09:37 PM] Pyright language server 1.1.337 starting
  [Info  - 6:09:37 PM] Server root directory: C:\Users\user\.cache\pyright-python\1.1.337\node_modules\pyright\dist
  [Info  - 6:09:37 PM] Starting service instance "project"
  Received pythonPath from Python extension: c:\Users\user\Documents\project\.venv\Scripts\python.exe
  [Info  - 6:09:42 PM] Setting pythonPath for service "project": "c:\Users\user\Documents\project\.venv\Scripts\python.exe"
  [Info  - 6:09:42 PM] Loading pyproject.toml file at C:\Users\user\Documents\project\pyproject.toml
  [Info  - 6:09:42 PM] Assuming Python version 3.12
  [Info  - 6:09:42 PM] Found 671 source files
  ```

  any idea what could be causing this?
