### PR TITLE
Fixed bug in code flow analysis that resulted in an incorrect type ev…

### DIFF
--- a/packages/pyright-internal/src/analyzer/binder.ts
+++ b/packages/pyright-internal/src/analyzer/binder.ts
@@ -3240,6 +3240,8 @@ export class Binder extends ParseTreeWalker {
 
     private _createCallFlowNode(node: CallNode) {
         if (!this._isCodeUnreachable()) {
+            this._addExceptTargets(this._currentFlowNode!);
+
             const flowNode: FlowCall = {
                 flags: FlowFlags.Call,
                 id: this._getUniqueFlowNodeId(),
@@ -3248,10 +3250,6 @@ export class Binder extends ParseTreeWalker {
             };
 
             this._currentFlowNode = flowNode;
-        }
-
-        if (!this._isCodeUnreachable()) {
-            this._addExceptTargets(this._currentFlowNode!);
         }
     }
 

--- a/packages/pyright-internal/src/analyzer/codeFlowEngine.ts
+++ b/packages/pyright-internal/src/analyzer/codeFlowEngine.ts
@@ -492,6 +492,10 @@ export function getCodeFlowEngine(
                                     }
                                 }
 
+                                if (flowTypeResult && !isFlowNodeReachable(flowNode)) {
+                                    flowTypeResult = undefined;
+                                }
+
                                 return setCacheEntry(curFlowNode, flowTypeResult?.type, !!flowTypeResult?.isIncomplete);
                             }
 

--- a/packages/pyright-internal/src/tests/samples/with3.py
+++ b/packages/pyright-internal/src/tests/samples/with3.py
@@ -3,6 +3,7 @@
 # for the __exit__ or __aexit__ method.
 
 from contextlib import suppress, AsyncExitStack
+from typing import Never
 
 
 def test1() -> None:
@@ -71,3 +72,18 @@ def test4() -> None:
 async def test5() -> str:
     async with AsyncExitStack():
         return "from exit stack"
+
+
+def no_return() -> Never:
+    raise Exception()
+
+
+def test6():
+    val = None
+    with suppress():
+        val = 1
+        no_return()
+        val = 2
+
+    assert val is not None
+    reveal_type(val, expected_text="Literal[1]")


### PR DESCRIPTION
…aluation when a "NoReturn" call is made within a code block protected by an exception-suppressing context manager. This addresses #6850.