### PR TITLE
Fixed bug in `isinstance` type narrowing logic that leads to incorrec…

### DIFF
--- a/packages/pyright-internal/src/analyzer/typeGuards.ts
+++ b/packages/pyright-internal/src/analyzer/typeGuards.ts
@@ -1402,6 +1402,12 @@ function narrowTypeForIsInstance(
                     isClassRelationshipIndeterminate = true;
                 }
 
+                // If both the variable type and the filter type ar generics, we can't
+                // determine the relationship between the two.
+                if (isTypeVar(varType) && isTypeVar(filterType)) {
+                    isClassRelationshipIndeterminate = true;
+                }
+
                 if (isPositiveTest) {
                     if (filterIsSuperclass) {
                         // If the variable type is a subclass of the isinstance filter,

--- a/packages/pyright-internal/src/tests/samples/typeNarrowingIsinstance2.py
+++ b/packages/pyright-internal/src/tests/samples/typeNarrowingIsinstance2.py
@@ -26,7 +26,7 @@ class ClassC:
         if isinstance(id, cls):
             reveal_type(id, expected_text="object*")
         else:
-            reveal_type(id, expected_text="int")
+            reveal_type(id, expected_text="int | object*")
 
 
 TD = TypeVar("TD", bound="ClassD")
@@ -38,7 +38,7 @@ class ClassD:
         if isinstance(id, cls):
             reveal_type(id, expected_text="ClassD*")
         else:
-            reveal_type(id, expected_text="int")
+            reveal_type(id, expected_text="int | ClassD*")
 
 
 class ClassE:
@@ -47,4 +47,4 @@ class ClassE:
         if isinstance(id, cls):
             reveal_type(id, expected_text="Self@ClassE")
         else:
-            reveal_type(id, expected_text="int")
+            reveal_type(id, expected_text="int | ClassE*")


### PR DESCRIPTION
…t narrowed type when the filter type (the second argument) and the test type (the first argument) are both type variables. This addresses #7081.