### PR TITLE
Drop support for node 12

### DIFF
--- a/docs/ci-integration.md
+++ b/docs/ci-integration.md
@@ -90,7 +90,7 @@ vercomp () {
 # Node version check
 echo "Checking node version..."
 NODE_VERSION=`node -v | cut -d'v' -f2`
-MIN_NODE_VERSION="10.15.2"
+MIN_NODE_VERSION="14.21.3"
 vercomp $MIN_NODE_VERSION $NODE_VERSION
 # 1 == gt
 if [[ $? -eq 1 ]]; then

--- a/packages/pyright/package-lock.json
+++ b/packages/pyright/package-lock.json
@@ -23,7 +23,7 @@
                 "webpack-cli": "^5.1.4"
             },
             "engines": {
-                "node": ">=12.0.0"
+                "node": ">=14.0.0"
             },
             "optionalDependencies": {
                 "fsevents": "~2.3.3"

--- a/packages/pyright/package.json
+++ b/packages/pyright/package.json
@@ -9,7 +9,7 @@
     },
     "publisher": "Microsoft Corporation",
     "engines": {
-        "node": ">=12.0.0"
+        "node": ">=14.0.0"
     },
     "repository": {
         "type": "git",


### PR DESCRIPTION
This commit https://github.com/microsoft/pyright/commit/e955fab18e5a2994c83d5909bbb644705dd4eb75 brought in a dependency change that requires node 14 or higher.

This change ups the minimum engine required to 14 so that we can use this dependency.