### PR TITLE
Show `str` method docstrings when called on `LiteralString`

### DIFF
--- a/packages/pyright-internal/src/analyzer/typeDocStringUtils.ts
+++ b/packages/pyright-internal/src/analyzer/typeDocStringUtils.ts
@@ -64,6 +64,7 @@ function isInheritedFromBuiltin(type: FunctionType | OverloadedFunctionType, cla
         type.details.moduleName === 'builtins' &&
         !!classType &&
         !!type.boundToType &&
+        !ClassType.isBuiltIn(type.boundToType) &&
         !ClassType.isSameGenericClass(classType, type.boundToType)
     );
 }

--- a/packages/pyright-internal/src/analyzer/typeDocStringUtils.ts
+++ b/packages/pyright-internal/src/analyzer/typeDocStringUtils.ts
@@ -61,11 +61,10 @@ function isInheritedFromBuiltin(type: FunctionType | OverloadedFunctionType, cla
     // Functions that are bound to a different type than where they
     // were declared are inherited.
     return (
-        type.details.moduleName === 'builtins' &&
-        !!classType &&
+        !!type.details.methodClass &&
+        ClassType.isBuiltIn(type.details.methodClass) &&
         !!type.boundToType &&
-        !ClassType.isBuiltIn(type.boundToType) &&
-        !ClassType.isSameGenericClass(classType, type.boundToType)
+        !ClassType.isBuiltIn(type.boundToType)
     );
 }
 

--- a/packages/pyright-internal/src/analyzer/types.ts
+++ b/packages/pyright-internal/src/analyzer/types.ts
@@ -1189,6 +1189,11 @@ export namespace ClassType {
             return true;
         }
 
+        // Handle LiteralString as a special case.
+        if (ClassType.isBuiltIn(classType, 'str') && ClassType.isBuiltIn(type2, 'LiteralString')) {
+            return true;
+        }
+
         // Compare most of the details fields. We intentionally skip the isAbstractClass
         // flag because it gets set dynamically.
         if (

--- a/packages/pyright-internal/src/analyzer/types.ts
+++ b/packages/pyright-internal/src/analyzer/types.ts
@@ -1189,14 +1189,6 @@ export namespace ClassType {
             return true;
         }
 
-        // Handle LiteralString as a special case.
-        if (
-            (ClassType.isBuiltIn(classType, 'str') && ClassType.isBuiltIn(type2, 'LiteralString')) ||
-            (ClassType.isBuiltIn(classType, 'LiteralString') && ClassType.isBuiltIn(type2, 'str'))
-        ) {
-            return true;
-        }
-
         // Compare most of the details fields. We intentionally skip the isAbstractClass
         // flag because it gets set dynamically.
         if (

--- a/packages/pyright-internal/src/analyzer/types.ts
+++ b/packages/pyright-internal/src/analyzer/types.ts
@@ -1190,7 +1190,10 @@ export namespace ClassType {
         }
 
         // Handle LiteralString as a special case.
-        if (ClassType.isBuiltIn(classType, 'str') && ClassType.isBuiltIn(type2, 'LiteralString')) {
+        if (
+            (ClassType.isBuiltIn(classType, 'str') && ClassType.isBuiltIn(type2, 'LiteralString')) ||
+            (ClassType.isBuiltIn(classType, 'LiteralString') && ClassType.isBuiltIn(type2, 'str'))
+        ) {
             return true;
         }
 

--- a/packages/pyright-internal/src/tests/fourslash/hover.builtinDocstrings.builtinInheritedByBuiltin.fourslash.ts
+++ b/packages/pyright-internal/src/tests/fourslash/hover.builtinDocstrings.builtinInheritedByBuiltin.fourslash.ts
@@ -1,0 +1,24 @@
+/// <reference path="fourslash.ts" />
+
+// @filename: typeshed-fallback/stdlib/builtins.pyi
+//// class baseClass:
+////     def method(self) -> None: ...
+////
+//// class derivedClass(baseClass): ...
+
+// @filename: typeshed-fallback/stdlib/builtins.py
+//// class baseClass:
+////     def method(self) -> None:
+////         """baseClass doc string"""
+////         pass
+////
+//// class derivedClass(baseClass):
+////     pass
+
+// @filename: test.py
+//// x = derivedClass()
+//// x.[|/*marker*/method|]()
+
+helper.verifyHover('markdown', {
+    marker: '```python\n(method) def method() -> None\n```\n---\nbaseClass doc string',
+});

--- a/packages/pyright-internal/src/tests/fourslash/hover.builtinDocstrings.builtinInheritedByUserCode.fourslash.ts
+++ b/packages/pyright-internal/src/tests/fourslash/hover.builtinDocstrings.builtinInheritedByUserCode.fourslash.ts
@@ -1,0 +1,22 @@
+/// <reference path="fourslash.ts" />
+
+// @filename: typeshed-fallback/stdlib/builtins.pyi
+//// class baseClass:
+////     def method(self) -> None: ...
+
+// @filename: typeshed-fallback/stdlib/builtins.py
+//// class baseClass:
+////     def method(self) -> None:
+////         """baseClass doc string"""
+////         pass
+
+// @filename: test.py
+//// class derivedClass(baseClass):
+////     pass
+////
+//// x = derivedClass()
+//// x.[|/*marker*/method|]()
+
+helper.verifyHover('markdown', {
+    marker: '```python\n(method) def method() -> None\n```',
+});


### PR DESCRIPTION
Address https://github.com/microsoft/pylance-release/issues/5566

Pylance is failing to get the docstring for `str` methods when they are called on `LiteralString` objects. See https://github.com/microsoft/pylance-release/issues/5566#issuecomment-1974835169. It's [this `isInheritedFromBuiltin` check](https://github.com/microsoft/pyright/blob/c64f9b3f1f2dbe89af8346dfab2e69a5af1460bb/packages/pyright-internal/src/analyzer/typeDocStringUtils.ts#L82) that prevents the docstring from being used.

I changed`isInheritedFromBuiltin` to return `false` if both the base class and derived class are builtins. From the comments where this function is called, I believe the intent is to avoid showing docstrings from builtin types on library/user types that inherit from them. But when the derived type is also a builtin, I'm thinking we should still show the docstring.

I was also thinking about changing `isSameGenericClass` to think that `str` and `LiteralString` were the "same", but that caused a lot of test failures. Mainly false negatives I think, which in hindsight makes sense.