### PR TITLE
Addressed a bug that led to a false positive (missing error) when a "…

### DIFF
--- a/packages/pyright-internal/src/analyzer/types.ts
+++ b/packages/pyright-internal/src/analyzer/types.ts
@@ -199,10 +199,16 @@ export namespace TypeBase {
         return clone;
     }
 
-    export function cloneAsSpecialForm<T extends TypeBase>(type: T, specialForm: ClassType): T {
+    export function cloneAsSpecialForm<T extends TypeBase>(type: T, specialForm: ClassType | undefined): T {
         const clone = { ...type };
         delete clone.cached;
-        clone.specialForm = specialForm;
+
+        if (specialForm) {
+            clone.specialForm = specialForm;
+        } else {
+            delete clone.specialForm;
+        }
+
         return clone;
     }
 
@@ -2448,7 +2454,6 @@ export interface TypeVarDetails {
     constraints: Type[];
     boundType?: Type | undefined;
     defaultType?: Type | undefined;
-    runtimeClass?: ClassType | undefined;
 
     isParamSpec: boolean;
     isVariadic: boolean;
@@ -2525,8 +2530,8 @@ export namespace TypeVarType {
         return create(name, /* isParamSpec */ false, TypeFlags.Instance);
     }
 
-    export function createInstantiable(name: string, isParamSpec = false, runtimeClass?: ClassType) {
-        return create(name, isParamSpec, TypeFlags.Instantiable, runtimeClass);
+    export function createInstantiable(name: string, isParamSpec = false) {
+        return create(name, isParamSpec, TypeFlags.Instantiable);
     }
 
     export function cloneAsInstance(type: TypeVarType): TypeVarType {
@@ -2657,7 +2662,7 @@ export namespace TypeVarType {
         return `${name}.${scopeId}`;
     }
 
-    function create(name: string, isParamSpec: boolean, typeFlags: TypeFlags, runtimeClass?: ClassType): TypeVarType {
+    function create(name: string, isParamSpec: boolean, typeFlags: TypeFlags): TypeVarType {
         const newTypeVarType: TypeVarType = {
             category: TypeCategory.TypeVar,
             details: {
@@ -2667,7 +2672,6 @@ export namespace TypeVarType {
                 isParamSpec,
                 isVariadic: false,
                 isSynthesized: false,
-                runtimeClass,
             },
             flags: typeFlags,
         };

--- a/packages/pyright-internal/src/tests/samples/classes1.py
+++ b/packages/pyright-internal/src/tests/samples/classes1.py
@@ -2,7 +2,10 @@
 # handle various class definition cases.
 
 
-from typing import Any
+from typing import Any, TypeVar
+
+
+T = TypeVar("T")
 
 
 class A:
@@ -60,3 +63,17 @@ def func1(x: type) -> object:
         pass
 
     return Y()
+
+
+# This should generate an error because a TypeVar can't be used as a base class.
+class K(T):
+    pass
+
+
+class L(type[T]):
+    pass
+
+
+def func2(cls: type[T]):
+    class M(cls):
+        pass

--- a/packages/pyright-internal/src/tests/typeEvaluator3.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator3.test.ts
@@ -766,7 +766,7 @@ test('RecursiveTypeAlias14', () => {
 test('Classes1', () => {
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['classes1.py']);
 
-    TestUtils.validateResults(analysisResults, 1);
+    TestUtils.validateResults(analysisResults, 2);
 });
 
 test('Classes3', () => {


### PR DESCRIPTION
…bare" TypeVar is used as a base class in a class statement. This addresses #7023.