### PR TITLE
Fixed bug that led to a false positive when a zero-argument form of `…

### DIFF
--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -8210,9 +8210,7 @@ export function createTypeEvaluator(importLookup: ImportLookup, evaluatorOptions
         }
 
         const enclosingFunction = ParseTreeUtils.getEnclosingFunctionEvaluationScope(node);
-        const enclosingClass = enclosingFunction
-            ? ParseTreeUtils.getEnclosingClass(enclosingFunction, /* stopAtFunction */ true)
-            : undefined;
+        const enclosingClass = enclosingFunction ? ParseTreeUtils.getEnclosingClass(enclosingFunction) : undefined;
         const enclosingClassType = enclosingClass ? getTypeOfClass(enclosingClass)?.classType : undefined;
 
         // Determine which class the "super" call is applied to. If

--- a/packages/pyright-internal/src/tests/samples/super1.py
+++ b/packages/pyright-internal/src/tests/samples/super1.py
@@ -40,6 +40,10 @@ class Bar(ClassB, ClassC):
         # This should generate an error
         super().non_method1()
 
+    def method(self):
+        def inner():
+            super().method1()
+
 
 super(Bar)
 


### PR DESCRIPTION
…super` is called within an inner function or lambda. This addresses #6093.