### PR TITLE
Send unnecssary/deprecated diagnostics when clients don't support tags

### DIFF
--- a/packages/pyright-internal/src/languageServerBase.ts
+++ b/packages/pyright-internal/src/languageServerBase.ts
@@ -1516,21 +1516,19 @@ export abstract class LanguageServerBase implements LanguageServerInterface, Dis
                 diag.category === DiagnosticCategory.UnusedCode ||
                 diag.category === DiagnosticCategory.UnreachableCode
             ) {
-                vsDiag.tags = [DiagnosticTag.Unnecessary];
-                vsDiag.severity = DiagnosticSeverity.Hint;
-
-                // If the client doesn't support "unnecessary" tags, don't report unused code.
-                if (!this.client.supportsUnnecessaryDiagnosticTag) {
-                    return;
+                // If the client doesn't support "unnecessary" tags, don't attach them.
+                if (this.client.supportsUnnecessaryDiagnosticTag) {
+                    vsDiag.tags = [DiagnosticTag.Unnecessary];
                 }
+
+                vsDiag.severity = DiagnosticSeverity.Hint;
             } else if (diag.category === DiagnosticCategory.Deprecated) {
-                vsDiag.tags = [DiagnosticTag.Deprecated];
-                vsDiag.severity = DiagnosticSeverity.Hint;
-
-                // If the client doesn't support "deprecated" tags, don't report.
-                if (!this.client.supportsDeprecatedDiagnosticTag) {
-                    return;
+                // If the client doesn't support "deprecated" tags, don't attach them.
+                if (this.client.supportsDeprecatedDiagnosticTag) {
+                    vsDiag.tags = [DiagnosticTag.Deprecated];
                 }
+
+                vsDiag.severity = DiagnosticSeverity.Hint;
             } else if (diag.category === DiagnosticCategory.TaskItem) {
                 vsDiag.tags = [VSDiagnosticTag.TaskItem as DiagnosticTag];
 


### PR DESCRIPTION
Previously if an LSP client didn't declare tagSupport in the client capabilities for publishDiagnostic, pyright didn't send diagnostics for unnecessary or deprecated diagnostics. I think it's still valuable to send these regardless of support for tags. When a client doesn't support tags, we can just skip attaching them.