### PR TITLE
Fix emptyUri being used as a file path

### DIFF
--- a/packages/pyright-internal/src/common/uri/emptyUri.ts
+++ b/packages/pyright-internal/src/common/uri/emptyUri.ts
@@ -6,7 +6,6 @@
  * URI class that represents an empty URI.
  */
 
-import * as debug from '../debug';
 import { BaseUri } from './baseUri';
 import { Uri } from './uri';
 
@@ -55,7 +54,7 @@ export class EmptyUri extends BaseUri {
     }
 
     override getFilePath(): string {
-        debug.fail(`EmptyUri.getFilePath() should not be called.`);
+        return '';
     }
 
     override toString(): string {


### PR DESCRIPTION
Addresses https://github.com/microsoft/pyright/issues/6737.

The old logic would have just passed an empty path here, so make `EmptyUri.getFilePath` return an empty path.