### PR TITLE
Grant write permissions as needed to workflows that use GITHUB_TOKEN

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,6 +55,8 @@ jobs:
     runs-on: ubuntu-latest
     name: Create release
     needs: [build]
+    permissions:
+      contents: write
 
     steps:
       - name: Download artifacts


### PR DESCRIPTION
Fixes https://github.com/microsoft/pyrx/issues/4535 in combination with https://github.com/microsoft/pyrx/pull/4584.

On Thursday (Feb 1), [`GITHUB_TOKEN` will become read-only within the `microsoft` org](https://docs.opensource.microsoft.com/github/apps/permission-changes/). The `build.yml` step that creates a GitHub release is the only place I found (in pyright) where we are using `GITHUB_TOKEN` to write to GitHub objects and we had not already provided explicit permissions. I made an identical change in pyrx and have confirmed that `contents: write` is sufficient here.