### PR TITLE
Expanded handling of python versions to handle more than just major/m…

### DIFF
--- a/packages/pyright-internal/src/analyzer/analyzerFileInfo.ts
+++ b/packages/pyright-internal/src/analyzer/analyzerFileInfo.ts
@@ -10,7 +10,7 @@
 
 import { DiagnosticRuleSet, ExecutionEnvironment } from '../common/configOptions';
 import { TextRangeDiagnosticSink } from '../common/diagnosticSink';
-import { PythonVersion } from '../common/pythonVersion';
+import { pythonVersion3_13 } from '../common/pythonVersion';
 import { TextRange } from '../common/textRange';
 import { TextRangeCollection } from '../common/textRangeCollection';
 import { Uri } from '../common/uri/uri';
@@ -78,7 +78,7 @@ export function isAnnotationEvaluationPostponed(fileInfo: AnalyzerFileInfo) {
     // It was tentatively approved for 3.12, but they decided to defer until the next
     // release to reduce the risk.
     // https://discuss.python.org/t/pep-649-deferred-evaluation-of-annotations-tentatively-accepted/21331
-    if (fileInfo.executionEnvironment.pythonVersion >= PythonVersion.V3_13) {
+    if (fileInfo.executionEnvironment.pythonVersion.isGreaterOrEqualTo(pythonVersion3_13)) {
         return true;
     }
 

--- a/packages/pyright-internal/src/analyzer/checker.ts
+++ b/packages/pyright-internal/src/analyzer/checker.ts
@@ -20,7 +20,7 @@ import { DiagnosticLevel } from '../common/configOptions';
 import { assert, assertNever } from '../common/debug';
 import { ActionKind, Diagnostic, DiagnosticAddendum, RenameShadowedFileAction } from '../common/diagnostic';
 import { DiagnosticRule } from '../common/diagnosticRules';
-import { PythonVersion, versionToString } from '../common/pythonVersion';
+import { pythonVersion3_12, pythonVersion3_5, pythonVersion3_6 } from '../common/pythonVersion';
 import { TextRange } from '../common/textRange';
 import { Uri } from '../common/uri/uri';
 import { DefinitionProvider } from '../languageService/definitionProvider';
@@ -616,7 +616,7 @@ export class Checker extends ParseTreeWalker {
 
             if (
                 this._fileInfo.diagnosticRuleSet.reportTypeCommentUsage !== 'none' &&
-                this._fileInfo.executionEnvironment.pythonVersion >= PythonVersion.V3_5
+                this._fileInfo.executionEnvironment.pythonVersion.isGreaterOrEqualTo(pythonVersion3_5)
             ) {
                 this._evaluator.addDiagnostic(
                     DiagnosticRule.reportTypeCommentUsage,
@@ -1190,7 +1190,7 @@ export class Checker extends ParseTreeWalker {
 
             if (
                 this._fileInfo.diagnosticRuleSet.reportTypeCommentUsage !== 'none' &&
-                this._fileInfo.executionEnvironment.pythonVersion >= PythonVersion.V3_6
+                this._fileInfo.executionEnvironment.pythonVersion.isGreaterOrEqualTo(pythonVersion3_6)
             ) {
                 this._evaluator.addDiagnostic(
                     DiagnosticRule.reportTypeCommentUsage,
@@ -1352,7 +1352,7 @@ export class Checker extends ParseTreeWalker {
         // associated with f-strings that we need to validate. Determine whether
         // we're within an f-string (or multiple f-strings if nesting is used).
         const fStringContainers: FormatStringNode[] = [];
-        if (this._fileInfo.executionEnvironment.pythonVersion < PythonVersion.V3_12) {
+        if (this._fileInfo.executionEnvironment.pythonVersion.isLessThan(pythonVersion3_12)) {
             let curNode: ParseNode | undefined = node;
             while (curNode) {
                 if (curNode.nodeType === ParseNodeType.FormatString) {
@@ -4244,12 +4244,12 @@ export class Checker extends ParseTreeWalker {
                     (isInstantiableClass(type) && type.details.fullName === deprecatedForm.fullName) ||
                     type.typeAliasInfo?.fullName === deprecatedForm.fullName
                 ) {
-                    if (this._fileInfo.executionEnvironment.pythonVersion >= deprecatedForm.version) {
+                    if (this._fileInfo.executionEnvironment.pythonVersion.isGreaterOrEqualTo(deprecatedForm.version)) {
                         if (!deprecatedForm.typingImportOnly || isImportFromTyping) {
                             if (this._fileInfo.diagnosticRuleSet.reportDeprecated === 'none') {
                                 this._evaluator.addDeprecated(
                                     LocMessage.deprecatedType().format({
-                                        version: versionToString(deprecatedForm.version),
+                                        version: deprecatedForm.version.toString(),
                                         replacement: deprecatedForm.replacementText,
                                     }),
                                     node
@@ -4258,7 +4258,7 @@ export class Checker extends ParseTreeWalker {
                                 this._evaluator.addDiagnostic(
                                     DiagnosticRule.reportDeprecated,
                                     LocMessage.deprecatedType().format({
-                                        version: versionToString(deprecatedForm.version),
+                                        version: deprecatedForm.version.toString(),
                                         replacement: deprecatedForm.replacementText,
                                     }),
                                     node

--- a/packages/pyright-internal/src/analyzer/deprecatedSymbols.ts
+++ b/packages/pyright-internal/src/analyzer/deprecatedSymbols.ts
@@ -7,7 +7,7 @@
  * A list of implicitly-deprecated symbols as defined in PEP 585, etc.
  */
 
-import { PythonVersion } from '../common/pythonVersion';
+import { PythonVersion, pythonVersion3_10, pythonVersion3_9 } from '../common/pythonVersion';
 
 export interface DeprecatedForm {
     // The version of Python where this symbol becomes deprecated
@@ -24,17 +24,17 @@ export interface DeprecatedForm {
 }
 
 export const deprecatedAliases = new Map<string, DeprecatedForm>([
-    ['Tuple', { version: PythonVersion.V3_9, fullName: 'builtins.tuple', replacementText: 'tuple' }],
-    ['List', { version: PythonVersion.V3_9, fullName: 'builtins.list', replacementText: 'list' }],
-    ['Dict', { version: PythonVersion.V3_9, fullName: 'builtins.dict', replacementText: 'dict' }],
-    ['Set', { version: PythonVersion.V3_9, fullName: 'builtins.set', replacementText: 'set' }],
-    ['FrozenSet', { version: PythonVersion.V3_9, fullName: 'builtins.frozenset', replacementText: 'frozenset' }],
-    ['Type', { version: PythonVersion.V3_9, fullName: 'builtins.type', replacementText: 'type' }],
-    ['Deque', { version: PythonVersion.V3_9, fullName: 'collections.deque', replacementText: 'collections.deque' }],
+    ['Tuple', { version: pythonVersion3_9, fullName: 'builtins.tuple', replacementText: 'tuple' }],
+    ['List', { version: pythonVersion3_9, fullName: 'builtins.list', replacementText: 'list' }],
+    ['Dict', { version: pythonVersion3_9, fullName: 'builtins.dict', replacementText: 'dict' }],
+    ['Set', { version: pythonVersion3_9, fullName: 'builtins.set', replacementText: 'set' }],
+    ['FrozenSet', { version: pythonVersion3_9, fullName: 'builtins.frozenset', replacementText: 'frozenset' }],
+    ['Type', { version: pythonVersion3_9, fullName: 'builtins.type', replacementText: 'type' }],
+    ['Deque', { version: pythonVersion3_9, fullName: 'collections.deque', replacementText: 'collections.deque' }],
     [
         'DefaultDict',
         {
-            version: PythonVersion.V3_9,
+            version: pythonVersion3_9,
             fullName: 'collections.defaultdict',
             replacementText: 'collections.defaultdict',
         },
@@ -42,7 +42,7 @@ export const deprecatedAliases = new Map<string, DeprecatedForm>([
     [
         'OrderedDict',
         {
-            version: PythonVersion.V3_9,
+            version: pythonVersion3_9,
             fullName: 'collections.OrderedDict',
             replacementText: 'collections.OrderedDict',
             typingImportOnly: true,
@@ -51,7 +51,7 @@ export const deprecatedAliases = new Map<string, DeprecatedForm>([
     [
         'Counter',
         {
-            version: PythonVersion.V3_9,
+            version: pythonVersion3_9,
             fullName: 'collections.Counter',
             replacementText: 'collections.Counter',
             typingImportOnly: true,
@@ -60,7 +60,7 @@ export const deprecatedAliases = new Map<string, DeprecatedForm>([
     [
         'ChainMap',
         {
-            version: PythonVersion.V3_9,
+            version: pythonVersion3_9,
             fullName: 'collections.ChainMap',
             replacementText: 'collections.ChainMap',
             typingImportOnly: true,
@@ -69,7 +69,7 @@ export const deprecatedAliases = new Map<string, DeprecatedForm>([
     [
         'Awaitable',
         {
-            version: PythonVersion.V3_9,
+            version: pythonVersion3_9,
             fullName: 'typing.Awaitable',
             replacementText: 'collections.abc.Awaitable',
             typingImportOnly: true,
@@ -78,7 +78,7 @@ export const deprecatedAliases = new Map<string, DeprecatedForm>([
     [
         'Coroutine',
         {
-            version: PythonVersion.V3_9,
+            version: pythonVersion3_9,
             fullName: 'typing.Coroutine',
             replacementText: 'collections.abc.Coroutine',
             typingImportOnly: true,
@@ -87,7 +87,7 @@ export const deprecatedAliases = new Map<string, DeprecatedForm>([
     [
         'AsyncIterable',
         {
-            version: PythonVersion.V3_9,
+            version: pythonVersion3_9,
             fullName: 'typing.AsyncIterable',
             replacementText: 'collections.abc.AsyncIterable',
             typingImportOnly: true,
@@ -96,7 +96,7 @@ export const deprecatedAliases = new Map<string, DeprecatedForm>([
     [
         'AsyncIterator',
         {
-            version: PythonVersion.V3_9,
+            version: pythonVersion3_9,
             fullName: 'typing.AsyncIterator',
             replacementText: 'collections.abc.AsyncIterator',
             typingImportOnly: true,
@@ -105,7 +105,7 @@ export const deprecatedAliases = new Map<string, DeprecatedForm>([
     [
         'AsyncGenerator',
         {
-            version: PythonVersion.V3_9,
+            version: pythonVersion3_9,
             fullName: 'typing.AsyncGenerator',
             replacementText: 'collections.abc.AsyncGenerator',
             typingImportOnly: true,
@@ -114,7 +114,7 @@ export const deprecatedAliases = new Map<string, DeprecatedForm>([
     [
         'Iterable',
         {
-            version: PythonVersion.V3_9,
+            version: pythonVersion3_9,
             fullName: 'typing.Iterable',
             replacementText: 'collections.abc.Iterable',
             typingImportOnly: true,
@@ -123,7 +123,7 @@ export const deprecatedAliases = new Map<string, DeprecatedForm>([
     [
         'Iterator',
         {
-            version: PythonVersion.V3_9,
+            version: pythonVersion3_9,
             fullName: 'typing.Iterator',
             replacementText: 'collections.abc.Iterator',
             typingImportOnly: true,
@@ -132,7 +132,7 @@ export const deprecatedAliases = new Map<string, DeprecatedForm>([
     [
         'Generator',
         {
-            version: PythonVersion.V3_9,
+            version: pythonVersion3_9,
             fullName: 'typing.Generator',
             replacementText: 'collections.abc.Generator',
             typingImportOnly: true,
@@ -141,7 +141,7 @@ export const deprecatedAliases = new Map<string, DeprecatedForm>([
     [
         'Reversible',
         {
-            version: PythonVersion.V3_9,
+            version: pythonVersion3_9,
             fullName: 'typing.Reversible',
             replacementText: 'collections.abc.Reversible',
             typingImportOnly: true,
@@ -150,7 +150,7 @@ export const deprecatedAliases = new Map<string, DeprecatedForm>([
     [
         'Container',
         {
-            version: PythonVersion.V3_9,
+            version: pythonVersion3_9,
             fullName: 'typing.Container',
             replacementText: 'collections.abc.Container',
             typingImportOnly: true,
@@ -159,7 +159,7 @@ export const deprecatedAliases = new Map<string, DeprecatedForm>([
     [
         'Collection',
         {
-            version: PythonVersion.V3_9,
+            version: pythonVersion3_9,
             fullName: 'typing.Collection',
             replacementText: 'collections.abc.Collection',
             typingImportOnly: true,
@@ -168,7 +168,7 @@ export const deprecatedAliases = new Map<string, DeprecatedForm>([
     [
         'AbstractSet',
         {
-            version: PythonVersion.V3_9,
+            version: pythonVersion3_9,
             fullName: 'typing.AbstractSet',
             replacementText: 'collections.abc.Set',
         },
@@ -176,7 +176,7 @@ export const deprecatedAliases = new Map<string, DeprecatedForm>([
     [
         'MutableSet',
         {
-            version: PythonVersion.V3_9,
+            version: pythonVersion3_9,
             fullName: 'typing.MutableSet',
             replacementText: 'collections.abc.MutableSet',
             typingImportOnly: true,
@@ -185,7 +185,7 @@ export const deprecatedAliases = new Map<string, DeprecatedForm>([
     [
         'Mapping',
         {
-            version: PythonVersion.V3_9,
+            version: pythonVersion3_9,
             fullName: 'typing.Mapping',
             replacementText: 'collections.abc.Mapping',
             typingImportOnly: true,
@@ -194,7 +194,7 @@ export const deprecatedAliases = new Map<string, DeprecatedForm>([
     [
         'MutableMapping',
         {
-            version: PythonVersion.V3_9,
+            version: pythonVersion3_9,
             fullName: 'typing.MutableMapping',
             replacementText: 'collections.abc.MutableMapping',
             typingImportOnly: true,
@@ -203,7 +203,7 @@ export const deprecatedAliases = new Map<string, DeprecatedForm>([
     [
         'Sequence',
         {
-            version: PythonVersion.V3_9,
+            version: pythonVersion3_9,
             fullName: 'typing.Sequence',
             replacementText: 'collections.abc.Sequence',
             typingImportOnly: true,
@@ -212,7 +212,7 @@ export const deprecatedAliases = new Map<string, DeprecatedForm>([
     [
         'MutableSequence',
         {
-            version: PythonVersion.V3_9,
+            version: pythonVersion3_9,
             fullName: 'typing.MutableSequence',
             replacementText: 'collections.abc.MutableSequence',
             typingImportOnly: true,
@@ -221,7 +221,7 @@ export const deprecatedAliases = new Map<string, DeprecatedForm>([
     [
         'ByteString',
         {
-            version: PythonVersion.V3_9,
+            version: pythonVersion3_9,
             fullName: 'typing.ByteString',
             replacementText: 'collections.abc.ByteString',
             typingImportOnly: true,
@@ -230,7 +230,7 @@ export const deprecatedAliases = new Map<string, DeprecatedForm>([
     [
         'MappingView',
         {
-            version: PythonVersion.V3_9,
+            version: pythonVersion3_9,
             fullName: 'typing.MappingView',
             replacementText: 'collections.abc.MappingView',
             typingImportOnly: true,
@@ -239,7 +239,7 @@ export const deprecatedAliases = new Map<string, DeprecatedForm>([
     [
         'KeysView',
         {
-            version: PythonVersion.V3_9,
+            version: pythonVersion3_9,
             fullName: 'typing.KeysView',
             replacementText: 'collections.abc.KeysView',
             typingImportOnly: true,
@@ -248,7 +248,7 @@ export const deprecatedAliases = new Map<string, DeprecatedForm>([
     [
         'ItemsView',
         {
-            version: PythonVersion.V3_9,
+            version: pythonVersion3_9,
             fullName: 'typing.ItemsView',
             replacementText: 'collections.abc.ItemsView',
             typingImportOnly: true,
@@ -257,7 +257,7 @@ export const deprecatedAliases = new Map<string, DeprecatedForm>([
     [
         'ValuesView',
         {
-            version: PythonVersion.V3_9,
+            version: pythonVersion3_9,
             fullName: 'typing.ValuesView',
             replacementText: 'collections.abc.ValuesView',
             typingImportOnly: true,
@@ -266,7 +266,7 @@ export const deprecatedAliases = new Map<string, DeprecatedForm>([
     [
         'ContextManager',
         {
-            version: PythonVersion.V3_9,
+            version: pythonVersion3_9,
             fullName: 'contextlib.AbstractContextManager',
             replacementText: 'contextlib.AbstractContextManager',
             typingImportOnly: true,
@@ -275,7 +275,7 @@ export const deprecatedAliases = new Map<string, DeprecatedForm>([
     [
         'AsyncContextManager',
         {
-            version: PythonVersion.V3_9,
+            version: pythonVersion3_9,
             fullName: 'contextlib.AbstractAsyncContextManager',
             replacementText: 'contextlib.AbstractAsyncContextManager',
             typingImportOnly: true,
@@ -284,7 +284,7 @@ export const deprecatedAliases = new Map<string, DeprecatedForm>([
     [
         'Pattern',
         {
-            version: PythonVersion.V3_9,
+            version: pythonVersion3_9,
             fullName: 're.Pattern',
             replacementText: 're.Pattern',
             typingImportOnly: true,
@@ -293,7 +293,7 @@ export const deprecatedAliases = new Map<string, DeprecatedForm>([
     [
         'Match',
         {
-            version: PythonVersion.V3_9,
+            version: pythonVersion3_9,
             fullName: 're.Match',
             replacementText: 're.Match',
             typingImportOnly: true,
@@ -302,12 +302,12 @@ export const deprecatedAliases = new Map<string, DeprecatedForm>([
 ]);
 
 export const deprecatedSpecialForms = new Map<string, DeprecatedForm>([
-    ['Optional', { version: PythonVersion.V3_10, fullName: 'typing.Optional', replacementText: '| None' }],
-    ['Union', { version: PythonVersion.V3_10, fullName: 'typing.Union', replacementText: '|' }],
+    ['Optional', { version: pythonVersion3_10, fullName: 'typing.Optional', replacementText: '| None' }],
+    ['Union', { version: pythonVersion3_10, fullName: 'typing.Union', replacementText: '|' }],
     [
         'Callable',
         {
-            version: PythonVersion.V3_9,
+            version: pythonVersion3_9,
             fullName: 'typing.Callable',
             replacementText: 'collections.abc.Callable',
             typingImportOnly: true,

--- a/packages/pyright-internal/src/analyzer/importResolver.ts
+++ b/packages/pyright-internal/src/analyzer/importResolver.ts
@@ -15,7 +15,7 @@ import { ConfigOptions, ExecutionEnvironment, matchFileSpecs } from '../common/c
 import { Host } from '../common/host';
 import { stubsSuffix } from '../common/pathConsts';
 import { stripFileExtension } from '../common/pathUtils';
-import { PythonVersion, versionFromString } from '../common/pythonVersion';
+import { PythonVersion, pythonVersion3_0 } from '../common/pythonVersion';
 import { ServiceProvider } from '../common/serviceProvider';
 import { ServiceKeys } from '../common/serviceProviderExtensions';
 import * as StringUtils from '../common/stringUtils';
@@ -471,7 +471,7 @@ export class ImportResolver {
         this._cachedTypeshedStdLibModuleVersionInfo.forEach((versionInfo, moduleName) => {
             let shouldExcludeModule = false;
 
-            if (versionInfo.max !== undefined && pythonVersion > versionInfo.max) {
+            if (versionInfo.max !== undefined && pythonVersion.isGreaterThan(versionInfo.max)) {
                 shouldExcludeModule = true;
             }
 
@@ -2062,11 +2062,11 @@ export class ImportResolver {
             const versionInfo = this._cachedTypeshedStdLibModuleVersionInfo.get(namePartsToConsider.join('.'));
 
             if (versionInfo) {
-                if (pythonVersion < versionInfo.min) {
+                if (pythonVersion.isLessThan(versionInfo.min)) {
                     return false;
                 }
 
-                if (versionInfo.max !== undefined && pythonVersion > versionInfo.max) {
+                if (versionInfo.max !== undefined && pythonVersion.isGreaterThan(versionInfo.max)) {
                     return false;
                 }
 
@@ -2137,14 +2137,14 @@ export class ImportResolver {
                             // If the version ends in "+", strip it off.
                             minVersionString = minVersionString.substr(0, minVersionString.length - 1);
                         }
-                        let minVersion = versionFromString(minVersionString);
+                        let minVersion = PythonVersion.fromString(minVersionString);
                         if (!minVersion) {
-                            minVersion = PythonVersion.V3_0;
+                            minVersion = pythonVersion3_0;
                         }
 
                         let maxVersion: PythonVersion | undefined;
                         if (versionSplit.length > 1) {
-                            maxVersion = versionFromString(versionSplit[1].trim());
+                            maxVersion = PythonVersion.fromString(versionSplit[1].trim());
                         }
 
                         // A semicolon can be followed by a semicolon-delimited list of other

--- a/packages/pyright-internal/src/analyzer/operations.ts
+++ b/packages/pyright-internal/src/analyzer/operations.ts
@@ -10,7 +10,7 @@
 
 import { DiagnosticAddendum } from '../common/diagnostic';
 import { DiagnosticRule } from '../common/diagnosticRules';
-import { PythonVersion } from '../common/pythonVersion';
+import { pythonVersion3_10 } from '../common/pythonVersion';
 import { LocMessage } from '../localization/localize';
 import {
     AugmentedAssignmentNode,
@@ -621,7 +621,7 @@ export function getTypeOfBinaryOperation(
             const unionNotationSupported =
                 fileInfo.isStubFile ||
                 (flags & EvaluatorFlags.AllowForwardReferences) !== 0 ||
-                fileInfo.executionEnvironment.pythonVersion >= PythonVersion.V3_10;
+                fileInfo.executionEnvironment.pythonVersion.isGreaterOrEqualTo(pythonVersion3_10);
             if (!unionNotationSupported) {
                 // If the left type is Any, we can't say for sure whether this
                 // is an illegal syntax or a valid application of the "|" operator.

--- a/packages/pyright-internal/src/analyzer/pythonPathUtils.ts
+++ b/packages/pyright-internal/src/analyzer/pythonPathUtils.ts
@@ -12,7 +12,7 @@ import { compareComparableValues } from '../common/core';
 import { FileSystem } from '../common/fileSystem';
 import { Host } from '../common/host';
 import * as pathConsts from '../common/pathConsts';
-import { PythonVersion, versionToString } from '../common/pythonVersion';
+import { PythonVersion } from '../common/pythonVersion';
 import { Uri } from '../common/uri/uri';
 import { getFileSystemEntries, isDirectory, tryStat } from '../common/uri/uriUtils';
 
@@ -156,7 +156,7 @@ function findSitePackagesPath(
     // version), prefer that over other python directories.
     if (pythonVersion) {
         const preferredDir = candidateDirs.find(
-            (dirName) => dirName.fileName === `python${versionToString(pythonVersion)}`
+            (dirName) => dirName.fileName === `python${pythonVersion.toMajorMinorString()}`
         );
         if (preferredDir) {
             const dirPath = preferredDir.combinePaths(pathConsts.sitePackages);

--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -24,7 +24,13 @@ import { assert, assertNever, fail } from '../common/debug';
 import { DiagnosticAddendum } from '../common/diagnostic';
 import { DiagnosticRule } from '../common/diagnosticRules';
 import { convertOffsetToPosition, convertOffsetsToRange } from '../common/positionUtils';
-import { PythonVersion } from '../common/pythonVersion';
+import {
+    PythonVersion,
+    pythonVersion3_13,
+    pythonVersion3_6,
+    pythonVersion3_7,
+    pythonVersion3_9,
+} from '../common/pythonVersion';
 import { TextRange } from '../common/textRange';
 import { Uri } from '../common/uri/uri';
 import { LocAddendum, LocMessage, ParameterizedString } from '../localization/localize';
@@ -424,21 +430,21 @@ interface ValidateArgTypeOptions {
 // It lists the first version of Python where subscripting is
 // allowed.
 const nonSubscriptableBuiltinTypes: Map<string, PythonVersion> = new Map([
-    ['asyncio.futures.Future', PythonVersion.V3_9],
-    ['asyncio.tasks.Task', PythonVersion.V3_9],
-    ['builtins.dict', PythonVersion.V3_9],
-    ['builtins.frozenset', PythonVersion.V3_9],
-    ['builtins.list', PythonVersion.V3_9],
-    ['builtins._PathLike', PythonVersion.V3_9],
-    ['builtins.set', PythonVersion.V3_9],
-    ['builtins.tuple', PythonVersion.V3_9],
-    ['collections.ChainMap', PythonVersion.V3_9],
-    ['collections.Counter', PythonVersion.V3_9],
-    ['collections.defaultdict', PythonVersion.V3_9],
-    ['collections.DefaultDict', PythonVersion.V3_9],
-    ['collections.deque', PythonVersion.V3_9],
-    ['collections.OrderedDict', PythonVersion.V3_9],
-    ['queue.Queue', PythonVersion.V3_9],
+    ['asyncio.futures.Future', pythonVersion3_9],
+    ['asyncio.tasks.Task', pythonVersion3_9],
+    ['builtins.dict', pythonVersion3_9],
+    ['builtins.frozenset', pythonVersion3_9],
+    ['builtins.list', pythonVersion3_9],
+    ['builtins._PathLike', pythonVersion3_9],
+    ['builtins.set', pythonVersion3_9],
+    ['builtins.tuple', pythonVersion3_9],
+    ['collections.ChainMap', pythonVersion3_9],
+    ['collections.Counter', pythonVersion3_9],
+    ['collections.defaultdict', pythonVersion3_9],
+    ['collections.DefaultDict', pythonVersion3_9],
+    ['collections.deque', pythonVersion3_9],
+    ['collections.OrderedDict', pythonVersion3_9],
+    ['queue.Queue', pythonVersion3_9],
 ]);
 
 // Some types that do not inherit from others are still considered
@@ -5379,7 +5385,7 @@ export function createTypeEvaluator(importLookup: ImportLookup, evaluatorOptions
                         const getAttrSymbol = ModuleType.getField(baseType, '__getattr__');
                         if (getAttrSymbol) {
                             const isModuleGetAttrSupported =
-                                fileInfo.executionEnvironment.pythonVersion >= PythonVersion.V3_7 ||
+                                fileInfo.executionEnvironment.pythonVersion.isGreaterOrEqualTo(pythonVersion3_7) ||
                                 getAttrSymbol.getDeclarations().some((decl) => decl.uri.hasExtension('.pyi'));
 
                             if (isModuleGetAttrSupported) {
@@ -6359,7 +6365,7 @@ export function createTypeEvaluator(importLookup: ImportLookup, evaluatorOptions
                     const minPythonVersion = nonSubscriptableBuiltinTypes.get(baseTypeResult.type.details.fullName);
                     if (
                         minPythonVersion !== undefined &&
-                        fileInfo.executionEnvironment.pythonVersion < minPythonVersion &&
+                        fileInfo.executionEnvironment.pythonVersion.isLessThan(minPythonVersion) &&
                         !fileInfo.isStubFile
                     ) {
                         addError(
@@ -12254,7 +12260,7 @@ export function createTypeEvaluator(importLookup: ImportLookup, evaluatorOptions
                     const fileInfo = AnalyzerNodeInfo.getFileInfo(errorNode);
                     if (
                         !fileInfo.isStubFile &&
-                        fileInfo.executionEnvironment.pythonVersion < PythonVersion.V3_13 &&
+                        fileInfo.executionEnvironment.pythonVersion.isLessThan(pythonVersion3_13) &&
                         classType.details.moduleName !== 'typing_extensions'
                     ) {
                         addError(LocMessage.typeVarDefaultIllegal(), defaultValueNode!);
@@ -12396,7 +12402,7 @@ export function createTypeEvaluator(importLookup: ImportLookup, evaluatorOptions
                     const fileInfo = AnalyzerNodeInfo.getFileInfo(errorNode);
                     if (
                         !fileInfo.isStubFile &&
-                        fileInfo.executionEnvironment.pythonVersion < PythonVersion.V3_13 &&
+                        fileInfo.executionEnvironment.pythonVersion.isLessThan(pythonVersion3_13) &&
                         classType.details.moduleName !== 'typing_extensions'
                     ) {
                         addError(LocMessage.typeVarDefaultIllegal(), expr!);
@@ -12475,7 +12481,7 @@ export function createTypeEvaluator(importLookup: ImportLookup, evaluatorOptions
                     const fileInfo = AnalyzerNodeInfo.getFileInfo(errorNode);
                     if (
                         !fileInfo.isStubFile &&
-                        fileInfo.executionEnvironment.pythonVersion < PythonVersion.V3_13 &&
+                        fileInfo.executionEnvironment.pythonVersion.isLessThan(pythonVersion3_13) &&
                         classType.details.moduleName !== 'typing_extensions'
                     ) {
                         addError(LocMessage.typeVarDefaultIllegal(), expr!);
@@ -16194,7 +16200,7 @@ export function createTypeEvaluator(importLookup: ImportLookup, evaluatorOptions
                                 if (
                                     !fileInfo.isStubFile &&
                                     !ClassType.isTypingExtensionClass(argType) &&
-                                    fileInfo.executionEnvironment.pythonVersion < PythonVersion.V3_7
+                                    fileInfo.executionEnvironment.pythonVersion.isLessThan(pythonVersion3_7)
                                 ) {
                                     addError(LocMessage.protocolIllegal(), arg.valueExpression);
                                 }
@@ -16207,7 +16213,7 @@ export function createTypeEvaluator(importLookup: ImportLookup, evaluatorOptions
 
                             // If the class directly derives from NamedTuple (in Python 3.6 or
                             // newer), it's considered a (read-only) dataclass.
-                            if (fileInfo.executionEnvironment.pythonVersion >= PythonVersion.V3_6) {
+                            if (fileInfo.executionEnvironment.pythonVersion.isGreaterOrEqualTo(pythonVersion3_6)) {
                                 if (ClassType.isBuiltIn(argType, 'NamedTuple')) {
                                     classType.details.flags |=
                                         ClassTypeFlags.DataClass |
@@ -18642,7 +18648,10 @@ export function createTypeEvaluator(importLookup: ImportLookup, evaluatorOptions
 
                     // Handle PEP 562 support for module-level __getattr__ function,
                     // introduced in Python 3.7.
-                    if (fileInfo.executionEnvironment.pythonVersion >= PythonVersion.V3_7 || fileInfo.isStubFile) {
+                    if (
+                        fileInfo.executionEnvironment.pythonVersion.isGreaterOrEqualTo(pythonVersion3_7) ||
+                        fileInfo.isStubFile
+                    ) {
                         const getAttrSymbol = importLookupInfo.symbolTable.get('__getattr__');
                         if (getAttrSymbol) {
                             const getAttrType = getEffectiveTypeOfSymbol(getAttrSymbol);
@@ -19694,7 +19703,7 @@ export function createTypeEvaluator(importLookup: ImportLookup, evaluatorOptions
         const fileInfo = AnalyzerNodeInfo.getFileInfo(errorNode);
         if (
             fileInfo.isStubFile ||
-            fileInfo.executionEnvironment.pythonVersion >= PythonVersion.V3_9 ||
+            fileInfo.executionEnvironment.pythonVersion.isGreaterOrEqualTo(pythonVersion3_9) ||
             isAnnotationEvaluationPostponed(AnalyzerNodeInfo.getFileInfo(errorNode)) ||
             (flags & EvaluatorFlags.AllowForwardReferences) !== 0
         ) {

--- a/packages/pyright-internal/src/common/configOptions.ts
+++ b/packages/pyright-internal/src/common/configOptions.ts
@@ -18,7 +18,7 @@ import { TaskListToken } from './diagnostic';
 import { DiagnosticRule } from './diagnosticRules';
 import { FileSystem } from './fileSystem';
 import { Host } from './host';
-import { PythonVersion, latestStablePythonVersion, versionFromString, versionToString } from './pythonVersion';
+import { PythonVersion, latestStablePythonVersion } from './pythonVersion';
 import { ServiceProvider } from './serviceProvider';
 import { ServiceKeys } from './serviceProviderExtensions';
 import { Uri } from './uri/uri';
@@ -58,7 +58,7 @@ export class ExecutionEnvironment {
     ) {
         this.name = name;
         this.root = root;
-        this.pythonVersion = defaultPythonVersion || latestStablePythonVersion;
+        this.pythonVersion = defaultPythonVersion ?? latestStablePythonVersion;
         this.pythonPlatform = defaultPythonPlatform;
         this.extraPaths = Array.from(defaultExtraPaths ?? []);
     }
@@ -1278,7 +1278,7 @@ export class ConfigOptions {
         // Read the default "pythonVersion".
         if (configObj.pythonVersion !== undefined) {
             if (typeof configObj.pythonVersion === 'string') {
-                const version = versionFromString(configObj.pythonVersion);
+                const version = PythonVersion.fromString(configObj.pythonVersion);
                 if (version) {
                     this.defaultPythonVersion = version;
                 } else {
@@ -1473,7 +1473,7 @@ export class ConfigOptions {
         const importFailureInfo: string[] = [];
         this.defaultPythonVersion = host.getPythonVersion(this.pythonPath, importFailureInfo);
         if (this.defaultPythonVersion !== undefined) {
-            console.info(`Assuming Python version ${versionToString(this.defaultPythonVersion)}`);
+            console.info(`Assuming Python version ${this.defaultPythonVersion.toString()}`);
         }
 
         for (const log of importFailureInfo) {
@@ -1596,7 +1596,7 @@ export class ConfigOptions {
             // Validate the pythonVersion.
             if (envObj.pythonVersion) {
                 if (typeof envObj.pythonVersion === 'string') {
-                    const version = versionFromString(envObj.pythonVersion);
+                    const version = PythonVersion.fromString(envObj.pythonVersion);
                     if (version) {
                         newExecEnv.pythonVersion = version;
                     } else {

--- a/packages/pyright-internal/src/common/pythonVersion.ts
+++ b/packages/pyright-internal/src/common/pythonVersion.ts
@@ -7,68 +7,200 @@
  * Types and functions that relate to the Python language version.
  */
 
-export enum PythonVersion {
-    // The order of this enumeration is significant. We assume
-    // that we can use comparison operators to check for older
-    // or newer versions.
-    V3_0 = 0x0300,
-    V3_1 = 0x0301,
-    V3_2 = 0x0302,
-    V3_3 = 0x0303,
-    V3_4 = 0x0304,
-    V3_5 = 0x0305,
-    V3_6 = 0x0306,
-    V3_7 = 0x0307,
-    V3_8 = 0x0308,
-    V3_9 = 0x0309,
-    V3_10 = 0x030a,
-    V3_11 = 0x030b,
-    V3_12 = 0x030c,
-    V3_13 = 0x030d,
-}
+export type PythonReleaseLevel = 'alpha' | 'beta' | 'candidate' | 'final';
 
-export const latestStablePythonVersion = PythonVersion.V3_12;
+export class PythonVersion {
+    constructor(
+        private _major: number,
+        private _minor: number,
+        private _micro?: number,
+        private _releaseLevel?: PythonReleaseLevel,
+        private _serial?: number
+    ) {}
 
-export function versionToString(version: PythonVersion): string {
-    const majorVersion = (version >> 8) & 0xff;
-    const minorVersion = version & 0xff;
-    return `${majorVersion}.${minorVersion}`;
-}
-
-export function versionFromString(verString: string): PythonVersion | undefined {
-    const split = verString.split('.');
-    if (split.length < 2) {
-        return undefined;
+    get major() {
+        return this._major;
     }
 
-    const majorVersion = parseInt(split[0], 10);
-    const minorVersion = parseInt(split[1], 10);
+    get minor() {
+        return this._minor;
+    }
 
-    return versionFromMajorMinor(majorVersion, minorVersion);
+    get micro() {
+        return this._micro;
+    }
+
+    get releaseLevel() {
+        return this._releaseLevel;
+    }
+
+    get serial() {
+        return this._serial;
+    }
+
+    isEqualTo(other: PythonVersion) {
+        if (this.major !== other.major || this.minor !== other.minor) {
+            return false;
+        }
+
+        if (this._micro === undefined || other._micro === undefined) {
+            return true;
+        } else if (this._micro !== other._micro) {
+            return false;
+        }
+
+        if (this._releaseLevel === undefined || other._releaseLevel === undefined) {
+            return true;
+        } else if (this._releaseLevel !== other._releaseLevel) {
+            return false;
+        }
+
+        if (this._serial === undefined || other._serial === undefined) {
+            return true;
+        } else if (this._serial !== other._serial) {
+            return false;
+        }
+
+        return true;
+    }
+
+    isGreaterThan(other: PythonVersion) {
+        if (this.major > other.major) {
+            return true;
+        } else if (this.major < other.major) {
+            return false;
+        }
+
+        if (this.minor > other.minor) {
+            return true;
+        } else if (this.minor < other.minor) {
+            return false;
+        }
+
+        if (this._micro === undefined || other._micro === undefined || this._micro < other._micro) {
+            return false;
+        } else if (this._micro > other._micro) {
+            return true;
+        }
+
+        // We leverage the fact that the alphabetical ordering
+        // of the release level designators are ordered by increasing
+        // release level.
+        if (
+            this._releaseLevel === undefined ||
+            other._releaseLevel === undefined ||
+            this._releaseLevel < other._releaseLevel
+        ) {
+            return false;
+        } else if (this._releaseLevel > other._releaseLevel) {
+            return true;
+        }
+
+        if (this._serial === undefined || other._serial === undefined || this._serial < other._serial) {
+            return false;
+        } else if (this._serial > other._serial) {
+            return true;
+        }
+
+        // They are exactly equal!
+        return false;
+    }
+
+    isGreaterOrEqualTo(other: PythonVersion) {
+        return this.isEqualTo(other) || this.isGreaterThan(other);
+    }
+
+    isLessThan(other: PythonVersion) {
+        return !this.isGreaterOrEqualTo(other);
+    }
+
+    isLessOrEqualTo(other: PythonVersion) {
+        return !this.isGreaterThan(other);
+    }
+
+    toMajorMinorString(): string {
+        return `${this._major}.${this._minor}`;
+    }
+
+    toString(): string {
+        let version = this.toMajorMinorString();
+
+        if (this._micro === undefined) {
+            return version;
+        }
+
+        version += `.${this._micro}`;
+
+        if (this._releaseLevel === undefined) {
+            return version;
+        }
+
+        version += `.${this._releaseLevel}`;
+
+        if (this._serial === undefined) {
+            return version;
+        }
+
+        version += `.${this._serial}`;
+        return version;
+    }
+
+    static fromString(val: string): PythonVersion | undefined {
+        const split = val.split('.');
+
+        if (split.length < 2) {
+            return undefined;
+        }
+
+        const major = parseInt(split[0], 10);
+        const minor = parseInt(split[1], 10);
+
+        if (isNaN(major) || isNaN(minor)) {
+            return undefined;
+        }
+
+        let micro: number | undefined;
+        if (split.length >= 3) {
+            micro = parseInt(split[2], 10);
+            if (isNaN(micro)) {
+                micro = undefined;
+            }
+        }
+
+        let releaseLevel: PythonReleaseLevel | undefined;
+        if (split.length >= 4) {
+            const releaseLevels: PythonReleaseLevel[] = ['alpha', 'beta', 'candidate', 'final'];
+            if (releaseLevels.some((level) => level === split[3])) {
+                releaseLevel = split[3] as PythonReleaseLevel;
+            }
+        }
+
+        let serial: number | undefined;
+        if (split.length >= 5) {
+            serial = parseInt(split[4], 10);
+            if (isNaN(serial)) {
+                serial = undefined;
+            }
+        }
+
+        return new PythonVersion(major, minor, micro, releaseLevel, serial);
+    }
 }
 
-export function versionFromMajorMinor(major: number, minor: number): PythonVersion | undefined {
-    if (isNaN(major) || isNaN(minor)) {
-        return undefined;
-    }
+// Predefine some versions.
+export const pythonVersion3_0 = new PythonVersion(3, 0);
+export const pythonVersion3_1 = new PythonVersion(3, 1);
+export const pythonVersion3_2 = new PythonVersion(3, 2);
+export const pythonVersion3_3 = new PythonVersion(3, 3);
+export const pythonVersion3_4 = new PythonVersion(3, 4);
+export const pythonVersion3_5 = new PythonVersion(3, 5);
+export const pythonVersion3_6 = new PythonVersion(3, 6);
+export const pythonVersion3_7 = new PythonVersion(3, 7);
+export const pythonVersion3_8 = new PythonVersion(3, 8);
+export const pythonVersion3_9 = new PythonVersion(3, 9);
+export const pythonVersion3_10 = new PythonVersion(3, 10);
+export const pythonVersion3_11 = new PythonVersion(3, 11);
+export const pythonVersion3_12 = new PythonVersion(3, 12);
+export const pythonVersion3_13 = new PythonVersion(3, 13);
 
-    if (major > 255 || minor > 255) {
-        return undefined;
-    }
-
-    const value = major * 256 + minor;
-    if (PythonVersion[value] === undefined) {
-        return undefined;
-    }
-
-    // Pyright currently supports only 3.x.
-    if (!is3x(value)) {
-        return undefined;
-    }
-
-    return value;
-}
-
-export function is3x(version: PythonVersion): boolean {
-    return version >> 8 === 3;
-}
+export const latestStablePythonVersion = pythonVersion3_12;

--- a/packages/pyright-internal/src/languageService/completionProvider.ts
+++ b/packages/pyright-internal/src/languageService/completionProvider.ts
@@ -79,7 +79,7 @@ import { fail } from '../common/debug';
 import { ProgramView } from '../common/extensibility';
 import { fromLSPAny, toLSPAny } from '../common/lspUtils';
 import { convertOffsetToPosition, convertPositionToOffset } from '../common/positionUtils';
-import { PythonVersion } from '../common/pythonVersion';
+import { PythonVersion, pythonVersion3_10, pythonVersion3_5 } from '../common/pythonVersion';
 import * as StringUtils from '../common/stringUtils';
 import { comparePositions, Position, TextRange } from '../common/textRange';
 import { TextRangeCollection } from '../common/textRangeCollection';
@@ -173,10 +173,10 @@ namespace Keywords {
     const python3_10: string[] = [...python3_5, 'case', 'match'];
 
     export function forVersion(version: PythonVersion): string[] {
-        if (version >= PythonVersion.V3_10) {
+        if (version.isGreaterOrEqualTo(pythonVersion3_10)) {
             return python3_10;
         }
-        if (version >= PythonVersion.V3_5) {
+        if (version.isGreaterOrEqualTo(pythonVersion3_5)) {
             return python3_5;
         }
         return base;

--- a/packages/pyright-internal/src/parser/parser.ts
+++ b/packages/pyright-internal/src/parser/parser.ts
@@ -17,7 +17,19 @@ import { assert } from '../common/debug';
 import { Diagnostic, DiagnosticAddendum } from '../common/diagnostic';
 import { DiagnosticSink } from '../common/diagnosticSink';
 import { convertOffsetsToRange } from '../common/positionUtils';
-import { PythonVersion, latestStablePythonVersion } from '../common/pythonVersion';
+import {
+    PythonVersion,
+    latestStablePythonVersion,
+    pythonVersion3_10,
+    pythonVersion3_11,
+    pythonVersion3_12,
+    pythonVersion3_13,
+    pythonVersion3_3,
+    pythonVersion3_5,
+    pythonVersion3_6,
+    pythonVersion3_8,
+    pythonVersion3_9,
+} from '../common/pythonVersion';
 import { TextRange } from '../common/textRange';
 import { TextRangeCollection } from '../common/textRangeCollection';
 import { timingStats } from '../common/timing';
@@ -455,7 +467,7 @@ export class Parser {
     private _parseTypeAliasStatement(): TypeAliasNode {
         const typeToken = this._getKeywordToken(KeywordType.Type);
 
-        if (!this._parseOptions.isStubFile && this._getLanguageVersion() < PythonVersion.V3_12) {
+        if (!this._parseOptions.isStubFile && this._getLanguageVersion().isLessThan(pythonVersion3_12)) {
             this._addSyntaxError(LocMessage.typeAliasStatementIllegal(), typeToken);
         }
 
@@ -555,7 +567,7 @@ export class Parser {
                 /* allowUnpack */ typeParamCategory === TypeParameterCategory.TypeVarTuple
             );
 
-            if (!this._parseOptions.isStubFile && this._getLanguageVersion() < PythonVersion.V3_13) {
+            if (!this._parseOptions.isStubFile && this._getLanguageVersion().isLessThan(pythonVersion3_13)) {
                 this._addSyntaxError(LocMessage.typeVarDefaultIllegal(), defaultExpression);
             }
         }
@@ -680,7 +692,7 @@ export class Parser {
         }
 
         // This feature requires Python 3.10.
-        if (this._getLanguageVersion() < PythonVersion.V3_10) {
+        if (this._getLanguageVersion().isLessThan(pythonVersion3_10)) {
             this._addSyntaxError(LocMessage.matchIncompatible(), matchToken);
         }
 
@@ -1603,7 +1615,7 @@ export class Parser {
 
             // Versions of Python earlier than 3.9 didn't allow unpack operators if the
             // tuple wasn't enclosed in parentheses.
-            if (this._getLanguageVersion() < PythonVersion.V3_9 && !this._parseOptions.isStubFile) {
+            if (this._getLanguageVersion().isLessThan(pythonVersion3_9) && !this._parseOptions.isStubFile) {
                 if (seqExpr.nodeType === ParseNodeType.Tuple && !seqExpr.enclosedInParens) {
                     let sawStar = false;
                     seqExpr.expressions.forEach((expr) => {
@@ -1779,7 +1791,7 @@ export class Parser {
             const possibleStarToken = this._peekToken();
             let isExceptGroup = false;
             if (this._consumeTokenIfOperator(OperatorType.Multiply)) {
-                if (this._getLanguageVersion() < PythonVersion.V3_11 && !this._parseOptions.isStubFile) {
+                if (this._getLanguageVersion().isLessThan(pythonVersion3_11) && !this._parseOptions.isStubFile) {
                     this._addSyntaxError(LocMessage.exceptionGroupIncompatible(), possibleStarToken);
                 }
                 isExceptGroup = true;
@@ -1878,7 +1890,7 @@ export class Parser {
         if (possibleOpenBracket.type === TokenType.OpenBracket) {
             typeParameters = this._parseTypeParameterList();
 
-            if (!this._parseOptions.isStubFile && this._getLanguageVersion() < PythonVersion.V3_12) {
+            if (!this._parseOptions.isStubFile && this._getLanguageVersion().isLessThan(pythonVersion3_12)) {
                 this._addSyntaxError(LocMessage.functionTypeParametersIllegal(), typeParameters);
             }
         }
@@ -2092,7 +2104,7 @@ export class Parser {
         } else if (this._consumeTokenIfOperator(OperatorType.Power)) {
             starCount = 2;
         } else if (this._consumeTokenIfOperator(OperatorType.Divide)) {
-            if (this._getLanguageVersion() < PythonVersion.V3_8 && !this._parseOptions.isStubFile) {
+            if (this._getLanguageVersion().isLessThan(pythonVersion3_8) && !this._parseOptions.isStubFile) {
                 this._addSyntaxError(LocMessage.positionOnlyIncompatible(), firstToken);
             }
             slashCount = 1;
@@ -2196,7 +2208,7 @@ export class Parser {
 
         if (isParenthesizedWithItemList) {
             this._consumeTokenIfType(TokenType.OpenParenthesis);
-            if (this._getLanguageVersion() < PythonVersion.V3_9) {
+            if (this._getLanguageVersion().isLessThan(pythonVersion3_9)) {
                 this._addSyntaxError(LocMessage.parenthesizedContextManagerIllegal(), possibleParen);
             }
         }
@@ -2305,7 +2317,7 @@ export class Parser {
 
         // Versions of Python prior to 3.9 support a limited set of
         // expression forms.
-        if (this._getLanguageVersion() < PythonVersion.V3_9) {
+        if (this._getLanguageVersion().isLessThan(pythonVersion3_9)) {
             let isSupportedExpressionForm = false;
             if (this._isNameOrMemberAccessExpression(expression)) {
                 isSupportedExpressionForm = true;
@@ -2356,7 +2368,7 @@ export class Parser {
         if (possibleOpenBracket.type === TokenType.OpenBracket) {
             typeParameters = this._parseTypeParameterList();
 
-            if (!this._parseOptions.isStubFile && this._getLanguageVersion() < PythonVersion.V3_12) {
+            if (!this._parseOptions.isStubFile && this._getLanguageVersion().isLessThan(pythonVersion3_12)) {
                 this._addSyntaxError(LocMessage.classTypeParametersIllegal(), typeParameters);
             }
         }
@@ -2818,7 +2830,7 @@ export class Parser {
 
         const nextToken = this._peekToken();
         if (this._consumeTokenIfKeyword(KeywordType.From)) {
-            if (this._getLanguageVersion() < PythonVersion.V3_3) {
+            if (this._getLanguageVersion().isLessThan(pythonVersion3_3)) {
                 this._addSyntaxError(LocMessage.yieldFromIllegal(), nextToken);
             }
             return YieldFromNode.create(yieldToken, this._parseTestExpression(/* allowAssignmentExpression */ false));
@@ -3155,7 +3167,7 @@ export class Parser {
             this._addSyntaxError(LocMessage.walrusNotAllowed(), walrusToken);
         }
 
-        if (this._getLanguageVersion() < PythonVersion.V3_8) {
+        if (this._getLanguageVersion().isLessThan(pythonVersion3_8)) {
             this._addSyntaxError(LocMessage.walrusIllegal(), walrusToken);
         }
 
@@ -3448,7 +3460,7 @@ export class Parser {
         let awaitToken: KeywordToken | undefined;
         if (this._peekKeywordType() === KeywordType.Await) {
             awaitToken = this._getKeywordToken(KeywordType.Await);
-            if (this._getLanguageVersion() < PythonVersion.V3_5) {
+            if (this._getLanguageVersion().isLessThan(pythonVersion3_5)) {
                 this._addSyntaxError(LocMessage.awaitIllegal(), awaitToken);
             }
         }
@@ -3632,7 +3644,7 @@ export class Parser {
                     valueExpr = this._parseTestExpression(/* allowAssignmentExpression */ true);
 
                     // Python 3.10 and newer allow assignment expressions to be used inside of a subscript.
-                    if (!this._parseOptions.isStubFile && this._getLanguageVersion() < PythonVersion.V3_10) {
+                    if (!this._parseOptions.isStubFile && this._getLanguageVersion().isLessThan(pythonVersion3_10)) {
                         this._addSyntaxError(LocMessage.assignmentExprInSubscript(), valueExpr);
                     }
                 }
@@ -3659,7 +3671,7 @@ export class Parser {
                 const unpackListAllowed =
                     this._parseOptions.isStubFile ||
                     this._isParsingQuotedText ||
-                    this._getLanguageVersion() >= PythonVersion.V3_11;
+                    this._getLanguageVersion().isGreaterOrEqualTo(pythonVersion3_11);
 
                 if (argType === ArgumentCategory.UnpackedList && !unpackListAllowed) {
                     this._addSyntaxError(LocMessage.unpackedSubscriptIllegal(), argNode);
@@ -3713,7 +3725,7 @@ export class Parser {
             if (nextTokenType !== TokenType.Colon) {
                 // Python 3.10 and newer allow assignment expressions to be used inside of a subscript.
                 const allowAssignmentExpression =
-                    this._parseOptions.isStubFile || this._getLanguageVersion() >= PythonVersion.V3_10;
+                    this._parseOptions.isStubFile || this._getLanguageVersion().isGreaterOrEqualTo(pythonVersion3_10);
                 sliceExpressions[sliceIndex] = this._parseTestExpression(allowAssignmentExpression);
             }
             sliceIndex++;
@@ -4312,7 +4324,7 @@ export class Parser {
             annotationExpr = this._parseTypeAnnotation();
             leftExpr = TypeAnnotationNode.create(leftExpr, annotationExpr);
 
-            if (!this._parseOptions.isStubFile && this._getLanguageVersion() < PythonVersion.V3_6) {
+            if (!this._parseOptions.isStubFile && this._getLanguageVersion().isLessThan(pythonVersion3_6)) {
                 this._addSyntaxError(LocMessage.varAnnotationIllegal(), annotationExpr);
             }
 
@@ -4492,7 +4504,7 @@ export class Parser {
             allowUnpack &&
             !this._parseOptions.isStubFile &&
             !this._isParsingQuotedText &&
-            this._getLanguageVersion() < PythonVersion.V3_11
+            this._getLanguageVersion().isLessThan(pythonVersion3_11)
         ) {
             this._addSyntaxError(LocMessage.unpackedSubscriptIllegal(), startToken);
         }
@@ -4520,7 +4532,7 @@ export class Parser {
         }
 
         if (stringToken.flags & StringTokenFlags.Format) {
-            if (this._getLanguageVersion() < PythonVersion.V3_6) {
+            if (this._getLanguageVersion().isLessThan(pythonVersion3_6)) {
                 this._addSyntaxError(LocMessage.formatStringIllegal(), stringToken);
             }
 
@@ -4675,7 +4687,7 @@ export class Parser {
             (nextToken as OperatorToken).operatorType === OperatorType.Assign
         ) {
             // This feature requires Python 3.8 or newer.
-            if (this._parseOptions.pythonVersion < PythonVersion.V3_8) {
+            if (this._parseOptions.pythonVersion.isLessThan(pythonVersion3_8)) {
                 this._addSyntaxError(LocMessage.formatStringDebuggingIllegal(), nextToken);
             }
 
@@ -4924,7 +4936,7 @@ export class Parser {
             return;
         }
 
-        if (this._parseOptions.pythonVersion >= PythonVersion.V3_8) {
+        if (this._parseOptions.pythonVersion.isGreaterOrEqualTo(pythonVersion3_8)) {
             return;
         }
 

--- a/packages/pyright-internal/src/pyright.ts
+++ b/packages/pyright-internal/src/pyright.ts
@@ -29,7 +29,7 @@ import { Diagnostic, DiagnosticCategory, compareDiagnostics } from './common/dia
 import { FileDiagnostics } from './common/diagnosticSink';
 import { FullAccessHost } from './common/fullAccessHost';
 import { combinePaths, normalizePath } from './common/pathUtils';
-import { versionFromString } from './common/pythonVersion';
+import { PythonVersion } from './common/pythonVersion';
 import { RealTempFile, createFromRealFileSystem } from './common/realFileSystem';
 import { ServiceProvider } from './common/serviceProvider';
 import { createServiceProvider } from './common/serviceProviderExtensions';
@@ -286,7 +286,7 @@ async function processArgs(): Promise<ExitStatus> {
     }
 
     if (args.pythonversion) {
-        const version = versionFromString(args.pythonversion);
+        const version = PythonVersion.fromString(args.pythonversion);
         if (version) {
             options.pythonVersion = version;
         } else {

--- a/packages/pyright-internal/src/tests/checker.test.ts
+++ b/packages/pyright-internal/src/tests/checker.test.ts
@@ -10,7 +10,7 @@
  */
 
 import { ConfigOptions } from '../common/configOptions';
-import { PythonVersion } from '../common/pythonVersion';
+import { pythonVersion3_10, pythonVersion3_8, pythonVersion3_9 } from '../common/pythonVersion';
 import { Uri } from '../common/uri/uri';
 import * as TestUtils from './testUtils';
 
@@ -171,11 +171,11 @@ test('With3', () => {
 test('With4', () => {
     const configOptions = new ConfigOptions(Uri.empty());
 
-    configOptions.defaultPythonVersion = PythonVersion.V3_8;
+    configOptions.defaultPythonVersion = pythonVersion3_8;
     const analysisResults1 = TestUtils.typeAnalyzeSampleFiles(['with4.py'], configOptions);
     TestUtils.validateResults(analysisResults1, 4);
 
-    configOptions.defaultPythonVersion = PythonVersion.V3_9;
+    configOptions.defaultPythonVersion = pythonVersion3_9;
     const analysisResults2 = TestUtils.typeAnalyzeSampleFiles(['with4.py'], configOptions);
     TestUtils.validateResults(analysisResults2, 0);
 });
@@ -499,45 +499,45 @@ test('UninitializedVariable2', () => {
 test('Deprecated1', () => {
     const configOptions = new ConfigOptions(Uri.empty());
 
-    configOptions.defaultPythonVersion = PythonVersion.V3_8;
+    configOptions.defaultPythonVersion = pythonVersion3_8;
     const analysisResults1 = TestUtils.typeAnalyzeSampleFiles(['deprecated1.py'], configOptions);
     TestUtils.validateResults(analysisResults1, 0, 0, 0, undefined, undefined, 0);
 
-    configOptions.defaultPythonVersion = PythonVersion.V3_9;
+    configOptions.defaultPythonVersion = pythonVersion3_9;
     const analysisResults2 = TestUtils.typeAnalyzeSampleFiles(['deprecated1.py'], configOptions);
     TestUtils.validateResults(analysisResults2, 0, 0, 0, undefined, undefined, 0);
 
-    configOptions.defaultPythonVersion = PythonVersion.V3_10;
+    configOptions.defaultPythonVersion = pythonVersion3_10;
     const analysisResults3 = TestUtils.typeAnalyzeSampleFiles(['deprecated1.py'], configOptions);
     TestUtils.validateResults(analysisResults3, 0, 0, 0, undefined, undefined, 0);
 
     // Now enable the deprecateTypingAliases setting.
     configOptions.diagnosticRuleSet.deprecateTypingAliases = true;
 
-    configOptions.defaultPythonVersion = PythonVersion.V3_8;
+    configOptions.defaultPythonVersion = pythonVersion3_8;
     const analysisResults4 = TestUtils.typeAnalyzeSampleFiles(['deprecated1.py'], configOptions);
     TestUtils.validateResults(analysisResults4, 0, 0, 0, undefined, undefined, 0);
 
-    configOptions.defaultPythonVersion = PythonVersion.V3_9;
+    configOptions.defaultPythonVersion = pythonVersion3_9;
     const analysisResults5 = TestUtils.typeAnalyzeSampleFiles(['deprecated1.py'], configOptions);
     TestUtils.validateResults(analysisResults5, 0, 0, 0, undefined, undefined, 45);
 
-    configOptions.defaultPythonVersion = PythonVersion.V3_10;
+    configOptions.defaultPythonVersion = pythonVersion3_10;
     const analysisResults6 = TestUtils.typeAnalyzeSampleFiles(['deprecated1.py'], configOptions);
     TestUtils.validateResults(analysisResults6, 0, 0, 0, undefined, undefined, 49);
 
     // Now change reportDeprecated to emit an error.
     configOptions.diagnosticRuleSet.reportDeprecated = 'error';
 
-    configOptions.defaultPythonVersion = PythonVersion.V3_8;
+    configOptions.defaultPythonVersion = pythonVersion3_8;
     const analysisResults7 = TestUtils.typeAnalyzeSampleFiles(['deprecated1.py'], configOptions);
     TestUtils.validateResults(analysisResults7, 0, 0, 0, undefined, undefined, 0);
 
-    configOptions.defaultPythonVersion = PythonVersion.V3_9;
+    configOptions.defaultPythonVersion = pythonVersion3_9;
     const analysisResults8 = TestUtils.typeAnalyzeSampleFiles(['deprecated1.py'], configOptions);
     TestUtils.validateResults(analysisResults8, 45, 0, 0, undefined, undefined, 0);
 
-    configOptions.defaultPythonVersion = PythonVersion.V3_10;
+    configOptions.defaultPythonVersion = pythonVersion3_10;
     const analysisResults9 = TestUtils.typeAnalyzeSampleFiles(['deprecated1.py'], configOptions);
     TestUtils.validateResults(analysisResults9, 49, 0, 0, undefined, undefined, 0);
 });

--- a/packages/pyright-internal/src/tests/config.test.ts
+++ b/packages/pyright-internal/src/tests/config.test.ts
@@ -10,18 +10,18 @@
 import assert from 'assert';
 
 import { AnalyzerService } from '../analyzer/service';
+import { deserialize, serialize } from '../backgroundThreadBase';
 import { CommandLineOptions } from '../common/commandLineOptions';
 import { ConfigOptions, ExecutionEnvironment } from '../common/configOptions';
 import { ConsoleInterface, NullConsole } from '../common/console';
 import { NoAccessHost } from '../common/host';
 import { combinePaths, normalizePath, normalizeSlashes } from '../common/pathUtils';
-import { PythonVersion } from '../common/pythonVersion';
+import { pythonVersion3_9 } from '../common/pythonVersion';
 import { createFromRealFileSystem } from '../common/realFileSystem';
 import { createServiceProvider } from '../common/serviceProviderExtensions';
 import { Uri } from '../common/uri/uri';
 import { TestAccessHost } from './harness/testAccessHost';
 import { TestFileSystem } from './harness/vfs/filesystem';
-import { deserialize, serialize } from '../backgroundThreadBase';
 
 function createAnalyzer(console?: ConsoleInterface) {
     const cons = console ?? new NullConsole();
@@ -63,11 +63,11 @@ test('FindFilesVirtualEnvAutoDetectExclude', () => {
     service.setOptions(commandLineOptions);
 
     // The config file is empty, so no 'exclude' are specified
-    // The myvenv directory is detected as a venv and will be automatically excluded
+    // The myVenv directory is detected as a venv and will be automatically excluded
     const fileList = service.test_getFileNamesFromFileSpecs();
 
-    // There are 3 python files in the workspace, outside of myvenv
-    // There is 1 python file in myvenv, which should be excluded
+    // There are 3 python files in the workspace, outside of myVenv
+    // There is 1 python file in myVenv, which should be excluded
     const fileNames = fileList.map((p) => p.fileName).sort();
     assert.deepStrictEqual(fileNames, ['sample1.py', 'sample2.py', 'sample3.py']);
 });
@@ -83,9 +83,9 @@ test('FindFilesVirtualEnvAutoDetectInclude', () => {
     // Config file defines 'exclude' folder so virtual env will be included
     const fileList = service.test_getFileNamesFromFileSpecs();
 
-    // There are 3 python files in the workspace, outside of myvenv
+    // There are 3 python files in the workspace, outside of myVenv
     // There is 1 more python file in excluded folder
-    // There is 1 python file in myvenv, which should be included
+    // There is 1 python file in myVenv, which should be included
     const fileNames = fileList.map((p) => p.fileName).sort();
     assert.deepStrictEqual(fileNames, ['library1.py', 'sample1.py', 'sample2.py', 'sample3.py']);
 });
@@ -305,7 +305,7 @@ test('BasicPyprojectTomlParsing', () => {
     service.setOptions(commandLineOptions);
 
     const configOptions = service.test_getConfigOptions(commandLineOptions);
-    assert.strictEqual(configOptions.defaultPythonVersion!, PythonVersion.V3_9);
+    assert.strictEqual(configOptions.defaultPythonVersion!.toString(), pythonVersion3_9.toString());
     assert.strictEqual(configOptions.diagnosticRuleSet.reportMissingImports, 'error');
     assert.strictEqual(configOptions.diagnosticRuleSet.reportUnusedClass, 'warning');
 });

--- a/packages/pyright-internal/src/tests/fourSlashParser.test.ts
+++ b/packages/pyright-internal/src/tests/fourSlashParser.test.ts
@@ -128,7 +128,7 @@ test('Marker', () => {
 });
 
 test('MarkerWithData', () => {
-    // embeded json data
+    // embedded json data
     const code = `
 ////class A:
 ////    {| "data1":"1", "data2":"2" |}pass
@@ -147,7 +147,7 @@ test('MarkerWithData', () => {
 });
 
 test('MarkerWithDataAndName', () => {
-    // embeded json data with "name"
+    // embedded json data with "name"
     const code = `
 ////class A:
 ////    {| "name": "marker1", "data1":"1", "data2":"2" |}pass

--- a/packages/pyright-internal/src/tests/languageServer.test.ts
+++ b/packages/pyright-internal/src/tests/languageServer.test.ts
@@ -17,7 +17,7 @@ import {
 } from 'vscode-languageserver';
 
 import { convertOffsetToPosition } from '../common/positionUtils';
-import { PythonVersion } from '../common/pythonVersion';
+import { PythonVersion, pythonVersion3_10 } from '../common/pythonVersion';
 
 import { isArray } from '../common/core';
 import { normalizeSlashes } from '../common/pathUtils';
@@ -40,7 +40,7 @@ describe(`Basic language server tests`, () => {
         code: string,
         callInitialize = true,
         extraSettings?: { item: ConfigurationItem; value: any }[],
-        pythonVersion: PythonVersion = PythonVersion.V3_10,
+        pythonVersion: PythonVersion = pythonVersion3_10,
         supportsBackgroundThread?: boolean
     ) {
         const result = await runPyrightServer(

--- a/packages/pyright-internal/src/tests/lsp/customLsp.ts
+++ b/packages/pyright-internal/src/tests/lsp/customLsp.ts
@@ -131,7 +131,7 @@ export namespace CustomLSP {
         logFile: Uri; // Helpful for debugging
         code: string; // Fourslash data.
         projectRoots: Uri[];
-        pythonVersion: number;
+        pythonVersion: string;
         backgroundAnalysis?: boolean;
     }
 

--- a/packages/pyright-internal/src/tests/lsp/languageServer.ts
+++ b/packages/pyright-internal/src/tests/lsp/languageServer.ts
@@ -31,6 +31,7 @@ import { BackgroundAnalysis, BackgroundAnalysisRunner } from '../../backgroundAn
 import { BackgroundAnalysisBase } from '../../backgroundAnalysisBase';
 import { serialize } from '../../backgroundThreadBase';
 import { FileSystem } from '../../common/fileSystem';
+import { PythonVersion } from '../../common/pythonVersion';
 import { ServiceKeys } from '../../common/serviceProviderExtensions';
 import { ServerSettings } from '../../languageServerBase';
 import { PyrightFileSystem } from '../../pyrightFileSystem';
@@ -112,7 +113,7 @@ function createTestHost(testServerData: CustomLSP.TestServerStartOptions) {
     ) => {
         return { stdout: scriptOutput, stderr: '', exitCode: 0 };
     };
-    const options = new TestHostOptions({ version: testServerData.pythonVersion, runScript });
+    const options = new TestHostOptions({ version: PythonVersion.fromString(testServerData.pythonVersion), runScript });
     const projectRootPaths = testServerData.projectRoots.map((p) => getFileLikePath(p));
     const testData = parseTestData(
         testServerData.projectRoots.length === 1 ? projectRootPaths[0] : DEFAULT_WORKSPACE_ROOT,

--- a/packages/pyright-internal/src/tests/lsp/languageServerTestUtils.ts
+++ b/packages/pyright-internal/src/tests/lsp/languageServerTestUtils.ts
@@ -60,7 +60,7 @@ import { LimitedAccessHost } from '../../common/fullAccessHost';
 import { HostKind, ScriptOutput } from '../../common/host';
 import { combinePaths, resolvePaths } from '../../common/pathUtils';
 import { convertOffsetToPosition } from '../../common/positionUtils';
-import { PythonVersion } from '../../common/pythonVersion';
+import { PythonVersion, pythonVersion3_10 } from '../../common/pythonVersion';
 import { FileUri } from '../../common/uri/fileUri';
 import { Uri } from '../../common/uri/uri';
 import { ParseOptions, Parser } from '../../parser/parser';
@@ -124,7 +124,7 @@ export class TestHostOptions {
     ) => Promise<ScriptOutput>;
 
     constructor({
-        version = PythonVersion.V3_10,
+        version = pythonVersion3_10,
         platform = PythonPlatform.Linux,
         searchPaths = [libFolder, distlibFolder],
         runScript = async (
@@ -237,7 +237,7 @@ export function getParseResults(fileContents: string, isStubFile = false, ipytho
     const parseOptions = new ParseOptions();
     parseOptions.ipythonMode = ipythonMode;
     parseOptions.isStubFile = isStubFile;
-    parseOptions.pythonVersion = PythonVersion.V3_10;
+    parseOptions.pythonVersion = pythonVersion3_10;
     parseOptions.skipFunctionAndClassBody = false;
 
     // Parse the token stream, building the abstract syntax tree.
@@ -325,7 +325,7 @@ export async function runPyrightServer(
     code: string,
     callInitialize = true,
     extraSettings?: { item: ConfigurationItem; value: any }[],
-    pythonVersion: PythonVersion = PythonVersion.V3_10,
+    pythonVersion: PythonVersion = pythonVersion3_10,
     backgroundAnalysis?: boolean
 ): Promise<PyrightServerInfo> {
     // Normalize the URIs for all of the settings.
@@ -341,7 +341,7 @@ export async function runPyrightServer(
         testName: expect.getState().currentTestName ?? 'NoName',
         code,
         projectRoots: projectRootsArray.map((p) => (p.includes(':') ? Uri.parse(p, true) : Uri.file(p))),
-        pythonVersion,
+        pythonVersion: pythonVersion.toString(),
         backgroundAnalysis,
         logFile: Uri.file(path.join(__dirname, `log${process.pid}.txt`)),
         pid: process.pid.toString(),
@@ -410,10 +410,10 @@ export async function runPyrightServer(
             info.logs.push(p);
         }),
         info.connection.onRequest(SemanticTokensRefreshRequest.type, () => {
-            // empty. Sliently ignore for now.
+            // Empty. Silently ignore for now.
         }),
         info.connection.onRequest(InlayHintRefreshRequest.type, () => {
-            // empty. Sliently ignore for now.
+            // Empty. Silently ignore for now.
         }),
         info.connection.onRequest(ApplyWorkspaceEditRequest.type, (p) => {
             info.workspaceEdits.push(p);

--- a/packages/pyright-internal/src/tests/typeEvaluator1.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator1.test.ts
@@ -13,7 +13,13 @@ import * as assert from 'assert';
 import * as AnalyzerNodeInfo from '../analyzer/analyzerNodeInfo';
 import { ScopeType } from '../analyzer/scope';
 import { ConfigOptions } from '../common/configOptions';
-import { PythonVersion } from '../common/pythonVersion';
+import {
+    pythonVersion3_10,
+    pythonVersion3_11,
+    pythonVersion3_7,
+    pythonVersion3_8,
+    pythonVersion3_9,
+} from '../common/pythonVersion';
 import { Uri } from '../common/uri/uri';
 import * as TestUtils from './testUtils';
 
@@ -632,12 +638,12 @@ test('Unpack3', () => {
     const configOptions = new ConfigOptions(Uri.empty());
 
     // Analyze with Python 3.7 settings.
-    configOptions.defaultPythonVersion = PythonVersion.V3_7;
+    configOptions.defaultPythonVersion = pythonVersion3_7;
     const analysisResults37 = TestUtils.typeAnalyzeSampleFiles(['unpack3.py'], configOptions);
     TestUtils.validateResults(analysisResults37, 1);
 
     // Analyze with Python 3.8 settings.
-    configOptions.defaultPythonVersion = PythonVersion.V3_8;
+    configOptions.defaultPythonVersion = pythonVersion3_8;
     const analysisResults38 = TestUtils.typeAnalyzeSampleFiles(['unpack3.py'], configOptions);
     TestUtils.validateResults(analysisResults38, 0);
 });
@@ -646,12 +652,12 @@ test('Unpack4', () => {
     const configOptions = new ConfigOptions(Uri.empty());
 
     // Analyze with Python 3.8 settings.
-    configOptions.defaultPythonVersion = PythonVersion.V3_8;
+    configOptions.defaultPythonVersion = pythonVersion3_8;
     const analysisResults38 = TestUtils.typeAnalyzeSampleFiles(['unpack4.py'], configOptions);
     TestUtils.validateResults(analysisResults38, 2);
 
     // Analyze with Python 3.9 settings.
-    configOptions.defaultPythonVersion = PythonVersion.V3_9;
+    configOptions.defaultPythonVersion = pythonVersion3_9;
     const analysisResults39 = TestUtils.typeAnalyzeSampleFiles(['unpack4.py'], configOptions);
     TestUtils.validateResults(analysisResults39, 1);
 });
@@ -659,7 +665,7 @@ test('Unpack4', () => {
 test('Unpack4', () => {
     const configOptions = new ConfigOptions(Uri.empty());
 
-    configOptions.defaultPythonVersion = PythonVersion.V3_11;
+    configOptions.defaultPythonVersion = pythonVersion3_11;
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['unpack5.py'], configOptions);
     TestUtils.validateResults(analysisResults, 0);
 });
@@ -770,12 +776,12 @@ test('Call3', () => {
     const configOptions = new ConfigOptions(Uri.empty());
 
     // Analyze with Python 3.7 settings. This will generate more errors.
-    configOptions.defaultPythonVersion = PythonVersion.V3_7;
+    configOptions.defaultPythonVersion = pythonVersion3_7;
     const analysisResults37 = TestUtils.typeAnalyzeSampleFiles(['call3.py'], configOptions);
     TestUtils.validateResults(analysisResults37, 36);
 
     // Analyze with Python 3.8 settings.
-    configOptions.defaultPythonVersion = PythonVersion.V3_8;
+    configOptions.defaultPythonVersion = pythonVersion3_8;
     const analysisResults38 = TestUtils.typeAnalyzeSampleFiles(['call3.py'], configOptions);
     TestUtils.validateResults(analysisResults38, 20);
 });
@@ -1624,11 +1630,11 @@ test('TupleUnpack1', () => {
 test('TupleUnpack2', () => {
     const configOptions = new ConfigOptions(Uri.empty());
 
-    configOptions.defaultPythonVersion = PythonVersion.V3_10;
+    configOptions.defaultPythonVersion = pythonVersion3_10;
     const analysisResults1 = TestUtils.typeAnalyzeSampleFiles(['tupleUnpack2.py'], configOptions);
     TestUtils.validateResults(analysisResults1, 18);
 
-    configOptions.defaultPythonVersion = PythonVersion.V3_11;
+    configOptions.defaultPythonVersion = pythonVersion3_11;
     const analysisResults2 = TestUtils.typeAnalyzeSampleFiles(['tupleUnpack2.py'], configOptions);
     TestUtils.validateResults(analysisResults2, 4);
 });
@@ -1636,7 +1642,7 @@ test('TupleUnpack2', () => {
 test('TupleUnpack3', () => {
     const configOptions = new ConfigOptions(Uri.empty());
 
-    configOptions.defaultPythonVersion = PythonVersion.V3_11;
+    configOptions.defaultPythonVersion = pythonVersion3_11;
     const analysisResults1 = TestUtils.typeAnalyzeSampleFiles(['tupleUnpack3.py'], configOptions);
     TestUtils.validateResults(analysisResults1, 1);
 });
@@ -1716,13 +1722,13 @@ test('Dictionary4', () => {
 test('StaticExpression1', () => {
     const configOptions = new ConfigOptions(Uri.empty());
 
-    configOptions.defaultPythonVersion = PythonVersion.V3_8;
+    configOptions.defaultPythonVersion = pythonVersion3_8;
     configOptions.defaultPythonPlatform = 'windows';
 
     const analysisResults1 = TestUtils.typeAnalyzeSampleFiles(['staticExpression1.py'], configOptions);
     TestUtils.validateResults(analysisResults1, 9);
 
-    configOptions.defaultPythonVersion = PythonVersion.V3_11;
+    configOptions.defaultPythonVersion = pythonVersion3_11;
     configOptions.defaultPythonPlatform = 'Linux';
 
     const analysisResults2 = TestUtils.typeAnalyzeSampleFiles(['staticExpression1.py'], configOptions);

--- a/packages/pyright-internal/src/tests/typeEvaluator2.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator2.test.ts
@@ -9,7 +9,7 @@
  */
 
 import { ConfigOptions } from '../common/configOptions';
-import { PythonVersion } from '../common/pythonVersion';
+import { pythonVersion3_10, pythonVersion3_9 } from '../common/pythonVersion';
 import { Uri } from '../common/uri/uri';
 import * as TestUtils from './testUtils';
 
@@ -296,11 +296,11 @@ test('isInstance2', () => {
 test('isInstance3', () => {
     const configOptions = new ConfigOptions(Uri.empty());
 
-    configOptions.defaultPythonVersion = PythonVersion.V3_9;
+    configOptions.defaultPythonVersion = pythonVersion3_9;
     const analysisResults1 = TestUtils.typeAnalyzeSampleFiles(['isinstance3.py'], configOptions);
     TestUtils.validateResults(analysisResults1, 4);
 
-    configOptions.defaultPythonVersion = PythonVersion.V3_10;
+    configOptions.defaultPythonVersion = pythonVersion3_10;
     const analysisResults2 = TestUtils.typeAnalyzeSampleFiles(['isinstance3.py'], configOptions);
     TestUtils.validateResults(analysisResults2, 4);
 });

--- a/packages/pyright-internal/src/tests/typeEvaluator3.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator3.test.ts
@@ -9,7 +9,7 @@
  */
 
 import { ConfigOptions } from '../common/configOptions';
-import { PythonVersion } from '../common/pythonVersion';
+import { pythonVersion3_10, pythonVersion3_11, pythonVersion3_8, pythonVersion3_9 } from '../common/pythonVersion';
 import { Uri } from '../common/uri/uri';
 import * as TestUtils from './testUtils';
 
@@ -150,7 +150,7 @@ test('Coroutines1', () => {
 
     // This functionality is deprecated in Python 3.11, so the type no longer
     // exists in typing.pyi after that point.
-    configOptions.defaultPythonVersion = PythonVersion.V3_10;
+    configOptions.defaultPythonVersion = pythonVersion3_10;
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['coroutines1.py'], configOptions);
 
     TestUtils.validateResults(analysisResults, 4);
@@ -167,7 +167,7 @@ test('Coroutines3', () => {
 
     // This functionality is deprecated in Python 3.11, so the type no longer
     // exists in typing.pyi after that point.
-    configOptions.defaultPythonVersion = PythonVersion.V3_10;
+    configOptions.defaultPythonVersion = pythonVersion3_10;
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['coroutines3.py'], configOptions);
 
     TestUtils.validateResults(analysisResults, 0);
@@ -590,11 +590,11 @@ test('TypeAlias3', () => {
 test('TypeAlias4', () => {
     const configOptions = new ConfigOptions(Uri.empty());
 
-    configOptions.defaultPythonVersion = PythonVersion.V3_9;
+    configOptions.defaultPythonVersion = pythonVersion3_9;
     const analysisResults3_9 = TestUtils.typeAnalyzeSampleFiles(['typeAlias4.py'], configOptions);
     TestUtils.validateResults(analysisResults3_9, 1);
 
-    configOptions.defaultPythonVersion = PythonVersion.V3_10;
+    configOptions.defaultPythonVersion = pythonVersion3_10;
     const analysisResults3_10 = TestUtils.typeAnalyzeSampleFiles(['typeAlias4.py'], configOptions);
     TestUtils.validateResults(analysisResults3_10, 11);
 });
@@ -721,7 +721,7 @@ test('RecursiveTypeAlias2', () => {
 test('RecursiveTypeAlias3', () => {
     const configOptions = new ConfigOptions(Uri.empty());
 
-    configOptions.defaultPythonVersion = PythonVersion.V3_10;
+    configOptions.defaultPythonVersion = pythonVersion3_10;
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['recursiveTypeAlias3.py'], configOptions);
 
     TestUtils.validateResults(analysisResults, 4);
@@ -909,7 +909,7 @@ test('MethodOverride4', () => {
 test('MethodOverride5', () => {
     const configOptions = new ConfigOptions(Uri.empty());
 
-    configOptions.defaultPythonVersion = PythonVersion.V3_11;
+    configOptions.defaultPythonVersion = pythonVersion3_11;
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['methodOverride5.py'], configOptions);
     TestUtils.validateResults(analysisResults, 0);
 });
@@ -1065,7 +1065,7 @@ test('ProtocolModule4', () => {
 test('VariadicTypeVar1', () => {
     const configOptions = new ConfigOptions(Uri.empty());
 
-    configOptions.defaultPythonVersion = PythonVersion.V3_11;
+    configOptions.defaultPythonVersion = pythonVersion3_11;
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['variadicTypeVar1.py'], configOptions);
     TestUtils.validateResults(analysisResults, 19);
 });
@@ -1073,7 +1073,7 @@ test('VariadicTypeVar1', () => {
 test('VariadicTypeVar2', () => {
     const configOptions = new ConfigOptions(Uri.empty());
 
-    configOptions.defaultPythonVersion = PythonVersion.V3_11;
+    configOptions.defaultPythonVersion = pythonVersion3_11;
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['variadicTypeVar2.py'], configOptions);
     TestUtils.validateResults(analysisResults, 15);
 });
@@ -1081,7 +1081,7 @@ test('VariadicTypeVar2', () => {
 test('VariadicTypeVar3', () => {
     const configOptions = new ConfigOptions(Uri.empty());
 
-    configOptions.defaultPythonVersion = PythonVersion.V3_11;
+    configOptions.defaultPythonVersion = pythonVersion3_11;
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['variadicTypeVar3.py'], configOptions);
     TestUtils.validateResults(analysisResults, 5);
 });
@@ -1089,7 +1089,7 @@ test('VariadicTypeVar3', () => {
 test('VariadicTypeVar4', () => {
     const configOptions = new ConfigOptions(Uri.empty());
 
-    configOptions.defaultPythonVersion = PythonVersion.V3_11;
+    configOptions.defaultPythonVersion = pythonVersion3_11;
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['variadicTypeVar4.py'], configOptions);
     TestUtils.validateResults(analysisResults, 4);
 });
@@ -1097,7 +1097,7 @@ test('VariadicTypeVar4', () => {
 test('VariadicTypeVar5', () => {
     const configOptions = new ConfigOptions(Uri.empty());
 
-    configOptions.defaultPythonVersion = PythonVersion.V3_11;
+    configOptions.defaultPythonVersion = pythonVersion3_11;
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['variadicTypeVar5.py'], configOptions);
     TestUtils.validateResults(analysisResults, 9);
 });
@@ -1105,7 +1105,7 @@ test('VariadicTypeVar5', () => {
 test('VariadicTypeVar6', () => {
     const configOptions = new ConfigOptions(Uri.empty());
 
-    configOptions.defaultPythonVersion = PythonVersion.V3_11;
+    configOptions.defaultPythonVersion = pythonVersion3_11;
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['variadicTypeVar6.py'], configOptions);
     TestUtils.validateResults(analysisResults, 10);
 });
@@ -1113,7 +1113,7 @@ test('VariadicTypeVar6', () => {
 test('VariadicTypeVar7', () => {
     const configOptions = new ConfigOptions(Uri.empty());
 
-    configOptions.defaultPythonVersion = PythonVersion.V3_11;
+    configOptions.defaultPythonVersion = pythonVersion3_11;
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['variadicTypeVar7.py'], configOptions);
     TestUtils.validateResults(analysisResults, 6);
 });
@@ -1121,7 +1121,7 @@ test('VariadicTypeVar7', () => {
 test('VariadicTypeVar8', () => {
     const configOptions = new ConfigOptions(Uri.empty());
 
-    configOptions.defaultPythonVersion = PythonVersion.V3_11;
+    configOptions.defaultPythonVersion = pythonVersion3_11;
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['variadicTypeVar8.py'], configOptions);
     TestUtils.validateResults(analysisResults, 5);
 });
@@ -1129,7 +1129,7 @@ test('VariadicTypeVar8', () => {
 test('VariadicTypeVar9', () => {
     const configOptions = new ConfigOptions(Uri.empty());
 
-    configOptions.defaultPythonVersion = PythonVersion.V3_11;
+    configOptions.defaultPythonVersion = pythonVersion3_11;
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['variadicTypeVar9.py'], configOptions);
     TestUtils.validateResults(analysisResults, 0);
 });
@@ -1137,7 +1137,7 @@ test('VariadicTypeVar9', () => {
 test('VariadicTypeVar10', () => {
     const configOptions = new ConfigOptions(Uri.empty());
 
-    configOptions.defaultPythonVersion = PythonVersion.V3_11;
+    configOptions.defaultPythonVersion = pythonVersion3_11;
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['variadicTypeVar10.py'], configOptions);
     TestUtils.validateResults(analysisResults, 2);
 });
@@ -1145,7 +1145,7 @@ test('VariadicTypeVar10', () => {
 test('VariadicTypeVar11', () => {
     const configOptions = new ConfigOptions(Uri.empty());
 
-    configOptions.defaultPythonVersion = PythonVersion.V3_11;
+    configOptions.defaultPythonVersion = pythonVersion3_11;
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['variadicTypeVar11.py'], configOptions);
     TestUtils.validateResults(analysisResults, 4);
 });
@@ -1153,7 +1153,7 @@ test('VariadicTypeVar11', () => {
 test('VariadicTypeVar12', () => {
     const configOptions = new ConfigOptions(Uri.empty());
 
-    configOptions.defaultPythonVersion = PythonVersion.V3_11;
+    configOptions.defaultPythonVersion = pythonVersion3_11;
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['variadicTypeVar12.py'], configOptions);
     TestUtils.validateResults(analysisResults, 0);
 });
@@ -1161,7 +1161,7 @@ test('VariadicTypeVar12', () => {
 test('VariadicTypeVar13', () => {
     const configOptions = new ConfigOptions(Uri.empty());
 
-    configOptions.defaultPythonVersion = PythonVersion.V3_11;
+    configOptions.defaultPythonVersion = pythonVersion3_11;
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['variadicTypeVar13.py'], configOptions);
     TestUtils.validateResults(analysisResults, 1);
 });
@@ -1169,7 +1169,7 @@ test('VariadicTypeVar13', () => {
 test('VariadicTypeVar14', () => {
     const configOptions = new ConfigOptions(Uri.empty());
 
-    configOptions.defaultPythonVersion = PythonVersion.V3_11;
+    configOptions.defaultPythonVersion = pythonVersion3_11;
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['variadicTypeVar14.py'], configOptions);
     TestUtils.validateResults(analysisResults, 6);
 });
@@ -1177,7 +1177,7 @@ test('VariadicTypeVar14', () => {
 test('VariadicTypeVar15', () => {
     const configOptions = new ConfigOptions(Uri.empty());
 
-    configOptions.defaultPythonVersion = PythonVersion.V3_11;
+    configOptions.defaultPythonVersion = pythonVersion3_11;
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['variadicTypeVar15.py'], configOptions);
     TestUtils.validateResults(analysisResults, 0);
 });
@@ -1185,7 +1185,7 @@ test('VariadicTypeVar15', () => {
 test('VariadicTypeVar16', () => {
     const configOptions = new ConfigOptions(Uri.empty());
 
-    configOptions.defaultPythonVersion = PythonVersion.V3_11;
+    configOptions.defaultPythonVersion = pythonVersion3_11;
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['variadicTypeVar16.py'], configOptions);
     TestUtils.validateResults(analysisResults, 0);
 });
@@ -1193,7 +1193,7 @@ test('VariadicTypeVar16', () => {
 test('VariadicTypeVar17', () => {
     const configOptions = new ConfigOptions(Uri.empty());
 
-    configOptions.defaultPythonVersion = PythonVersion.V3_11;
+    configOptions.defaultPythonVersion = pythonVersion3_11;
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['variadicTypeVar17.py'], configOptions);
     TestUtils.validateResults(analysisResults, 0);
 });
@@ -1201,7 +1201,7 @@ test('VariadicTypeVar17', () => {
 test('VariadicTypeVar18', () => {
     const configOptions = new ConfigOptions(Uri.empty());
 
-    configOptions.defaultPythonVersion = PythonVersion.V3_11;
+    configOptions.defaultPythonVersion = pythonVersion3_11;
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['variadicTypeVar18.py'], configOptions);
     TestUtils.validateResults(analysisResults, 2);
 });
@@ -1209,7 +1209,7 @@ test('VariadicTypeVar18', () => {
 test('VariadicTypeVar19', () => {
     const configOptions = new ConfigOptions(Uri.empty());
 
-    configOptions.defaultPythonVersion = PythonVersion.V3_11;
+    configOptions.defaultPythonVersion = pythonVersion3_11;
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['variadicTypeVar19.py'], configOptions);
     TestUtils.validateResults(analysisResults, 0);
 });
@@ -1217,7 +1217,7 @@ test('VariadicTypeVar19', () => {
 test('VariadicTypeVar20', () => {
     const configOptions = new ConfigOptions(Uri.empty());
 
-    configOptions.defaultPythonVersion = PythonVersion.V3_11;
+    configOptions.defaultPythonVersion = pythonVersion3_11;
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['variadicTypeVar20.py'], configOptions);
     TestUtils.validateResults(analysisResults, 0);
 });
@@ -1225,7 +1225,7 @@ test('VariadicTypeVar20', () => {
 test('VariadicTypeVar21', () => {
     const configOptions = new ConfigOptions(Uri.empty());
 
-    configOptions.defaultPythonVersion = PythonVersion.V3_11;
+    configOptions.defaultPythonVersion = pythonVersion3_11;
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['variadicTypeVar21.py'], configOptions);
     TestUtils.validateResults(analysisResults, 0);
 });
@@ -1233,7 +1233,7 @@ test('VariadicTypeVar21', () => {
 test('VariadicTypeVar22', () => {
     const configOptions = new ConfigOptions(Uri.empty());
 
-    configOptions.defaultPythonVersion = PythonVersion.V3_11;
+    configOptions.defaultPythonVersion = pythonVersion3_11;
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['variadicTypeVar22.py'], configOptions);
     TestUtils.validateResults(analysisResults, 3);
 });
@@ -1241,7 +1241,7 @@ test('VariadicTypeVar22', () => {
 test('VariadicTypeVar23', () => {
     const configOptions = new ConfigOptions(Uri.empty());
 
-    configOptions.defaultPythonVersion = PythonVersion.V3_11;
+    configOptions.defaultPythonVersion = pythonVersion3_11;
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['variadicTypeVar23.py'], configOptions);
     TestUtils.validateResults(analysisResults, 0);
 });
@@ -1249,7 +1249,7 @@ test('VariadicTypeVar23', () => {
 test('VariadicTypeVar24', () => {
     const configOptions = new ConfigOptions(Uri.empty());
 
-    configOptions.defaultPythonVersion = PythonVersion.V3_11;
+    configOptions.defaultPythonVersion = pythonVersion3_11;
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['variadicTypeVar24.py'], configOptions);
     TestUtils.validateResults(analysisResults, 0);
 });
@@ -1257,7 +1257,7 @@ test('VariadicTypeVar24', () => {
 test('VariadicTypeVar25', () => {
     const configOptions = new ConfigOptions(Uri.empty());
 
-    configOptions.defaultPythonVersion = PythonVersion.V3_11;
+    configOptions.defaultPythonVersion = pythonVersion3_11;
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['variadicTypeVar25.py'], configOptions);
     TestUtils.validateResults(analysisResults, 0);
 });
@@ -1265,7 +1265,7 @@ test('VariadicTypeVar25', () => {
 test('VariadicTypeVar26', () => {
     const configOptions = new ConfigOptions(Uri.empty());
 
-    configOptions.defaultPythonVersion = PythonVersion.V3_11;
+    configOptions.defaultPythonVersion = pythonVersion3_11;
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['variadicTypeVar26.py'], configOptions);
     TestUtils.validateResults(analysisResults, 3);
 });
@@ -1273,7 +1273,7 @@ test('VariadicTypeVar26', () => {
 test('VariadicTypeVar27', () => {
     const configOptions = new ConfigOptions(Uri.empty());
 
-    configOptions.defaultPythonVersion = PythonVersion.V3_11;
+    configOptions.defaultPythonVersion = pythonVersion3_11;
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['variadicTypeVar27.py'], configOptions);
     TestUtils.validateResults(analysisResults, 1);
 });
@@ -1281,7 +1281,7 @@ test('VariadicTypeVar27', () => {
 test('VariadicTypeVar28', () => {
     const configOptions = new ConfigOptions(Uri.empty());
 
-    configOptions.defaultPythonVersion = PythonVersion.V3_11;
+    configOptions.defaultPythonVersion = pythonVersion3_11;
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['variadicTypeVar28.py'], configOptions);
     TestUtils.validateResults(analysisResults, 0);
 });
@@ -1289,7 +1289,7 @@ test('VariadicTypeVar28', () => {
 test('Match1', () => {
     const configOptions = new ConfigOptions(Uri.empty());
 
-    configOptions.defaultPythonVersion = PythonVersion.V3_10;
+    configOptions.defaultPythonVersion = pythonVersion3_10;
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['match1.py'], configOptions);
     TestUtils.validateResults(analysisResults, 21);
 });
@@ -1297,7 +1297,7 @@ test('Match1', () => {
 test('Match2', () => {
     const configOptions = new ConfigOptions(Uri.empty());
 
-    configOptions.defaultPythonVersion = PythonVersion.V3_10;
+    configOptions.defaultPythonVersion = pythonVersion3_10;
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['match2.py'], configOptions);
     TestUtils.validateResults(analysisResults, 2);
 });
@@ -1305,7 +1305,7 @@ test('Match2', () => {
 test('Match3', () => {
     const configOptions = new ConfigOptions(Uri.empty());
 
-    configOptions.defaultPythonVersion = PythonVersion.V3_10;
+    configOptions.defaultPythonVersion = pythonVersion3_10;
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['match3.py'], configOptions);
     TestUtils.validateResults(analysisResults, 0);
 });
@@ -1313,7 +1313,7 @@ test('Match3', () => {
 test('MatchSequence1', () => {
     const configOptions = new ConfigOptions(Uri.empty());
 
-    configOptions.defaultPythonVersion = PythonVersion.V3_10;
+    configOptions.defaultPythonVersion = pythonVersion3_10;
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['matchSequence1.py'], configOptions);
     TestUtils.validateResults(analysisResults, 2);
 });
@@ -1321,7 +1321,7 @@ test('MatchSequence1', () => {
 test('MatchClass1', () => {
     const configOptions = new ConfigOptions(Uri.empty());
 
-    configOptions.defaultPythonVersion = PythonVersion.V3_10;
+    configOptions.defaultPythonVersion = pythonVersion3_10;
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['matchClass1.py'], configOptions);
     TestUtils.validateResults(analysisResults, 4);
 });
@@ -1329,7 +1329,7 @@ test('MatchClass1', () => {
 test('MatchClass2', () => {
     const configOptions = new ConfigOptions(Uri.empty());
 
-    configOptions.defaultPythonVersion = PythonVersion.V3_10;
+    configOptions.defaultPythonVersion = pythonVersion3_10;
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['matchClass2.py'], configOptions);
     TestUtils.validateResults(analysisResults, 0);
 });
@@ -1337,7 +1337,7 @@ test('MatchClass2', () => {
 test('MatchClass3', () => {
     const configOptions = new ConfigOptions(Uri.empty());
 
-    configOptions.defaultPythonVersion = PythonVersion.V3_10;
+    configOptions.defaultPythonVersion = pythonVersion3_10;
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['matchClass3.py'], configOptions);
     TestUtils.validateResults(analysisResults, 0);
 });
@@ -1345,7 +1345,7 @@ test('MatchClass3', () => {
 test('MatchClass4', () => {
     const configOptions = new ConfigOptions(Uri.empty());
 
-    configOptions.defaultPythonVersion = PythonVersion.V3_10;
+    configOptions.defaultPythonVersion = pythonVersion3_10;
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['matchClass4.py'], configOptions);
     TestUtils.validateResults(analysisResults, 0);
 });
@@ -1353,7 +1353,7 @@ test('MatchClass4', () => {
 test('MatchClass5', () => {
     const configOptions = new ConfigOptions(Uri.empty());
 
-    configOptions.defaultPythonVersion = PythonVersion.V3_10;
+    configOptions.defaultPythonVersion = pythonVersion3_10;
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['matchClass5.py'], configOptions);
     TestUtils.validateResults(analysisResults, 5);
 });
@@ -1361,7 +1361,7 @@ test('MatchClass5', () => {
 test('MatchClass6', () => {
     const configOptions = new ConfigOptions(Uri.empty());
 
-    configOptions.defaultPythonVersion = PythonVersion.V3_10;
+    configOptions.defaultPythonVersion = pythonVersion3_10;
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['matchClass6.py'], configOptions);
     TestUtils.validateResults(analysisResults, 0);
 });
@@ -1369,7 +1369,7 @@ test('MatchClass6', () => {
 test('MatchValue1', () => {
     const configOptions = new ConfigOptions(Uri.empty());
 
-    configOptions.defaultPythonVersion = PythonVersion.V3_10;
+    configOptions.defaultPythonVersion = pythonVersion3_10;
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['matchValue1.py'], configOptions);
     TestUtils.validateResults(analysisResults, 0);
 });
@@ -1377,7 +1377,7 @@ test('MatchValue1', () => {
 test('MatchMapping1', () => {
     const configOptions = new ConfigOptions(Uri.empty());
 
-    configOptions.defaultPythonVersion = PythonVersion.V3_10;
+    configOptions.defaultPythonVersion = pythonVersion3_10;
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['matchMapping1.py'], configOptions);
     TestUtils.validateResults(analysisResults, 2);
 });
@@ -1385,7 +1385,7 @@ test('MatchMapping1', () => {
 test('MatchLiteral1', () => {
     const configOptions = new ConfigOptions(Uri.empty());
 
-    configOptions.defaultPythonVersion = PythonVersion.V3_10;
+    configOptions.defaultPythonVersion = pythonVersion3_10;
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['matchLiteral1.py'], configOptions);
     TestUtils.validateResults(analysisResults, 0);
 });
@@ -1393,7 +1393,7 @@ test('MatchLiteral1', () => {
 test('MatchLiteral2', () => {
     const configOptions = new ConfigOptions(Uri.empty());
 
-    configOptions.defaultPythonVersion = PythonVersion.V3_10;
+    configOptions.defaultPythonVersion = pythonVersion3_10;
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['matchLiteral2.py'], configOptions);
     TestUtils.validateResults(analysisResults, 0);
 });
@@ -1401,7 +1401,7 @@ test('MatchLiteral2', () => {
 test('MatchExhaustion1', () => {
     const configOptions = new ConfigOptions(Uri.empty());
 
-    configOptions.defaultPythonVersion = PythonVersion.V3_10;
+    configOptions.defaultPythonVersion = pythonVersion3_10;
     configOptions.diagnosticRuleSet.reportMatchNotExhaustive = 'none';
     const analysisResults1 = TestUtils.typeAnalyzeSampleFiles(['matchExhaustion1.py'], configOptions);
     TestUtils.validateResults(analysisResults1, 0);
@@ -1414,7 +1414,7 @@ test('MatchExhaustion1', () => {
 test('MatchUnnecessary1', () => {
     const configOptions = new ConfigOptions(Uri.empty());
 
-    configOptions.defaultPythonVersion = PythonVersion.V3_10;
+    configOptions.defaultPythonVersion = pythonVersion3_10;
     const analysisResults1 = TestUtils.typeAnalyzeSampleFiles(['matchUnnecessary1.py'], configOptions);
     TestUtils.validateResults(analysisResults1, 0);
 
@@ -1739,12 +1739,12 @@ test('Subscript1', () => {
     const configOptions = new ConfigOptions(Uri.empty());
 
     // Analyze with Python 3.8 settings.
-    configOptions.defaultPythonVersion = PythonVersion.V3_8;
+    configOptions.defaultPythonVersion = pythonVersion3_8;
     const analysisResults38 = TestUtils.typeAnalyzeSampleFiles(['subscript1.py'], configOptions);
     TestUtils.validateResults(analysisResults38, 18);
 
     // Analyze with Python 3.8 settings.
-    configOptions.defaultPythonVersion = PythonVersion.V3_9;
+    configOptions.defaultPythonVersion = pythonVersion3_10;
     const analysisResults39 = TestUtils.typeAnalyzeSampleFiles(['subscript1.py'], configOptions);
     TestUtils.validateResults(analysisResults39, 0);
 });
@@ -1758,13 +1758,13 @@ test('Subscript3', () => {
     const configOptions = new ConfigOptions(Uri.empty());
 
     // Analyze with Python 3.9 settings.
-    configOptions.defaultPythonVersion = PythonVersion.V3_9;
+    configOptions.defaultPythonVersion = pythonVersion3_9;
     const analysisResults39 = TestUtils.typeAnalyzeSampleFiles(['subscript3.py'], configOptions);
     TestUtils.validateResults(analysisResults39, 37);
 
     // Analyze with Python 3.10 settings.
     // These are disabled because PEP 637 was rejected.
-    // configOptions.defaultPythonVersion = PythonVersion.V3_10;
+    // configOptions.defaultPythonVersion = pythonVersion3_10;
     // const analysisResults310 = TestUtils.typeAnalyzeSampleFiles(['subscript3.py'], configOptions);
     // TestUtils.validateResults(analysisResults310, 11);
 });
@@ -1790,12 +1790,12 @@ test('Decorator3', () => {
     const configOptions = new ConfigOptions(Uri.empty());
 
     // Analyze with Python 3.8 settings.
-    configOptions.defaultPythonVersion = PythonVersion.V3_8;
+    configOptions.defaultPythonVersion = pythonVersion3_8;
     const analysisResults38 = TestUtils.typeAnalyzeSampleFiles(['decorator3.py'], configOptions);
     TestUtils.validateResults(analysisResults38, 3);
 
     // Analyze with Python 3.8 settings.
-    configOptions.defaultPythonVersion = PythonVersion.V3_9;
+    configOptions.defaultPythonVersion = pythonVersion3_10;
     const analysisResults39 = TestUtils.typeAnalyzeSampleFiles(['decorator3.py'], configOptions);
     TestUtils.validateResults(analysisResults39, 0);
 });

--- a/packages/pyright-internal/src/tests/typeEvaluator4.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator4.test.ts
@@ -11,14 +11,21 @@
 import * as assert from 'assert';
 
 import { ConfigOptions } from '../common/configOptions';
-import { PythonVersion } from '../common/pythonVersion';
+import {
+    pythonVersion3_10,
+    pythonVersion3_11,
+    pythonVersion3_12,
+    pythonVersion3_7,
+    pythonVersion3_8,
+    pythonVersion3_9,
+} from '../common/pythonVersion';
 import { Uri } from '../common/uri/uri';
 import * as TestUtils from './testUtils';
 
 test('Required1', () => {
     // Analyze with Python 3.10 settings.
     const configOptions = new ConfigOptions(Uri.empty());
-    configOptions.defaultPythonVersion = PythonVersion.V3_10;
+    configOptions.defaultPythonVersion = pythonVersion3_10;
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['required1.py'], configOptions);
 
     TestUtils.validateResults(analysisResults, 8);
@@ -27,7 +34,7 @@ test('Required1', () => {
 test('Required2', () => {
     // Analyze with Python 3.10 settings.
     const configOptions = new ConfigOptions(Uri.empty());
-    configOptions.defaultPythonVersion = PythonVersion.V3_10;
+    configOptions.defaultPythonVersion = pythonVersion3_10;
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['required2.py'], configOptions);
 
     TestUtils.validateResults(analysisResults, 7);
@@ -36,7 +43,7 @@ test('Required2', () => {
 test('Required3', () => {
     // Analyze with Python 3.10 settings.
     const configOptions = new ConfigOptions(Uri.empty());
-    configOptions.defaultPythonVersion = PythonVersion.V3_10;
+    configOptions.defaultPythonVersion = pythonVersion3_10;
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['required3.py'], configOptions);
 
     TestUtils.validateResults(analysisResults, 2);
@@ -408,11 +415,11 @@ test('CallSite2', () => {
 test('FString1', () => {
     const configOptions = new ConfigOptions(Uri.empty());
 
-    configOptions.defaultPythonVersion = PythonVersion.V3_11;
+    configOptions.defaultPythonVersion = pythonVersion3_11;
     const analysisResults1 = TestUtils.typeAnalyzeSampleFiles(['fstring1.py'], configOptions);
     TestUtils.validateResults(analysisResults1, 14, 1);
 
-    configOptions.defaultPythonVersion = PythonVersion.V3_12;
+    configOptions.defaultPythonVersion = pythonVersion3_12;
     const analysisResults2 = TestUtils.typeAnalyzeSampleFiles(['fstring1.py'], configOptions);
     TestUtils.validateResults(analysisResults2, 10, 1);
 });
@@ -436,12 +443,12 @@ test('FString5', () => {
     const configOptions = new ConfigOptions(Uri.empty());
 
     // Analyze with Python 3.7 settings. This will generate errors.
-    configOptions.defaultPythonVersion = PythonVersion.V3_7;
+    configOptions.defaultPythonVersion = pythonVersion3_7;
     const analysisResults37 = TestUtils.typeAnalyzeSampleFiles(['fstring5.py'], configOptions);
     TestUtils.validateResults(analysisResults37, 6);
 
     // Analyze with Python 3.8 settings.
-    configOptions.defaultPythonVersion = PythonVersion.V3_8;
+    configOptions.defaultPythonVersion = pythonVersion3_8;
     const analysisResults38 = TestUtils.typeAnalyzeSampleFiles(['fstring5.py'], configOptions);
     TestUtils.validateResults(analysisResults38, 0);
 });
@@ -682,7 +689,7 @@ test('DataClassFrozen1', () => {
 
 test('DataClassKwOnly1', () => {
     const configOptions = new ConfigOptions(Uri.empty());
-    configOptions.defaultPythonVersion = PythonVersion.V3_10;
+    configOptions.defaultPythonVersion = pythonVersion3_10;
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['dataclassKwOnly1.py'], configOptions);
 
     TestUtils.validateResults(analysisResults, 3);
@@ -690,7 +697,7 @@ test('DataClassKwOnly1', () => {
 
 test('DataClassSlots1', () => {
     const configOptions = new ConfigOptions(Uri.empty());
-    configOptions.defaultPythonVersion = PythonVersion.V3_10;
+    configOptions.defaultPythonVersion = pythonVersion3_10;
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['dataclassSlots1.py'], configOptions);
 
     TestUtils.validateResults(analysisResults, 5);
@@ -803,12 +810,12 @@ test('Unions1', () => {
     configOptions.diagnosticRuleSet.disableBytesTypePromotions = true;
 
     // Analyze with Python 3.9 settings. This will generate errors.
-    configOptions.defaultPythonVersion = PythonVersion.V3_9;
+    configOptions.defaultPythonVersion = pythonVersion3_9;
     const analysisResults3_9 = TestUtils.typeAnalyzeSampleFiles(['unions1.py'], configOptions);
     TestUtils.validateResults(analysisResults3_9, 11);
 
     // Analyze with Python 3.10 settings.
-    configOptions.defaultPythonVersion = PythonVersion.V3_10;
+    configOptions.defaultPythonVersion = pythonVersion3_10;
     const analysisResults3_10 = TestUtils.typeAnalyzeSampleFiles(['unions1.py'], configOptions);
     TestUtils.validateResults(analysisResults3_10, 0);
 });
@@ -817,7 +824,7 @@ test('Unions2', () => {
     const configOptions = new ConfigOptions(Uri.empty());
 
     // Analyze with Python 3.8 settings.
-    configOptions.defaultPythonVersion = PythonVersion.V3_8;
+    configOptions.defaultPythonVersion = pythonVersion3_8;
     const analysisResults38 = TestUtils.typeAnalyzeSampleFiles(['unions2.py'], configOptions);
     TestUtils.validateResults(analysisResults38, 0);
 });
@@ -826,12 +833,12 @@ test('Unions3', () => {
     const configOptions = new ConfigOptions(Uri.empty());
 
     // Analyze with Python 3.9 settings. This will generate errors.
-    configOptions.defaultPythonVersion = PythonVersion.V3_9;
+    configOptions.defaultPythonVersion = pythonVersion3_9;
     const analysisResults3_9 = TestUtils.typeAnalyzeSampleFiles(['unions3.py'], configOptions);
     TestUtils.validateResults(analysisResults3_9, 1);
 
     // Analyze with Python 3.10 settings.
-    configOptions.defaultPythonVersion = PythonVersion.V3_10;
+    configOptions.defaultPythonVersion = pythonVersion3_10;
     const analysisResults3_10 = TestUtils.typeAnalyzeSampleFiles(['unions3.py'], configOptions);
     TestUtils.validateResults(analysisResults3_10, 0);
 });
@@ -862,11 +869,11 @@ test('ParamSpec1', () => {
 test('ParamSpec2', () => {
     const configOptions = new ConfigOptions(Uri.empty());
 
-    configOptions.defaultPythonVersion = PythonVersion.V3_9;
+    configOptions.defaultPythonVersion = pythonVersion3_9;
     const analysisResults39 = TestUtils.typeAnalyzeSampleFiles(['paramSpec2.py'], configOptions);
     TestUtils.validateResults(analysisResults39, 9);
 
-    configOptions.defaultPythonVersion = PythonVersion.V3_10;
+    configOptions.defaultPythonVersion = pythonVersion3_10;
     const analysisResults310 = TestUtils.typeAnalyzeSampleFiles(['paramSpec2.py'], configOptions);
     TestUtils.validateResults(analysisResults310, 0);
 });
@@ -1215,11 +1222,11 @@ test('TypeVar12', () => {
 test('Annotated1', () => {
     const configOptions = new ConfigOptions(Uri.empty());
 
-    configOptions.defaultPythonVersion = PythonVersion.V3_8;
+    configOptions.defaultPythonVersion = pythonVersion3_8;
     const analysisResults38 = TestUtils.typeAnalyzeSampleFiles(['annotated1.py'], configOptions);
     TestUtils.validateResults(analysisResults38, 6);
 
-    configOptions.defaultPythonVersion = PythonVersion.V3_11;
+    configOptions.defaultPythonVersion = pythonVersion3_11;
     const analysisResults39 = TestUtils.typeAnalyzeSampleFiles(['annotated1.py'], configOptions);
     TestUtils.validateResults(analysisResults39, 3);
 });
@@ -1281,11 +1288,11 @@ test('TryExcept6', () => {
 test('TryExcept7', () => {
     const configOptions = new ConfigOptions(Uri.empty());
 
-    configOptions.defaultPythonVersion = PythonVersion.V3_10;
+    configOptions.defaultPythonVersion = pythonVersion3_10;
     const analysisResults1 = TestUtils.typeAnalyzeSampleFiles(['tryExcept7.py'], configOptions);
     TestUtils.validateResults(analysisResults1, 3);
 
-    configOptions.defaultPythonVersion = PythonVersion.V3_11;
+    configOptions.defaultPythonVersion = pythonVersion3_11;
     const analysisResults2 = TestUtils.typeAnalyzeSampleFiles(['tryExcept7.py'], configOptions);
     TestUtils.validateResults(analysisResults2, 0);
 });
@@ -1293,7 +1300,7 @@ test('TryExcept7', () => {
 test('TryExcept8', () => {
     const configOptions = new ConfigOptions(Uri.empty());
 
-    configOptions.defaultPythonVersion = PythonVersion.V3_11;
+    configOptions.defaultPythonVersion = pythonVersion3_11;
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['tryExcept8.py'], configOptions);
     TestUtils.validateResults(analysisResults, 3);
 });

--- a/packages/pyright-internal/src/tests/typeEvaluator5.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator5.test.ts
@@ -9,13 +9,13 @@
  */
 
 import { ConfigOptions } from '../common/configOptions';
-import { PythonVersion } from '../common/pythonVersion';
+import { pythonVersion3_11, pythonVersion3_12, pythonVersion3_13 } from '../common/pythonVersion';
 import { Uri } from '../common/uri/uri';
 import * as TestUtils from './testUtils';
 
 test('TypeParams1', () => {
     const configOptions = new ConfigOptions(Uri.empty());
-    configOptions.defaultPythonVersion = PythonVersion.V3_12;
+    configOptions.defaultPythonVersion = pythonVersion3_12;
 
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['typeParams1.py'], configOptions);
     TestUtils.validateResults(analysisResults, 4);
@@ -24,18 +24,18 @@ test('TypeParams1', () => {
 test('TypeParams2', () => {
     const configOptions = new ConfigOptions(Uri.empty());
 
-    configOptions.defaultPythonVersion = PythonVersion.V3_11;
+    configOptions.defaultPythonVersion = pythonVersion3_11;
     const analysisResults1 = TestUtils.typeAnalyzeSampleFiles(['typeParams2.py'], configOptions);
     TestUtils.validateResults(analysisResults1, 2);
 
-    configOptions.defaultPythonVersion = PythonVersion.V3_12;
+    configOptions.defaultPythonVersion = pythonVersion3_12;
     const analysisResults2 = TestUtils.typeAnalyzeSampleFiles(['typeParams2.py'], configOptions);
     TestUtils.validateResults(analysisResults2, 0);
 });
 
 test('TypeParams3', () => {
     const configOptions = new ConfigOptions(Uri.empty());
-    configOptions.defaultPythonVersion = PythonVersion.V3_12;
+    configOptions.defaultPythonVersion = pythonVersion3_12;
 
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['typeParams3.py'], configOptions);
     TestUtils.validateResults(analysisResults, 7);
@@ -43,7 +43,7 @@ test('TypeParams3', () => {
 
 test('TypeParams4', () => {
     const configOptions = new ConfigOptions(Uri.empty());
-    configOptions.defaultPythonVersion = PythonVersion.V3_12;
+    configOptions.defaultPythonVersion = pythonVersion3_12;
 
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['typeParams4.py'], configOptions);
     TestUtils.validateResults(analysisResults, 2);
@@ -51,7 +51,7 @@ test('TypeParams4', () => {
 
 test('TypeParams5', () => {
     const configOptions = new ConfigOptions(Uri.empty());
-    configOptions.defaultPythonVersion = PythonVersion.V3_12;
+    configOptions.defaultPythonVersion = pythonVersion3_12;
 
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['typeParams5.py'], configOptions);
     TestUtils.validateResults(analysisResults, 7);
@@ -59,7 +59,7 @@ test('TypeParams5', () => {
 
 test('TypeParams6', () => {
     const configOptions = new ConfigOptions(Uri.empty());
-    configOptions.defaultPythonVersion = PythonVersion.V3_12;
+    configOptions.defaultPythonVersion = pythonVersion3_12;
 
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['typeParams6.py'], configOptions);
     TestUtils.validateResults(analysisResults, 3);
@@ -67,7 +67,7 @@ test('TypeParams6', () => {
 
 test('TypeParams7', () => {
     const configOptions = new ConfigOptions(Uri.empty());
-    configOptions.defaultPythonVersion = PythonVersion.V3_12;
+    configOptions.defaultPythonVersion = pythonVersion3_12;
 
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['typeParams7.py'], configOptions);
     TestUtils.validateResults(analysisResults, 4);
@@ -75,7 +75,7 @@ test('TypeParams7', () => {
 
 test('AutoVariance1', () => {
     const configOptions = new ConfigOptions(Uri.empty());
-    configOptions.defaultPythonVersion = PythonVersion.V3_12;
+    configOptions.defaultPythonVersion = pythonVersion3_12;
 
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['autoVariance1.py'], configOptions);
     TestUtils.validateResults(analysisResults, 16);
@@ -83,7 +83,7 @@ test('AutoVariance1', () => {
 
 test('AutoVariance2', () => {
     const configOptions = new ConfigOptions(Uri.empty());
-    configOptions.defaultPythonVersion = PythonVersion.V3_12;
+    configOptions.defaultPythonVersion = pythonVersion3_12;
 
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['autoVariance2.py'], configOptions);
     TestUtils.validateResults(analysisResults, 0);
@@ -91,7 +91,7 @@ test('AutoVariance2', () => {
 
 test('AutoVariance3', () => {
     const configOptions = new ConfigOptions(Uri.empty());
-    configOptions.defaultPythonVersion = PythonVersion.V3_12;
+    configOptions.defaultPythonVersion = pythonVersion3_12;
 
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['autoVariance3.py'], configOptions);
     TestUtils.validateResults(analysisResults, 18);
@@ -99,7 +99,7 @@ test('AutoVariance3', () => {
 
 test('AutoVariance4', () => {
     const configOptions = new ConfigOptions(Uri.empty());
-    configOptions.defaultPythonVersion = PythonVersion.V3_12;
+    configOptions.defaultPythonVersion = pythonVersion3_12;
 
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['autoVariance4.py'], configOptions);
     TestUtils.validateResults(analysisResults, 4);
@@ -112,7 +112,7 @@ test('AutoVariance5', () => {
 
 test('TypeAliasStatement1', () => {
     const configOptions = new ConfigOptions(Uri.empty());
-    configOptions.defaultPythonVersion = PythonVersion.V3_12;
+    configOptions.defaultPythonVersion = pythonVersion3_12;
 
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['typeAliasStatement1.py'], configOptions);
     TestUtils.validateResults(analysisResults, 9);
@@ -121,18 +121,18 @@ test('TypeAliasStatement1', () => {
 test('TypeAliasStatement2', () => {
     const configOptions = new ConfigOptions(Uri.empty());
 
-    configOptions.defaultPythonVersion = PythonVersion.V3_11;
+    configOptions.defaultPythonVersion = pythonVersion3_11;
     const analysisResults1 = TestUtils.typeAnalyzeSampleFiles(['typeAliasStatement2.py'], configOptions);
     TestUtils.validateResults(analysisResults1, 1);
 
-    configOptions.defaultPythonVersion = PythonVersion.V3_12;
+    configOptions.defaultPythonVersion = pythonVersion3_12;
     const analysisResults2 = TestUtils.typeAnalyzeSampleFiles(['typeAliasStatement2.py'], configOptions);
     TestUtils.validateResults(analysisResults2, 0);
 });
 
 test('TypeAliasStatement3', () => {
     const configOptions = new ConfigOptions(Uri.empty());
-    configOptions.defaultPythonVersion = PythonVersion.V3_12;
+    configOptions.defaultPythonVersion = pythonVersion3_12;
 
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['typeAliasStatement3.py'], configOptions);
     TestUtils.validateResults(analysisResults, 2);
@@ -140,7 +140,7 @@ test('TypeAliasStatement3', () => {
 
 test('TypeAliasStatement4', () => {
     const configOptions = new ConfigOptions(Uri.empty());
-    configOptions.defaultPythonVersion = PythonVersion.V3_12;
+    configOptions.defaultPythonVersion = pythonVersion3_12;
 
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['typeAliasStatement4.py'], configOptions);
     TestUtils.validateResults(analysisResults, 5);
@@ -184,7 +184,7 @@ test('TypeVarDefault1', () => {
 
 test('TypeVarDefault2', () => {
     const configOptions = new ConfigOptions(Uri.empty());
-    configOptions.defaultPythonVersion = PythonVersion.V3_13;
+    configOptions.defaultPythonVersion = pythonVersion3_13;
 
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['typeVarDefault2.py'], configOptions);
     TestUtils.validateResults(analysisResults, 23);
@@ -192,7 +192,7 @@ test('TypeVarDefault2', () => {
 
 test('TypeVarDefault3', () => {
     const configOptions = new ConfigOptions(Uri.empty());
-    configOptions.defaultPythonVersion = PythonVersion.V3_13;
+    configOptions.defaultPythonVersion = pythonVersion3_13;
 
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['typeVarDefault3.py'], configOptions);
     TestUtils.validateResults(analysisResults, 8);
@@ -200,7 +200,7 @@ test('TypeVarDefault3', () => {
 
 test('TypeVarDefault4', () => {
     const configOptions = new ConfigOptions(Uri.empty());
-    configOptions.defaultPythonVersion = PythonVersion.V3_13;
+    configOptions.defaultPythonVersion = pythonVersion3_13;
 
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['typeVarDefault4.py'], configOptions);
     TestUtils.validateResults(analysisResults, 3);
@@ -208,7 +208,7 @@ test('TypeVarDefault4', () => {
 
 test('TypeVarDefault5', () => {
     const configOptions = new ConfigOptions(Uri.empty());
-    configOptions.defaultPythonVersion = PythonVersion.V3_13;
+    configOptions.defaultPythonVersion = pythonVersion3_13;
 
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['typeVarDefault5.py'], configOptions);
     TestUtils.validateResults(analysisResults, 0);
@@ -221,7 +221,7 @@ test('TypeVarDefaultClass1', () => {
 
 test('TypeVarDefaultClass2', () => {
     const configOptions = new ConfigOptions(Uri.empty());
-    configOptions.defaultPythonVersion = PythonVersion.V3_13;
+    configOptions.defaultPythonVersion = pythonVersion3_13;
 
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['typeVarDefaultClass2.py'], configOptions);
     TestUtils.validateResults(analysisResults, 9);
@@ -229,7 +229,7 @@ test('TypeVarDefaultClass2', () => {
 
 test('TypeVarDefaultClass3', () => {
     const configOptions = new ConfigOptions(Uri.empty());
-    configOptions.defaultPythonVersion = PythonVersion.V3_13;
+    configOptions.defaultPythonVersion = pythonVersion3_13;
 
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['typeVarDefaultClass3.py'], configOptions);
     TestUtils.validateResults(analysisResults, 10);
@@ -237,7 +237,7 @@ test('TypeVarDefaultClass3', () => {
 
 test('TypeVarDefaultClass4', () => {
     const configOptions = new ConfigOptions(Uri.empty());
-    configOptions.defaultPythonVersion = PythonVersion.V3_13;
+    configOptions.defaultPythonVersion = pythonVersion3_13;
 
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['typeVarDefaultClass4.py'], configOptions);
     TestUtils.validateResults(analysisResults, 0);
@@ -255,7 +255,7 @@ test('TypeVarDefaultTypeAlias2', () => {
 
 test('TypeVarDefaultTypeAlias3', () => {
     const configOptions = new ConfigOptions(Uri.empty());
-    configOptions.defaultPythonVersion = PythonVersion.V3_13;
+    configOptions.defaultPythonVersion = pythonVersion3_13;
 
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['typeVarDefaultTypeAlias3.py'], configOptions);
     TestUtils.validateResults(analysisResults, 10);
@@ -273,7 +273,7 @@ test('TypeVarDefaultFunction2', () => {
 
 test('TypeVarDefaultFunction3', () => {
     const configOptions = new ConfigOptions(Uri.empty());
-    configOptions.defaultPythonVersion = PythonVersion.V3_13;
+    configOptions.defaultPythonVersion = pythonVersion3_13;
 
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['typeVarDefaultFunction3.py'], configOptions);
     TestUtils.validateResults(analysisResults, 1);
@@ -311,7 +311,7 @@ test('TypePrinter3', () => {
 
 test('TypeAliasType1', () => {
     const configOptions = new ConfigOptions(Uri.empty());
-    configOptions.defaultPythonVersion = PythonVersion.V3_12;
+    configOptions.defaultPythonVersion = pythonVersion3_12;
 
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['typeAliasType1.py'], configOptions);
     TestUtils.validateResults(analysisResults, 14);


### PR DESCRIPTION
…inor version numbers. Pyright now handles micro, releaseLevel, and serial numbers as well. This addresses #7132.