### PR TITLE
Fixed a recent regression that results in a false positive error when…

### DIFF
--- a/packages/pyright-internal/src/analyzer/checker.ts
+++ b/packages/pyright-internal/src/analyzer/checker.ts
@@ -4808,18 +4808,33 @@ export class Checker extends ParseTreeWalker {
 
         // Is there a custom "__new__" and/or "__init__" method? If so, we'll
         // verify that the signature of these calls is compatible with the values.
-        const newMemberTypeResult = getBoundNewMethod(
+        let newMemberTypeResult = getBoundNewMethod(
             this._evaluator,
             node.name,
             classType,
-            MemberAccessFlags.SkipBaseClasses
+            MemberAccessFlags.SkipObjectBaseClass
         );
-        const initMemberTypeResult = getBoundInitMethod(
+
+        // If this __new__ comes from a built-in class like Enum, we'll ignore it.
+        if (newMemberTypeResult?.classType) {
+            if (isClass(newMemberTypeResult.classType) && ClassType.isBuiltIn(newMemberTypeResult.classType)) {
+                newMemberTypeResult = undefined;
+            }
+        }
+
+        let initMemberTypeResult = getBoundInitMethod(
             this._evaluator,
             node.name,
             ClassType.cloneAsInstance(classType),
-            MemberAccessFlags.SkipBaseClasses
+            MemberAccessFlags.SkipObjectBaseClass
         );
+
+        // If this __init__ comes from a built-in class like Enum, we'll ignore it.
+        if (initMemberTypeResult?.classType) {
+            if (isClass(initMemberTypeResult.classType) && ClassType.isBuiltIn(initMemberTypeResult.classType)) {
+                initMemberTypeResult = undefined;
+            }
+        }
 
         classType.details.fields.forEach((symbol, name) => {
             // Enum members don't have type annotations.

--- a/packages/pyright-internal/src/analyzer/enums.ts
+++ b/packages/pyright-internal/src/analyzer/enums.ts
@@ -516,9 +516,14 @@ export function getTypeOfEnumMember(
         // it may implement some magic that computes different values for
         // the "_value_" attribute. If we see a customer __new__ or __init__,
         // we'll assume the value type is what we computed above, or Any.
-        const newMember = lookUpClassMember(classType, '__new__', MemberAccessFlags.SkipBaseClasses);
-        const initMember = lookUpClassMember(classType, '__init__', MemberAccessFlags.SkipBaseClasses);
-        if (newMember || initMember) {
+        const newMember = lookUpClassMember(classType, '__new__', MemberAccessFlags.SkipObjectBaseClass);
+        const initMember = lookUpClassMember(classType, '__init__', MemberAccessFlags.SkipObjectBaseClass);
+
+        if (newMember && isClass(newMember.classType) && !ClassType.isBuiltIn(newMember.classType)) {
+            return { type: valueType ?? AnyType.create(), isIncomplete };
+        }
+
+        if (initMember && isClass(initMember.classType) && !ClassType.isBuiltIn(initMember.classType)) {
             return { type: valueType ?? AnyType.create(), isIncomplete };
         }
 

--- a/packages/pyright-internal/src/languageService/completionProvider.ts
+++ b/packages/pyright-internal/src/languageService/completionProvider.ts
@@ -489,7 +489,7 @@ export class CompletionProvider {
                     const isDeclaredStaticMethod =
                         isFunction(declaredType) && FunctionType.isStaticMethod(declaredType);
 
-                    // Special-case the "__init__subclass__" method because it's an implicit
+                    // Special-case the "__init_subclass__" method because it's an implicit
                     // classmethod that the type evaluator flags as a real classmethod.
                     const isDeclaredClassMethod =
                         isFunction(declaredType) &&

--- a/packages/pyright-internal/src/tests/samples/enum1.py
+++ b/packages/pyright-internal/src/tests/samples/enum1.py
@@ -1,6 +1,7 @@
 # This sample tests the type checker's handling of Enum.
 
 from enum import Enum, EnumMeta, IntEnum
+from typing import Self
 
 
 TestEnum1 = Enum("TestEnum1", "   A   B, , ,C , \t D\t")
@@ -226,3 +227,16 @@ class TestEnum16(Enum):
 
 reveal_type(TestEnum16.D, expected_text="Literal[TestEnum16.C]")
 reveal_type(TestEnum16.D.value, expected_text="Literal[3]")
+
+
+class TestEnum17(IntEnum):
+    def __new__(cls, val: int, doc: str) -> Self:
+        obj = int.__new__(cls, val)
+        obj._value_ = val
+        obj.__doc__ = doc
+        return obj
+
+
+class TestEnum18(TestEnum17):
+    A = (1, "A")
+    B = (2, "B")


### PR DESCRIPTION
… an `Enum` subclass overrides `__new__` or `__init__` and then a subclass of that class assigns tuple values when defining enum members. This addresses #7252.