### PR TITLE
Fixed bug that results in incorrect type narrowing in the negative (f…

### DIFF
--- a/packages/pyright-internal/src/analyzer/patternMatching.ts
+++ b/packages/pyright-internal/src/analyzer/patternMatching.ts
@@ -749,10 +749,15 @@ function narrowTypeBasedOnClassPattern(
                 }
 
                 // We might be able to narrow further based on arguments, but only
-                // if the types match exactly or the subtype is a final class and
-                // therefore cannot be subclassed.
+                // if the types match exactly, the subject subtype is a final class (and
+                // therefore cannot be subclassed), or the pattern class is a protocol
+                // class.
                 if (!evaluator.assignType(subjectSubtypeExpanded, classInstance)) {
-                    if (isClass(subjectSubtypeExpanded) && !ClassType.isFinal(subjectSubtypeExpanded)) {
+                    if (
+                        isClass(subjectSubtypeExpanded) &&
+                        !ClassType.isFinal(subjectSubtypeExpanded) &&
+                        !ClassType.isProtocolClass(classInstance)
+                    ) {
                         return subjectSubtypeExpanded;
                     }
                 }

--- a/packages/pyright-internal/src/tests/samples/matchClass3.py
+++ b/packages/pyright-internal/src/tests/samples/matchClass3.py
@@ -1,40 +1,48 @@
 # This sample tests class-based pattern matching when the class is
 # marked final and can be discriminated based on the argument patterns.
 
-from typing import final
+from typing import final, Protocol, runtime_checkable
+from dataclasses import dataclass
 
 
 class A:
     title: str
 
+
 class B:
     name: str
+
 
 class C:
     name: str
 
+
 def func1(r: A | B | C):
     match r:
         case object(title=_):
-            reveal_type(r, expected_text='A | B | C')
+            reveal_type(r, expected_text="A | B | C")
 
         case object(name=_):
-            reveal_type(r, expected_text='A | B | C')
+            reveal_type(r, expected_text="A | B | C")
 
         case _:
-            reveal_type(r, expected_text='A | B | C')
+            reveal_type(r, expected_text="A | B | C")
+
 
 @final
 class AFinal:
     title: str
 
+
 @final
 class BFinal:
     name: str
 
+
 @final
 class CFinal:
     name: str
+
 
 @final
 class DFinal:
@@ -44,10 +52,29 @@ class DFinal:
 def func2(r: AFinal | BFinal | CFinal | DFinal):
     match r:
         case object(title=_):
-            reveal_type(r, expected_text='AFinal')
+            reveal_type(r, expected_text="AFinal")
 
         case object(name=_):
-            reveal_type(r, expected_text='BFinal | CFinal')
+            reveal_type(r, expected_text="BFinal | CFinal")
 
         case _:
-            reveal_type(r, expected_text='DFinal')
+            reveal_type(r, expected_text="DFinal")
+
+
+@runtime_checkable
+class ProtoE(Protocol):
+    __match_args__ = ("x",)
+    x: int
+
+
+@dataclass
+class E:
+    x: int
+
+
+match E(1):
+    case ProtoE(x):
+        pass
+
+    case y:
+        reveal_type(y, expected_text="Never")


### PR DESCRIPTION
…all-through) case when a runtime-checkable protocol class is used as a class pattern with arguments within a match statement. This addresses #7550.