### PR TITLE
RFC: add semantic tokens to pyright

### DIFF
--- a/packages/pyright-internal/src/languageService/semanticTokensProvider.ts
+++ b/packages/pyright-internal/src/languageService/semanticTokensProvider.ts
@@ -1,0 +1,277 @@
+import { CancellationToken, SemanticTokensBuilder } from 'vscode-languageserver';
+import {
+    Range,
+    SemanticTokenModifiers,
+    SemanticTokenTypes,
+    SemanticTokens,
+    integer
+} from 'vscode-languageserver-protocol';
+import { AnalyzerFileInfo } from '../analyzer/analyzerFileInfo';
+import * as AnalyzerNodeInfo from '../analyzer/analyzerNodeInfo';
+import { Declaration, DeclarationType, FunctionDeclaration } from '../analyzer/declaration';
+import * as ParseTreeUtils from '../analyzer/parseTreeUtils';
+import { ParseTreeWalker } from '../analyzer/parseTreeWalker';
+import { TypeEvaluator } from '../analyzer/typeEvaluatorTypes';
+import { throwIfCancellationRequested } from '../common/cancellationUtils';
+import { ProgramView } from '../common/extensibility';
+import { convertOffsetToPosition } from '../common/positionUtils';
+import { TextRange, doesRangeContain } from '../common/textRange';
+import { TextRangeCollection } from '../common/textRangeCollection';
+import { Uri } from '../common/uri/uri';
+import { FunctionNode, ModuleNode, NameNode, ParseNodeType } from '../parser/parseNodes';
+import { ParseResults } from '../parser/parser';
+import { Token } from '../parser/tokenizerTypes';
+
+export interface SemanticTokenEntry {
+    line: integer;
+    start: integer;
+    length: integer;
+    type: SemanticTokenTypes;
+    modifiers: SemanticTokenModifiers[];
+}
+
+export interface SemanticTokensResult {
+    data: SemanticTokenEntry[];
+}
+
+export class SemanticTokensGenerator extends ParseTreeWalker {
+    private readonly _parseResults: ParseResults;
+    private readonly _moduleNode: ModuleNode;
+    private readonly _fileInfo: AnalyzerFileInfo;
+    private readonly _lines: TextRangeCollection<TextRange>
+    private readonly _evaluator: TypeEvaluator;
+    private readonly _range: Range | undefined;
+    private readonly _data: SemanticTokenEntry[];
+    private _dataLen: integer;
+
+    constructor(
+        parseResults: ParseResults,
+        evaluator: TypeEvaluator,
+        range: Range | undefined,
+    ) {
+        super();
+
+        this._parseResults = parseResults;
+        this._moduleNode = parseResults.parseTree;
+        this._fileInfo = AnalyzerNodeInfo.getFileInfo(this._moduleNode)!;
+        this._lines = parseResults.tokenizerOutput.lines;
+        this._evaluator = evaluator;
+        this._range = range;
+        this._data = [];
+        this._dataLen = 0;
+    }
+
+    generate(): SemanticTokensResult {
+        this.walk(this._moduleNode);
+        // return this._builder.build();
+        return {
+            data: this._data,
+        };
+    }
+
+    private _pushToken(token: Token, type: SemanticTokenTypes, modifiers: SemanticTokenModifiers[]) {
+        const start = token.start;
+        const length = token.length;
+        const position = convertOffsetToPosition(start, this._lines);
+
+        if (this._range) {
+            if (!doesRangeContain(this._range, position)) {
+                return;
+            }
+        }
+
+        this._data[this._dataLen++] = {
+            line: position.line,
+            start: position.character,
+            length: length,
+            type: type,
+            modifiers: modifiers,
+        };
+    }
+
+    // override visitCall()
+
+    override visitName(node: NameNode) {
+        const declarations = this._evaluator.getDeclarationsForNameNode(node);
+        if (declarations && declarations.length > 0) {
+            const primaryDeclaration: Declaration = declarations[0];
+            const options = {
+                allowExternallyHiddenAccess: false,
+                skipFileNeededCheck: false,
+            };
+            const resolvedDecl = this._evaluator.resolveAliasDeclaration(primaryDeclaration, true, options);
+            const position = convertOffsetToPosition(node.token.start, this._lines);
+
+            const modifiers: SemanticTokenModifiers[] = [];
+            if (resolvedDecl) {
+                if (doesRangeContain(resolvedDecl.range, position)) {
+                    modifiers.push(SemanticTokenModifiers.declaration);
+                }
+
+                switch (resolvedDecl.type) {
+                     case DeclarationType.Intrinsic: {
+                        this._pushToken(node.token, SemanticTokenTypes.macro, modifiers);
+                        break;
+                    }
+                    case DeclarationType.Variable: {
+                        const containingClassNode = ParseTreeUtils.getEnclosingClass(resolvedDecl.node, true);
+                        if (containingClassNode) {
+                            modifiers.push(SemanticTokenModifiers.modification);
+                        }
+                        this._pushToken(node.token, SemanticTokenTypes.variable, modifiers);
+                        break;
+                    }
+                    case DeclarationType.Parameter: {
+                        this._pushToken(node.token, SemanticTokenTypes.parameter, modifiers);
+                        break;
+                    }
+                    case DeclarationType.Function: {
+                        const functionDeclaration: FunctionDeclaration = resolvedDecl;
+                        let type = SemanticTokenTypes.function;
+                        if (functionDeclaration.isMethod) {
+                            type = SemanticTokenTypes.method;
+                            const functionNode: FunctionNode = functionDeclaration.node;
+                            for (const decorator of functionNode.decorators) {
+                                if (decorator.expression.nodeType === ParseNodeType.Name) {
+                                    const decoratorName = decorator.expression.value;
+                                    if (decoratorName === 'staticmethod') {
+                                        modifiers.push(SemanticTokenModifiers.static);
+                                    } else if (decoratorName === 'classmethod') {
+                                        modifiers.push(SemanticTokenModifiers.static);
+                                    } else if (decoratorName === 'property') {
+                                        type = SemanticTokenTypes.property;
+                                    }
+                                }
+                            }
+                        }
+                        this._pushToken(node.token, type, modifiers);
+                        break;
+                    }
+                    case DeclarationType.Class: {
+                        this._pushToken(node.token, SemanticTokenTypes.class, modifiers);
+                        break;
+                    }
+                    case DeclarationType.SpecialBuiltInClass: {
+                        modifiers.push(SemanticTokenModifiers.defaultLibrary);
+                        this._pushToken(node.token, SemanticTokenTypes.class, modifiers);
+                        break;
+                    }
+                    case DeclarationType.Alias: {
+                        this._pushToken(node.token, SemanticTokenTypes.namespace, modifiers);
+                        break;
+                    }
+                }
+            } else {
+                if (primaryDeclaration.type === DeclarationType.Alias) {
+                    const position = convertOffsetToPosition(node.token.start, this._lines);
+                    console.log(`??? ${node.token.value}: ${position.line}:${position.character} ${primaryDeclaration.type}`);
+                }
+            }
+        }
+        return true;
+    }
+}
+
+export const providedTokenTypes = [
+    SemanticTokenTypes.namespace,
+    SemanticTokenTypes.type,
+    SemanticTokenTypes.class,
+    SemanticTokenTypes.enum,
+    SemanticTokenTypes.interface,
+    SemanticTokenTypes.struct,
+    SemanticTokenTypes.typeParameter,
+    SemanticTokenTypes.parameter,
+    SemanticTokenTypes.variable,
+    SemanticTokenTypes.property,
+    SemanticTokenTypes.enumMember,
+    SemanticTokenTypes.event,
+    SemanticTokenTypes.function,
+    SemanticTokenTypes.method,
+    SemanticTokenTypes.macro,
+    SemanticTokenTypes.keyword,
+    SemanticTokenTypes.modifier,
+    SemanticTokenTypes.comment,
+    SemanticTokenTypes.string,
+    SemanticTokenTypes.number,
+    SemanticTokenTypes.regexp,
+    SemanticTokenTypes.operator,
+];
+
+export const providedTokenModifiers = [
+    SemanticTokenModifiers.declaration,
+    SemanticTokenModifiers.definition,
+    SemanticTokenModifiers.readonly,
+    SemanticTokenModifiers.static,
+    SemanticTokenModifiers.deprecated,
+    SemanticTokenModifiers.abstract,
+    SemanticTokenModifiers.async,
+    SemanticTokenModifiers.modification,
+    SemanticTokenModifiers.documentation,
+    SemanticTokenModifiers.defaultLibrary,
+];
+
+
+export class SemanticTokensProvider {
+    constructor(
+        private _program: ProgramView,
+        private _uri: Uri,
+        private _token: CancellationToken
+    ) {
+    }
+
+    getResult(range?: Range): SemanticTokensResult | null {
+        const parseResults = this._program.getParseResults(this._uri);
+        if (!parseResults) {
+            return null;
+        }
+
+        const sourceFileInfo = this._program.getSourceFileInfo(this._uri);
+        if (!sourceFileInfo) {
+            return null;
+        }
+        const sourceFile = sourceFileInfo.sourceFile;
+        const generator = new SemanticTokensGenerator(
+            parseResults,
+            this._program.evaluator!,
+            range
+        );
+        return generator.generate();
+    }
+
+    getTokens(builder: SemanticTokensBuilder, range?: Range) {
+        throwIfCancellationRequested(this._token);
+
+        const result = this.getResult(range);
+        if (!result) {
+            return;
+        }
+
+        for (const entry of result.data) {
+            const type = providedTokenTypes.indexOf(entry.type);
+            if (type < 0) {
+                continue;
+            }
+            let modifiers = 0;
+            for (const modifier of entry.modifiers) {
+                const flag = providedTokenModifiers.indexOf(modifier);
+                if (flag < 0) {
+                    continue;
+                }
+                modifiers |= 1 << flag;
+            }
+            builder.push(entry.line, entry.start, entry.length, type, modifiers);
+        }
+    }
+
+    getSemanticTokens(): SemanticTokens {
+        const builder = new SemanticTokensBuilder();
+        this.getTokens(builder);
+        return builder.build()
+    }
+
+    getSemanticTokensForRange(range: Range): SemanticTokens {
+        const builder = new SemanticTokensBuilder();
+        this.getTokens(builder, range);
+        return builder.build()
+    }
+}

--- a/packages/pyright-internal/src/tests/semanticTokens.test.ts
+++ b/packages/pyright-internal/src/tests/semanticTokens.test.ts
@@ -1,0 +1,140 @@
+import assert from 'assert';
+import { CancellationToken } from 'vscode-jsonrpc';
+import { SemanticTokenModifiers, SemanticTokenTypes, integer } from 'vscode-languageserver-types';
+
+import { Program } from '../analyzer/program';
+import { AnalyzerService } from '../analyzer/service';
+import { IPythonMode } from '../analyzer/sourceFile';
+import { ConfigOptions } from '../common/configOptions';
+import { NullConsole } from '../common/console';
+import { normalizeSlashes } from '../common/pathUtils';
+import { ServiceProvider } from '../common/serviceProvider';
+import { Uri } from '../common/uri/uri';
+import { SemanticTokenEntry, SemanticTokensProvider } from '../languageService/semanticTokensProvider';
+import { parseTestData } from './harness/fourslash/fourSlashParser';
+import { TestAccessHost } from './harness/testAccessHost';
+import * as host from './harness/testHost';
+import { createFromFileSystem, distlibFolder, libFolder } from './harness/vfs/factory';
+import * as vfs from './harness/vfs/filesystem';
+
+test('check direct declarations', async () => {
+    const code = `
+// @filename: test2.py
+//// [|/*marker*/
+//// def foo(): pass
+//// @dataclass
+//// class Foo:
+////     name: str
+////     count: int
+////     @property
+////     def bar(self):
+////         return self.count + 1
+//// f = Foo("a", 2)
+//// f.name
+//// f.count
+//// |]
+    `;
+
+    const basePath = normalizeSlashes('/');
+    const { data, service } = createServiceWithChainedSourceFiles(basePath, code);
+
+    const marker = data.markerPositions.get('marker')!;
+    const range = data.ranges.find((r) => r.marker === marker)!;
+
+    const parseResults = service.getParseResult(marker.fileUri)!;
+    analyze(service.test_program);
+
+    var provider = new SemanticTokensProvider(service.test_program, marker.fileUri, CancellationToken.None);
+    const result = provider.getResult();
+    assert(result);
+
+    // def foo(): pass
+    checkEntry(result.data[0], 1, 4, 3, SemanticTokenTypes.function, [SemanticTokenModifiers.declaration]);
+
+    // class Foo
+    checkEntry(result.data[1], 3, 6, 3, SemanticTokenTypes.class, [SemanticTokenModifiers.declaration]);
+
+    // name: str
+    checkEntry(result.data[2], 4, 4, 4, SemanticTokenTypes.variable, [
+        SemanticTokenModifiers.declaration,
+        SemanticTokenModifiers.modification,
+    ]);
+    checkEntry(result.data[3], 4, 10, 3, SemanticTokenTypes.class, []);
+
+    // count: int
+    checkEntry(result.data[4], 5, 4, 5, SemanticTokenTypes.variable, [
+        SemanticTokenModifiers.declaration,
+        SemanticTokenModifiers.modification,
+    ]);
+    checkEntry(result.data[5], 5, 11, 3, SemanticTokenTypes.class, []);
+
+    // @property
+    checkEntry(result.data[6], 6, 5, 8, SemanticTokenTypes.class, []);
+
+    // def bar(self):
+    checkEntry(result.data[7], 7, 8, 3, SemanticTokenTypes.property, [SemanticTokenModifiers.declaration]);
+    checkEntry(result.data[8], 7, 12, 4, SemanticTokenTypes.parameter, [SemanticTokenModifiers.declaration]);
+
+    // return self.count + 1
+    checkEntry(result.data[9], 8, 15, 4, SemanticTokenTypes.parameter, []);
+    checkEntry(result.data[10], 8, 20, 5, SemanticTokenTypes.variable, [SemanticTokenModifiers.modification]);
+
+    // f = Foo("a", 2)
+    checkEntry(result.data[11], 9, 0, 1, SemanticTokenTypes.variable, [SemanticTokenModifiers.declaration]);
+    checkEntry(result.data[12], 9, 4, 3, SemanticTokenTypes.class, []);
+
+    // f.name
+    checkEntry(result.data[13], 10, 0, 1, SemanticTokenTypes.variable, []);
+    checkEntry(result.data[14], 10, 2, 4, SemanticTokenTypes.variable, [SemanticTokenModifiers.modification]);
+
+    // f.count
+    checkEntry(result.data[15], 11, 0, 1, SemanticTokenTypes.variable, []);
+    checkEntry(result.data[16], 11, 2, 5, SemanticTokenTypes.variable, [SemanticTokenModifiers.modification]);
+});
+
+function checkEntry(
+    entry: SemanticTokenEntry,
+    line: integer,
+    start: integer,
+    length: integer,
+    type: SemanticTokenTypes,
+    modifiers: SemanticTokenModifiers[]
+) {
+    assert.strictEqual(entry.line, line);
+    assert.strictEqual(entry.start, start);
+    assert.strictEqual(entry.length, length);
+    assert.strictEqual(entry.type, type);
+    assert.deepStrictEqual(entry.modifiers, modifiers);
+}
+
+function createServiceWithChainedSourceFiles(basePath: string, code: string) {
+    const fs = createFromFileSystem(host.HOST, /*ignoreCase*/ false, { cwd: basePath });
+    const service = new AnalyzerService(
+        'test service',
+        new ServiceProvider(),
+        {
+            console: new NullConsole(),
+
+            hostFactory: () => new TestAccessHost(Uri.file(vfs.MODULE_PATH), [libFolder, distlibFolder]),
+            importResolverFactory: AnalyzerService.createImportResolver,
+            configOptions: new ConfigOptions(Uri.file(basePath)),
+            fileSystem: fs,
+        }
+    );
+
+    const data = parseTestData(basePath, code, '');
+
+    let chainedFilePath: Uri | undefined;
+    for (const file of data.files) {
+        const uri = Uri.file(file.fileName);
+        service.setFileOpened(uri, 1, file.content, IPythonMode.None, chainedFilePath);
+        chainedFilePath = uri;
+    }
+    return { data, service };
+}
+
+function analyze(program: Program) {
+    while (program.analyze()) {
+        // Process all queued items
+    }
+}


### PR DESCRIPTION
Dear all, this is by no means complete (hence the RFC), but before I spend any more time on this I would like to hear your opinions (especially @erictraut), if this patch can/will ever be merged.

This patch implements bare-bones semantic tokens for `pyright` to be used in open-source forks of `VSCode` that are prohibited from using the official `pylance` extension (i.e. `VSCodium`). I have irregularly updated this patch so far and the semantic tokens seem to be quite functional for my purposes. The mapping between `pyright` types and actual semantic tokens might need some more tweaking but I think other people could already benefit from the functionality as it right now. 

Having maintained this patch doing this for many months, I can at the very least claim that the necessary changes were very uncomplicated to maintain (especially after the last rewrite of `languageServerBase.ts`).

Now to address the elephant in the room: This clearly competes with the official implementation of semantic tokens in `pylance`, so I expect you will not be able to merge this patch. Am I correct or would it be alright to have this (potentially inferior) implementation in `pyright`?

Thanks!