### PR TITLE
Fixed recent regression whereby a type created with `NewType` was no …

### DIFF
--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -12809,16 +12809,29 @@ export function createTypeEvaluator(importLookup: ImportLookup, evaluatorOptions
         }
 
         if (!isInstantiableClass(baseClass)) {
-            addError(Localizer.Diagnostic.newTypeNotAClass(), argList[1].node || errorNode);
+            addDiagnostic(
+                AnalyzerNodeInfo.getFileInfo(errorNode).diagnosticRuleSet.reportGeneralTypeIssues,
+                DiagnosticRule.reportGeneralTypeIssues,
+                Localizer.Diagnostic.newTypeNotAClass(),
+                argList[1].node || errorNode
+            );
             return undefined;
         }
 
         if (ClassType.isProtocolClass(baseClass) || ClassType.isTypedDictClass(baseClass)) {
-            addError(Localizer.Diagnostic.newTypeProtocolClass(), argList[1].node || errorNode);
+            addDiagnostic(
+                AnalyzerNodeInfo.getFileInfo(errorNode).diagnosticRuleSet.reportGeneralTypeIssues,
+                DiagnosticRule.reportGeneralTypeIssues,
+                Localizer.Diagnostic.newTypeProtocolClass(),
+                argList[1].node || errorNode
+            );
         } else if (baseClass.literalValue !== undefined) {
-            addError(Localizer.Diagnostic.newTypeLiteral(), argList[1].node || errorNode);
-        } else if (ClassType.isNewTypeClass(baseClass)) {
-            addError(Localizer.Diagnostic.newTypeNewTypeClass(), argList[1].node || errorNode);
+            addDiagnostic(
+                AnalyzerNodeInfo.getFileInfo(errorNode).diagnosticRuleSet.reportGeneralTypeIssues,
+                DiagnosticRule.reportGeneralTypeIssues,
+                Localizer.Diagnostic.newTypeLiteral(),
+                argList[1].node || errorNode
+            );
         }
 
         let classFlags = baseClass.details.flags & ~(ClassTypeFlags.BuiltInClass | ClassTypeFlags.SpecialBuiltIn);

--- a/packages/pyright-internal/src/localization/localize.ts
+++ b/packages/pyright-internal/src/localization/localize.ts
@@ -654,7 +654,6 @@ export namespace Localizer {
         export const newTypeBadName = () => getRawString('Diagnostic.newTypeBadName');
         export const newTypeLiteral = () => getRawString('Diagnostic.newTypeLiteral');
         export const newTypeNameMismatch = () => getRawString('Diagnostic.newTypeNameMismatch');
-        export const newTypeNewTypeClass = () => getRawString('Diagnostic.newTypeNewTypeClass');
         export const newTypeNotAClass = () => getRawString('Diagnostic.newTypeNotAClass');
         export const newTypeParamCount = () => getRawString('Diagnostic.newTypeParamCount');
         export const newTypeProtocolClass = () => getRawString('Diagnostic.newTypeProtocolClass');

--- a/packages/pyright-internal/src/localization/package.nls.en-us.json
+++ b/packages/pyright-internal/src/localization/package.nls.en-us.json
@@ -295,7 +295,6 @@
         "newTypeBadName": "The first argument to NewType must be a string literal",
         "newTypeLiteral": "NewType cannot be used with Literal type",
         "newTypeNameMismatch": "NewType must be assigned to a variable with the same name",
-        "newTypeNewTypeClass": "NewType cannot be used with a class created with NewType",
         "newTypeNotAClass": "Expected class as second argument to NewType",
         "newTypeParamCount": "NewType requires two positional arguments",
         "newTypeProtocolClass": "NewType cannot be used with structural type (a protocol or TypedDict class)",

--- a/packages/pyright-internal/src/tests/samples/newType1.py
+++ b/packages/pyright-internal/src/tests/samples/newType1.py
@@ -60,8 +60,7 @@ class TD1(TypedDict):
 # This should generate an error because type cannot be a TypedDict.
 NewTypeBad7 = NewType("NewTypeBad7", TD1)
 
-# This should generate an error because type cannot be another NewType.
-NewTypeBad8 = NewType("NewTypeBad8", MyString)
+NewTypeGood8 = NewType("NewTypeGood8", MyString)
 
 # This should generate an error because the name doesn't match.
 NewTypeBad9 = NewType("NewTypeBad9Not", int)

--- a/packages/pyright-internal/src/tests/typeEvaluator2.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator2.test.ts
@@ -242,7 +242,7 @@ test('MissingSuper1', () => {
 test('NewType1', () => {
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['newType1.py']);
 
-    TestUtils.validateResults(analysisResults, 12);
+    TestUtils.validateResults(analysisResults, 11);
 });
 
 test('NewType2', () => {


### PR DESCRIPTION
…longer allowed as an argument for another `NewType`. This addresses #6976.