### PR TITLE
Make sure web uris aren't read from disk

### DIFF
--- a/packages/pyright-internal/src/tests/uri.test.ts
+++ b/packages/pyright-internal/src/tests/uri.test.ts
@@ -792,3 +792,11 @@ test('Realcase use cwd implicitly', () => {
     const fspaths = fsentries.map((entry) => fs.realCasePath(uri.combinePaths(entry)).getFilePath());
     assert.deepStrictEqual(lowerCaseDrive(paths), fspaths);
 });
+
+test('Web URIs dont exist', () => {
+    const fs = createFromRealFileSystem();
+    const uri = Uri.parse('http://www.bing.com', /*ignoreCase*/ true);
+    assert(!fs.existsSync(uri));
+    const stat = fs.statSync(uri);
+    assert(!stat.isFile());
+});


### PR DESCRIPTION
Follow up to https://github.com/microsoft/pyright/pull/6790

Pyright cannot handle non file URIs, hence the original reason for the assert. However the old pre URI change Pyright would just silently fail on these files. This makes it more explicit.