### PR TITLE
Fixed a bug that results in a false negative when passing an unpacked…

### DIFF
--- a/packages/pyright-internal/src/analyzer/parameterUtils.ts
+++ b/packages/pyright-internal/src/analyzer/parameterUtils.ts
@@ -116,10 +116,6 @@ export function getParameterListDetails(type: FunctionType): ParameterListDetail
         }
     }
 
-    if (positionOnlyIndex >= 0) {
-        result.firstPositionOrKeywordIndex = positionOnlyIndex + 1;
-    }
-
     for (let i = 0; i < positionOnlyIndex; i++) {
         if (type.details.parameters[i].hasDefault) {
             break;
@@ -325,6 +321,11 @@ export function getParameterListDetails(type: FunctionType): ParameterListDetail
         ) {
             result.paramSpec = TypeVarType.cloneForParamSpecAccess(secondLastParam.type, undefined);
         }
+    }
+
+    result.firstPositionOrKeywordIndex = result.params.findIndex((p) => p.source !== ParameterSource.PositionOnly);
+    if (result.firstPositionOrKeywordIndex < 0) {
+        result.firstPositionOrKeywordIndex = result.params.length;
     }
 
     return result;

--- a/packages/pyright-internal/src/tests/samples/call2.py
+++ b/packages/pyright-internal/src/tests/samples/call2.py
@@ -83,8 +83,7 @@ def func7(*args: Any, param0: int, param1: int, param2: str):
 def func8(
     y: str,
     z: bool = ...,
-) -> None:
-    ...
+) -> None: ...
 
 
 kwargs1: dict[str, int] = {}
@@ -92,8 +91,7 @@ kwargs1: dict[str, int] = {}
 func8(z=False, **kwargs1)
 
 
-class MyStr(str):
-    ...
+class MyStr(str): ...
 
 
 kwargs2: dict[MyStr, MyStr] = {}
@@ -107,8 +105,7 @@ def func9(
     a: str = ...,
     b: str,
     c: str,
-) -> None:
-    ...
+) -> None: ...
 
 
 kwargs3: dict[str, str] = {}
@@ -121,8 +118,7 @@ func9(0, *args4, **kwargs3)
 func9(*args4, **kwargs3)
 
 
-def func10(x: int):
-    ...
+def func10(x: int): ...
 
 
 func10(1, *())
@@ -141,3 +137,11 @@ func10(*("",))
 
 def func11(y: tuple[int, ...]):
     func10(1, *y)
+
+
+def func12(x: int, /, y: str):
+    pass
+
+
+# This should generate an error.
+func12(1, **{"z": None})

--- a/packages/pyright-internal/src/tests/typeEvaluator1.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator1.test.ts
@@ -763,7 +763,7 @@ test('Call1', () => {
 test('Call2', () => {
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['call2.py']);
 
-    TestUtils.validateResults(analysisResults, 16);
+    TestUtils.validateResults(analysisResults, 17);
 });
 
 test('Call3', () => {


### PR DESCRIPTION
… dict of the wrong type to a function that contains a positional-only parameter marker plus one or more keyword parameters. This addresses #7271.