### PR TITLE
Fixed a bug that led to a false negative when an illegal form of tupl…

### DIFF
--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -15052,12 +15052,16 @@ export function createTypeEvaluator(importLookup: ImportLookup, evaluatorOptions
                                 !typeArgs[0].type.isVariadicInUnion
                             ) {
                                 addError(LocMessage.typeVarTupleContext(), typeArgs[0].node);
+                            } else if (sawUnpacked) {
+                                addError(LocMessage.ellipsisAfterUnpacked(), typeArg.node);
                             }
                         }
                     } else if (isParamSpec(typeArg.type) && allowParamSpec) {
                         // Nothing to do - this is allowed.
                     } else if (isVariadicTypeVar(typeArg.type) && paramLimit === undefined) {
-                        noteSawUnpacked(typeArg);
+                        if (!typeArg.type.isVariadicInUnion) {
+                            noteSawUnpacked(typeArg);
+                        }
                         validateVariadicTypeVarIsUnpacked(typeArg.type, typeArg.node);
                     } else if (paramLimit === undefined && isUnpacked(typeArg.type)) {
                         noteSawUnpacked(typeArg);
@@ -15104,8 +15108,6 @@ export function createTypeEvaluator(importLookup: ImportLookup, evaluatorOptions
                     if (index === 1 && isEllipsisType(typeArgTypes[index])) {
                         if (tupleTypeArgTypes.length === 1 && !tupleTypeArgTypes[0].isUnbounded) {
                             tupleTypeArgTypes[0] = { type: tupleTypeArgTypes[0].type, isUnbounded: true };
-                        } else {
-                            addError(LocMessage.ellipsisSecondArg(), typeArg.node);
                         }
                     } else if (isUnpackedClass(typeArg.type) && typeArg.type.tupleTypeArguments) {
                         appendArray(tupleTypeArgTypes, typeArg.type.tupleTypeArguments);

--- a/packages/pyright-internal/src/localization/localize.ts
+++ b/packages/pyright-internal/src/localization/localize.ts
@@ -429,6 +429,7 @@ export namespace Localizer {
         export const duplicateStarStarPattern = () => getRawString('Diagnostic.duplicateStarStarPattern');
         export const duplicatePositionOnly = () => getRawString('Diagnostic.duplicatePositionOnly');
         export const duplicateUnpack = () => getRawString('Diagnostic.duplicateUnpack');
+        export const ellipsisAfterUnpacked = () => getRawString('Diagnostic.ellipsisAfterUnpacked');
         export const ellipsisContext = () => getRawString('Diagnostic.ellipsisContext');
         export const ellipsisSecondArg = () => getRawString('Diagnostic.ellipsisSecondArg');
         export const enumClassOverride = () =>

--- a/packages/pyright-internal/src/localization/package.nls.en-us.json
+++ b/packages/pyright-internal/src/localization/package.nls.en-us.json
@@ -133,6 +133,7 @@
         "duplicateStarStarPattern": "Only one \"**\" entry allowed",
         "duplicatePositionOnly": "Only one \"/\" parameter allowed",
         "duplicateUnpack": "Only one unpack operation allowed in list",
+        "ellipsisAfterUnpacked": "\"...\" cannot be used with an unpacked TypeVarTuple or tuple",
         "ellipsisContext": "\"...\" is not allowed in this context",
         "ellipsisSecondArg": "\"...\" is allowed only as the second of two arguments",
         "enumClassOverride": "Enum class \"{name}\" is final and cannot be subclassed",

--- a/packages/pyright-internal/src/tests/samples/tuple2.py
+++ b/packages/pyright-internal/src/tests/samples/tuple2.py
@@ -13,8 +13,14 @@ all_ints3 = all_ints2
 # This should generate an error.
 bad_ellipsis1: tuple[...]
 
-# This should generate an error
+# This should generate an error.
 bad_ellipsis2: tuple[int, int, ...]
 
-# This should generate an error
+# This should generate an error.
 bad_ellipsis3: tuple[int, ..., int]
+
+# This should generate an error.
+bad_ellipsis4: tuple[*tuple[int], ...]
+
+# This should generate an error.
+bad_ellipsis5: tuple[*tuple[int, ...], ...]

--- a/packages/pyright-internal/src/tests/samples/tupleUnpack1.py
+++ b/packages/pyright-internal/src/tests/samples/tupleUnpack1.py
@@ -28,8 +28,8 @@ def func5(v5: tuple[Unpack[tuple[Unpack[tuple[bool, ...]]]], ...]):
     pass
 
 
-def func6(v6: tuple[Unpack[tuple[bool]], ...]):
-    reveal_type(v6, expected_text="tuple[bool, ...]")
+def func6(v6: tuple[Unpack[tuple[bool]]]):
+    reveal_type(v6, expected_text="tuple[bool]")
 
 
 def func7(v7: tuple[Unpack[tuple[bool, Unpack[tuple[int, float]]]]]):

--- a/packages/pyright-internal/src/tests/samples/tupleUnpack2.py
+++ b/packages/pyright-internal/src/tests/samples/tupleUnpack2.py
@@ -29,8 +29,8 @@ def func5(v5: tuple[*tuple[*tuple[bool, ...]], ...]):
     pass
 
 
-def func6(v6: tuple[*tuple[bool], ...]):
-    reveal_type(v6, expected_text="tuple[bool, ...]")
+def func6(v6: tuple[*tuple[bool]]):
+    reveal_type(v6, expected_text="tuple[bool]")
 
 
 def func7(v7: tuple[*tuple[bool, *tuple[int, float]]]):

--- a/packages/pyright-internal/src/tests/typeEvaluator1.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator1.test.ts
@@ -1276,7 +1276,7 @@ test('Tuple1', () => {
 test('Tuple2', () => {
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['tuple2.py']);
 
-    TestUtils.validateResults(analysisResults, 3);
+    TestUtils.validateResults(analysisResults, 5);
 });
 
 test('Tuple3', () => {


### PR DESCRIPTION
…e was used: `tuple[*tuple[str], ...]`.