### PR TITLE
Changed the way pyright identifies an "unimplemented protocol method"…

### DIFF
--- a/packages/pyright-internal/src/tests/samples/classes11.py
+++ b/packages/pyright-internal/src/tests/samples/classes11.py
@@ -1,12 +1,16 @@
 # This sample tests the detection of mutually-incompatible base classes
 # in classes that use multiple inheritance.
 
-from typing import Collection, Mapping, Sequence, TypeVar
+from typing import Collection, Iterator, Mapping, Sequence, TypeVar
 
 
 # This should generate an error.
 class A(Mapping[str, int], Collection[int]):
-    ...
+    def __len__(self) -> int:
+        ...
+
+    def __iter__(self) -> Iterator[str]:
+        ...
 
 
 # This should generate an error.
@@ -37,9 +41,16 @@ S = TypeVar("S")
 
 
 class G(Mapping[T, S], Collection[T]):
-    ...
+    def __len__(self) -> int:
+        ...
 
+    def __iter__(self) -> Iterator[T]:
+        ...
 
 # This should generate an error.
 class H(Mapping[T, S], Collection[S]):
-    ...
+    def __len__(self) -> int:
+        ...
+
+    def __iter__(self) -> Iterator[T]:
+        ...

--- a/packages/pyright-internal/src/tests/samples/constructor10.py
+++ b/packages/pyright-internal/src/tests/samples/constructor10.py
@@ -13,6 +13,8 @@ class A(Iterator[_T_co]):
     def __new__(cls, __iterable: Iterable[_T]) -> "A[tuple[_T, _T]]":
         ...
 
+    def __next__(self) -> _T_co: ...
+
 
 def func1(iterable: Iterable[_T]) -> Iterator[tuple[_T, _T, _T]]:
     for (a, _), (b, c) in A(A(iterable)):

--- a/packages/pyright-internal/src/tests/samples/genericType24.py
+++ b/packages/pyright-internal/src/tests/samples/genericType24.py
@@ -1,13 +1,14 @@
 # This sample tests a case where a default argument in a parent class
 # needs to be specialized in the context of a child class.
 
-from typing import Generic, Iterable, TypeVar
+from typing import Generic, Iterable, Iterator, TypeVar
 
 T = TypeVar("T")
 
 
 class IterableProxy(Iterable[T]):
-    ...
+    def __iter__(self) -> Iterator[T]:
+        ...
 
 
 class Parent(Generic[T]):

--- a/packages/pyright-internal/src/tests/samples/genericType44.py
+++ b/packages/pyright-internal/src/tests/samples/genericType44.py
@@ -3,13 +3,14 @@
 # invariant type parameter. Literal types need to be handled
 # carefully in this case.
 
-from typing import Awaitable, Literal, TypeVar
+from typing import Any, Awaitable, Generator, Literal, TypeVar
 
 _T = TypeVar("_T")
 
 
 class Future(Awaitable[_T]):
-    ...
+    def __await__(self) -> Generator[Any, None, _T]:
+        ...
 
 
 def func1(future: Future[_T]) -> Future[_T]:

--- a/packages/pyright-internal/src/tests/samples/solver24.py
+++ b/packages/pyright-internal/src/tests/samples/solver24.py
@@ -2,7 +2,7 @@
 # a union of type variables.
 
 from os import PathLike
-from typing import AnyStr, Generic, Iterable, Iterator, TypeAlias, TypeVar
+from typing import AnyStr, Generic, Iterable, Iterator, Protocol, TypeAlias, TypeVar
 
 V = TypeVar("V")
 V_co = TypeVar("V_co", covariant=True)
@@ -34,7 +34,7 @@ class ClassC(Generic[AnyStr]):
     ...
 
 
-class ClassD(Iterator[ClassC[AnyStr]]):
+class ClassD(Iterator[ClassC[AnyStr]], Protocol):
     ...
 
 

--- a/packages/pyright-internal/src/tests/samples/solver30.py
+++ b/packages/pyright-internal/src/tests/samples/solver30.py
@@ -1,7 +1,7 @@
 # This sample tests the case where a deeply nested set of calls requires
 # the use of bidirectional type inference to evaluate the type of a lambda.
 
-from typing import Any, Callable, Iterable, Iterator, TypeVar
+from typing import Any, Callable, Iterable, Iterator, Protocol, TypeVar
 
 X = TypeVar("X")
 Y = TypeVar("Y")
@@ -25,6 +25,9 @@ def func2(a: Iterable[Y]) -> Iterable[Y]:
 
 class func3(Iterator[Z]):
     def __init__(self, a: Callable[[Z], Any], b: Iterable[Z]) -> None:
+        ...
+
+    def __next__(self) -> Z:
         ...
 
 


### PR DESCRIPTION
… within a stub file. It now looks at whether the method is decorated with `@abstractmethod`. Previously, it assumed all such methods were potentially implemented. This addresses #6946.