### PR TITLE
Fixed bug in narrowing logic for sequence pattern magic where special…

### DIFF
--- a/packages/pyright-internal/src/analyzer/patternMatching.ts
+++ b/packages/pyright-internal/src/analyzer/patternMatching.ts
@@ -1236,6 +1236,13 @@ function getSequencePatternInfo(
                     ClassType.isBuiltIn(mroClass, 'bytes') ||
                     ClassType.isBuiltIn(mroClass, 'bytearray')
                 ) {
+                    // This is definitely not a match.
+                    sequenceInfo.push({
+                        subtype,
+                        entryTypes: [],
+                        isIndeterminateLength: true,
+                        isDefiniteNoMatch: true,
+                    });
                     return;
                 }
 

--- a/packages/pyright-internal/src/tests/samples/matchSequence1.py
+++ b/packages/pyright-internal/src/tests/samples/matchSequence1.py
@@ -427,3 +427,11 @@ def test_negative_narrowing6(a: str | None, b: str | None):
             reveal_type(x, expected_text="tuple[None, str | None]")
         case (a, b) as x:
             reveal_type(x, expected_text="tuple[str | None, str | None]")
+
+
+def test_negative_narrowing7(a: tuple[str, str] | str):
+    match a:
+        case (_, _):
+            reveal_type(a, expected_text="tuple[str, str]")
+        case _:
+            reveal_type(a, expected_text="str")


### PR DESCRIPTION
… cases of `str`, `bytes`, and `bytearray` were not handled correctly. This addresses #6670.