### PR TITLE
Fix URI return value on renames

### DIFF
--- a/packages/pyright-internal/src/common/workspaceEditUtils.ts
+++ b/packages/pyright-internal/src/common/workspaceEditUtils.ts
@@ -230,11 +230,11 @@ function _convertToWorkspaceEditWithDocumentChanges(
     }
 
     // Text edit's file path must refer to original file paths unless it is a new file just created.
-    const mapPerFile = createMapFromItems(editActions.edits, (e) => e.fileUri.key);
-    for (const [key, value] of mapPerFile) {
+    const mapPerFile = createMapFromItems(editActions.edits, (e) => e.fileUri.toString());
+    for (const [uri, value] of mapPerFile) {
         workspaceEdit.documentChanges!.push(
             TextDocumentEdit.create(
-                { uri: key, version: null },
+                { uri, version: null },
                 Array.from(
                     value.map((v) => ({
                         range: v.range,

--- a/packages/pyright-internal/src/tests/harness/fourslash/workspaceEditTestUtils.ts
+++ b/packages/pyright-internal/src/tests/harness/fourslash/workspaceEditTestUtils.ts
@@ -91,6 +91,11 @@ export function verifyDocumentEdits(
                             return false;
                         }
 
+                        if (!actualEdit.textDocument.uri.includes(':')) {
+                            // Not returning a URI, so fail.
+                            return false;
+                        }
+
                         return textEditsAreSame(expectedEdit.edits, actualEdit.edits);
                     }
                     case 'create': {


### PR DESCRIPTION
Addresses https://github.com/microsoft/pyright/issues/6725

Root cause was using the fileuri.key value as the return value for the uri of a document. However the tests were running the same logic on the expected changes so it wasn't verifying the URIs were actually URIs, just that the changes were the same.