### PR TITLE
Fixed bug that results in false positive error when a `__new__` metho…

### DIFF
--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -17166,7 +17166,7 @@ export function createTypeEvaluator(importLookup: ImportLookup, evaluatorOptions
                                 const paramInfo = paramListDetails.params[paramIndex];
                                 const argParam: ValidateArgTypeParams = {
                                     paramCategory: paramInfo.param.category,
-                                    paramType: FunctionType.getEffectiveParameterType(newMethodType, paramInfo.index),
+                                    paramType: paramInfo.type,
                                     requiresTypeVarMatching: false,
                                     argument: arg,
                                     errorNode: arg.valueExpression ?? errorNode,


### PR DESCRIPTION
…d in a metaclass uses PEP 692 (unpacked TypeDict) to annotate its `**kwargs` parameter. This addresses #7514.