### PR TITLE
Fixed a bug in the type verifier that resulted in a false negative wh…

### DIFF
--- a/packages/pyright-internal/src/analyzer/binder.ts
+++ b/packages/pyright-internal/src/analyzer/binder.ts
@@ -1931,7 +1931,7 @@ export class Binder extends ParseTreeWalker {
                             loadSymbolsFromPath: true,
                             range: getEmptyRange(),
                             usesLocalName: false,
-                            moduleName: this._formatModuleName(node.module.nameParts),
+                            moduleName: this._formatModuleName(node.module),
                             isInExceptSuite: this._isInExceptSuite,
                         };
 
@@ -1958,7 +1958,7 @@ export class Binder extends ParseTreeWalker {
                         symbolName: importedName,
                         submoduleFallback,
                         range: convertTextRangeToRange(nameNode, this._fileInfo.lines),
-                        moduleName: this._formatModuleName(node.module.nameParts),
+                        moduleName: this._formatModuleName(node.module),
                         isInExceptSuite: this._isInExceptSuite,
                         isNativeLib: importInfo?.isNativeLib,
                     };
@@ -2333,9 +2333,8 @@ export class Binder extends ParseTreeWalker {
         return true;
     }
 
-    private _formatModuleName(nameParts: NameNode[]): string {
-        // Ignore the leading dots for purposes of module name formatting.
-        return nameParts.map((name) => name.value).join('.');
+    private _formatModuleName(node: ModuleNameNode): string {
+        return '.'.repeat(node.leadingDots) + node.nameParts.map((part) => part.value).join('.');
     }
 
     private _removeActiveTypeParameters(node: TypeParameterListNode) {
@@ -2543,7 +2542,7 @@ export class Binder extends ParseTreeWalker {
                 loadSymbolsFromPath: false,
                 range: getEmptyRange(),
                 usesLocalName: !!importAlias,
-                moduleName: importAlias ? this._formatModuleName(node.module.nameParts) : firstNamePartValue,
+                moduleName: this._formatModuleName(node.module),
                 firstNamePart: firstNamePartValue,
                 isInExceptSuite: this._isInExceptSuite,
             };
@@ -2559,7 +2558,7 @@ export class Binder extends ParseTreeWalker {
                 range: getEmptyRange(),
                 usesLocalName: !!importAlias,
                 moduleName: importInfo?.importName ?? '',
-                firstNamePart: importAlias ? this._formatModuleName(node.module.nameParts) : firstNamePartValue,
+                firstNamePart: firstNamePartValue,
                 isUnresolved: true,
                 isInExceptSuite: this._isInExceptSuite,
             };

--- a/packages/pyright-internal/src/pyright.ts
+++ b/packages/pyright-internal/src/pyright.ts
@@ -489,7 +489,14 @@ function verifyPackageTypes(
     ignoreUnknownTypesFromImports: boolean
 ): ExitStatus {
     try {
-        const verifier = new PackageTypeVerifier(serviceProvider, options, packageName, ignoreUnknownTypesFromImports);
+        const host = new FullAccessHost(serviceProvider);
+        const verifier = new PackageTypeVerifier(
+            serviceProvider,
+            host,
+            options,
+            packageName,
+            ignoreUnknownTypesFromImports
+        );
         const report = verifier.verify();
         const jsonReport = buildTypeCompletenessReport(packageName, report, minSeverityLevel);
 
@@ -726,9 +733,6 @@ function printTypeCompletenessReportText(results: PyrightJsonResults, verboseOut
     if (completenessReport.ignoreUnknownTypesFromImports) {
         console.info(`    (Ignoring unknown types imported from other packages)`);
     }
-    console.info(`  Functions without docstring: ${completenessReport.missingFunctionDocStringCount}`);
-    console.info(`  Functions without default param: ${completenessReport.missingDefaultParamCount}`);
-    console.info(`  Classes without docstring: ${completenessReport.missingClassDocStringCount}`);
     console.info('');
     console.info(
         `Other symbols referenced but not exported by "${completenessReport.packageName}": ${
@@ -740,6 +744,11 @@ function printTypeCompletenessReportText(results: PyrightJsonResults, verboseOut
     console.info(`  With known type: ${completenessReport.otherSymbolCounts.withKnownType}`);
     console.info(`  With ambiguous type: ${completenessReport.otherSymbolCounts.withAmbiguousType}`);
     console.info(`  With unknown type: ${completenessReport.otherSymbolCounts.withUnknownType}`);
+    console.info('');
+    console.info(`Symbols without documentation:`);
+    console.info(`  Functions without docstring: ${completenessReport.missingFunctionDocStringCount}`);
+    console.info(`  Functions without default param: ${completenessReport.missingDefaultParamCount}`);
+    console.info(`  Classes without docstring: ${completenessReport.missingClassDocStringCount}`);
     console.info('');
     console.info(`Type completeness score: ${Math.round(completenessReport.completenessScore * 1000) / 10}%`);
     console.info('');

--- a/packages/pyright-internal/src/tests/fourslash/fourslash.ts
+++ b/packages/pyright-internal/src/tests/fourslash/fourslash.ts
@@ -10,8 +10,8 @@
  * get ignored when test run due to how test code is injected when running.
  * see - server\pyright\server\src\tests\harness\fourslash\runner.ts@runCode - for more detail
  *
- * when run, helper variable will be bount to TestState (server\pyright\server\src\tests\harness\fourslash\testState.ts)
- * so make sure Foruslash type is in sync with TestState
+ * when run, helper variable will be bound to TestState (server\pyright\server\src\tests\harness\fourslash\testState.ts)
+ * so make sure Fourslash type is in sync with TestState
  *
  * for how markup language and helper is used in fourslash tests, see these 2 tests
  * server\pyright\server\src\tests\fourSlashParser.test.ts
@@ -347,6 +347,12 @@ declare namespace _ {
                 };
             },
             isUntitled?: boolean
+        ): void;
+        verifyTypeVerifierResults(
+            packageName: string,
+            ignoreUnknownTypesFromImports: boolean,
+            verboseOutput: boolean,
+            expected: object
         ): void;
 
         replace(start: number, length: number, text: string): void;

--- a/packages/pyright-internal/src/tests/fourslash/typeVerifier.fourslash.ts
+++ b/packages/pyright-internal/src/tests/fourslash/typeVerifier.fourslash.ts
@@ -1,0 +1,50 @@
+/// <reference path="fourslash.ts" />
+
+// @filename: test_pkg/py.typed
+// @library: true
+////
+
+// @filename: test_pkg/__init__.py
+// @library: true
+////
+//// from .submodule1 import A as A
+//// from ._submodule2 import B as B, func1 as func1
+////
+
+// @filename: test_pkg/submodule1.py
+// @library: true
+////
+//// class A:
+////     ...
+
+// @filename: test_pkg/_submodule2.py
+// @library: true
+////
+//// class B:
+////     ...
+////
+//// def func1(a: int = ...) -> None:
+////     ...
+
+{
+    helper.verifyTypeVerifierResults('test_pkg', /* ignoreUnknownTypesFromImports */ false, /* verboseOutput */ false, {
+        generalDiagnostics: [],
+        missingClassDocStringCount: 4,
+        missingDefaultParamCount: 1,
+        missingFunctionDocStringCount: 1,
+        moduleName: 'test_pkg',
+        packageName: 'test_pkg',
+        modules: new Map<string, object>([
+            ['/lib/site-packages/test_pkg/__init__.py', {}],
+            ['/lib/site-packages/test_pkg/submodule1.py', {}],
+        ]),
+        symbols: new Map<string, object>([
+            ['test_pkg.submodule1', {}],
+            ['test_pkg.submodule1.A', {}],
+            ['test_pkg.A', {}],
+            ['test_pkg.B', {}],
+            ['test_pkg._submodule2.B', {}],
+            ['test_pkg.func1', {}],
+        ]),
+    });
+}

--- a/packages/pyright-internal/src/tests/harness/fourslash/testState.ts
+++ b/packages/pyright-internal/src/tests/harness/fourslash/testState.ts
@@ -27,11 +27,14 @@ import {
 
 import { BackgroundAnalysisProgramFactory, InvalidatedReason } from '../../../analyzer/backgroundAnalysisProgram';
 import { ImportResolver, ImportResolverFactory } from '../../../analyzer/importResolver';
+import { PackageTypeReport } from '../../../analyzer/packageTypeReport';
+import { PackageTypeVerifier } from '../../../analyzer/packageTypeVerifier';
 import { findNodeByOffset } from '../../../analyzer/parseTreeUtils';
 import { Program } from '../../../analyzer/program';
 import { AnalyzerService } from '../../../analyzer/service';
 import { CommandResult } from '../../../commands/commandResult';
 import { Char } from '../../../common/charCodes';
+import { CommandLineOptions } from '../../../common/commandLineOptions';
 import { ConfigOptions, SignatureDisplayType } from '../../../common/configOptions';
 import { ConsoleInterface, NullConsole } from '../../../common/console';
 import { Comparison, isNumber, isString, toBoolean } from '../../../common/core';
@@ -1457,6 +1460,36 @@ export class TestState {
                 actual ?? { documentChanges: [] }
             );
         }
+    }
+
+    verifyTypeVerifierResults(
+        packageName: string,
+        ignoreUnknownTypesFromImports: boolean,
+        verboseOutput: boolean,
+        expected: PackageTypeReport
+    ) {
+        const commandLineOptions = new CommandLineOptions(
+            this.configOptions.projectRoot.getFilePath(),
+            /* fromVsCodeExtension */ false
+        );
+        commandLineOptions.verboseOutput = verboseOutput;
+        const verifier = new PackageTypeVerifier(
+            this.serviceProvider,
+            testAccessHost,
+            commandLineOptions,
+            packageName,
+            ignoreUnknownTypesFromImports
+        );
+        const report = verifier.verify();
+
+        assert.strictEqual(report.generalDiagnostics.length, expected.generalDiagnostics.length);
+        assert.strictEqual(report.missingClassDocStringCount, expected.missingClassDocStringCount);
+        assert.strictEqual(report.missingDefaultParamCount, expected.missingDefaultParamCount);
+        assert.strictEqual(report.missingFunctionDocStringCount, expected.missingFunctionDocStringCount);
+        assert.strictEqual(report.moduleName, expected.moduleName);
+        assert.strictEqual(report.packageName, expected.packageName);
+        assert.deepStrictEqual(Array.from(expected.modules.keys()), Array.from(report.modules.keys()));
+        assert.deepStrictEqual(Array.from(report.symbols.keys()), Array.from(expected.symbols.keys()));
     }
 
     setCancelled(numberOfCalls: number): void {


### PR DESCRIPTION
…en docstrings are missing from a class or function that is defined in a private module but re-exported from a public module. This addresses #6758.