### PR TITLE
Fixed bug that led to improper type narrowing for class patterns when…

### DIFF
--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -221,6 +221,7 @@ import {
     getTypeVarArgumentsRecursive,
     getTypeVarScopeId,
     getTypeVarScopeIds,
+    getUnknownTypeForCallable,
     getUnknownTypeForParamSpec,
     isCallableType,
     isDescriptorInstance,
@@ -2180,12 +2181,7 @@ export function createTypeEvaluator(importLookup: ImportLookup, evaluatorOptions
         }
 
         if (isAnyOrUnknown(boundMethodResult.type)) {
-            const unknownFunction = FunctionType.createSynthesizedInstance(
-                '',
-                FunctionTypeFlags.SkipArgsKwargsCompatibilityCheck
-            );
-            FunctionType.addDefaultParameters(unknownFunction);
-            return unknownFunction;
+            return getUnknownTypeForCallable();
         }
 
         return undefined;
@@ -3712,15 +3708,7 @@ export function createTypeEvaluator(importLookup: ImportLookup, evaluatorOptions
                 subtype.details.parameters.length === 0 &&
                 subtype.details.paramSpec
             ) {
-                const concreteFunction = FunctionType.createInstance(
-                    '',
-                    '',
-                    '',
-                    FunctionTypeFlags.SynthesizedMethod | FunctionTypeFlags.SkipArgsKwargsCompatibilityCheck
-                );
-                FunctionType.addDefaultParameters(concreteFunction);
-
-                return FunctionType.cloneForParamSpec(subtype, concreteFunction);
+                return FunctionType.cloneForParamSpec(subtype, getUnknownTypeForCallable());
             }
 
             if (isTypeVar(subtype) && subtype.details.isVariadic) {

--- a/packages/pyright-internal/src/analyzer/typeUtils.ts
+++ b/packages/pyright-internal/src/analyzer/typeUtils.ts
@@ -1049,6 +1049,14 @@ export function getUnknownTypeForParamSpec(): FunctionType {
     return newFunction;
 }
 
+// Returns the equivalent of "Callable[..., Unknown]".
+export function getUnknownTypeForCallable(): FunctionType {
+    const newFunction = FunctionType.createSynthesizedInstance('', FunctionTypeFlags.SkipArgsKwargsCompatibilityCheck);
+    FunctionType.addDefaultParameters(newFunction);
+    newFunction.details.declaredReturnType = UnknownType.create();
+    return newFunction;
+}
+
 // If the class is generic and not already specialized, this function
 // "self specializes" the class, filling in its own type parameters
 // as type arguments.

--- a/packages/pyright-internal/src/tests/samples/matchClass6.py
+++ b/packages/pyright-internal/src/tests/samples/matchClass6.py
@@ -1,0 +1,26 @@
+# This sample tests the case where `Callable()` is used as a class pattern.
+
+from collections.abc import Callable
+from typing import TypeVar
+
+T = TypeVar("T")
+
+
+def func1(obj: T | Callable[..., T]) -> T | None:
+    match obj:
+        case Callable():
+            reveal_type(obj, expected_text="((...) -> Unknown) | ((...) -> T@func1)")
+            return obj()
+
+
+def func2(obj: T | Callable[..., T]) -> T | None:
+    if isinstance(obj, Callable):
+        reveal_type(obj, expected_text="((...) -> Unknown) | ((...) -> T@func2)")
+        return obj()
+
+
+def func3(obj: type[int] | Callable[..., str]) -> int | str | None:
+    match obj:
+        case Callable():
+            reveal_type(obj, expected_text="type[int] | ((...) -> str)")
+            return obj()

--- a/packages/pyright-internal/src/tests/typeEvaluator3.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator3.test.ts
@@ -1293,6 +1293,14 @@ test('MatchClass5', () => {
     TestUtils.validateResults(analysisResults, 5);
 });
 
+test('MatchClass6', () => {
+    const configOptions = new ConfigOptions('.');
+
+    configOptions.defaultPythonVersion = PythonVersion.V3_10;
+    const analysisResults = TestUtils.typeAnalyzeSampleFiles(['matchClass6.py'], configOptions);
+    TestUtils.validateResults(analysisResults, 0);
+});
+
 test('MatchValue1', () => {
     const configOptions = new ConfigOptions('.');
 


### PR DESCRIPTION
… `Callable` is used. This addresses #6648.