### PR TITLE
Fixed hard-coded type information for module attribute `__package__`.…

### DIFF
--- a/packages/pyright-internal/src/analyzer/binder.ts
+++ b/packages/pyright-internal/src/analyzer/binder.ts
@@ -283,7 +283,7 @@ export class Binder extends ParseTreeWalker {
                 // List taken from https://docs.python.org/3/reference/import.html#__name__
                 this._addImplicitSymbolToCurrentScope('__name__', node, 'str');
                 this._addImplicitSymbolToCurrentScope('__loader__', node, 'Any');
-                this._addImplicitSymbolToCurrentScope('__package__', node, 'str');
+                this._addImplicitSymbolToCurrentScope('__package__', node, 'str | None');
                 this._addImplicitSymbolToCurrentScope('__spec__', node, 'Any');
                 this._addImplicitSymbolToCurrentScope('__path__', node, 'Iterable[str]');
                 this._addImplicitSymbolToCurrentScope('__file__', node, 'str');
@@ -293,9 +293,14 @@ export class Binder extends ParseTreeWalker {
                 this._addImplicitSymbolToCurrentScope('__builtins__', node, 'Any');
 
                 // If there is a static docstring provided in the module, assume
-                // that the type of `__doc__` is `str` rather than `str | None`.
+                // that the type of `__doc__` is `str` rather than `str | None`. This
+                // doesn't apply to stub files.
                 const moduleDocString = ParseTreeUtils.getDocString(node.statements);
-                this._addImplicitSymbolToCurrentScope('__doc__', node, moduleDocString ? 'str' : 'str | None');
+                this._addImplicitSymbolToCurrentScope(
+                    '__doc__',
+                    node,
+                    !this._fileInfo.isStubFile && moduleDocString ? 'str' : 'str | None'
+                );
 
                 // Create a start node for the module.
                 this._currentFlowNode = this._createStartFlowNode();

--- a/packages/pyright-internal/src/tests/samples/module3.py
+++ b/packages/pyright-internal/src/tests/samples/module3.py
@@ -1,0 +1,15 @@
+# This sample tests accesses to standard attributes of a module.
+
+import datetime
+
+reveal_type(datetime.__name__, expected_text="str")
+reveal_type(datetime.__loader__, expected_text="Any")
+reveal_type(datetime.__package__, expected_text="str | None")
+reveal_type(datetime.__spec__, expected_text="Any")
+reveal_type(datetime.__path__, expected_text="Iterable[str]")
+reveal_type(datetime.__file__, expected_text="str")
+reveal_type(datetime.__cached__, expected_text="str")
+reveal_type(datetime.__dict__, expected_text="dict[str, Any]")
+reveal_type(datetime.__annotations__, expected_text="dict[str, Any]")
+reveal_type(datetime.__builtins__, expected_text="Any")
+reveal_type(datetime.__doc__, expected_text="str | None")

--- a/packages/pyright-internal/src/tests/typeEvaluator3.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator3.test.ts
@@ -25,6 +25,12 @@ test('Module2', () => {
     TestUtils.validateResults(analysisResults, 0);
 });
 
+test('Module3', () => {
+    const analysisResults = TestUtils.typeAnalyzeSampleFiles(['module3.py']);
+
+    TestUtils.validateResults(analysisResults, 0);
+});
+
 test('Ellipsis1', () => {
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['ellipsis1.pyi']);
 


### PR DESCRIPTION
… It should be `str | None` rather than `str`. This addresses #7408.