### PR TITLE
Fixed a bug that results in incorrect type narrowing of enums that de…

### DIFF
--- a/packages/pyright-internal/src/analyzer/typeGuards.ts
+++ b/packages/pyright-internal/src/analyzer/typeGuards.ts
@@ -2497,6 +2497,14 @@ export function enumerateLiteralsForType(evaluator: TypeEvaluator, type: ClassTy
     }
 
     if (ClassType.isEnumClass(type)) {
+        // Enum expansion doesn't apply to enum classes that derive
+        // from enum.Flag.
+        if (
+            type.details.baseClasses.some((baseClass) => isClass(baseClass) && ClassType.isBuiltIn(baseClass, 'Flag'))
+        ) {
+            return undefined;
+        }
+
         // Enumerate all of the values in this enumeration.
         const enumList: ClassType[] = [];
         const fields = type.details.fields;

--- a/packages/pyright-internal/src/tests/samples/typeNarrowingEnum1.py
+++ b/packages/pyright-internal/src/tests/samples/typeNarrowingEnum1.py
@@ -1,7 +1,7 @@
 # This sample tests exhaustive type narrowing for enums
 # and the use of "Never" and "NoReturn".
 
-from enum import Enum
+from enum import Enum, Flag
 from typing import Literal, NoReturn, Union
 
 
@@ -56,3 +56,15 @@ def func4(val: Union[str, int]) -> Union[str, int]:
         # point, it should be assignable to Union[str, int]
         # because Never is assignable to any type.
         return val
+
+
+class MyFlags(Flag):
+    V1 = 1
+    V2 = 2
+
+
+def func5(val: MyFlags):
+    if val == MyFlags.V1 or val == MyFlags.V2:
+        return
+
+    reveal_type(val, expected_text="MyFlags")


### PR DESCRIPTION
…rive from `enum.Flag`. In this case, we can't use enum expansion to a union of literals. This addresses #7576.