### PR TITLE
Return invalid path from `WebUri.getFilePath` rather than asserting

### DIFF
--- a/packages/pyright-internal/src/common/uri/webUri.ts
+++ b/packages/pyright-internal/src/common/uri/webUri.ts
@@ -11,7 +11,6 @@
  * - vscode-vfs://github.com/microsoft/debugpy/debugpy/launcher/debugAdapter.py
  */
 
-import * as debug from '../debug';
 import { getRootLength, hasTrailingDirectorySeparator, normalizeSlashes, resolvePaths } from '../pathUtils';
 import { BaseUri } from './baseUri';
 import { cacheMethodWithNoArgs, cacheProperty, cacheStaticFunc } from './memoization';
@@ -161,7 +160,7 @@ export class WebUri extends BaseUri {
     }
 
     override getFilePath(): string {
-        debug.fail(`${this} is not a file based URI.`);
+        return '';
     }
 
     override combinePaths(...paths: string[]): Uri {

--- a/packages/pyright-internal/src/tests/uri.test.ts
+++ b/packages/pyright-internal/src/tests/uri.test.ts
@@ -137,6 +137,11 @@ test('root', () => {
     assert.ok(root10.isRoot());
 });
 
+test('getFilePath', () => {
+    const webUri = Uri.parse('foo:///a/b/c', true);
+    assert.equal(webUri.getFilePath(), '');
+});
+
 test('empty', () => {
     const empty = Uri.parse('', true);
     assert.equal(empty.isEmpty(), true);


### PR DESCRIPTION
Addresses #6787 

`WebUri.getFilePath` currently asserts, but it is called in [a number of scenarios](https://github.com/microsoft/pyright/issues/6787#issuecomment-1866880452). This change works around the problem by returning an empty string from `WebUri.getFilePath` (rather than asserting) just as `EmptyUri` does.

I think this is just a stop-gap solution. I'm guessing that @rchiodo was not expecting to see virtual file system URIs in Pyright. Rich should take a look when he gets back from vacation and see if we need to do something bigger to address virtual file system usage in Pyright. He's in the middle of merging the URI refactoring into Pylance. There may be some virtual file system work he was planning to do there that needs to come over to Pyright.