### PR TITLE
Fixed a bug that led to a combinatoric explosion and an infinite loop…

### DIFF
--- a/packages/pyright-internal/src/analyzer/types.ts
+++ b/packages/pyright-internal/src/analyzer/types.ts
@@ -3370,6 +3370,7 @@ function _addTypeIfUnique(unionType: UnionType, typeToAdd: UnionableType) {
                     typeToAdd.details.typeParameters.map(() => UnknownType.create()),
                     /* isTypeArgumentExplicit */ true
                 );
+                return;
             }
         }
 


### PR DESCRIPTION
… in certain edge cases involving a class with an untyped constructor and methods that return recursive types. This addresses #6770.