### PR TITLE
Fixed a bug that resulted in an incorrect type evaluation for a union…

### DIFF
--- a/packages/pyright-internal/src/analyzer/operations.ts
+++ b/packages/pyright-internal/src/analyzer/operations.ts
@@ -649,7 +649,7 @@ export function getTypeOfBinaryOperation(
 
             const unionClass = evaluator.getUnionClassType();
             if (unionClass && isInstantiableClass(unionClass)) {
-                newUnion = TypeBase.cloneAsSpecialForm(newUnion, unionClass);
+                newUnion = TypeBase.cloneAsSpecialForm(newUnion, ClassType.cloneAsInstance(unionClass));
             }
 
             // Check for "stringified" forward reference type expressions. The "|" operator

--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -14510,7 +14510,7 @@ export function createTypeEvaluator(importLookup: ImportLookup, evaluatorOptions
 
         let optionalType = combineTypes([typeArg0Type, noneClassType ?? UnknownType.create()]);
         if (unionClassType && isInstantiableClass(unionClassType)) {
-            optionalType = TypeBase.cloneAsSpecialForm(optionalType, unionClassType);
+            optionalType = TypeBase.cloneAsSpecialForm(optionalType, ClassType.cloneAsInstance(unionClassType));
         }
 
         return optionalType;
@@ -15203,7 +15203,7 @@ export function createTypeEvaluator(importLookup: ImportLookup, evaluatorOptions
 
         let unionType = combineTypes(types);
         if (unionClassType && isInstantiableClass(unionClassType)) {
-            unionType = TypeBase.cloneAsSpecialForm(unionType, unionClassType);
+            unionType = TypeBase.cloneAsSpecialForm(unionType, ClassType.cloneAsInstance(unionClassType));
         }
 
         return unionType;

--- a/packages/pyright-internal/src/tests/samples/unions5.py
+++ b/packages/pyright-internal/src/tests/samples/unions5.py
@@ -1,7 +1,8 @@
 # This sample tests the handling of runtime union expressions that
 # are used in contexts other than a type annotation.
 
-from typing import Union
+from types import UnionType
+from typing import Optional, Union
 
 
 class Class1:
@@ -35,3 +36,9 @@ print(b2.a)
 
 # This should generate an error
 b2()
+
+
+c1: UnionType
+c1 = int | str
+c1 = Union[int, str]
+c1 = Optional[int]


### PR DESCRIPTION
… type used as a runtime expression. The type should be `UnionType`, not `type[UnionType]`.