### PR TITLE
Eliminated the limitation that unpack operators cannot be used within…

### DIFF
--- a/packages/pyright-internal/src/parser/parseNodes.ts
+++ b/packages/pyright-internal/src/parser/parseNodes.ts
@@ -1189,11 +1189,13 @@ export namespace TernaryNode {
 export interface UnpackNode extends ParseNodeBase {
     readonly nodeType: ParseNodeType.Unpack;
     expression: ExpressionNode;
+    starToken: Token;
 }
 
 export namespace UnpackNode {
     export function create(starToken: Token, expression: ExpressionNode) {
         const node: UnpackNode = {
+            starToken,
             start: starToken.start,
             length: starToken.length,
             nodeType: ParseNodeType.Unpack,

--- a/packages/pyright-internal/src/parser/parser.ts
+++ b/packages/pyright-internal/src/parser/parser.ts
@@ -4503,20 +4503,18 @@ export class Parser {
         const startToken = this._peekToken();
         const isUnpack = this._consumeTokenIfOperator(OperatorType.Multiply);
 
-        if (isUnpack) {
-            if (!allowUnpack) {
-                this._addError(Localizer.Diagnostic.unpackInAnnotation(), startToken);
-            } else if (
-                !this._parseOptions.isStubFile &&
-                !this._isParsingQuotedText &&
-                this._getLanguageVersion() < PythonVersion.V3_11
-            ) {
-                this._addError(Localizer.Diagnostic.unpackedSubscriptIllegal(), startToken);
-            }
+        if (
+            isUnpack &&
+            allowUnpack &&
+            !this._parseOptions.isStubFile &&
+            !this._isParsingQuotedText &&
+            this._getLanguageVersion() < PythonVersion.V3_11
+        ) {
+            this._addError(Localizer.Diagnostic.unpackedSubscriptIllegal(), startToken);
         }
 
         let result = this._parseTestExpression(/* allowAssignmentExpression */ false);
-        if (isUnpack && allowUnpack) {
+        if (isUnpack) {
             result = UnpackNode.create(startToken, result);
         }
 

--- a/packages/pyright-internal/src/tests/samples/annotated1.py
+++ b/packages/pyright-internal/src/tests/samples/annotated1.py
@@ -53,7 +53,7 @@ d: Annotated[int]
 _T = TypeVar("_T")
 Param = Annotated[_T, "x"]
 
-x: Param[int] = 3
+x1: Param[int] = 3
 
 
 class A:
@@ -76,3 +76,5 @@ Alias2 = str
 Alias3 = Alias1[Alias2]
 
 reveal_type(Alias3, expected_text="type[str]")
+
+x2: Annotated[str, [*(1, 2)]]


### PR DESCRIPTION
… `Annotated` expressions when using an alias of `Annotated`. This partially addresses #6714.