### PR TITLE
Changed handling of `tuple` with multiple unpacked embedded tuples. T…

### DIFF
--- a/packages/pyright-internal/src/tests/samples/callable6.py
+++ b/packages/pyright-internal/src/tests/samples/callable6.py
@@ -1,15 +1,17 @@
 # This sample tests the use of unpacked tuples in a Callable, as described
 # in PEP 646.
 
-from typing import Callable, TypeVar, Union
+from typing import Callable, TypeVar
 from typing_extensions import TypeVarTuple, Unpack
 
 _T = TypeVar("_T", bound=int)
 
 TA1 = Callable[[_T, Unpack[tuple[int, ...]], tuple[int, int, str], str], _T]
 
-# This should generate an error
-TA2 = Callable[[int, Unpack[tuple[int, ...]], Unpack[tuple[int, int, str]], str], int]
+# This should generate an error.
+TA2 = Callable[
+    [int, Unpack[tuple[int, ...]], Unpack[tuple[int, int, str, ...]], str], int
+]
 
 TA3 = Callable[[int, Unpack[tuple[int, int]], str], int]
 

--- a/packages/pyright-internal/src/tests/samples/tupleUnpack1.py
+++ b/packages/pyright-internal/src/tests/samples/tupleUnpack1.py
@@ -9,9 +9,8 @@ def func1(v1: tuple[int, Unpack[tuple[bool, bool]], str]):
     reveal_type(v1, expected_text="tuple[int, bool, bool, str]")
 
 
-# This should generate an error because multiple unpacks.
 def func2(v2: tuple[int, Unpack[tuple[bool, bool]], str, Unpack[tuple[bool, bool]]]):
-    pass
+    reveal_type(v2, expected_text="tuple[int, bool, bool, str, bool, bool]")
 
 
 def func3(v3: tuple[int, Unpack[tuple[bool, ...]], str]):

--- a/packages/pyright-internal/src/tests/samples/tupleUnpack2.py
+++ b/packages/pyright-internal/src/tests/samples/tupleUnpack2.py
@@ -10,9 +10,8 @@ def func1(v1: tuple[int, *tuple[bool, bool], str]):
     reveal_type(v1, expected_text="tuple[int, bool, bool, str]")
 
 
-# This should generate an error because multiple unpacks.
 def func2(v2: tuple[int, *tuple[bool, bool], str, *tuple[bool, bool]]):
-    pass
+    reveal_type(v2, expected_text="tuple[int, bool, bool, str, bool, bool]")
 
 
 def func3(v3: tuple[int, *tuple[bool, ...], str]):

--- a/packages/pyright-internal/src/tests/typeEvaluator1.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator1.test.ts
@@ -1582,7 +1582,7 @@ test('TotalOrdering1', () => {
 test('TupleUnpack1', () => {
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['tupleUnpack1.py']);
 
-    TestUtils.validateResults(analysisResults, 6);
+    TestUtils.validateResults(analysisResults, 5);
 });
 
 test('TupleUnpack2', () => {
@@ -1590,11 +1590,11 @@ test('TupleUnpack2', () => {
 
     configOptions.defaultPythonVersion = PythonVersion.V3_10;
     const analysisResults1 = TestUtils.typeAnalyzeSampleFiles(['tupleUnpack2.py'], configOptions);
-    TestUtils.validateResults(analysisResults1, 19);
+    TestUtils.validateResults(analysisResults1, 18);
 
     configOptions.defaultPythonVersion = PythonVersion.V3_11;
     const analysisResults2 = TestUtils.typeAnalyzeSampleFiles(['tupleUnpack2.py'], configOptions);
-    TestUtils.validateResults(analysisResults2, 5);
+    TestUtils.validateResults(analysisResults2, 4);
 });
 
 test('TupleUnpack3', () => {


### PR DESCRIPTION
…ype spec now clarifies this is OK as long as there are not multiple unbounded embedded tuples. This addresses #7114.