### PR TITLE
Potential method to shorten evaluation time for certain packages

### DIFF
--- a/packages/pyright-internal/src/analyzer/backgroundAnalysisProgram.ts
+++ b/packages/pyright-internal/src/analyzer/backgroundAnalysisProgram.ts
@@ -20,6 +20,7 @@ import { Uri } from '../common/uri/uri';
 import { AnalysisCompleteCallback, analyzeProgram } from './analysis';
 import { ImportResolver } from './importResolver';
 import { MaxAnalysisTime, OpenFileOptions, Program } from './program';
+import { Type } from './types';
 
 export enum InvalidatedReason {
     Reanalyzed,
@@ -41,7 +42,8 @@ export class BackgroundAnalysisProgram {
         private _importResolver: ImportResolver,
         private _backgroundAnalysis?: BackgroundAnalysisBase,
         private readonly _maxAnalysisTime?: MaxAnalysisTime,
-        private readonly _disableChecker?: boolean
+        private readonly _disableChecker?: boolean,
+        shouldExpandTypeFilter = (type: Type) => true
     ) {
         this._program = new Program(
             this.importResolver,
@@ -49,7 +51,8 @@ export class BackgroundAnalysisProgram {
             this._serviceProvider,
             undefined,
             this._disableChecker,
-            serviceId
+            serviceId,
+            shouldExpandTypeFilter
         );
     }
 

--- a/packages/pyright-internal/src/analyzer/program.ts
+++ b/packages/pyright-internal/src/analyzer/program.ts
@@ -161,7 +161,8 @@ export class Program {
         readonly serviceProvider: ServiceProvider,
         logTracker?: LogTracker,
         private _disableChecker?: boolean,
-        id?: string
+        id?: string,
+        private _shouldExpandTypeFilter = (type: Type) => true
     ) {
         this._console = serviceProvider.tryGet(ServiceKeys.console) || new StandardConsole();
         this._logTracker = logTracker ?? new LogTracker(this._console, 'FG');
@@ -955,7 +956,10 @@ export class Program {
             this._importResolver,
             this._configOptions,
             this.serviceProvider,
-            new LogTracker(this._console, 'Cloned')
+            new LogTracker(this._console, 'Cloned'),
+            this._disableChecker,
+            this.id,
+            this._shouldExpandTypeFilter
         );
 
         // Cloned program will use whatever user files the program currently has.
@@ -1624,6 +1628,7 @@ export class Program {
                 minimumLoggingThreshold: this._configOptions.typeEvaluationTimeThreshold,
                 evaluateUnknownImportsAsAny: !!this._configOptions.evaluateUnknownImportsAsAny,
                 verifyTypeCacheEvaluatorFlags: !!this._configOptions.internalTestMode,
+                shouldExpandType: this._shouldExpandTypeFilter,
             },
             this._logTracker,
             this._configOptions.logTypeEvaluationTime

--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -555,6 +555,7 @@ export interface EvaluatorOptions {
     minimumLoggingThreshold: number;
     evaluateUnknownImportsAsAny: boolean;
     verifyTypeCacheEvaluatorFlags: boolean;
+    shouldExpandType: (type: Type) => boolean;
 }
 
 // Describes a "deferred class completion" that is run when a class type is
@@ -1660,6 +1661,9 @@ export function createTypeEvaluator(importLookup: ImportLookup, evaluatorOptions
         }
 
         return mapSubtypes(type, (subtype) => {
+            if (!evaluatorOptions.shouldExpandType(subtype)) {
+                return subtype;
+            }
             if (isClass(subtype)) {
                 if (subtype.literalValue !== undefined) {
                     return ClassType.cloneWithLiteral(subtype, /* value */ undefined);
@@ -3872,6 +3876,9 @@ export function createTypeEvaluator(importLookup: ImportLookup, evaluatorOptions
     ): Type {
         const newSubtypes: Type[] = [];
         let typeChanged = false;
+        if (!evaluatorOptions.shouldExpandType(type)) {
+            return type;
+        }
 
         function expandSubtype(unexpandedType: Type, isLastSubtype: boolean) {
             let expandedType = isUnion(unexpandedType) ? unexpandedType : makeTopLevelTypeVarsConcrete(unexpandedType);

--- a/packages/pyright-internal/src/backgroundAnalysisBase.ts
+++ b/packages/pyright-internal/src/backgroundAnalysisBase.ts
@@ -38,6 +38,7 @@ import { LogTracker } from './common/logTracker';
 import { ServiceProvider } from './common/serviceProvider';
 import { Range } from './common/textRange';
 import { Uri } from './common/uri/uri';
+import { Type } from './analyzer/types';
 
 export class BackgroundAnalysisBase {
     private _worker: Worker | undefined;
@@ -292,7 +293,7 @@ export abstract class BackgroundAnalysisRunnerBase extends BackgroundThreadBase 
     protected logTracker: LogTracker;
     protected isCaseSensitive = true;
 
-    protected constructor(protected serviceProvider: ServiceProvider) {
+    protected constructor(protected serviceProvider: ServiceProvider, shouldExpandTypeFilter = (type: Type) => true) {
         super(workerData as InitializationData, serviceProvider);
 
         // Stash the base directory into a global variable.
@@ -304,7 +305,15 @@ export abstract class BackgroundAnalysisRunnerBase extends BackgroundThreadBase 
         const console = this.getConsole();
         this.logTracker = new LogTracker(console, `BG(${threadId})`);
 
-        this._program = new Program(this.importResolver, this._configOptions, serviceProvider, this.logTracker);
+        this._program = new Program(
+            this.importResolver,
+            this._configOptions,
+            serviceProvider,
+            this.logTracker,
+            /* disableChecker */ undefined,
+            /* id */ undefined,
+            shouldExpandTypeFilter
+        );
     }
 
     get program(): Program {


### PR DESCRIPTION
See this comment here:
https://github.com/microsoft/pyright/issues/7159#issuecomment-1992769774

After some investigation I found that sympy is just evaluating a lot more types. This change allows a limit be set for expanding types. Internally in Pylance I was thinking we'd have a setting like so:

```json
"python.analysis.minimizedPackages": ["sympy"]
```

This would be applied to the `type` argument on the filter to see what module the type comes from. If a package is in this list, the user will still get some information, but the package will analyze much faster.

The alternative would be to provide type stubs for these packages, but that can take a long time. This is more like a shortcut for when we know certain packages are slow to analyze.

