### PR TITLE
Removed implicit `__qualname__` attribute from the module namespace. …

### DIFF
--- a/packages/pyright-internal/src/analyzer/binder.ts
+++ b/packages/pyright-internal/src/analyzer/binder.ts
@@ -275,7 +275,6 @@ export class Binder extends ParseTreeWalker {
                 // Bind implicit names.
                 // List taken from https://docs.python.org/3/reference/import.html#__name__
                 this._addImplicitSymbolToCurrentScope('__name__', node, 'str');
-                this._addImplicitSymbolToCurrentScope('__qualname__', node, 'str');
                 this._addImplicitSymbolToCurrentScope('__loader__', node, 'Any');
                 this._addImplicitSymbolToCurrentScope('__package__', node, 'str');
                 this._addImplicitSymbolToCurrentScope('__spec__', node, 'Any');


### PR DESCRIPTION
…It doesn't exist at runtime, so this was leading to a false negative. This addresses #6699.