### PR TITLE
Fixed a bug that resulted in an incorrect type evaluation when a gene…

### DIFF
--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -14062,13 +14062,13 @@ export function createTypeEvaluator(importLookup: ImportLookup, evaluatorOptions
         let typeErrors = false;
 
         // If any of the "for" clauses are marked async or any of the "if" clauses
-        // or the final expression contain an "await" operator anywhere within
-        // the expression, it is treated as an async generator.
-        let isAsync = node.forIfNodes.some((comp) => {
+        // or any clause other than the leftmost "for" contain an "await" operator,
+        // it is treated as an async generator.
+        let isAsync = node.forIfNodes.some((comp, index) => {
             if (comp.nodeType === ParseNodeType.ListComprehensionFor && comp.isAsync) {
                 return true;
             }
-            return ParseTreeUtils.containsAwaitNode(comp);
+            return index > 0 && ParseTreeUtils.containsAwaitNode(comp);
         });
         let type: Type = UnknownType.create();
 

--- a/packages/pyright-internal/src/tests/samples/generator4.py
+++ b/packages/pyright-internal/src/tests/samples/generator4.py
@@ -1,6 +1,8 @@
 # This sample tests various type checking operations relating to
 # async generator functions where the return type is inferred.
 
+from typing import AsyncGenerator, Awaitable, Generator, Iterator
+
 
 async def g1():
     yield 1
@@ -10,9 +12,6 @@ async def g1():
 async def g2():
     async for v in g1():
         yield v
-
-
-from typing import AsyncGenerator, Generator
 
 
 def g1_explicit1() -> Generator[int, None, None]:
@@ -31,3 +30,42 @@ async def g2_explicit():
 
     async for v in g1_explicit2():
         yield v
+
+
+async def g3(xs: Awaitable[list[int]]) -> list[int]:
+    return [x for x in await xs]
+
+
+async def g4(xs: list[Awaitable[int]]) -> list[int]:
+    return [await x for x in xs]
+
+
+class SomeIterable:
+    def __init__(self):
+        self.x = 1
+
+    def __iter__(self) -> Iterator[int]:
+        yield self.x
+
+
+async def func1() -> SomeIterable:
+    return SomeIterable()
+
+
+def func2() -> Iterator[int]:
+    yield 2
+
+
+def g5() -> None:
+    val = (y for y in func2())
+    reveal_type(val, expected_text="Generator[int, None, None]")
+
+
+async def g6() -> None:
+    val = (x + y for y in func2() for x in await func1())
+    reveal_type(val, expected_text="AsyncGenerator[int, None]")
+
+
+async def g7() -> None:
+    val = (x + y for y in await func1() for x in func2())
+    reveal_type(val, expected_text="Generator[int, None, None]")


### PR DESCRIPTION
…rator uses an `await` operator within the left-most `for`. This shouldn't result in an `AsyncGenerator` despite what the Python documentation indicates. This addresses #6999.