### PR TITLE
Fixed spec conformance issue with TypeVarTuple constraint solving. Th…

### DIFF
--- a/packages/pyright-internal/src/tests/samples/variadicTypeVar11.py
+++ b/packages/pyright-internal/src/tests/samples/variadicTypeVar11.py
@@ -44,11 +44,11 @@ def func2(a: tuple[int, *_Xs], b: tuple[int, *_Xs]) -> Union[*_Xs]:
     ...
 
 
-def func3(p1: tuple[int], p2: tuple[int, str]):
-    # This should generate an error
+def func3(p1: tuple[int], p2: tuple[int, str], p3: tuple[int, int]):
+    # This should generate an error.
     v1 = func1(p1, p2)
 
-    # This should generate an error
+    # This should generate an error.
     v2 = func2(p1, p2)
 
     v3 = func2(p2, p2)
@@ -57,8 +57,11 @@ def func3(p1: tuple[int], p2: tuple[int, str]):
     v4 = func2((3, "hi"), p2)
     reveal_type(v4, expected_text="str")
 
-    v5 = func2((3, 3), p2)
-    reveal_type(v5, expected_text="str | int")
+    # This should generate an error.
+    func2((3, 3), p2)
+
+    v5 = func2((3, 3), p3)
+    reveal_type(v5, expected_text="int")
 
 
 def func4(a: int, *args: *_Xs, **kwargs: str) -> tuple[int, *_Xs]:

--- a/packages/pyright-internal/src/tests/samples/variadicTypeVar4.py
+++ b/packages/pyright-internal/src/tests/samples/variadicTypeVar4.py
@@ -43,11 +43,11 @@ def func2(a: tuple[int, Unpack[_Xs]], b: tuple[int, Unpack[_Xs]]) -> Union[Unpac
     ...
 
 
-def func3(p1: tuple[int], p2: tuple[int, str]):
-    # This should generate an error
+def func3(p1: tuple[int], p2: tuple[int, str], p3: tuple[int, int]):
+    # This should generate an error.
     v1 = func1(p1, p2)
 
-    # This should generate an error
+    # This should generate an error.
     v2 = func2(p1, p2)
 
     v3 = func2(p2, p2)
@@ -56,8 +56,11 @@ def func3(p1: tuple[int], p2: tuple[int, str]):
     v4 = func2((3, "hi"), p2)
     reveal_type(v4, expected_text="str")
 
-    v5 = func2((3, 3), p2)
-    reveal_type(v5, expected_text="str | int")
+    # This should generate an error.
+    func2((3, 3), p2)
+
+    v5 = func2((3, 3), p3)
+    reveal_type(v5, expected_text="int")
 
 
 def func4(a: int, *args: Unpack[_Xs], **kwargs: str) -> tuple[int, Unpack[_Xs]]:

--- a/packages/pyright-internal/src/tests/typeEvaluator3.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator3.test.ts
@@ -1055,7 +1055,7 @@ test('VariadicTypeVar4', () => {
 
     configOptions.defaultPythonVersion = PythonVersion.V3_11;
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['variadicTypeVar4.py'], configOptions);
-    TestUtils.validateResults(analysisResults, 3);
+    TestUtils.validateResults(analysisResults, 4);
 });
 
 test('VariadicTypeVar5', () => {
@@ -1111,7 +1111,7 @@ test('VariadicTypeVar11', () => {
 
     configOptions.defaultPythonVersion = PythonVersion.V3_11;
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['variadicTypeVar11.py'], configOptions);
-    TestUtils.validateResults(analysisResults, 3);
+    TestUtils.validateResults(analysisResults, 4);
 });
 
 test('VariadicTypeVar12', () => {


### PR DESCRIPTION
…e spec indicates that if a TypeVarTuple is used multiple times in a callee's signature, the tuple must "match exactly". This addresses #6888.