### PR TITLE
Save some memory in token creation

### DIFF
--- a/packages/pyright-internal/src/analyzer/parseTreeUtils.ts
+++ b/packages/pyright-internal/src/analyzer/parseTreeUtils.ts
@@ -277,7 +277,7 @@ export function printExpression(node: ExpressionNode, flags = PrintExpressionFla
             let escapedString = node.token.escapedValue;
             if ((flags & PrintExpressionFlags.DoNotLimitStringLength) === 0) {
                 const maxStringLength = 32;
-                escapedString = escapedString.substring(0, maxStringLength);
+                escapedString = escapedString.slice(0, maxStringLength);
             }
 
             if (node.token.flags & StringTokenFlags.Triplicate) {

--- a/packages/pyright-internal/src/commands/dumpFileDebugInfoCommand.ts
+++ b/packages/pyright-internal/src/commands/dumpFileDebugInfoCommand.ts
@@ -1344,7 +1344,6 @@ function getKeywordTypeString(type: KeywordType) {
 const StringTokenFlagsStrings: [StringTokenFlags, string][] = [
     [StringTokenFlags.Bytes, 'Bytes'],
     [StringTokenFlags.DoubleQuote, 'DoubleQuote'],
-    [StringTokenFlags.ExceedsMaxSize, 'ExceedsMaxSize'],
     [StringTokenFlags.Format, 'Format'],
     [StringTokenFlags.Raw, 'Raw'],
     [StringTokenFlags.SingleQuote, 'SingleQuote'],

--- a/packages/pyright-internal/src/parser/parser.ts
+++ b/packages/pyright-internal/src/parser/parser.ts
@@ -4555,14 +4555,12 @@ export class Parser {
         const interTokenContents = this._fileContents!.slice(curToken.start + curToken.length, nextToken.start);
         const commentRegEx = /^(\s*#\s*type:\s*)([^\r\n]*)/;
         const match = interTokenContents.match(commentRegEx);
-        if (!match || match.index === undefined) {
+        if (!match) {
             return undefined;
         }
 
-        // Synthesize a string token and StringNode using the position of the
-        // type. (Slicing is more memory efficient than using the regex results)
-        const typeIndex = match.index + match[1].length;
-        const typeString = interTokenContents.slice(typeIndex, typeIndex + match[2].length);
+        // Synthesize a string token and StringNode.
+        const typeString = match[2];
 
         // Ignore all "ignore" comments. Include "[" in the regular
         // expression because mypy supports ignore comments of the

--- a/packages/pyright-internal/src/parser/parser.ts
+++ b/packages/pyright-internal/src/parser/parser.ts
@@ -4552,15 +4552,17 @@ export class Parser {
             return undefined;
         }
 
-        const interTokenContents = this._fileContents!.substring(curToken.start + curToken.length, nextToken.start);
+        const interTokenContents = this._fileContents!.slice(curToken.start + curToken.length, nextToken.start);
         const commentRegEx = /^(\s*#\s*type:\s*)([^\r\n]*)/;
         const match = interTokenContents.match(commentRegEx);
-        if (!match) {
+        if (!match || !match.index) {
             return undefined;
         }
 
-        // Synthesize a string token and StringNode.
-        const typeString = match[2];
+        // Synthesize a string token and StringNode using the position of the
+        // type. (Slicing is more memory efficient than using the regex results)
+        const typeIndex = match.index + match[1].length;
+        const typeString = interTokenContents.slice(typeIndex, typeIndex + match[2].length);
 
         // Ignore all "ignore" comments. Include "[" in the regular
         // expression because mypy supports ignore comments of the

--- a/packages/pyright-internal/src/parser/parser.ts
+++ b/packages/pyright-internal/src/parser/parser.ts
@@ -4555,7 +4555,7 @@ export class Parser {
         const interTokenContents = this._fileContents!.slice(curToken.start + curToken.length, nextToken.start);
         const commentRegEx = /^(\s*#\s*type:\s*)([^\r\n]*)/;
         const match = interTokenContents.match(commentRegEx);
-        if (!match || !match.index) {
+        if (!match || match.index === undefined) {
             return undefined;
         }
 

--- a/packages/pyright-internal/src/parser/stringTokenUtils.ts
+++ b/packages/pyright-internal/src/parser/stringTokenUtils.ts
@@ -9,7 +9,6 @@
  */
 
 import { Char } from '../common/charCodes';
-import { maxStringTokenLength } from './tokenizer';
 import { FStringMiddleToken, StringToken, StringTokenFlags } from './tokenizerTypes';
 
 export const enum UnescapeErrorType {
@@ -93,14 +92,11 @@ export function getUnescapedString(stringToken: StringToken | FStringMiddleToken
     const addInvalidEscapeOffset = () => {
         // Invalid escapes are not reported for raw strings.
         if (!isRaw) {
-            // If this is the last character of a truncated string, don't report.
-            if ((stringToken.flags & StringTokenFlags.ExceedsMaxSize) === 0 || strOffset < maxStringTokenLength) {
-                output.unescapeErrors.push({
-                    offset: strOffset - 1,
-                    length: 2,
-                    errorType: UnescapeErrorType.InvalidEscapeSequence,
-                });
-            }
+            output.unescapeErrors.push({
+                offset: strOffset - 1,
+                length: 2,
+                errorType: UnescapeErrorType.InvalidEscapeSequence,
+            });
         }
     };
 

--- a/packages/pyright-internal/src/parser/stringTokenUtils.ts
+++ b/packages/pyright-internal/src/parser/stringTokenUtils.ts
@@ -40,10 +40,14 @@ interface IncompleteUnescapedString {
     nonAsciiInBytes: boolean;
 }
 
-function completeUnescapedString(incomplete: IncompleteUnescapedString): UnescapedString {
+function completeUnescapedString(incomplete: IncompleteUnescapedString, originalString: string): UnescapedString {
+    const newValue = incomplete.valueParts.join('');
+    // Use the original string if it's identical. This prevents us from allocating memory to hold
+    // a copy (a copy is made because the original string is a 'slice' of another, so it doesn't exist in the cache yet).
+    const value = originalString !== newValue ? newValue : originalString;
     return {
         ...incomplete,
-        value: incomplete.valueParts.join(''),
+        value,
     };
 }
 
@@ -142,7 +146,7 @@ export function getUnescapedString(stringToken: StringToken | FStringMiddleToken
     while (true) {
         let curChar = getEscapedCharacter();
         if (curChar === Char.EndOfText) {
-            return completeUnescapedString(output);
+            return completeUnescapedString(output, escapedString);
         }
 
         if (curChar === Char.Backslash) {

--- a/packages/pyright-internal/src/parser/tokenizer.ts
+++ b/packages/pyright-internal/src/parser/tokenizer.ts
@@ -266,7 +266,7 @@ export class Tokenizer {
         } else if (length < 0 || start + length > text.length) {
             throw new Error(`Invalid range length (start=${start}, length=${length}, text.length=${text.length})`);
         } else if (start + length < text.length) {
-            text = text.substring(0, start + length);
+            text = text.slice(0, start + length);
         }
 
         this._cs = new CharacterStream(text);
@@ -432,7 +432,7 @@ export class Tokenizer {
         if (stringPrefixLength >= 0) {
             let stringPrefix = '';
             if (stringPrefixLength > 0) {
-                stringPrefix = this._cs.getText().substring(this._cs.position, this._cs.position + stringPrefixLength);
+                stringPrefix = this._cs.getText().slice(this._cs.position, this._cs.position + stringPrefixLength);
                 // Indeed a string
                 this._cs.advance(stringPrefixLength);
             }
@@ -860,7 +860,7 @@ export class Tokenizer {
         }
 
         if (this._cs.position > start) {
-            const value = this._cs.getText().substring(start, this._cs.position);
+            const value = this._cs.getText().slice(start, this._cs.position);
             if (_keywords.has(value)) {
                 this._tokens.push(
                     KeywordToken.create(start, this._cs.position - start, _keywords.get(value)!, this._getComments())
@@ -926,9 +926,9 @@ export class Tokenizer {
             }
 
             if (radix > 0) {
-                const text = this._cs.getText().substring(start, this._cs.position);
+                const text = this._cs.getText().slice(start, this._cs.position);
                 const simpleIntText = text.replace(/_/g, '');
-                let intValue: number | bigint = parseInt(simpleIntText.substring(leadingChars), radix);
+                let intValue: number | bigint = parseInt(simpleIntText.slice(leadingChars), radix);
 
                 if (!isNaN(intValue)) {
                     const bigIntValue = BigInt(simpleIntText);
@@ -979,7 +979,7 @@ export class Tokenizer {
         }
 
         if (isDecimalInteger) {
-            let text = this._cs.getText().substring(start, this._cs.position);
+            let text = this._cs.getText().slice(start, this._cs.position);
             const simpleIntText = text.replace(/_/g, '');
             let intValue: number | bigint = parseInt(simpleIntText, 10);
 
@@ -1015,7 +1015,7 @@ export class Tokenizer {
             (this._cs.currentChar === Char.Period && this._cs.nextChar >= Char._0 && this._cs.nextChar <= Char._9)
         ) {
             if (this._skipFloatingPointCandidate()) {
-                let text = this._cs.getText().substring(start, this._cs.position);
+                let text = this._cs.getText().slice(start, this._cs.position);
                 const value = parseFloat(text);
                 if (!isNaN(value)) {
                     let isImaginary = false;
@@ -1244,7 +1244,7 @@ export class Tokenizer {
 
             if (type === CommentType.IPythonMagic || type === CommentType.IPythonShellEscape) {
                 const length = this._cs.position - begin;
-                const value = this._cs.getText().substring(begin, begin + length);
+                const value = this._cs.getText().slice(begin, begin + length);
 
                 // is it multiline magics?
                 // %magic command \
@@ -1368,7 +1368,7 @@ export class Tokenizer {
         if (this._cs.lookAhead(2) === Char.SingleQuote || this._cs.lookAhead(2) === Char.DoubleQuote) {
             const prefix = this._cs
                 .getText()
-                .substring(this._cs.position, this._cs.position + 2)
+                .slice(this._cs.position, this._cs.position + 2)
                 .toLowerCase();
             switch (prefix) {
                 case 'rf':

--- a/packages/pyright-internal/src/parser/tokenizer.ts
+++ b/packages/pyright-internal/src/parser/tokenizer.ts
@@ -143,8 +143,6 @@ const _byteOrderMarker = 0xfeff;
 
 const defaultTabSize = 8;
 
-export const maxStringTokenLength = 32 * 1024;
-
 export interface TokenizerOutput {
     // List of all tokens.
     tokens: TextRangeCollection<Token>;

--- a/packages/pyright-internal/src/parser/tokenizerTypes.ts
+++ b/packages/pyright-internal/src/parser/tokenizerTypes.ts
@@ -173,7 +173,6 @@ export const enum StringTokenFlags {
 
     // Error conditions
     Unterminated = 1 << 16,
-    ExceedsMaxSize = 1 << 17,
 }
 
 export const enum CommentType {


### PR DESCRIPTION
While investigating this issue:
https://github.com/microsoft/pylance-release/issues/5440

Erik and I noticed that the `escapedValue` for a bunch of different tokens was not actually allocated from the original string. It was an entirely new string, meaning a new allocation.

It seems that it doesn't need to be that way. It can just point to the original string.

I verified this uses less memory by snapshotting a run of pylance with a file with a lot of string literals in it.

In the original version, we end up with a parse tree like so:

![image](https://github.com/microsoft/pyright/assets/19672699/c2f50f40-8d55-4f12-a225-262226de880b)

You can see that it's allocated 18.9 MB for the tokens themselves.

If we expand into these tokens, you can see one of the largest ones has its own copy of the giant literal string at the top of the file:

![image](https://github.com/microsoft/pyright/assets/19672699/fa0e5b39-25c0-4d14-93ca-09bbac60e59c)

That token has 32K allocated to hold that large literal string.

After this change, the amount of memory for the same run goes down by 800K:

![image](https://github.com/microsoft/pyright/assets/19672699/9383b4dd-2000-4165-b124-3a17adbbdd4c)

And if we find that same token with the escaped value, it's now a `sliced` value, which is really just a reference to the original string:

![image](https://github.com/microsoft/pyright/assets/19672699/07940be1-ba46-40a8-a327-2fc33cd67f52)


