### PR TITLE
Fixed a bug in the function type assignment logic that leads to a fal…

### DIFF
--- a/packages/pyright-internal/src/analyzer/parameterUtils.ts
+++ b/packages/pyright-internal/src/analyzer/parameterUtils.ts
@@ -113,7 +113,7 @@ export function getParameterListDetails(type: FunctionType): ParameterListDetail
     }
 
     if (positionOnlyIndex >= 0) {
-        result.firstPositionOrKeywordIndex = positionOnlyIndex;
+        result.firstPositionOrKeywordIndex = positionOnlyIndex + 1;
     }
 
     for (let i = 0; i < positionOnlyIndex; i++) {

--- a/packages/pyright-internal/src/tests/samples/paramSpec51.py
+++ b/packages/pyright-internal/src/tests/samples/paramSpec51.py
@@ -1,0 +1,53 @@
+# This sample tests a case where a method-scoped ParamSpec is used within one
+# of several overloads but not in others.
+
+from typing import Callable, Concatenate, overload, Any
+from typing_extensions import ParamSpec, Self
+
+P = ParamSpec("P")
+
+
+class A:
+    @overload
+    def method1(
+        self,
+        cb: Callable[Concatenate[Self, P], None],
+        *args: P.args,
+        **kwargs: P.kwargs,
+    ) -> None:
+        ...
+
+    @overload
+    def method1(
+        self, cb: tuple[Callable[..., None], str], *args: Any, **kwargs: Any
+    ) -> None:
+        ...
+
+    def method1(self, cb, *args, **kwargs) -> None:
+        if isinstance(cb, tuple):
+            cb[0](self, *args, **kwargs)
+        else:
+            cb(self, *args, **kwargs)
+
+
+def func1(fo: A, x: int) -> None:
+    ...
+
+
+def func2(fo: A, x: int, /, y: str) -> None:
+    ...
+
+
+def func3(fo: A, x: int, /, y: str, *, z: tuple[int, int]) -> None:
+    ...
+
+
+a = A()
+
+a.method1(func1, 1)
+a.method1(func2, 3, "f1")
+a.method1(func3, 6, "f2", z=(0, 1))
+
+a.method1((func1, "f1"), 1)
+a.method1((func2, "f2"), 2, "a")
+a.method1((func3, "f3"), 3, "b", z=(0, 1))

--- a/packages/pyright-internal/src/tests/typeEvaluator4.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator4.test.ts
@@ -1106,6 +1106,11 @@ test('ParamSpec50', () => {
     TestUtils.validateResults(results, 2);
 });
 
+test('ParamSpec51', () => {
+    const results = TestUtils.typeAnalyzeSampleFiles(['paramSpec51.py']);
+    TestUtils.validateResults(results, 0);
+});
+
 test('ClassVar1', () => {
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['classVar1.py']);
 


### PR DESCRIPTION
…se positive under certain circumstances involving a ParamSpec in an overload with a callback that includes a positional-only parameter separator. This addresses #6796.