### PR TITLE
Fixed a bug that leads to a false negative when `Self` is used within…

### DIFF
--- a/packages/pyright-internal/src/localization/localize.ts
+++ b/packages/pyright-internal/src/localization/localize.ts
@@ -838,6 +838,7 @@ export namespace Localizer {
                 getRawString('Diagnostic.revealTypeExpectedTypeMismatch')
             );
         export const selfTypeContext = () => getRawString('Diagnostic.selfTypeContext');
+        export const selfTypeMetaclass = () => getRawString('Diagnostic.selfTypeMetaclass');
         export const selfTypeWithTypedSelfOrCls = () => getRawString('Diagnostic.selfTypeWithTypedSelfOrCls');
         export const setterGetterTypeMismatch = () => getRawString('Diagnostic.setterGetterTypeMismatch');
         export const starPatternInAsPattern = () => getRawString('Diagnostic.starPatternInAsPattern');

--- a/packages/pyright-internal/src/localization/package.nls.en-us.json
+++ b/packages/pyright-internal/src/localization/package.nls.en-us.json
@@ -399,6 +399,7 @@
         "revealTypeExpectedTextMismatch": "Type text mismatch; expected \"{expected}\" but received \"{received}\"",
         "revealTypeExpectedTypeMismatch": "Type mismatch; expected \"{expected}\" but received \"{received}\"",
         "selfTypeContext": "\"Self\" is not valid in this context",
+        "selfTypeMetaclass": "\"Self\" cannot be used within a metaclass (a subclass of \"type\")",
         "selfTypeWithTypedSelfOrCls": "\"Self\" cannot be used in a function with a `self` or `cls` parameter that has a type annotation other than \"Self\"",
         "setterGetterTypeMismatch": "Property setter value type is not assignable to the getter return type",
         "singleOverload": "\"{name}\" is marked as overload, but additional overloads are missing",

--- a/packages/pyright-internal/src/tests/samples/metaclass9.py
+++ b/packages/pyright-internal/src/tests/samples/metaclass9.py
@@ -1,12 +1,13 @@
 # This sample tests the handling of metaclass keyword arguments.
 
-from typing import Any
-from typing_extensions import Self
+from typing import Any, TypeVar
+
+T = TypeVar("T")
 
 
 class Meta1(type):
     def __new__(
-        cls: type[Self],
+        cls: type[T],
         cls_name: str,
         bases: tuple[type, ...],
         attrs: dict[str, Any],
@@ -14,7 +15,7 @@ class Meta1(type):
         param1: int,
         param2: str,
         param3: str = "",
-    ) -> Self:
+    ) -> T:
         ...
 
 
@@ -43,14 +44,14 @@ class Class1_5(metaclass=Meta1, param2="", param1=1, param4=3):
 
 class Meta2(type):
     def __new__(
-        cls: type[Self],
+        cls: type[T],
         cls_name: str,
         bases: tuple[type, ...],
         attrs: dict[str, Any],
         *,
         param1: int,
         **kwargs: str,
-    ) -> Self:
+    ) -> T:
         ...
 
 

--- a/packages/pyright-internal/src/tests/samples/self1.py
+++ b/packages/pyright-internal/src/tests/samples/self1.py
@@ -1,6 +1,6 @@
 # This sample tests various error conditions for the Self type
 
-from typing import Callable, TypeVar
+from typing import Callable, Generic, TypeVar
 from typing_extensions import Self
 
 
@@ -96,3 +96,25 @@ class C:
             return bar
 
         return inner
+
+
+class D(Generic[T]):
+    ...
+
+
+# This should generate an error because "Self" cannot be used
+# within a generic class definition.
+class E(D[Self]):
+    ...
+
+
+class MetaA(type):
+    # This should generate an error because "Self" isn't
+    # allowed in a metaclass.
+    def __new__(cls, *args: object) -> Self:
+        ...
+
+    # This should generate an error because "Self" isn't
+    # allowed in a metaclass.
+    def __mul__(cls, count: int) -> list[Self]:
+        ...

--- a/packages/pyright-internal/src/tests/samples/with6.py
+++ b/packages/pyright-internal/src/tests/samples/with6.py
@@ -2,11 +2,10 @@
 # manager work with the "with" statement.
 
 from types import TracebackType
-from typing import Self
 
 
 class ClassA(type):
-    def __enter__(cls) -> Self:
+    def __enter__(cls) -> "ClassA":
         print("Enter A")
         return cls
 

--- a/packages/pyright-internal/src/tests/typeEvaluator1.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator1.test.ts
@@ -1456,7 +1456,7 @@ test('Parameters1', () => {
 test('Self1', () => {
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['self1.py']);
 
-    TestUtils.validateResults(analysisResults, 12);
+    TestUtils.validateResults(analysisResults, 15);
 });
 
 test('Self2', () => {


### PR DESCRIPTION
… a class definition statement. PEP 637 explicitly rejects this usage of `Self`. This addresses #6805.

Fixed a bug that leads to a false negative when `Self` is used within a metaclass. PEP 637 explicitly rejects this usage of `Self`. This addresses #6806.