### PR TITLE
Fixed a bug that resulted in an incorrect implied specialization of a…

### DIFF
--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -4893,6 +4893,12 @@ export function createTypeEvaluator(importLookup: ImportLookup, evaluatorOptions
                 let defaultType: Type;
                 if (param.details.defaultType || param.details.isParamSpec) {
                     defaultType = applySolvedTypeVars(param, typeVarContext, { unknownIfNotFound: true });
+                } else if (param.details.isVariadic && tupleClassType && isInstantiableClass(tupleClassType)) {
+                    defaultType = ClassType.cloneForUnpacked(
+                        specializeTupleClass(ClassType.cloneAsInstance(tupleClassType), [
+                            { type: UnknownType.create(), isUnbounded: true },
+                        ])
+                    );
                 } else {
                     defaultType = UnknownType.create();
                 }

--- a/packages/pyright-internal/src/tests/samples/variadicTypeVar6.py
+++ b/packages/pyright-internal/src/tests/samples/variadicTypeVar6.py
@@ -17,10 +17,10 @@ class Array(Generic[Unpack[_Xs]]):
 
 Alias1 = Array[Unpack[_Xs]]
 
-# This should generate an error
+# This should generate an error.
 Alias2 = Array[_Xs]
 
-# This should generate an error
+# This should generate an error.
 Alias3 = Array[_T, int, _Xs]
 
 # This should generate an error if reportMissingTypeArgument is enabled.
@@ -73,7 +73,7 @@ Alias6 = tuple[int, Unpack[_Xs]]
 def func2(x: Alias6[float, bool], y: Alias6, z: Alias6[()]):
     reveal_type(x, expected_text="tuple[int, float, bool]")
 
-    reveal_type(y, expected_text="tuple[int, Unknown]")
+    reveal_type(y, expected_text="tuple[int, *tuple[Unknown, ...]]")
 
     reveal_type(z, expected_text="tuple[int]")
 

--- a/packages/pyright-internal/src/tests/samples/variadicTypeVar9.py
+++ b/packages/pyright-internal/src/tests/samples/variadicTypeVar9.py
@@ -5,12 +5,12 @@ from typing import Callable, Generic, TypeVar
 from typing_extensions import TypeVarTuple, Unpack
 
 
-P = TypeVarTuple("P")
+Ts = TypeVarTuple("Ts")
 T = TypeVar("T", covariant=True)
 
 
-class Call(Generic[Unpack[P]]):
-    def __init__(self, *args: Unpack[P]) -> None:
+class Call(Generic[Unpack[Ts]]):
+    def __init__(self, *args: Unpack[Ts]) -> None:
         self.args = args
 
 
@@ -19,12 +19,12 @@ class Return(Generic[T]):
         self.result = result
 
 
-TailRec = Call[Unpack[P]] | Return[T]
+TailRec = Call[Unpack[Ts]] | Return[T]
 
 
 def tail_rec(
-    fn: Callable[[Unpack[P]], TailRec[Unpack[P], T]]
-) -> Callable[[Unpack[P]], T]:
+    fn: Callable[[Unpack[Ts]], TailRec[Unpack[Ts], T]]
+) -> Callable[[Unpack[Ts]], T]:
     ...
 
 
@@ -36,3 +36,14 @@ def factorial(n: int, acc: int) -> TailRec[int, int, int]:
 
 
 reveal_type(factorial, expected_text="(int, int) -> int")
+
+
+Alias10 = tuple[T, *Ts]
+Alias11 = tuple[*Ts]
+Alias12 = tuple[T, *Ts, T]
+
+
+def func5(a10: Alias10, a11: Alias11, a12: Alias12):
+    reveal_type(a10, expected_text="tuple[Unknown, *tuple[Unknown, ...]]")
+    reveal_type(a11, expected_text="tuple[Unknown, ...]")
+    reveal_type(a12, expected_text="tuple[Unknown, *tuple[Unknown, ...], Unknown]")


### PR DESCRIPTION
… generic type alias that is parameterized by a TypeVarTuple. The implied type argument should be `*tuple[Unknown, ...]` in this case. This addresses #6902.