### PR TITLE
Typos in pyrightconfig.schema.json

### DIFF
--- a/packages/vscode-pyright/schemas/pyrightconfig.schema.json
+++ b/packages/vscode-pyright/schemas/pyrightconfig.schema.json
@@ -470,7 +470,7 @@
     "reportSelfClsParameterName": {
       "$id": "#/properties/reportSelfClsParameterName",
       "$ref": "#/definitions/diagnostic",
-      "title": "Controls reporting assert expressions that will always evaluate to true",
+      "title": "Controls reporting missing or misnamed self parameters",
       "default": "warning"
     },
     "reportImplicitStringConcatenation": {

--- a/packages/vscode-pyright/schemas/pyrightconfig.schema.json
+++ b/packages/vscode-pyright/schemas/pyrightconfig.schema.json
@@ -242,7 +242,7 @@
     "reportWildcardImportFromLibrary": {
       "$id": "#/properties/reportWildcardImportFromLibrary",
       "$ref": "#/definitions/diagnostic",
-      "title": "Controls reporting of wlidcard import from external library",
+      "title": "Controls reporting of wildcard import from external library",
       "default": "warning"
     },
     "reportOptionalSubscript": {


### PR DESCRIPTION
Fix a simple typo and a copy & paste error. The new description is derived from that in [the configuration documentation file](https://github.com/microsoft/pyright/blob/main/docs/configuration.md#type-check-diagnostics-settings).