### PR TITLE
Fixed bug that results in a false positive error under certain circum…

### DIFF
--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -11685,7 +11685,8 @@ export function createTypeEvaluator(importLookup: ImportLookup, evaluatorOptions
 
             for (const arg of argList) {
                 const argType = getTypeOfArgument(arg)?.type;
-                const isArgTypeCompatible = argType && (isTypeSame(argType, paramSpec) || isAnyOrUnknown(argType));
+                const isArgTypeCompatible =
+                    argType && (isTypeSame(argType, paramSpec, { ignoreTypeFlags: true }) || isAnyOrUnknown(argType));
 
                 if (arg.argumentCategory === ArgumentCategory.UnpackedList && !sawArgs && isArgTypeCompatible) {
                     sawArgs = true;

--- a/packages/pyright-internal/src/tests/samples/paramSpec3.py
+++ b/packages/pyright-internal/src/tests/samples/paramSpec3.py
@@ -1,6 +1,14 @@
 # This sample tests ParamSpec (PEP 612) behavior.
 
-from typing import Awaitable, Callable, Generic, ParamSpec, TypeVar, overload
+from typing import (
+    Awaitable,
+    Callable,
+    Generic,
+    Iterable,
+    ParamSpec,
+    TypeVar,
+    overload,
+)
 
 P = ParamSpec("P")
 R = TypeVar("R")
@@ -71,3 +79,11 @@ def func5(f: Callable[[], list[T1]]) -> Callable[[list[T2]], list[T1 | T2]]:
         ...
 
     return decorator2(inner)
+
+
+def func6(x: Iterable[Callable[P, None]]) -> Callable[P, None]:
+    def inner(*args: P.args, **kwargs: P.kwargs) -> None:
+        for fn in x:
+            fn(*args, **kwargs)
+
+    return inner


### PR DESCRIPTION
…stances when calling an inner function that uses a ParamSpec defined scoped to an outer function. This addresses #6759.