### PR TITLE
Fix additional URI conversion problems for background thread

### DIFF
--- a/packages/pyright-internal/src/backgroundAnalysisBase.ts
+++ b/packages/pyright-internal/src/backgroundAnalysisBase.ts
@@ -646,7 +646,11 @@ export abstract class BackgroundAnalysisRunnerBase extends BackgroundThreadBase 
         const postableResults = {
             ...result,
             diagnostics: result.diagnostics.map((d) => {
-                return { ...d, fileUri: JSON.parse(JSON.stringify(d.fileUri)) };
+                return {
+                    ...d,
+                    fileUri: JSON.parse(JSON.stringify(d.fileUri)),
+                    diagnostics: convertDiagnostics(d.diagnostics),
+                };
             }),
         };
         port.postMessage({ requestType: 'analysisResult', data: postableResults });
@@ -719,7 +723,7 @@ function convertDiagnostics(diagnostics: Diagnostic[]) {
 
         if (d._relatedInfo) {
             for (const info of d._relatedInfo) {
-                diag.addRelatedInfo(info.message, info.fileUri, info.range);
+                diag.addRelatedInfo(info.message, JSON.parse(JSON.stringify(info.uri)), info.range);
             }
         }
 

--- a/packages/pyright-internal/src/languageServerBase.ts
+++ b/packages/pyright-internal/src/languageServerBase.ts
@@ -1566,10 +1566,10 @@ export abstract class LanguageServerBase implements LanguageServerInterface, Dis
             const relatedInfo = diag.getRelatedInfo();
             if (relatedInfo.length > 0) {
                 vsDiag.relatedInformation = relatedInfo
-                    .filter((info) => this.canNavigateToFile(info.uri, fs))
+                    .filter((info) => this.canNavigateToFile(Uri.fromJsonObj(info.uri), fs))
                     .map((info) =>
                         DiagnosticRelatedInformation.create(
-                            Location.create(info.uri.toString(), info.range),
+                            Location.create(Uri.fromJsonObj(info.uri).toString(), info.range),
                             info.message
                         )
                     );


### PR DESCRIPTION
Fixes additional `Uri` conversion problems for the background thread, specifically `DiagnosticRelatedInfo`, which was missed in #6678 after the implementation of the `Uri` class (#6519).