### PR TITLE
Fixed a bug that resulted in an incorrect type evaluation when a Type…

### DIFF
--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -11385,7 +11385,6 @@ export function createTypeEvaluator(importLookup: ImportLookup, evaluatorOptions
         let specializedReturnType = applySolvedTypeVars(returnType, typeVarContext, {
             unknownIfNotFound,
             unknownExemptTypeVars: getUnknownExemptTypeVarsForReturnType(type, returnType),
-            useUnknownOverDefault: skipUnknownArgCheck,
             eliminateUnsolvedInUnions,
             applyInScopePlaceholders: true,
         });

--- a/packages/pyright-internal/src/analyzer/typeUtils.ts
+++ b/packages/pyright-internal/src/analyzer/typeUtils.ts
@@ -244,7 +244,6 @@ export const enum AssignTypeFlags {
 export interface ApplyTypeVarOptions {
     unknownIfNotFound?: boolean;
     unknownExemptTypeVars?: TypeVarType[];
-    useUnknownOverDefault?: boolean;
     useNarrowBoundOnly?: boolean;
     eliminateUnsolvedInUnions?: boolean;
     typeClassType?: Type;
@@ -4226,7 +4225,7 @@ class ApplySolvedTypeVarsTransformer extends TypeVarTransformer {
 
             if (useDefaultOrUnknown) {
                 // Use the default value if there is one.
-                if (typeVar.details.defaultType && !this._options.useUnknownOverDefault) {
+                if (typeVar.details.defaultType) {
                     return this._solveDefaultType(typeVar.details.defaultType, recursionCount);
                 }
 

--- a/packages/pyright-internal/src/tests/samples/typeVarDefault5.py
+++ b/packages/pyright-internal/src/tests/samples/typeVarDefault5.py
@@ -2,6 +2,7 @@
 # with a constructor that defines an __init__ but no __new__.
 
 from dataclasses import dataclass
+from typing import Any, overload
 
 class ClassA: ...
 
@@ -12,3 +13,15 @@ class ClassB[T: ClassA = ClassA]:
 def post_comment[T: ClassA](owner: T) -> ClassB[T]:
     return ClassB(owner)
 
+
+class ClassC: ...
+
+
+@overload
+def func1(x: ClassA) -> ClassA: ...
+@overload
+def func1[T1 = str](x: ClassC | T1) -> T1: ...
+def func1(x: Any) -> Any: ...
+
+
+reveal_type(func1(ClassC()), expected_text="str")


### PR DESCRIPTION
…Var with a default (PEP 696) was used in an overload but was not solved. This addresses #7173.