### PR TITLE
Changed the behavior when accessing a class attribute from a generic …

### DIFF
--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -269,6 +269,7 @@ import {
     specializeClassType,
     specializeForBaseClass,
     specializeTupleClass,
+    specializeWithDefaultTypeArgs,
     synthesizeTypeVarForSelfCls,
     transformExpectedType,
     transformPossibleRecursiveTypeAlias,
@@ -2067,6 +2068,20 @@ export function createTypeEvaluator(importLookup: ImportLookup, evaluatorOptions
                 );
             }
             return { type: UnknownType.create() };
+        }
+
+        // If this is an unspecialized generic class, specialize it using the default
+        // values for its type parameters.
+        if (
+            isInstantiableClass(objectType) &&
+            !objectType.includeSubclasses &&
+            objectType.details.typeParameters.length > 0
+        ) {
+            // Skip this if we're suppressing the use of attribute access override,
+            // such as with dundered methods (like __call__).
+            if ((flags & MemberAccessFlags.SkipAttributeAccessOverride) === 0) {
+                objectType = specializeWithDefaultTypeArgs(objectType);
+            }
         }
 
         // Determine the class that was used to instantiate the objectType.

--- a/packages/pyright-internal/src/tests/samples/genericType9.py
+++ b/packages/pyright-internal/src/tests/samples/genericType9.py
@@ -28,15 +28,15 @@ class ClassASub2(ClassA[int]):
 
 
 def test1(val_str: str, val_int: int):
-    reveal_type(ClassA.func1(val_str), expected_text="ClassA[str]")
-    reveal_type(ClassASub1.func1(val_str), expected_text="ClassA[str]")
+    reveal_type(ClassA.func1(val_str), expected_text="ClassA[Unknown]")
+    reveal_type(ClassASub1.func1(val_str), expected_text="ClassA[Unknown]")
     reveal_type(ClassASub2.func1(val_int), expected_text="ClassA[int]")
 
     # This should generate an error because the argument type doesn't match.
     ClassASub2.func1(val_str)
 
-    reveal_type(ClassA.func2(val_str), expected_text="ClassA[str]")
-    reveal_type(ClassASub1.func2(val_str), expected_text="ClassA[str]")
+    reveal_type(ClassA.func2(val_str), expected_text="ClassA[Unknown]")
+    reveal_type(ClassASub1.func2(val_str), expected_text="ClassA[Unknown]")
     reveal_type(ClassASub2.func2(val_int), expected_text="ClassA[int]")
 
     # This should generate an error because the argument type doesn't match.

--- a/packages/pyright-internal/src/tests/samples/memberAccess14.py
+++ b/packages/pyright-internal/src/tests/samples/memberAccess14.py
@@ -14,45 +14,37 @@ CachedSlotPropertyT = TypeVar(
 
 
 class CachedSlotProperty(Generic[T_contra, V_co]):
-    def __init__(self, name: str, function: Callable[[T_contra], V_co]) -> None:
-        ...
+    def __init__(self, name: str, function: Callable[[T_contra], V_co]) -> None: ...
 
     @overload
     def __get__(
         self: CachedSlotPropertyT, instance: None, owner: type[T_contra]
-    ) -> CachedSlotPropertyT:
-        ...
+    ) -> CachedSlotPropertyT: ...
 
     @overload
-    def __get__(self, instance: T_contra, owner: Any) -> V_co:
-        ...
+    def __get__(self, instance: T_contra, owner: Any) -> V_co: ...
 
     def __get__(
         self: CachedSlotPropertyT, instance: T_contra | None, owner: Any
-    ) -> CachedSlotPropertyT | V_co:
-        ...
+    ) -> CachedSlotPropertyT | V_co: ...
 
 
 def cached_slot_property(
     name: str,
-) -> Callable[[Callable[[T_contra], V_co]], CachedSlotProperty[T_contra, V_co]]:
-    ...
+) -> Callable[[Callable[[T_contra], V_co]], CachedSlotProperty[T_contra, V_co]]: ...
 
 
 class C(Generic[T]):
-    def __init__(self, data: T) -> None:
-        ...
+    def __init__(self, data: T) -> None: ...
 
     @cached_slot_property("_prop")
-    def prop(self) -> int:
-        ...
+    def prop(self) -> int: ...
 
 
-class D(C[float]):
-    ...
+class D(C[float]): ...
 
 
-reveal_type(C.prop, expected_text="CachedSlotProperty[C[T@C], int]")
+reveal_type(C.prop, expected_text="CachedSlotProperty[C[Unknown], int]")
 reveal_type(D.prop, expected_text="CachedSlotProperty[D, int]")
 
 


### PR DESCRIPTION
…class that is not specialized. The class is now automatically specialized in the case using default type parameter values (from PEP 696) or Unknown. This change is required for conformance with PEP 696. It addresses #7445.