### PR TITLE
Leave enclosing parens when renaming parenthesized identifier

### DIFF
--- a/packages/pyright-internal/src/languageService/documentSymbolCollector.ts
+++ b/packages/pyright-internal/src/languageService/documentSymbolCollector.ts
@@ -303,7 +303,7 @@ export class DocumentSymbolCollector extends ParseTreeWalker {
     }
 
     private _addResult(node: NameNode | StringNode) {
-        const range: TextRange = node.nodeType === ParseNodeType.Name ? node : getStringNodeValueRange(node);
+        const range: TextRange = node.nodeType === ParseNodeType.Name ? node.token : getStringNodeValueRange(node);
         this._results.push({ node, range });
     }
 

--- a/packages/pyright-internal/src/tests/fourslash/rename.parens.fourslash.ts
+++ b/packages/pyright-internal/src/tests/fourslash/rename.parens.fourslash.ts
@@ -1,0 +1,22 @@
+/// <reference path="fourslash.ts" />
+
+// @filename: test.py
+//// [|/*marker*/A|] = True
+//// if False:
+////     pass
+//// elif([|A|]):
+////     pass
+
+{
+    helper.verifyRename({
+        marker: {
+            newName: 'RenamedA',
+            changes: helper
+                .getRangesByText()
+                .get('A')!
+                .map((r) => {
+                    return { filePath: r.fileName, range: helper.convertPositionRange(r), replacementText: 'RenamedA' };
+                }),
+        },
+    });
+}

--- a/packages/pyright-internal/src/tests/fourslash/rename.parens.fourslash.ts
+++ b/packages/pyright-internal/src/tests/fourslash/rename.parens.fourslash.ts
@@ -2,9 +2,7 @@
 
 // @filename: test.py
 //// [|/*marker*/A|] = True
-//// if False:
-////     pass
-//// elif([|A|]):
+//// if([|A|]):
 ////     pass
 
 {


### PR DESCRIPTION
Address https://github.com/microsoft/pylance-release/issues/4966

Given this code:

```python
A = True
if(A):
    pass
```

Currently, if you rename `A` to `B`, because the parens wrapping `A` in the `if`expression are removed, you'll get the following, which is invalid:

```python
B = True
ifB:
    pass
```

This change fixes the issue, but is it the best/correct fix?