### PR TITLE
Fixed bug that results in false positive when a list or set expressio…

### DIFF
--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -13653,9 +13653,20 @@ export function createTypeEvaluator(importLookup: ImportLookup, evaluatorOptions
             }
         });
 
-        const isTypeInvariant =
-            isClassInstance(inferenceContext.expectedType) &&
-            ClassType.isBuiltIn(inferenceContext.expectedType, builtInClassName);
+        let isTypeInvariant = false;
+
+        if (isClassInstance(inferenceContext.expectedType)) {
+            inferTypeParameterVarianceForClass(inferenceContext.expectedType);
+
+            if (
+                inferenceContext.expectedType.details.typeParameters.some(
+                    (t) => TypeVarType.getVariance(t) === Variance.Invariant
+                )
+            ) {
+                isTypeInvariant = true;
+            }
+        }
+
         const specializedEntryType = inferTypeArgFromExpectedEntryType(
             makeInferenceContext(expectedEntryType),
             entryTypes,

--- a/packages/pyright-internal/src/tests/samples/list1.py
+++ b/packages/pyright-internal/src/tests/samples/list1.py
@@ -2,7 +2,7 @@
 
 # pyright: strict, reportUnknownVariableType=false
 
-from typing import Any, Collection, Generic, Literal, Sequence, TypeVar
+from typing import Any, Collection, Generic, Literal, MutableSequence, Sequence, TypeVar
 
 
 v1 = [1, 2, 3]
@@ -27,15 +27,12 @@ _T = TypeVar("_T")
 
 
 class Baz(Generic[_T]):
-    def __get__(self, instance: Any, owner: Any) -> _T:
-        ...
+    def __get__(self, instance: Any, owner: Any) -> _T: ...
 
-    def __set__(self, instance: Any, value: _T) -> None:
-        ...
+    def __set__(self, instance: Any, value: _T) -> None: ...
 
 
-class Foo:
-    ...
+class Foo: ...
 
 
 class Bar:
@@ -68,8 +65,7 @@ v16: dict[str, list[str | None]] = {n: [None] * len(n) for n in ["a", "aa", "aaa
 ScalarKeysT = TypeVar("ScalarKeysT", bound=Literal["name", "country"])
 
 
-def func1(by: list[ScalarKeysT]) -> ScalarKeysT:
-    ...
+def func1(by: list[ScalarKeysT]) -> ScalarKeysT: ...
 
 
 reveal_type(func1(["country"]), expected_type="Literal['country']")
@@ -80,8 +76,7 @@ reveal_type(func1(["name", "country"]), expected_type="Literal['name', 'country'
 func1(["id"])
 
 
-def func2(thing: str | list[str | int] | list[list[str | int]]):
-    ...
+def func2(thing: str | list[str | int] | list[list[str | int]]): ...
 
 
 func2("")
@@ -99,3 +94,11 @@ def func3(value: _T) -> list[_T]:
 def func4(value: _T) -> list[_T]:
     # This should generate an error.
     return [value, str(value)]
+
+
+def func5():
+    v1: Sequence[int | str] = [1]
+    reveal_type(v1, expected_text="list[int]")
+
+    v2: MutableSequence[int | str] = [1]
+    reveal_type(v2, expected_text="list[int | str]")


### PR DESCRIPTION
…n is evaluated using bidirectional type inference when the expected type is `MutableSet` or `MutableSequence`. This addresses #7498.