### PR TITLE
Added support for Python 3.11 enum features: `enum.member` and `enum.…

### DIFF
--- a/packages/pyright-internal/src/analyzer/enums.ts
+++ b/packages/pyright-internal/src/analyzer/enums.ts
@@ -8,14 +8,7 @@
  */
 
 import { assert } from '../common/debug';
-import {
-    ArgumentCategory,
-    AssignmentNode,
-    ExpressionNode,
-    NameNode,
-    ParseNode,
-    ParseNodeType,
-} from '../parser/parseNodes';
+import { ArgumentCategory, ExpressionNode, NameNode, ParseNode, ParseNodeType } from '../parser/parseNodes';
 import { getFileInfo } from './analyzerNodeInfo';
 import { VariableDeclaration } from './declaration';
 import {
@@ -274,12 +267,13 @@ export function createEnumType(
 
 export function transformTypeForPossibleEnumClass(
     evaluator: TypeEvaluator,
-    node: NameNode,
+    statementNode: ParseNode,
+    nameNode: NameNode,
     getValueType: () => Type
 ): Type | undefined {
     // If the node is within a class that derives from the metaclass
     // "EnumMeta", we need to treat assignments differently.
-    const enclosingClassNode = getEnclosingClass(node, /* stopAtFunction */ true);
+    const enclosingClassNode = getEnclosingClass(statementNode, /* stopAtFunction */ true);
     if (!enclosingClassNode) {
         return undefined;
     }
@@ -299,30 +293,31 @@ export function transformTypeForPossibleEnumClass(
     let isMemberOfEnumeration = false;
     let isUnpackedTuple = false;
 
-    const assignmentNode = getParentNodeOfType(node, ParseNodeType.Assignment) as AssignmentNode | undefined;
-
-    if (assignmentNode && isNodeContainedWithin(node, assignmentNode.leftExpression)) {
+    if (
+        statementNode.nodeType === ParseNodeType.Assignment &&
+        isNodeContainedWithin(nameNode, statementNode.leftExpression)
+    ) {
         isMemberOfEnumeration = true;
 
-        if (getParentNodeOfType(node, ParseNodeType.Tuple)) {
+        if (getParentNodeOfType(nameNode, ParseNodeType.Tuple)) {
             isUnpackedTuple = true;
         }
     } else if (
-        getFileInfo(node).isStubFile &&
-        node.parent?.nodeType === ParseNodeType.TypeAnnotation &&
-        node.parent.valueExpression === node
+        getFileInfo(nameNode).isStubFile &&
+        nameNode.parent?.nodeType === ParseNodeType.TypeAnnotation &&
+        nameNode.parent.valueExpression === nameNode
     ) {
         isMemberOfEnumeration = true;
     }
 
     // The spec specifically excludes names that start and end with a single underscore.
     // This also includes dunder names.
-    if (isSingleDunderName(node.value)) {
+    if (isSingleDunderName(nameNode.value)) {
         isMemberOfEnumeration = false;
     }
 
     // Specifically exclude "value" and "name". These are reserved by the enum metaclass.
-    if (node.value === 'name' || node.value === 'value') {
+    if (nameNode.value === 'name' || nameNode.value === 'value') {
         isMemberOfEnumeration = false;
     }
 
@@ -348,7 +343,7 @@ export function transformTypeForPossibleEnumClass(
                 evaluator.getTypeOfIterator(
                     { type: valueType },
                     /* isAsync */ false,
-                    node,
+                    nameNode,
                     /* emitNotIterableError */ false
                 )?.type ?? UnknownType.create();
         }
@@ -365,11 +360,24 @@ export function transformTypeForPossibleEnumClass(
         isMemberOfEnumeration = false;
     }
 
+    // Handle the Python 3.11 "enum.member()" and "enum.nonmember()" features.
+    if (isClassInstance(valueType) && ClassType.isBuiltIn(valueType)) {
+        if (valueType.details.fullName === 'enum.nonmember') {
+            isMemberOfEnumeration = false;
+        } else if (valueType.details.fullName === 'enum.member') {
+            valueType =
+                valueType.typeArguments && valueType.typeArguments.length > 0
+                    ? valueType.typeArguments[0]
+                    : UnknownType.create();
+            isMemberOfEnumeration = true;
+        }
+    }
+
     if (isMemberOfEnumeration) {
         const enumLiteral = new EnumLiteral(
             enumClassInfo.classType.details.fullName,
             enumClassInfo.classType.details.name,
-            node.value,
+            nameNode.value,
             valueType
         );
         return ClassType.cloneAsInstance(ClassType.cloneWithLiteral(enumClassInfo.classType, enumLiteral));

--- a/packages/pyright-internal/src/tests/samples/enum9.py
+++ b/packages/pyright-internal/src/tests/samples/enum9.py
@@ -1,0 +1,27 @@
+# This sample tests the enum.member and enum.nonmember classes introduced
+# in Python 3.11.
+
+import enum
+from typing import Literal
+
+
+class E(enum.Enum):
+    MEMBER = 1
+    ANOTHER_MEMBER = enum.member(2)
+    NON_MEMBER = enum.nonmember(3)
+
+    @enum.member
+    @staticmethod
+    def ALSO_A_MEMBER() -> Literal[4]:
+        return 4
+
+
+reveal_type(E.MEMBER, expected_text="Literal[E.MEMBER]")
+reveal_type(E.ANOTHER_MEMBER, expected_text="Literal[E.ANOTHER_MEMBER]")
+reveal_type(E.ALSO_A_MEMBER, expected_text="Literal[E.ALSO_A_MEMBER]")
+reveal_type(E.NON_MEMBER, expected_text="nonmember[int]")
+
+
+reveal_type(E.MEMBER.value, expected_text="Literal[1]")
+reveal_type(E.ANOTHER_MEMBER.value, expected_text="int")
+reveal_type(E.ALSO_A_MEMBER.value, expected_text="() -> Literal[4]")

--- a/packages/pyright-internal/src/tests/typeEvaluator3.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator3.test.ts
@@ -944,6 +944,12 @@ test('Enum8', () => {
     TestUtils.validateResults(analysisResults, 0);
 });
 
+test('Enum9', () => {
+    const analysisResults = TestUtils.typeAnalyzeSampleFiles(['enum9.py']);
+
+    TestUtils.validateResults(analysisResults, 0);
+});
+
 test('EnumAuto1', () => {
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['enumAuto1.py']);
 


### PR DESCRIPTION
…nonmember`. This addresses #6867.