### PR TITLE
Fixed a bug that leads to a false positive error when a `match` state…

### DIFF
--- a/packages/pyright-internal/src/analyzer/codeFlowEngine.ts
+++ b/packages/pyright-internal/src/analyzer/codeFlowEngine.ts
@@ -880,8 +880,12 @@ export function getCodeFlowEngine(
                     cacheEntry.incompleteSubtypes.some((subtype) => subtype.isPending)
                 ) {
                     // If entries have been added for all antecedents and there are pending entries
-                    // that have not been evaluated even once, treat it as incomplete.
-                    return { type: cacheEntry.type, isIncomplete: true };
+                    // that have not been evaluated even once, treat it as incomplete. We clean
+                    // any incomplete unknowns from the type here to assist with type convergence.
+                    return {
+                        type: cacheEntry.type ? cleanIncompleteUnknown(cacheEntry.type) : undefined,
+                        isIncomplete: true,
+                    };
                 }
 
                 let attemptCount = 0;

--- a/packages/pyright-internal/src/tests/samples/loop45.py
+++ b/packages/pyright-internal/src/tests/samples/loop45.py
@@ -1,0 +1,17 @@
+# This sample tests the case where a match statement is used in a loop
+# and the subject is potentially narrowed in the loop, therefore creating
+# a circular dependency.
+
+from typing import Literal
+
+
+def func1(lit: Literal["a", "b"]) -> None:
+    for _ in range(2):
+        match lit:
+            case "a":
+                v = "123"
+
+            case "b":
+                v = "234"
+
+        v.replace(",", ".")

--- a/packages/pyright-internal/src/tests/typeEvaluator3.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator3.test.ts
@@ -431,6 +431,12 @@ test('Loop44', () => {
     TestUtils.validateResults(analysisResults, 0);
 });
 
+test('Loop45', () => {
+    const analysisResults = TestUtils.typeAnalyzeSampleFiles(['loop45.py']);
+
+    TestUtils.validateResults(analysisResults, 0);
+});
+
 test('ForLoop1', () => {
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['forLoop1.py']);
 


### PR DESCRIPTION
…ment is used in a loop and the subject expression is potentially narrowed as a result of the `match` statement. This addresses #7371.