### PR TITLE
Added missing check for inconsistent use of `@final` in an overloaded…

### DIFF
--- a/packages/pyright-internal/src/localization/localize.ts
+++ b/packages/pyright-internal/src/localization/localize.ts
@@ -708,6 +708,12 @@ export namespace Localizer {
             new ParameterizedString<{ name: string }>(getRawString('Diagnostic.overloadAbstractMismatch'));
         export const overloadClassMethodInconsistent = () =>
             new ParameterizedString<{ name: string }>(getRawString('Diagnostic.overloadClassMethodInconsistent'));
+        export const overloadFinalInconsistencyImpl = () =>
+            new ParameterizedString<{ name: string }>(getRawString('Diagnostic.overloadFinalInconsistencyImpl'));
+        export const overloadFinalInconsistencyNoImpl = () =>
+            new ParameterizedString<{ name: string; index: number }>(
+                getRawString('Diagnostic.overloadFinalInconsistencyNoImpl')
+            );
         export const overloadImplementationMismatch = () =>
             new ParameterizedString<{ name: string; index: number }>(
                 getRawString('Diagnostic.overloadImplementationMismatch')

--- a/packages/pyright-internal/src/localization/package.nls.en-us.json
+++ b/packages/pyright-internal/src/localization/package.nls.en-us.json
@@ -330,6 +330,8 @@
         "overlappingOverload": "Overload {obscured} for \"{name}\" will never be used because its parameters overlap overload {obscuredBy}",
         "overloadAbstractMismatch": "Overloaded methods must all be abstract or not",
         "overloadClassMethodInconsistent": "Overloads for \"{name}\" use @classmethod inconsistently",
+        "overloadFinalInconsistencyImpl": "Overload for \"{name}\" is marked @final but implementation is not",
+        "overloadFinalInconsistencyNoImpl": "Overload {index} for \"{name}\" is marked @final but overload 1 is not",
         "overloadImplementationMismatch": "Overloaded implementation is not consistent with signature of overload {index}",
         "overloadReturnTypeMismatch": "Overload {prevIndex} for \"{name}\" overlaps overload {newIndex} and returns an incompatible type",
         "overloadStaticMethodInconsistent": "Overloads for \"{name}\" use @staticmethod inconsistently",

--- a/packages/pyright-internal/src/tests/samples/final2.py
+++ b/packages/pyright-internal/src/tests/samples/final2.py
@@ -1,6 +1,6 @@
 # This sample tests the handling of the @final method decorator.
 
-from typing import final
+from typing import Any, cast, final, overload
 
 
 class ClassA:
@@ -28,6 +28,32 @@ class ClassA:
     def __func6(self):
         pass
 
+    @overload
+    def func7(self, x: int) -> int:
+        ...
+
+    @overload
+    def func7(self, x: str) -> str:
+        ...
+
+    @final
+    def func7(self, x: int | str) -> int | str:
+        ...
+
+    # This should generate an error because the implementation
+    # of func8 is marked as not final but this overload is.
+    @overload
+    @final
+    def func8(self, x: int) -> int:
+        ...
+
+    @overload
+    def func8(self, x: str) -> str:
+        ...
+
+    def func8(self, x: int | str) -> int | str:
+        ...
+
 
 # This should generate an error because func3 is final.
 ClassA.func3 = lambda self: None
@@ -38,6 +64,9 @@ ClassA.func4 = lambda cls: None
 # This should generate an error because _func5 is final.
 ClassA._func5 = lambda self: None
 
+# This should generate an error because func7 is final.
+ClassA.func7 = cast(Any, lambda self, x: "")
+
 
 class ClassB(ClassA):
     def func1(self):
@@ -46,7 +75,6 @@ class ClassB(ClassA):
         @final
         def func1_inner():
             pass
-        
 
     @classmethod
     def func2(cls):
@@ -72,6 +100,20 @@ class ClassB(ClassA):
     # underscore symbols are exempt from this check.
     def __func6(self):
         pass
+
+    @overload
+    def func7(self, x: int) -> int:
+        ...
+
+    @overload
+    def func7(self, x: str) -> str:
+        ...
+
+    @final
+    # This should generate an error because func7 is
+    # defined as final.
+    def func7(self, x: int | str) -> int | str:
+        ...
 
 
 class Base4:

--- a/packages/pyright-internal/src/tests/samples/final6.pyi
+++ b/packages/pyright-internal/src/tests/samples/final6.pyi
@@ -1,0 +1,25 @@
+# This sample tests that an overloaded method in a stub honors the
+# @final on the first overload.
+
+from typing import final, overload
+
+class ClassA:
+    @overload
+    @final
+    def method1(self, x: int) -> int: ...
+    @overload
+    def method1(self, x: str) -> str: ...
+    @overload
+    def method2(self, x: int) -> int: ...
+    @overload
+    @final
+    # This should generate an error because the first overload
+    # is not marked @final but this one is.
+    def method2(self, x: str) -> str: ...
+
+class ClassB(ClassA):
+    @overload
+    def method1(self, x: int) -> int: ...
+    @overload
+    # This should generate an error.
+    def method1(self, x: str) -> str: ...

--- a/packages/pyright-internal/src/tests/typeEvaluator4.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator4.test.ts
@@ -362,7 +362,7 @@ test('Final1', () => {
 
 test('Final2', () => {
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['final2.py']);
-    TestUtils.validateResults(analysisResults, 9);
+    TestUtils.validateResults(analysisResults, 12);
 });
 
 test('Final3', () => {
@@ -378,6 +378,11 @@ test('Final4', () => {
 test('Final5', () => {
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['final5.py']);
     TestUtils.validateResults(analysisResults, 0);
+});
+
+test('Final6', () => {
+    const analysisResults = TestUtils.typeAnalyzeSampleFiles(['final6.pyi']);
+    TestUtils.validateResults(analysisResults, 2);
 });
 
 test('InferredTypes1', () => {


### PR DESCRIPTION
… function. Added missing check for override of an overloaded method marked `@final`. This addresses #6860 and #6866.