### PR TITLE
Changed the way pyright translates `tuple[()]` into a specialized `Se…

### DIFF
--- a/packages/pyright-internal/src/analyzer/typeUtils.ts
+++ b/packages/pyright-internal/src/analyzer/typeUtils.ts
@@ -2795,7 +2795,7 @@ export function specializeTupleClass(
     isTypeArgumentExplicit = true,
     isUnpackedTuple = false
 ): ClassType {
-    let combinedTupleType = combineTypes(
+    const combinedTupleType = combineTypes(
         typeArgs.map((t) => {
             if (isTypeVar(t.type) && isUnpackedVariadicTypeVar(t.type)) {
                 // Treat the unpacked TypeVarTuple as a union.
@@ -2805,11 +2805,6 @@ export function specializeTupleClass(
             return t.type;
         })
     );
-
-    // An empty tuple has an effective type of Any.
-    if (isNever(combinedTupleType)) {
-        combinedTupleType = AnyType.create();
-    }
 
     const clonedClassType = ClassType.cloneForSpecialization(
         classType,

--- a/packages/pyright-internal/src/tests/samples/tuple5.py
+++ b/packages/pyright-internal/src/tests/samples/tuple5.py
@@ -1,6 +1,11 @@
 # This sample tests the type checker's handling of
 # empty tuples and assignment to empty tuples.
 
+from typing import Sequence, TypeVar
+
+
+T = TypeVar("T")
+
 a: tuple[()] = ()
 
 # This should generate an error because the assigned
@@ -12,3 +17,11 @@ b: tuple[()] = (1,)
 # tuple has zero elements, but the destination is
 # expecting two.
 c: tuple[int, str] = ()
+
+
+def test_seq(x: Sequence[T]) -> Sequence[T]:
+    return x
+
+
+def func1(t1: tuple[()]):
+    reveal_type(test_seq(t1), expected_text="Sequence[Never]")


### PR DESCRIPTION
…quence`. It used to translate it to `Sequence[Any]`, but the typing spec now clarifies that it should be `Sequence[Never]`. This addresses #7118.