### PR TITLE
Fixed bug that resulted in incorrect type evaluation when a PEP-695 T…

### DIFF
--- a/packages/pyright-internal/src/analyzer/scopeUtils.ts
+++ b/packages/pyright-internal/src/analyzer/scopeUtils.ts
@@ -80,3 +80,17 @@ export function findTopNodeInScope(node: ParseNode, scope: Scope): ParseNode | u
 
     return undefined;
 }
+
+export function isScopeContainedWithin(scope: Scope, potentialParentScope: Scope): boolean {
+    let curScope: Scope | undefined = scope;
+
+    while (curScope) {
+        if (curScope.parent === potentialParentScope) {
+            return true;
+        }
+
+        curScope = curScope.parent;
+    }
+
+    return false;
+}

--- a/packages/pyright-internal/src/tests/samples/typeParams3.py
+++ b/packages/pyright-internal/src/tests/samples/typeParams3.py
@@ -1,6 +1,7 @@
 # This sample tests error conditions related to the use of PEP 695
 # type parameters outside of their valid scope.
 
+
 class ClassA[S]:
     s: S
 
@@ -12,10 +13,11 @@ class ClassA[S]:
             s: S
             t: T
             u: U
-            lambda : (S, T, U)
+            lambda: (S, T, U)
 
     # This should generate an error because T is out of scope.
     t: T
+
 
 # This should generate an error because S is out of scope.
 s: S
@@ -23,11 +25,12 @@ s: S
 # This should generate an error because T is out of scope.
 t: T
 
+
 def func1[A]():
     def func2[B]():
         a: A
         b: B
-    
+
         class ClassC[C](dict[B, C]):
             a: A
             b: B
@@ -38,11 +41,13 @@ def func1[A]():
                 b: B
                 c: C
                 d: D
-                e = lambda : (A, B, C, D)
+                e = lambda: (A, B, C, D)
+
     a: A
-    
+
     # This should generate an error because B is out of scope.
     b: B
+
 
 # This should generate an error because A is out of scope.
 a: A
@@ -55,3 +60,44 @@ type TA1[A] = list[A]
 # This should generate an error because B is out of scope.
 type TA2[A] = list[B]
 
+
+S = 0
+
+
+def outer1[S]():
+    S = ""
+    T = 1
+
+    def outer2[T]():
+        def inner1():
+            nonlocal S  # OK
+            reveal_type(S, expected_text="Literal['']")
+
+        def inner2():
+            global S  # OK
+            reveal_type(S, expected_text="Literal[0]")
+
+
+T = 0
+
+
+class Outer2[T]:
+    T = 1
+
+    reveal_type(T, expected_text="Literal[1]")
+
+    class Inner1:
+        T = ""
+
+        reveal_type(T, expected_text="Literal['']")
+
+        def inner_method(self):
+            reveal_type(T, expected_text="TypeVar")
+
+    def outer_method(self):
+        T = 3j
+
+        reveal_type(T, expected_text="complex")
+
+        def inner_func():
+            reveal_type(T, expected_text="complex")


### PR DESCRIPTION
…ypeVar is shadowed by an identifier of the same name within an inner scope. This addresses #6900.