### PR TITLE
Added support for `+` unary operator in `Literal` `int` type annotati…

### DIFF
--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -14631,13 +14631,18 @@ export function createTypeEvaluator(importLookup: ImportLookup, evaluatorOptions
                 } else if (itemExpr.constType === KeywordType.None) {
                     type = noneClassType ?? UnknownType.create();
                 }
-            } else if (
-                itemExpr.nodeType === ParseNodeType.UnaryOperation &&
-                itemExpr.operator === OperatorType.Subtract
-            ) {
-                if (itemExpr.expression.nodeType === ParseNodeType.Number) {
-                    if (!itemExpr.expression.isImaginary && itemExpr.expression.isInteger) {
-                        type = cloneBuiltinClassWithLiteral(node, 'int', -itemExpr.expression.value);
+            } else if (itemExpr.nodeType === ParseNodeType.UnaryOperation) {
+                if (itemExpr.operator === OperatorType.Subtract || itemExpr.operator === OperatorType.Add) {
+                    if (itemExpr.expression.nodeType === ParseNodeType.Number) {
+                        if (!itemExpr.expression.isImaginary && itemExpr.expression.isInteger) {
+                            type = cloneBuiltinClassWithLiteral(
+                                node,
+                                'int',
+                                itemExpr.operator === OperatorType.Subtract
+                                    ? -itemExpr.expression.value
+                                    : itemExpr.expression.value
+                            );
+                        }
                     }
                 }
             }

--- a/packages/pyright-internal/src/tests/samples/literals1.py
+++ b/packages/pyright-internal/src/tests/samples/literals1.py
@@ -40,7 +40,7 @@ invalidType = 3  # type: Literal[3.4]
 # is not a valid literal value.
 mismatch = 2  # type: Literal[3, 4, '5']
 
-a: Literal[3] = -(-(+++3))
+a: Literal[+3] = -(-(+++3))
 b: Literal[-2] = +-+2
 
 # This should generate an error because literals are


### PR DESCRIPTION
…ons. The typing spec was recently amended to allow this. This addresses #6968.