### PR TITLE
Fixed a bug that resulted in an incorrect type evaluation when an aug…

### DIFF
--- a/packages/pyright-internal/src/tests/samples/operator8.py
+++ b/packages/pyright-internal/src/tests/samples/operator8.py
@@ -144,3 +144,22 @@ def func8(values: Iterable[float]) -> float:
         (0, 0),
     )
     return total / num_of_values
+
+
+def func9(a: int) -> None:
+    b = 0
+    reveal_type(b, expected_text="Literal[0]")
+
+    def inner1() -> None:
+        nonlocal b
+        b += 1
+        reveal_type(b, expected_text="int")
+        b = b + 1
+
+    def inner2() -> None:
+        nonlocal b
+        b = b + 1
+        reveal_type(b, expected_text="int")
+
+    inner1()
+    inner2()


### PR DESCRIPTION
…mented assignment is used within an inner-scoped function to add a constant to a variable. Literal math should not be used in this case. This addresses #7431.