### PR TITLE
Debugging

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -17,6 +17,21 @@
             ]
         },
         {
+            "name": "Pyright CLI (pyright-internal)",
+            "type": "node",
+            "request": "launch",
+            "program": "${workspaceRoot}/packages/pyright-internal/debug.js",
+            "args": [
+                "--typeshedpath",
+                "${workspaceRoot}/packages/pyright-internal/typeshed-fallback",
+                "--version",
+            ],
+            "internalConsoleOptions": "openOnSessionStart",
+            "outFiles": [
+                "${workspaceRoot}/packages/pyright/dist/**/*.js"
+            ]
+        },
+        {
             "name": "Pyright tests",
             "type": "node",
             "request": "launch",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -28,7 +28,7 @@
             ],
             "internalConsoleOptions": "openOnSessionStart",
             "outFiles": [
-                "${workspaceRoot}/packages/pyright/dist/**/*.js"
+                "${workspaceRoot}/packages/pyright-internal/out/**/*.js"
             ]
         },
         {

--- a/docs/build-debug.md
+++ b/docs/build-debug.md
@@ -32,7 +32,7 @@ To install in VS Code, go to the extensions panel and choose “Install from VSI
 
 ## Debugging Pyright
 
-To debug pyright, open the root source directory within VS Code. Open the debug sub-panel and choose “Pyright CLI” from the debug target menu. Click on the green “run” icon or press F5 to build and launch the command-line version in the VS Code debugger.
+To debug pyright, open the root source directory within VS Code. Open the debug sub-panel and choose “Pyright CLI” from the debug target menu. Click on the green “run” icon or press F5 to build and launch the command-line version in the VS Code debugger. There's also a similar option that provides a slightly faster build/debug loop: make sure you've built the pyright-internal project e.g. with Terminal > Run Build Task > tsc: watch, then choose “Pyright CLI (pyright-internal)”.
 
 To debug the VS Code extension, select “Pyright extension” from the debug target menu. Click on the green “run” icon or press F5 to build and launch a second copy of VS Code with the extension. Within the second VS Code instance, open a python source file so the pyright extension is loaded. Return to the first instance of VS Code and select “Pyright extension attach server” from the debug target menu and click the green “run” icon. This will attach the debugger to the process that hosts the type checker. You can now set breakpoints, etc.
 

--- a/packages/pyright-internal/debug.js
+++ b/packages/pyright-internal/debug.js
@@ -1,0 +1,2 @@
+// This is an entry-point for debugging the pyright CLI
+require('./out/packages/pyright-internal/src/pyright').main();

--- a/packages/pyright-internal/tsconfig.json
+++ b/packages/pyright-internal/tsconfig.json
@@ -8,11 +8,13 @@
     "include": [
         "src/**/*",
         "src/localization/*.json",
-        "**/*.js"
+        "**/*.js",
+        "package.json",
     ],
     "exclude": [
         "node_modules",
         "dist",
-        "out"
+        "out",
+        "debug.js",
     ]
 }


### PR DESCRIPTION
I got a bit irritated in my edit-build-debug inner loop with the time to run webpack.

This commit adds a new launch target called "Pyright CLI (pyright-internal)" which bypasses webpack and just runs the package straight from the packages/pyright-internal/out directory where tsc has built it.