### PR TITLE
Added type enforcement for the `_value_` type in an Enum class. Also …

### DIFF
--- a/packages/pyright-internal/src/analyzer/constructors.ts
+++ b/packages/pyright-internal/src/analyzer/constructors.ts
@@ -61,15 +61,13 @@ export function getBoundNewMethod(
     evaluator: TypeEvaluator,
     errorNode: ExpressionNode,
     type: ClassType,
-    skipObjectBase = true
+    additionalFlags = MemberAccessFlags.SkipObjectBaseClass
 ) {
-    let flags =
+    const flags =
         MemberAccessFlags.SkipClassMembers |
         MemberAccessFlags.SkipAttributeAccessOverride |
-        MemberAccessFlags.TreatConstructorAsClassMethod;
-    if (skipObjectBase) {
-        flags |= MemberAccessFlags.SkipObjectBaseClass;
-    }
+        MemberAccessFlags.TreatConstructorAsClassMethod |
+        additionalFlags;
 
     return evaluator.getTypeOfBoundMember(errorNode, type, '__new__', { method: 'get' }, /* diag */ undefined, flags);
 }
@@ -79,12 +77,10 @@ export function getBoundInitMethod(
     evaluator: TypeEvaluator,
     errorNode: ExpressionNode,
     type: ClassType,
-    skipObjectBase = true
+    additionalFlags = MemberAccessFlags.SkipObjectBaseClass
 ) {
-    let flags = MemberAccessFlags.SkipInstanceMembers | MemberAccessFlags.SkipAttributeAccessOverride;
-    if (skipObjectBase) {
-        flags |= MemberAccessFlags.SkipObjectBaseClass;
-    }
+    const flags =
+        MemberAccessFlags.SkipInstanceMembers | MemberAccessFlags.SkipAttributeAccessOverride | additionalFlags;
 
     return evaluator.getTypeOfBoundMember(errorNode, type, '__init__', { method: 'get' }, /* diag */ undefined, flags);
 }

--- a/packages/pyright-internal/src/analyzer/enums.ts
+++ b/packages/pyright-internal/src/analyzer/enums.ts
@@ -361,30 +361,18 @@ export function transformTypeForPossibleEnumClass(
 
     let valueType: Type;
 
-    // If the class includes a __new__ method, we cannot assume that
-    // the value of each enum element is simply the value assigned to it.
-    // The __new__ method can transform the value in ways that we cannot
-    // determine statically.
-    const newMember = lookUpClassMember(enumClassInfo.classType, '__new__', MemberAccessFlags.SkipBaseClasses);
-    if (newMember) {
-        // We may want to change this to UnknownType in the future, but
-        // for now, we'll leave it as Any which is consistent with the
-        // type specified in the Enum class definition in enum.pyi.
-        valueType = AnyType.create();
-    } else {
-        valueType = getValueType();
+    valueType = getValueType();
 
-        // If the LHS is an unpacked tuple, we need to handle this as
-        // a special case.
-        if (isUnpackedTuple) {
-            valueType =
-                evaluator.getTypeOfIterator(
-                    { type: valueType },
-                    /* isAsync */ false,
-                    nameNode,
-                    /* emitNotIterableError */ false
-                )?.type ?? UnknownType.create();
-        }
+    // If the LHS is an unpacked tuple, we need to handle this as
+    // a special case.
+    if (isUnpackedTuple) {
+        valueType =
+            evaluator.getTypeOfIterator(
+                { type: valueType },
+                /* isAsync */ false,
+                nameNode,
+                /* emitNotIterableError */ false
+            )?.type ?? UnknownType.create();
     }
 
     // The spec excludes descriptors.
@@ -425,6 +413,7 @@ export function transformTypeForPossibleEnumClass(
         nameNode.value,
         valueType
     );
+
     return ClassType.cloneAsInstance(ClassType.cloneWithLiteral(enumClassInfo.classType, enumLiteral));
 }
 
@@ -440,6 +429,34 @@ export function isDeclInEnumClass(evaluator: TypeEvaluator, decl: VariableDeclar
     }
 
     return ClassType.isEnumClass(classInfo.classType);
+}
+
+export function getEnumDeclaredValueType(
+    evaluator: TypeEvaluator,
+    classType: ClassType,
+    declaredTypesOnly = false
+): Type | undefined {
+    // See if there is a declared type for "_value_".
+    let valueType: Type | undefined;
+
+    const declaredValueMember = lookUpClassMember(
+        classType,
+        '_value_',
+        declaredTypesOnly ? MemberAccessFlags.DeclaredTypesOnly : MemberAccessFlags.Default
+    );
+
+    // If the declared type comes from the 'Enum' base class, ignore it
+    // because it will be "Any", which isn't useful to us here.
+    if (
+        declaredValueMember &&
+        declaredValueMember.classType &&
+        isClass(declaredValueMember.classType) &&
+        !ClassType.isBuiltIn(declaredValueMember.classType, 'Enum')
+    ) {
+        valueType = evaluator.getTypeOfMember(declaredValueMember);
+    }
+
+    return valueType;
 }
 
 export function getTypeOfEnumMember(
@@ -488,25 +505,42 @@ export function getTypeOfEnumMember(
         }
     }
 
+    // See if there is a declared type for "_value_".
+    const valueType = getEnumDeclaredValueType(evaluator, classType);
+
     if (memberName === 'value' || memberName === '_value_') {
         // If the enum class has a custom metaclass, it may implement some
-        // "magic" that computes different values for the "value" attribute.
+        // "magic" that computes different values for the "_value_" attribute.
         // This occurs, for example, in the django TextChoices class. If we
-        // detect a custom metaclass, we'll assume the value is Any.
+        // detect a custom metaclass, we'll use the declared type of _value_
+        // if it is declared.
         const metaclass = classType.details.effectiveMetaclass;
         if (metaclass && isClass(metaclass) && !ClassType.isBuiltIn(metaclass)) {
-            return { type: AnyType.create(), isIncomplete };
+            return { type: valueType ?? AnyType.create(), isIncomplete };
         }
 
+        // If the enum class has a custom __new__ or __init__ method,
+        // it may implement some magic that computes different values for
+        // the "_value_" attribute. If we see a customer __new__ or __init__,
+        // we'll assume the value type is what we computed above, or Any.
+        const newMember = lookUpClassMember(classType, '__new__', MemberAccessFlags.SkipBaseClasses);
+        const initMember = lookUpClassMember(classType, '__init__', MemberAccessFlags.SkipBaseClasses);
+        if (newMember || initMember) {
+            return { type: valueType ?? AnyType.create(), isIncomplete };
+        }
+
+        // There were no explicit assignments to the "_value_" attribute, so we can
+        // assume that the values are assigned directly to the "_value_" by
+        // the EnumMeta metaclass.
         if (literalValue) {
             assert(literalValue instanceof EnumLiteral);
 
             // If there is no known value type for this literal value,
             // return undefined. This will cause the caller to fall back
-            // on the definition of `value` within the class definition
+            // on the definition of "_value_" within the class definition
             // (if present).
             if (isAny(literalValue.itemType)) {
-                return undefined;
+                return valueType ? { type: valueType, isIncomplete } : undefined;
             }
 
             return { type: literalValue.itemType, isIncomplete };

--- a/packages/pyright-internal/src/analyzer/parseTreeUtils.ts
+++ b/packages/pyright-internal/src/analyzer/parseTreeUtils.ts
@@ -1086,12 +1086,12 @@ export function isNodeContainedWithin(node: ParseNode, potentialContainer: Parse
     return false;
 }
 
-export function getParentNodeOfType(node: ParseNode, containerType: ParseNodeType): ParseNode | undefined {
+export function getParentNodeOfType<T extends ParseNode>(node: ParseNode, containerType: ParseNodeType): T | undefined {
     let curNode: ParseNode | undefined = node;
 
     while (curNode) {
         if (curNode.nodeType === containerType) {
-            return curNode;
+            return curNode as T;
         }
 
         curNode = curNode.parent;

--- a/packages/pyright-internal/src/languageService/completionProvider.ts
+++ b/packages/pyright-internal/src/languageService/completionProvider.ts
@@ -1081,9 +1081,12 @@ export class CompletionProvider {
                 ? stringToken
                 : undefined;
         } else if (node) {
-            const fStringContainer = ParseTreeUtils.getParentNodeOfType(node, ParseNodeType.FormatString);
+            const fStringContainer = ParseTreeUtils.getParentNodeOfType<FormatStringNode>(
+                node,
+                ParseNodeType.FormatString
+            );
             if (fStringContainer) {
-                this._stringLiteralContainer = (fStringContainer as FormatStringNode).token;
+                this._stringLiteralContainer = fStringContainer.token;
             }
         }
 

--- a/packages/pyright-internal/src/tests/samples/enum1.py
+++ b/packages/pyright-internal/src/tests/samples/enum1.py
@@ -203,3 +203,18 @@ class TestEnum13(metaclass=CustomEnumMeta1):
 
 TestEnum14 = TestEnum13("TestEnum14", "A, B, C")
 reveal_type(TestEnum14.A, expected_text="Literal[TestEnum14.A]")
+
+
+class TestEnum15(Enum):
+    _value_: str
+    A = 1
+    B = 2
+
+    def __init__(self, value: int):
+        self._value_ = str(value)
+
+
+te15_A = TestEnum15.A
+reveal_type(te15_A, expected_text="Literal[TestEnum15.A]")
+reveal_type(te15_A.value, expected_text="str")
+reveal_type(te15_A._value_, expected_text="str")

--- a/packages/pyright-internal/src/tests/samples/enum11.py
+++ b/packages/pyright-internal/src/tests/samples/enum11.py
@@ -1,0 +1,54 @@
+# This sample tests the validation of member values.
+
+from enum import Enum
+
+
+class Enum1(Enum):
+    _value_: int
+    RED = 1
+
+    # This should generate an error because of a type mismatch.
+    GREEN = "green"
+
+
+class Enum2(Enum):
+    def __new__(cls, value: int):
+        obj = object.__new__(cls)
+        obj._value_ = value
+
+    RED = 1
+
+    # This should generate an error because of a type mismatch.
+    GREEN = "green"
+
+    # This should generate an error because of a type mismatch.
+    BLUE = (1, "blue")
+
+
+class Enum3(Enum):
+    def __init__(self, value: int):
+        self._value_ = value
+
+    RED = 1
+
+    # This should generate an error because of a type mismatch.
+    GREEN = "green"
+
+    # This should generate an error because of a type mismatch.
+    BLUE = (1, "blue")
+
+
+class Enum4(Enum):
+    def __init__(self, value: int, other: str):
+        self._value_ = value
+
+    # This should generate an error because of a type mismatch.
+    RED = 1
+
+    # This should generate an error because of a type mismatch.
+    GREEN = "green"
+
+    BLUE = (1, "blue")
+
+    # This should generate an error because of a type mismatch.
+    GRAY = (1, "blue", 1)

--- a/packages/pyright-internal/src/tests/typeEvaluator3.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator3.test.ts
@@ -956,6 +956,12 @@ test('Enum10', () => {
     TestUtils.validateResults(analysisResults, 0);
 });
 
+test('Enum11', () => {
+    const analysisResults = TestUtils.typeAnalyzeSampleFiles(['enum11.py']);
+
+    TestUtils.validateResults(analysisResults, 8);
+});
+
 test('EnumAuto1', () => {
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['enumAuto1.py']);
 


### PR DESCRIPTION
…added enforcement for custom `__new__` and `__init__` method signatures. This addresses #7030 and #7029.