### PR TITLE
Fixed a bug in class pattern matching logic that incorrectly narrows …

### DIFF
--- a/packages/pyright-internal/src/analyzer/patternMatching.ts
+++ b/packages/pyright-internal/src/analyzer/patternMatching.ts
@@ -737,14 +737,20 @@ function narrowTypeBasedOnClassPattern(
                 }
 
                 if (pattern.arguments.length === 0) {
-                    if (
-                        isClass(classInstance) &&
-                        isClass(subjectSubtypeExpanded) &&
-                        ClassType.isSameGenericClass(classInstance, subjectSubtypeExpanded)
-                    ) {
-                        // We know that this match will always succeed, so we can
-                        // eliminate this subtype.
-                        return undefined;
+                    if (isClass(classInstance) && isClass(subjectSubtypeExpanded)) {
+                        if (ClassType.isSameGenericClass(classInstance, subjectSubtypeExpanded)) {
+                            // We know that this match will always succeed, so we can
+                            // eliminate this subtype.
+                            return undefined;
+                        }
+
+                        // Handle LiteralString as a special case.
+                        if (
+                            ClassType.isBuiltIn(classInstance, 'str') &&
+                            ClassType.isBuiltIn(subjectSubtypeExpanded, 'LiteralString')
+                        ) {
+                            return undefined;
+                        }
                     }
 
                     return subjectSubtypeExpanded;
@@ -853,17 +859,11 @@ function narrowTypeBasedOnClassPattern(
                             let resultType: Type;
 
                             if (
-                                evaluator.assignType(
-                                    expandedSubtype,
-                                    ClassType.cloneAsInstantiable(subjectSubtypeExpanded)
-                                )
+                                evaluator.assignType(ClassType.cloneAsInstance(expandedSubtype), subjectSubtypeExpanded)
                             ) {
                                 resultType = subjectSubtypeExpanded;
                             } else if (
-                                evaluator.assignType(
-                                    ClassType.cloneAsInstantiable(subjectSubtypeExpanded),
-                                    expandedSubtype
-                                )
+                                evaluator.assignType(subjectSubtypeExpanded, ClassType.cloneAsInstance(expandedSubtype))
                             ) {
                                 resultType = addConditionToType(
                                     convertToInstance(unexpandedSubtype),

--- a/packages/pyright-internal/src/tests/samples/matchClass1.py
+++ b/packages/pyright-internal/src/tests/samples/matchClass1.py
@@ -2,6 +2,7 @@
 # described in PEP 634) that contain class patterns.
 
 from typing import Any, Generic, Literal, NamedTuple, TypeVar
+from typing_extensions import LiteralString
 from dataclasses import dataclass, field
 
 foo = 3
@@ -88,6 +89,19 @@ def test_literal(value_to_match: Literal[3]):
         case str() as a3:
             reveal_type(a3, expected_text="Never")
             reveal_type(value_to_match, expected_text="Never")
+
+
+def test_literal_string(value_to_match: LiteralString) -> None:
+    match value_to_match:
+        case "a" as a1:
+            reveal_type(value_to_match, expected_text="Literal['a']")
+            reveal_type(a1, expected_text="Literal['a']")
+        case str() as a2:
+            reveal_type(value_to_match, expected_text="LiteralString")
+            reveal_type(a2, expected_text="LiteralString")
+        case a3:
+            reveal_type(value_to_match, expected_text="Never")
+            reveal_type(a3, expected_text="Never")
 
 
 TFloat = TypeVar("TFloat", bound=float)


### PR DESCRIPTION
…types when using a `str()` class pattern and a `LiteralString` subject. This addresses #6982.