### PR TITLE
Fixed bug that results in a false positive error when assigning a tup…

### DIFF
--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -22150,13 +22150,13 @@ export function createTypeEvaluator(importLookup: ImportLookup, evaluatorOptions
             destTypeArgs.splice(destTypeArgs.length - 1, 1);
         }
 
-        if (srcVariadicIndex >= 0) {
+        // If we're doing reverse type mappings and the source contains a variadic
+        // TypeVar, we need to adjust the dest so the reverse type mapping assignment
+        // can be performed.
+        if ((flags & AssignTypeFlags.ReverseTypeVarMatching) !== 0) {
             const destArgsToCapture = destTypeArgs.length - srcTypeArgs.length + 1;
 
-            // If we're doing reverse type mappings and the source contains a variadic
-            // TypeVar, we need to adjust the dest so the reverse type mapping assignment
-            // can be performed.
-            if (destArgsToCapture >= 0 && (flags & AssignTypeFlags.ReverseTypeVarMatching) !== 0) {
+            if (srcVariadicIndex >= 0 && destArgsToCapture >= 0) {
                 // If the only removed arg from the dest type args is itself a variadic,
                 // don't bother adjusting it.
                 const skipAdjustment =

--- a/packages/pyright-internal/src/tests/samples/variadicTypeVar19.py
+++ b/packages/pyright-internal/src/tests/samples/variadicTypeVar19.py
@@ -45,8 +45,7 @@ def func3():
         reveal_type(i, expected_text="tuple[int | str, int | str]")
 
 
-def func5(x: "Iterable[Union[*Ts]]") -> Iterable[Union[*Ts]]:
-    ...
+def func5(x: "Iterable[Union[*Ts]]") -> Iterable[Union[*Ts]]: ...
 
 
 def func6():
@@ -54,8 +53,7 @@ def func6():
     v2: list[int | str] = [i for i in func5([1, "foo"])]
 
 
-def func7(t: "tuple[*Ts]") -> "tuple[Union[*Ts], ...]":
-    ...
+def func7(t: "tuple[*Ts]") -> "tuple[Union[*Ts], ...]": ...
 
 
 def func8(a: int, b: str):
@@ -69,3 +67,10 @@ def func9(x: "tuple[T, ...]", y: "tuple[*Ts]") -> Generator[T | Union[*Ts], None
     for e in z:
         reveal_type(e, expected_text="T@func9 | Union[*Ts@func9]")
         yield e
+
+
+def func10(x: tuple[*Ts]): ...
+
+
+def func11(x: tuple[*Ts, int, int]):
+    func10(x)


### PR DESCRIPTION
…le value that includes an unpacked TypeVarTuple to another tuple that also includes an unpacked TypeVarTuple. This addresses #7285.