### PR TITLE
Fix usage of invalid path in packageTypeVerifier

### DIFF
--- a/packages/pyright-internal/src/analyzer/packageTypeVerifier.ts
+++ b/packages/pyright-internal/src/analyzer/packageTypeVerifier.ts
@@ -589,7 +589,7 @@ export class PackageTypeVerifier {
                         category: symbolCategory,
                         name,
                         fullName,
-                        fileUri: Uri.file(module.path, this._serviceProvider.fs().isCaseSensitive),
+                        fileUri: declPath,
                         isExported,
                         typeKnownStatus: TypeKnownStatus.Known,
                         referenceCount: 1,


### PR DESCRIPTION
`module` just happens to be an object in Javascript so that this used to work, but `module` is not defined at the location this is being used. I believe the intent was to use the declPath.

Addresses https://github.com/microsoft/pyright/issues/6722