### PR TITLE
Fixed a bug that resulted in incorrect variance inference for protoco…

### DIFF
--- a/packages/pyright-internal/src/analyzer/typeEvaluatorTypes.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluatorTypes.ts
@@ -47,6 +47,7 @@ import {
     TypeCondition,
     TypeVarType,
     UnknownType,
+    Variance,
 } from './types';
 import { AssignTypeFlags, ClassMember, InferenceContext, MemberAccessFlags } from './typeUtils';
 import { TypeVarContext } from './typeVarContext';
@@ -606,7 +607,7 @@ export interface TypeEvaluator {
         isTypeIncomplete: boolean,
         srcExpr: ExpressionNode
     ) => void;
-    assignClassToSelf: (destType: ClassType, srcType: ClassType) => boolean;
+    assignClassToSelf: (destType: ClassType, srcType: ClassType, assumedVariance: Variance) => boolean;
     getBuiltInObject: (node: ParseNode, name: string, typeArguments?: Type[]) => Type;
     getTypedDictClassType: () => ClassType | undefined;
     getTupleClassType: () => ClassType | undefined;

--- a/packages/pyright-internal/src/analyzer/typeUtils.ts
+++ b/packages/pyright-internal/src/analyzer/typeUtils.ts
@@ -231,6 +231,10 @@ export const enum AssignTypeFlags {
     // but a few of them are allowed in the context of an isinstance
     // or issubclass call.
     AllowIsinstanceSpecialForms = 1 << 15,
+
+    // When comparing two methods, skip the type check for the "self" or "cls"
+    // parameters. This is used for variance inference and validation.
+    IgnoreSelfClsParamCompatibility = 1 << 16,
 }
 
 export interface ApplyTypeVarOptions {

--- a/packages/pyright-internal/src/analyzer/types.ts
+++ b/packages/pyright-internal/src/analyzer/types.ts
@@ -871,14 +871,6 @@ export namespace ClassType {
         return newClassType;
     }
 
-    export function cloneWithNewTypeParameters(classType: ClassType, typeParams: TypeVarType[]): ClassType {
-        const newClassType = TypeBase.cloneType(classType);
-        newClassType.details = { ...newClassType.details };
-        newClassType.details.typeParameters = typeParams;
-        newClassType.details.requiresVarianceInference = false;
-        return newClassType;
-    }
-
     export function cloneRemoveTypePromotions(classType: ClassType): ClassType {
         if (!classType.includePromotions) {
             return classType;

--- a/packages/pyright-internal/src/tests/samples/constructor22.py
+++ b/packages/pyright-internal/src/tests/samples/constructor22.py
@@ -5,7 +5,7 @@
 from typing import Generic, Protocol, Tuple, TypeVar
 
 
-T = TypeVar("T")
+T = TypeVar("T", covariant=True)
 
 
 class A(Protocol[T]):

--- a/packages/pyright-internal/src/tests/samples/protocol17.py
+++ b/packages/pyright-internal/src/tests/samples/protocol17.py
@@ -101,3 +101,12 @@ class Protocol10(Protocol[_T1_co]):
 
 class Protocol11(Protocol[_T1]):
     x: _T1 | None
+
+
+class Protocol12(Protocol[_T1_contra]):
+    def m1(self: "Protocol12[_T1_contra]", x: _T1_contra) -> None:
+        ...
+
+    @classmethod
+    def m2(cls: "type[Protocol12[_T1_contra]]") -> None:
+        ...

--- a/packages/pyright-internal/src/tests/samples/protocol33.py
+++ b/packages/pyright-internal/src/tests/samples/protocol33.py
@@ -3,8 +3,8 @@
 
 from typing import Generic, TypeVar, Protocol
 
-T = TypeVar("T")
-U = TypeVar("U")
+T = TypeVar("T", covariant=True)
+U = TypeVar("U", covariant=True)
 
 
 class AProto(Generic[T, U], Protocol):

--- a/packages/pyright-internal/src/tests/samples/protocol40.py
+++ b/packages/pyright-internal/src/tests/samples/protocol40.py
@@ -3,7 +3,7 @@
 
 from typing import Generic, Protocol, TypeVar, Self
 
-T = TypeVar("T")
+T = TypeVar("T", covariant=True)
 S = TypeVar("S", covariant=True)
 
 

--- a/packages/pyright-internal/src/tests/samples/protocol46.py
+++ b/packages/pyright-internal/src/tests/samples/protocol46.py
@@ -9,11 +9,11 @@ T = TypeVar("T")
 
 
 class ProtoA(Protocol[T_contra, T]):
-    def method1(self) -> "ProtoA[T_contra, T]":
+    def method1(self, value: T_contra) -> "ProtoA[T_contra, T]":
         ...
 
     @classmethod
-    def method2(cls, value: T) -> None:
+    def method2(cls, value: T) -> T:
         ...
 
 
@@ -23,11 +23,11 @@ class ProtoB(Protocol[T_contra, T]):
 
 
 class ImplA:
-    def method1(self) -> Self:
+    def method1(self, value: int) -> Self:
         ...
 
     @classmethod
-    def method2(cls, value: int) -> None:
+    def method2(cls, value: int) -> int:
         ...
 
 
@@ -35,11 +35,11 @@ class ImplB:
     def method3(self) -> ImplA:
         ...
 
-    def method1(self) -> Self:
+    def method1(self, value: int) -> Self:
         ...
 
     @classmethod
-    def method2(cls: type[ProtoB[Never, T]], value: list[T]) -> None:
+    def method2(cls: type[ProtoB[Never, T]], value: list[T]) -> list[T]:
         ...
 
 


### PR DESCRIPTION
…ls (and for PEP inferred-variance TypeVars in PEP 695) when a `self` or `cls` parameter is explicitly annotated with a type that includes the type parameter. This addresses #6883.