### PR TITLE
Fixed a bug that led to incorrect type evaluation for a call that tar…

### DIFF
--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -10815,6 +10815,7 @@ export function createTypeEvaluator(importLookup: ImportLookup, evaluatorOptions
                                         argumentCategory: ArgumentCategory.Simple,
                                         typeResult: { type: defaultArgType },
                                     },
+                                    isDefaultArg: true,
                                     errorNode,
                                     paramName: param.name,
                                     isParamNameSynthesized: param.isNameSynthesized,
@@ -11855,6 +11856,12 @@ export function createTypeEvaluator(importLookup: ImportLookup, evaluatorOptions
                 if (argTypeResult.isIncomplete) {
                     isTypeIncomplete = true;
                 }
+            }
+
+            // If the argument came from a parameter's default argument value,
+            // we may need to specialize the type.
+            if (argParam.isDefaultArg) {
+                argType = applySolvedTypeVars(argType, typeVarContext);
             }
         }
 

--- a/packages/pyright-internal/src/analyzer/typeEvaluatorTypes.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluatorTypes.ts
@@ -303,6 +303,7 @@ export interface ValidateArgTypeParams {
     paramType: Type;
     requiresTypeVarMatching: boolean;
     argument: FunctionArgument;
+    isDefaultArg?: boolean;
     argType?: Type | undefined;
     errorNode: ExpressionNode;
     paramName?: string | undefined;

--- a/packages/pyright-internal/src/tests/samples/call13.py
+++ b/packages/pyright-internal/src/tests/samples/call13.py
@@ -1,0 +1,15 @@
+# This sample tests the case where a call invokes a generic function that
+# uses a default argument assigned to a parameter whose type is generic.
+
+from typing import TypeVar, Iterable, Callable
+
+T1 = TypeVar("T1")
+T2 = TypeVar("T2")
+
+
+def func1(values: Iterable[T1], func: Callable[[T1], T2] = lambda x: x) -> list[T2]:
+    return [func(value) for value in values]
+
+
+v1 = func1([1, 2, 3])
+reveal_type(v1, expected_text="list[int]")

--- a/packages/pyright-internal/src/tests/typeEvaluator1.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator1.test.ts
@@ -828,6 +828,12 @@ test('Call12', () => {
     TestUtils.validateResults(analysisResults, 2);
 });
 
+test('Call13', () => {
+    const analysisResults = TestUtils.typeAnalyzeSampleFiles(['call13.py']);
+
+    TestUtils.validateResults(analysisResults, 0);
+});
+
 test('Function1', () => {
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['function1.py']);
 


### PR DESCRIPTION
…gets a generic function that uses a default argument for one of the generic parameters. This addresses #7291.