### PR TITLE
Eliminated the limitation that `await`, assignment expressions, f-str…

### DIFF
--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -1139,6 +1139,10 @@ export function createTypeEvaluator(importLookup: ImportLookup, evaluatorOptions
             }
 
             case ParseNodeType.AssignmentExpression: {
+                if ((flags & EvaluatorFlags.ExpectingTypeAnnotation) !== 0) {
+                    addError(Localizer.Diagnostic.walrusNotAllowed(), node);
+                }
+
                 typeResult = getTypeOfExpression(node.rightExpression, flags, inferenceContext);
                 assignTypeToExpression(
                     node.name,
@@ -1336,6 +1340,11 @@ export function createTypeEvaluator(importLookup: ImportLookup, evaluatorOptions
     }
 
     function getTypeOfAwaitOperator(node: AwaitNode, flags: EvaluatorFlags, inferenceContext?: InferenceContext) {
+        if ((flags & EvaluatorFlags.ExpectingTypeAnnotation) !== 0) {
+            addError(Localizer.Diagnostic.awaitNotAllowed(), node);
+            return { type: UnknownType.create() };
+        }
+
         const effectiveExpectedType = inferenceContext
             ? createAwaitableReturnType(
                   node,

--- a/packages/pyright-internal/src/localization/localize.ts
+++ b/packages/pyright-internal/src/localization/localize.ts
@@ -246,6 +246,7 @@ export namespace Localizer {
         export const assignmentTargetExpr = () => getRawString('Diagnostic.assignmentTargetExpr');
         export const asyncNotInAsyncFunction = () => getRawString('Diagnostic.asyncNotInAsyncFunction');
         export const awaitIllegal = () => getRawString('Diagnostic.awaitIllegal');
+        export const awaitNotAllowed = () => getRawString('Diagnostic.awaitNotAllowed');
         export const awaitNotInAsync = () => getRawString('Diagnostic.awaitNotInAsync');
         export const backticksIllegal = () => getRawString('Diagnostic.backticksIllegal');
         export const baseClassCircular = () => getRawString('Diagnostic.baseClassCircular');

--- a/packages/pyright-internal/src/localization/package.nls.en-us.json
+++ b/packages/pyright-internal/src/localization/package.nls.en-us.json
@@ -30,6 +30,7 @@
         "assignmentTargetExpr": "Expression cannot be assignment target",
         "asyncNotInAsyncFunction": "Use of \"async\" not allowed outside of async function",
         "awaitIllegal": "Use of \"await\" requires Python 3.5 or newer",
+        "awaitNotAllowed": "Type annotations cannot use \"await\"",
         "awaitNotInAsync": "\"await\" allowed only within async function",
         "backticksIllegal": "Expressions surrounded by backticks are not supported in Python 3.x; use repr instead",
         "baseClassCircular": "Class cannot derive from itself",

--- a/packages/pyright-internal/src/tests/samples/annotated1.py
+++ b/packages/pyright-internal/src/tests/samples/annotated1.py
@@ -78,3 +78,13 @@ Alias3 = Alias1[Alias2]
 reveal_type(Alias3, expected_text="type[str]")
 
 x2: Annotated[str, [*(1, 2)]]
+x3: Annotated[str, (temp := 1)]
+
+
+async def func3():
+    x4: Annotated[str, await func3()]
+
+
+x5: Annotated[str, f""]
+x6: Annotated[str, "a" "b" "c"]
+x7: Annotated[str, "a\nb"]

--- a/packages/pyright-internal/src/tests/samples/assignmentExpr3.py
+++ b/packages/pyright-internal/src/tests/samples/assignmentExpr3.py
@@ -16,7 +16,7 @@ def foo3(answer=(p := 42)):  # Valid, though not great style
 
 default_value: int = 3
 
-# This should generate an error.
+# This should generate two errors.
 def foo4(answer: p := default_value = 5):  # INVALID
     ...
 

--- a/packages/pyright-internal/src/tests/typeEvaluator4.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator4.test.ts
@@ -109,7 +109,7 @@ test('AssignmentExpr2', () => {
 
 test('AssignmentExpr3', () => {
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['assignmentExpr3.py']);
-    TestUtils.validateResults(analysisResults, 4);
+    TestUtils.validateResults(analysisResults, 5);
 });
 
 test('AssignmentExpr4', () => {


### PR DESCRIPTION
…ings, string chains, and escaped strings cannot be used within `Annotated` expressions when using an alias of `Annotated`. This addresses #6714.