### PR TITLE
Added narrowing support for literal patterns in a `match` statement t…

### DIFF
--- a/packages/pyright-internal/src/analyzer/typeGuards.ts
+++ b/packages/pyright-internal/src/analyzer/typeGuards.ts
@@ -2227,7 +2227,7 @@ export function narrowTypeForDiscriminatedTupleComparison(
 // Attempts to narrow a type based on a comparison (equal or not equal)
 // between a discriminating field that has a declared literal type to a
 // literal value.
-function narrowTypeForDiscriminatedLiteralFieldComparison(
+export function narrowTypeForDiscriminatedLiteralFieldComparison(
     evaluator: TypeEvaluator,
     referenceType: Type,
     memberName: string,

--- a/packages/pyright-internal/src/tests/samples/matchLiteral2.py
+++ b/packages/pyright-internal/src/tests/samples/matchLiteral2.py
@@ -1,0 +1,33 @@
+# This sample tests type narrowing for a discriminated union that uses
+# literal patterns to discriminate between objects with literal tags.
+
+from typing import Literal
+
+
+class A:
+    tag: Literal["a"]
+    name: str
+
+
+class B:
+    tag: Literal["b"]
+    num: int
+
+
+class C:
+    tag: Literal["c"]
+    num: int
+
+
+def g(d: A | B | C) -> None:
+    match d.tag:
+        case "d":
+            reveal_type(d.tag, expected_text="Never")
+            reveal_type(d, expected_text="Never")
+        case "a" | "c":
+            reveal_type(d.tag, expected_text="Literal['a', 'c']")
+            reveal_type(d, expected_text="A | C")
+        case "b":
+            reveal_type(d.tag, expected_text="Literal['b']")
+            reveal_type(d, expected_text="B")
+

--- a/packages/pyright-internal/src/tests/typeEvaluator3.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator3.test.ts
@@ -1334,6 +1334,14 @@ test('MatchLiteral1', () => {
     TestUtils.validateResults(analysisResults, 0);
 });
 
+test('MatchLiteral2', () => {
+    const configOptions = new ConfigOptions(Uri.empty());
+
+    configOptions.defaultPythonVersion = PythonVersion.V3_10;
+    const analysisResults = TestUtils.typeAnalyzeSampleFiles(['matchLiteral2.py'], configOptions);
+    TestUtils.validateResults(analysisResults, 0);
+});
+
 test('MatchExhaustion1', () => {
     const configOptions = new ConfigOptions(Uri.empty());
 


### PR DESCRIPTION
…hat are used to discriminate between tagged unions of objects that can be discriminated based on a field with a literal type. This addresses #6752.