### PR TITLE
Removed support for `Union[*Ts]` and `Union[*tuple[...]]`. This funct…

### DIFF
--- a/packages/pyright-internal/src/localization/localize.ts
+++ b/packages/pyright-internal/src/localization/localize.ts
@@ -1078,6 +1078,8 @@ export namespace Localizer {
             new ParameterizedString<{ classType: string }>(getRawString('Diagnostic.uninitializedAbstractVariables'));
         export const uninitializedInstanceVariable = () =>
             new ParameterizedString<{ name: string }>(getRawString('Diagnostic.uninitializedInstanceVariable'));
+        export const unionUnpackedTuple = () => getRawString('Diagnostic.unionUnpackedTuple');
+        export const unionUnpackedTypeVarTuple = () => getRawString('Diagnostic.unionUnpackedTypeVarTuple');
         export const unmatchedEndregionComment = () => getRawString('Diagnostic.unmatchedEndregionComment');
         export const unmatchedRegionComment = () => getRawString('Diagnostic.unmatchedRegionComment');
         export const unnecessaryCast = () =>

--- a/packages/pyright-internal/src/localization/package.nls.en-us.json
+++ b/packages/pyright-internal/src/localization/package.nls.en-us.json
@@ -548,6 +548,8 @@
         "unionTypeArgCount": "Union requires two or more type arguments",
         "uninitializedAbstractVariables": "Variables defined in abstract base class are not initialized in final class \"{classType}\"",
         "uninitializedInstanceVariable": "Instance variable \"{name}\" is not initialized in the class body or __init__ method",
+        "unionUnpackedTuple": "Union cannot include an unpacked tuple",
+        "unionUnpackedTypeVarTuple": "Union cannot include an unpacked TypeVarTuple",
         "unmatchedEndregionComment": "#endregion is missing corresponding #region",
         "unmatchedRegionComment": "#region is missing corresponding #endregion",
         "unnecessaryCast": "Unnecessary \"cast\" call; type is already \"{type}\"",

--- a/packages/pyright-internal/src/tests/samples/callable6.py
+++ b/packages/pyright-internal/src/tests/samples/callable6.py
@@ -46,14 +46,12 @@ def func6(x: TA4):
 Ts = TypeVarTuple("Ts")
 
 
-def func3(
-    path: str, *args: Unpack[tuple[Unpack[Ts], str]]
-) -> Union[Unpack[tuple[Unpack[Ts], int]]]:
+def func3(path: str, *args: Unpack[tuple[Unpack[Ts], str]]) -> tuple[Unpack[Ts], int]:
     ...
 
 
 v3 = func3("", 1, "2", 3.3, None, "")
-reveal_type(v3, expected_text="int | str | float | None")
+reveal_type(v3, expected_text="tuple[int, str, float, None, int]")
 
 func3("", "")
 

--- a/packages/pyright-internal/src/tests/samples/tupleUnpack1.py
+++ b/packages/pyright-internal/src/tests/samples/tupleUnpack1.py
@@ -36,8 +36,8 @@ def func7(v7: tuple[Unpack[tuple[bool, Unpack[tuple[int, float]]]]]):
     reveal_type(v7, expected_text="tuple[bool, int, float]")
 
 
-def func8(v8: Union[Unpack[tuple[Unpack[tuple[bool, Unpack[tuple[int, ...]]]]]]]):
-    reveal_type(v8, expected_text="bool | int")
+def func8(v8: tuple[Unpack[tuple[bool, Unpack[tuple[int, ...]]]]]):
+    reveal_type(v8, expected_text="tuple[bool, *tuple[int, ...]]")
 
 
 # This should generate an error because unpack isn't allowed for simple parameters.

--- a/packages/pyright-internal/src/tests/samples/tupleUnpack2.py
+++ b/packages/pyright-internal/src/tests/samples/tupleUnpack2.py
@@ -37,8 +37,8 @@ def func7(v7: tuple[*tuple[bool, *tuple[int, float]]]):
     reveal_type(v7, expected_text="tuple[bool, int, float]")
 
 
-def func8(v8: Union[*tuple[*tuple[bool, *tuple[int, ...]]]]):
-    reveal_type(v8, expected_text="bool | int")
+def func8(v8: tuple[*tuple[bool, *tuple[int, ...]]]):
+    reveal_type(v8, expected_text="tuple[bool, *tuple[int, ...]]")
 
 # This should generate an error because unpack isn't allowed for simple parameters.
 def func9(v9: *tuple[int, int]):

--- a/packages/pyright-internal/src/tests/samples/variadicTypeVar1.py
+++ b/packages/pyright-internal/src/tests/samples/variadicTypeVar1.py
@@ -15,14 +15,14 @@ class ClassA(Generic[_T, Unpack[_Xs]]):
     def __init__(self, *args: Unpack[_Xs]) -> None:
         reveal_type(args, expected_text="tuple[*_Xs@ClassA]")
 
-    # This should generate an error
+    # This should generate two errors.
     def func2(self) -> Union[_Xs]:
         ...
 
     def func3(self) -> tuple[Unpack[_Xs]]:
         ...
 
-    # This should generate an error
+    # This should generate an error.
     def func4(self) -> tuple[_Xs]:
         ...
 

--- a/packages/pyright-internal/src/tests/samples/variadicTypeVar10.py
+++ b/packages/pyright-internal/src/tests/samples/variadicTypeVar10.py
@@ -28,7 +28,7 @@ def process_batch_channels(x: Array[Batch, Unpack[tuple[Any, ...]], Channels]) -
     ...
 
 
-def expect_variadic_array1(x: Array[Batch, Unpack[Shape]]) -> Union[Unpack[Shape]]:
+def expect_variadic_array1(x: Array[Batch, Unpack[Shape]]) -> tuple[Unpack[Shape]]:
     ...
 
 

--- a/packages/pyright-internal/src/tests/samples/variadicTypeVar11.py
+++ b/packages/pyright-internal/src/tests/samples/variadicTypeVar11.py
@@ -4,6 +4,9 @@
 
 # pyright: reportMissingModuleSource=false
 
+# Enable experimental features to support Union[*Ts].
+# pyright: enableExperimentalFeatures=true
+
 from typing import Generic, NewType, Union
 from typing_extensions import TypeVarTuple
 

--- a/packages/pyright-internal/src/tests/samples/variadicTypeVar19.py
+++ b/packages/pyright-internal/src/tests/samples/variadicTypeVar19.py
@@ -1,6 +1,9 @@
 # This sample tests the case where an unpacked TypeVarTuple is used
 # as one or more type arguments for a tuple.
 
+# Enable experimental features to support Union[*Ts].
+# pyright: enableExperimentalFeatures=true
+
 from typing import Generator, Iterable, TypeVar, TypeVarTuple, Union
 
 T = TypeVar("T")

--- a/packages/pyright-internal/src/tests/samples/variadicTypeVar2.py
+++ b/packages/pyright-internal/src/tests/samples/variadicTypeVar2.py
@@ -18,6 +18,7 @@ class ClassA(Generic[_T, Unpack[_Xs]]):
         # This should generate an error
         self.y: _Xs = shape
 
+    # This should generate two errors
     def func1(self) -> Union[Unpack[_Xs]]:
         ...
 

--- a/packages/pyright-internal/src/tests/samples/variadicTypeVar20.py
+++ b/packages/pyright-internal/src/tests/samples/variadicTypeVar20.py
@@ -1,6 +1,9 @@
 # This sample tests the case where an unpacked TypeVarTuple is assigned
 # to a non-variadic TypeVar during constraint solving.
 
+# Enable experimental features to support Union[*Ts].
+# pyright: enableExperimentalFeatures=true
+
 from typing import TypeVar, Tuple, Union
 from typing_extensions import reveal_type, TypeVarTuple
 

--- a/packages/pyright-internal/src/tests/samples/variadicTypeVar21.py
+++ b/packages/pyright-internal/src/tests/samples/variadicTypeVar21.py
@@ -2,6 +2,9 @@
 # TypeVarTuple is used in an unpacked argument and assigned to another
 # TypeVarTuple parameter.
 
+# Enable experimental features to support Union[*Ts].
+# pyright: enableExperimentalFeatures=true
+
 from typing import TypeVar, TypeVarTuple, Union, Unpack
 
 T = TypeVar("T")

--- a/packages/pyright-internal/src/tests/samples/variadicTypeVar22.py
+++ b/packages/pyright-internal/src/tests/samples/variadicTypeVar22.py
@@ -1,6 +1,9 @@
 # This sample tests the case where a TypeVarTuple is solved using
 # a tuple with literal values.
 
+# Enable experimental features to support Union[*Ts].
+# pyright: enableExperimentalFeatures=true
+
 from typing import Callable, Literal, TypeVarTuple, Union, Unpack
 
 Ts = TypeVarTuple("Ts")

--- a/packages/pyright-internal/src/tests/samples/variadicTypeVar24.py
+++ b/packages/pyright-internal/src/tests/samples/variadicTypeVar24.py
@@ -1,5 +1,7 @@
 # This sample tests the handling of `Union[*Ts]` in certain cases.
 
+# Enable experimental features to support Union[*Ts].
+# pyright: enableExperimentalFeatures=true
 
 from typing import Generic, TypeVarTuple, Union
 

--- a/packages/pyright-internal/src/tests/samples/variadicTypeVar3.py
+++ b/packages/pyright-internal/src/tests/samples/variadicTypeVar3.py
@@ -21,9 +21,8 @@ class Array(Generic[Unpack[_Xs]]):
         ...
 
 
-def linearize(value: Array[Unpack[_Xs]]) -> Sequence[Union[Unpack[_Xs]]]:
-    reveal_type(value, expected_text="Array[*_Xs@linearize]")
-    return []
+def linearize(value: Array[Unpack[_Xs]]) -> tuple[Unpack[_Xs]]:
+    ...
 
 
 def array_to_tuple(value: Array[Unpack[_Xs]]) -> tuple[complex, Unpack[_Xs]]:
@@ -39,13 +38,13 @@ def func1(x: Array[int, str, str, float], y: Array[()]):
     reveal_type(a1, expected_text="Array[int, float, str]")
 
     a2 = linearize(a1)
-    reveal_type(a2, expected_text="Sequence[int | float | str]")
+    reveal_type(a2, expected_text="tuple[int, float, str]")
 
     b1 = Array()
     reveal_type(b1, expected_text="Array[*tuple[()]]")
 
     b2 = linearize(b1)
-    reveal_type(b2, expected_text="Sequence[Never]")
+    reveal_type(b2, expected_text="tuple[()]")
 
     e = array_to_tuple(x)
     reveal_type(e, expected_text="tuple[complex, int, str, str, float]")

--- a/packages/pyright-internal/src/tests/samples/variadicTypeVar4.py
+++ b/packages/pyright-internal/src/tests/samples/variadicTypeVar4.py
@@ -3,6 +3,9 @@
 
 # pyright: reportMissingModuleSource=false
 
+# Enable experimental features to support Union[*Ts].
+# pyright: enableExperimentalFeatures=true
+
 from typing import Generic, NewType, Union
 from typing_extensions import TypeVarTuple, Unpack
 

--- a/packages/pyright-internal/src/tests/samples/variadicTypeVar5.py
+++ b/packages/pyright-internal/src/tests/samples/variadicTypeVar5.py
@@ -33,7 +33,7 @@ def callback4(a: int, b: complex, c: str) -> int:
     ...
 
 
-def callback5(a: int, *args: Unpack[_Xs]) -> Union[Unpack[_Xs]]:
+def callback5(a: int, *args: Unpack[_Xs]) -> tuple[Unpack[_Xs]]:
     ...
 
 

--- a/packages/pyright-internal/src/tests/samples/variadicTypeVar6.py
+++ b/packages/pyright-internal/src/tests/samples/variadicTypeVar6.py
@@ -52,18 +52,18 @@ y2: Alias4[float, str, str] = Array("3.4", 2, "hi", "hi")
 y3 = Alias4[float, str, str](3, 2, "hi", "hi")
 
 
-def func1(a: Alias4[_T, Unpack[_Xs]]) -> Union[_T, Unpack[_Xs]]:
+def func1(a: Alias4[_T, Unpack[_Xs]]) -> tuple[_T, Unpack[_Xs]]:
     ...
 
 
 z1 = func1(Array(3, 4, "hi", 3j))
-reveal_type(z1, expected_text="int | str | complex")
+reveal_type(z1, expected_text="tuple[int, str, complex]")
 
 # This should generate an error.
 z2 = func1(Array(3, 4.3, "hi", 3j))
 
 z3 = func1(Array(3.5, 4))
-reveal_type(z3, expected_text="float")
+reveal_type(z3, expected_text="tuple[float]")
 
 Alias6 = tuple[int, Unpack[_Xs]]
 

--- a/packages/pyright-internal/src/tests/samples/variadicTypeVar7.py
+++ b/packages/pyright-internal/src/tests/samples/variadicTypeVar7.py
@@ -2,6 +2,8 @@
 
 # pyright: reportMissingModuleSource=false
 
+# Enable experimental features to support Union[*Ts].
+# pyright: enableExperimentalFeatures=true
 
 from typing import Any, Callable, Generic, TypeVar, Union
 from typing_extensions import TypeVarTuple, Unpack

--- a/packages/pyright-internal/src/tests/samples/variadicTypeVar8.py
+++ b/packages/pyright-internal/src/tests/samples/variadicTypeVar8.py
@@ -2,6 +2,9 @@
 
 # pyright: reportMissingModuleSource=false
 
+# Enable experimental features to support Union[*Ts].
+# pyright: enableExperimentalFeatures=true
+
 from typing import TypeVar, Union
 from typing_extensions import TypeVarTuple, Unpack
 

--- a/packages/pyright-internal/src/tests/typeEvaluator1.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator1.test.ts
@@ -1590,7 +1590,7 @@ test('TupleUnpack2', () => {
 
     configOptions.defaultPythonVersion = PythonVersion.V3_10;
     const analysisResults1 = TestUtils.typeAnalyzeSampleFiles(['tupleUnpack2.py'], configOptions);
-    TestUtils.validateResults(analysisResults1, 20);
+    TestUtils.validateResults(analysisResults1, 19);
 
     configOptions.defaultPythonVersion = PythonVersion.V3_11;
     const analysisResults2 = TestUtils.typeAnalyzeSampleFiles(['tupleUnpack2.py'], configOptions);

--- a/packages/pyright-internal/src/tests/typeEvaluator3.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator3.test.ts
@@ -1025,7 +1025,7 @@ test('VariadicTypeVar1', () => {
 
     configOptions.defaultPythonVersion = PythonVersion.V3_11;
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['variadicTypeVar1.py'], configOptions);
-    TestUtils.validateResults(analysisResults, 18);
+    TestUtils.validateResults(analysisResults, 19);
 });
 
 test('VariadicTypeVar2', () => {
@@ -1033,7 +1033,7 @@ test('VariadicTypeVar2', () => {
 
     configOptions.defaultPythonVersion = PythonVersion.V3_11;
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['variadicTypeVar2.py'], configOptions);
-    TestUtils.validateResults(analysisResults, 13);
+    TestUtils.validateResults(analysisResults, 15);
 });
 
 test('VariadicTypeVar3', () => {


### PR DESCRIPTION
…ionality was included in an early draft of PEP 646 but was dropped in the final spec. The functionality can still be used in pyright if `useExperimentalFeatures` is set to true, but it will likely be removed entirely in the future. This addresses #6892.