### PR TITLE
Fixed a bug that resulted in a false positive error and incorrect typ…

### DIFF
--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -1051,6 +1051,7 @@ export function createTypeEvaluator(importLookup: ImportLookup, evaluatorOptions
 
         let typeResult: TypeResult | undefined;
         let expectingInstantiable = (flags & EvaluatorFlags.ExpectingInstantiableType) !== 0;
+        let allowSpeculativeCaching = true;
 
         switch (node.nodeType) {
             case ParseNodeType.Name: {
@@ -1192,6 +1193,10 @@ export function createTypeEvaluator(importLookup: ImportLookup, evaluatorOptions
                     node.rightExpression,
                     /* ignoreEmptyContainers */ true
                 );
+
+                // Don't allow speculative caching for assignment expressions because
+                // the target name node won't have a corresponding type cached speculatively.
+                allowSpeculativeCaching = false;
                 break;
             }
 
@@ -1270,7 +1275,7 @@ export function createTypeEvaluator(importLookup: ImportLookup, evaluatorOptions
             }
         }
 
-        writeTypeCache(node, typeResult, flags, inferenceContext, /* allowSpeculativeCaching */ true);
+        writeTypeCache(node, typeResult, flags, inferenceContext, allowSpeculativeCaching);
 
         // If there was an expected type, make sure that the result type is compatible.
         if (

--- a/packages/pyright-internal/src/tests/samples/assignmentExpr5.py
+++ b/packages/pyright-internal/src/tests/samples/assignmentExpr5.py
@@ -1,15 +1,24 @@
 # This sample tests the scoping rules for assignment expressions
 # within a list comprehension.
 
+# pyright: strict
+
 from typing import Tuple
 
 
-def foo() -> Tuple[str, int]:
+def func1() -> Tuple[str, int]:
     a = 3
     y = 4
-    b = [(a := x) for x in ["1", "2"] for y in ["1", "2"]]
+    _ = [(a := x) for x in ["1", "2"] for _ in ["1", "2"]]
 
     # The type of "y" should be int because the "y" within
     # the list comprehension doesn't leak outside. On the
     # other hand, "a" does leak outside the list comprehension.
     return (a, y)
+
+
+def get_value(x: int) -> int:
+    ...
+
+
+x = sum(max(value for x in range(10) if (value := get_value(x))) for _ in range(10))


### PR DESCRIPTION
…e evaluation when an assignment expression (walrus operator) is used in a comprehension. This addresses #6992.