### PR TITLE
Fixed a bug that results in an incorrect "Unbound" type evaluation fo…

### DIFF
--- a/packages/pyright-internal/src/analyzer/codeFlowEngine.ts
+++ b/packages/pyright-internal/src/analyzer/codeFlowEngine.ts
@@ -1212,7 +1212,7 @@ export function getCodeFlowEngine(
                                 const narrowedTypeResult = typeNarrowingCallback(refTypeInfo.type);
                                 const narrowedType = narrowedTypeResult?.type ?? refTypeInfo.type;
 
-                                if (isNever(narrowedType)) {
+                                if (isNever(narrowedType) && !refTypeInfo.isIncomplete) {
                                     isUnreachable = true;
                                 }
                             }

--- a/packages/pyright-internal/src/tests/samples/loop44.py
+++ b/packages/pyright-internal/src/tests/samples/loop44.py
@@ -1,0 +1,13 @@
+# This sample tests the case where a variable assigned within a loop
+# initially appears to be unreachable (while some variable types are
+# incomplete) but is later determined to be reachable.
+
+
+def func(lines: list[str], val: list[str] | None):
+    for line in lines:
+        if val is None:
+            if line == "":
+                val = []
+            continue
+        match = line
+        match.encode()

--- a/packages/pyright-internal/src/tests/typeEvaluator3.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator3.test.ts
@@ -425,6 +425,12 @@ test('Loop43', () => {
     TestUtils.validateResults(analysisResults, 0);
 });
 
+test('Loop44', () => {
+    const analysisResults = TestUtils.typeAnalyzeSampleFiles(['loop44.py']);
+
+    TestUtils.validateResults(analysisResults, 0);
+});
+
 test('ForLoop1', () => {
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['forLoop1.py']);
 


### PR DESCRIPTION
…r a variable assigned within a loop. This addresses #7217.