### PR TITLE
Fixed a bug that results in a false positive when a class-scoped Type…

### DIFF
--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -17538,6 +17538,14 @@ export function createTypeEvaluator(importLookup: ImportLookup, evaluatorOptions
                     annotatedType = getTypeOfParameterAnnotation(paramTypeNode, param.category);
                 }
 
+                if (annotatedType) {
+                    addTypeVarsToListIfUnique(
+                        typeParametersSeen,
+                        getTypeVarArgumentsRecursive(annotatedType),
+                        functionType.details.typeVarScopeId
+                    );
+                }
+
                 if (isVariadicTypeVar(annotatedType) && !annotatedType.isVariadicUnpacked) {
                     addError(
                         LocMessage.unpackedTypeVarTupleExpected().format({
@@ -17681,7 +17689,11 @@ export function createTypeEvaluator(importLookup: ImportLookup, evaluatorOptions
             FunctionType.addParameter(functionType, functionParam);
 
             if (functionParam.hasDeclaredType) {
-                addTypeVarsToListIfUnique(typeParametersSeen, getTypeVarArgumentsRecursive(functionParam.type));
+                addTypeVarsToListIfUnique(
+                    typeParametersSeen,
+                    getTypeVarArgumentsRecursive(functionParam.type),
+                    functionType.details.typeVarScopeId
+                );
             }
 
             if (param.name) {

--- a/packages/pyright-internal/src/analyzer/typeUtils.ts
+++ b/packages/pyright-internal/src/analyzer/typeUtils.ts
@@ -1944,8 +1944,12 @@ export function getClassFieldsRecursive(classType: ClassType): Map<string, Class
 
 // Combines two lists of type var types, maintaining the combined order
 // but removing any duplicates.
-export function addTypeVarsToListIfUnique(list1: TypeVarType[], list2: TypeVarType[]) {
+export function addTypeVarsToListIfUnique(list1: TypeVarType[], list2: TypeVarType[], typeVarScopeId?: TypeVarScopeId) {
     for (const type2 of list2) {
+        if (typeVarScopeId && type2.scopeId !== typeVarScopeId) {
+            continue;
+        }
+
         if (!list1.find((type1) => isTypeSame(convertToInstance(type1), convertToInstance(type2)))) {
             list1.push(type2);
         }

--- a/packages/pyright-internal/src/tests/samples/typeVarDefaultFunction2.py
+++ b/packages/pyright-internal/src/tests/samples/typeVarDefaultFunction2.py
@@ -49,3 +49,13 @@ class ClassB(Generic[T4, T5]):
 b1 = ClassB()
 reveal_type(b1.x, expected_text="int")
 reveal_type(b1.y, expected_text="int")
+
+
+T6 = TypeVar("T6", default=int)
+T7 = TypeVar("T7", default=T6)
+T8 = TypeVar("T8", default=int | None)
+
+
+class ClassC(Generic[T6, T7, T8]):
+    def __new__(cls, x: T7, /) -> Self: ...
+    def method1(self) -> T7: ...


### PR DESCRIPTION
…Var used within a method has a default that refers to another class-scoped TypeVar. This addresses #7553.