### PR TITLE
Fixed a bug that resulted in incorrect type evaluation when calling a…

### DIFF
--- a/packages/pyright-internal/src/analyzer/constraintSolver.ts
+++ b/packages/pyright-internal/src/analyzer/constraintSolver.ts
@@ -384,7 +384,12 @@ export function assignTypeToTypeVar(
             // There was previously no narrow bound. We've now established one.
             newNarrowTypeBound = adjSrcType;
         } else if (!isTypeSame(curNarrowTypeBound, adjSrcType, {}, recursionCount)) {
-            if (
+            if (isAnyOrUnknown(adjSrcType) && curEntry.tupleTypes) {
+                // Handle the tuple case specially. If Any or Unknown is assigned
+                // during the construction of a tuple, the resulting tuple type must
+                // be tuple[Any, ...], which is compatible with any tuple.
+                newNarrowTypeBound = adjSrcType;
+            } else if (
                 evaluator.assignType(
                     curNarrowTypeBound,
                     adjSrcType,
@@ -587,6 +592,17 @@ export function assignTypeToTypeVar(
         }
     }
 
+    // Update the tuple types based on the new type bounds. We need to
+    // switch to an unbounded tuple type since the length of the resulting
+    // tuple is indeterminate.
+    let newTupleTypes = curEntry?.tupleTypes;
+    if (newTupleTypes) {
+        const updatedType = newNarrowTypeBound ?? newWideTypeBound;
+        if (updatedType) {
+            newTupleTypes = [{ type: updatedType, isUnbounded: true }];
+        }
+    }
+
     if (!typeVarContext.isLocked() && isTypeVarInScope) {
         updateTypeVarType(
             evaluator,
@@ -594,6 +610,7 @@ export function assignTypeToTypeVar(
             destType,
             newNarrowTypeBound,
             newWideTypeBound,
+            newTupleTypes,
             (flags & (AssignTypeFlags.PopulatingExpectedType | AssignTypeFlags.RetainLiteralsForTypeVar)) !== 0
         );
     }
@@ -619,6 +636,7 @@ export function updateTypeVarType(
     destType: TypeVarType,
     narrowTypeBound: Type | undefined,
     wideTypeBound: Type | undefined,
+    tupleTypes: TupleTypeArgument[] | undefined = undefined,
     forceRetainLiterals = false
 ) {
     let narrowTypeBoundNoLiterals: Type | undefined;
@@ -637,7 +655,7 @@ export function updateTypeVarType(
         }
     }
 
-    typeVarContext.setTypeVarType(destType, narrowTypeBound, narrowTypeBoundNoLiterals, wideTypeBound);
+    typeVarContext.setTypeVarType(destType, narrowTypeBound, narrowTypeBoundNoLiterals, wideTypeBound, tupleTypes);
 }
 
 function assignTypeToConstrainedTypeVar(
@@ -842,6 +860,7 @@ function assignTypeToConstrainedTypeVar(
                 destType,
                 constrainedType,
                 curWideTypeBound,
+                /* tupleTypes */ undefined,
                 forceRetainLiterals
             );
         }

--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -22419,6 +22419,7 @@ export function createTypeEvaluator(importLookup: ImportLookup, evaluatorOptions
                     typeParam,
                     variance !== Variance.Contravariant ? typeArgType : undefined,
                     variance !== Variance.Covariant ? typeArgType : undefined,
+                    /* tupleTypes */ curSrcType.tupleTypeArguments,
                     /* forceRetainLiterals */ true
                 );
             }

--- a/packages/pyright-internal/src/analyzer/typeVarContext.ts
+++ b/packages/pyright-internal/src/analyzer/typeVarContext.ts
@@ -162,10 +162,17 @@ export class TypeVarSignatureContext {
         reference: TypeVarType,
         narrowBound: Type | undefined,
         narrowBoundNoLiterals?: Type,
-        wideBound?: Type
+        wideBound?: Type,
+        tupleTypes?: TupleTypeArgument[]
     ) {
         const key = TypeVarType.getNameWithScope(reference);
-        this._typeVarMap.set(key, { typeVar: reference, narrowBound, narrowBoundNoLiterals, wideBound });
+        this._typeVarMap.set(key, {
+            typeVar: reference,
+            narrowBound,
+            narrowBoundNoLiterals,
+            wideBound,
+            tupleTypes,
+        });
     }
 
     getTupleTypeVar(reference: TypeVarType): TupleTypeArgument[] | undefined {
@@ -450,12 +457,13 @@ export class TypeVarContext {
         reference: TypeVarType,
         narrowBound: Type | undefined,
         narrowBoundNoLiterals?: Type,
-        wideBound?: Type
+        wideBound?: Type,
+        tupleTypes?: TupleTypeArgument[]
     ) {
         assert(!this._isLocked);
 
         return this._signatureContexts.forEach((context) => {
-            context.setTypeVarType(reference, narrowBound, narrowBoundNoLiterals, wideBound);
+            context.setTypeVarType(reference, narrowBound, narrowBoundNoLiterals, wideBound, tupleTypes);
         });
     }
 

--- a/packages/pyright-internal/src/tests/samples/tuple18.py
+++ b/packages/pyright-internal/src/tests/samples/tuple18.py
@@ -1,6 +1,8 @@
 # This sample tests the case where the tuple constructor is called
 # explicitly with bidirectional type inference.
 
+from typing import Any, Iterable
+
 # This should generate an error.
 v1: tuple[float] = tuple([1.0, 2.0])
 
@@ -8,3 +10,8 @@ v1: tuple[float] = tuple([1.0, 2.0])
 v2: tuple[float] | tuple[float, float] = tuple([1.0, 2.0])
 
 v3: tuple[float, ...] = tuple([1, 2])
+
+
+def f(x: Iterable[Any], y: Iterable):
+    a: tuple[int, int] = tuple(x)
+    b: tuple[int, int] = tuple(y)


### PR DESCRIPTION
… `tuple` constructor with bidirectional type inference and the value passed to the constructor is an `Iterable[Any]`. This addresses #7085.