### PR TITLE
Refactored tokenizer and parser output to help reduce the amount of memory needed.

### DIFF
--- a/packages/pyright-internal/src/analyzer/checker.ts
+++ b/packages/pyright-internal/src/analyzer/checker.ts
@@ -89,7 +89,7 @@ import {
     YieldNode,
     isExpressionNode,
 } from '../parser/parseNodes';
-import { ParseResults } from '../parser/parser';
+import { ParserOutput } from '../parser/parser';
 import { UnescapeError, UnescapeErrorType, getUnescapedString } from '../parser/stringTokenUtils';
 import { OperatorType, StringTokenFlags, TokenType } from '../parser/tokenizerTypes';
 import { AnalyzerFileInfo } from './analyzerFileInfo';
@@ -224,9 +224,9 @@ export class Checker extends ParseTreeWalker {
     constructor(
         private _importResolver: ImportResolver,
         private _evaluator: TypeEvaluator,
-        parseResults: ParseResults,
+        parseResults: ParserOutput,
         private _sourceMapper: SourceMapper,
-        private _dependentFiles?: ParseResults[]
+        private _dependentFiles?: ParserOutput[]
     ) {
         super();
 

--- a/packages/pyright-internal/src/analyzer/packageTypeVerifier.ts
+++ b/packages/pyright-internal/src/analyzer/packageTypeVerifier.ts
@@ -283,7 +283,7 @@ export class PackageTypeVerifier {
                     isExported: true,
                 };
 
-                const parseTree = sourceFile.getParseResults()!.parseTree;
+                const parseTree = sourceFile.getParserOutput()!.parseTree;
                 const moduleScope = getScopeForNode(parseTree)!;
 
                 this._getPublicSymbolsInSymbolTable(
@@ -396,7 +396,7 @@ export class PackageTypeVerifier {
             const sourceFile = this._program.getBoundSourceFile(modulePath);
 
             if (sourceFile) {
-                const parseTree = sourceFile.getParseResults()!.parseTree;
+                const parseTree = sourceFile.getParserOutput()!.parseTree;
                 const moduleScope = getScopeForNode(parseTree)!;
 
                 this._getTypeKnownStatusForSymbolTable(

--- a/packages/pyright-internal/src/analyzer/service.ts
+++ b/packages/pyright-internal/src/analyzer/service.ts
@@ -17,6 +17,7 @@ import { CancellationProvider, DefaultCancellationProvider } from '../common/can
 import { CommandLineOptions } from '../common/commandLineOptions';
 import { ConfigOptions, matchFileSpecs } from '../common/configOptions';
 import { ConsoleInterface, LogLevel, StandardConsole, log } from '../common/console';
+import { isString } from '../common/core';
 import { Diagnostic } from '../common/diagnostic';
 import { FileEditAction } from '../common/editAction';
 import { EditableProgram, ProgramView } from '../common/extensibility';
@@ -25,10 +26,11 @@ import { FileWatcher, FileWatcherEventType, ignoredWatchEventFunction } from '..
 import { Host, HostFactory, NoAccessHost } from '../common/host';
 import { defaultStubsDirectory } from '../common/pathConsts';
 import { getFileName, isRootedDiskPath, normalizeSlashes } from '../common/pathUtils';
-import { ServiceProvider } from '../common/serviceProvider';
 import { ServiceKeys } from '../common/serviceKeys';
+import { ServiceProvider } from '../common/serviceProvider';
 import { Range } from '../common/textRange';
 import { timingStats } from '../common/timing';
+import { Uri } from '../common/uri/uri';
 import {
     FileSpec,
     forEachAncestorDirectory,
@@ -52,8 +54,6 @@ import { MaxAnalysisTime, Program } from './program';
 import { findPythonSearchPaths } from './pythonPathUtils';
 import { IPythonMode } from './sourceFile';
 import { TypeEvaluator } from './typeEvaluatorTypes';
-import { Uri } from '../common/uri/uri';
-import { isString } from '../common/core';
 
 export const configFileNames = ['pyrightconfig.json'];
 export const pyprojectTomlName = 'pyproject.toml';
@@ -352,7 +352,11 @@ export class AnalyzerService {
         this._backgroundAnalysisProgram.addInterimFile(uri);
     }
 
-    getParseResult(uri: Uri) {
+    getParserOutput(uri: Uri) {
+        return this._program.getParserOutput(uri);
+    }
+
+    getParseResults(uri: Uri) {
         return this._program.getParseResults(uri);
     }
 

--- a/packages/pyright-internal/src/analyzer/sourceFile.ts
+++ b/packages/pyright-internal/src/analyzer/sourceFile.ts
@@ -30,8 +30,8 @@ import { Duration, timingStats } from '../common/timing';
 import { Uri } from '../common/uri/uri';
 import { LocMessage } from '../localization/localize';
 import { ModuleNode } from '../parser/parseNodes';
-import { ModuleImport, ParseOptions, ParseResults, Parser } from '../parser/parser';
-import { IgnoreComment } from '../parser/tokenizer';
+import { ModuleImport, ParseFileResults, ParseOptions, Parser, ParserOutput } from '../parser/parser';
+import { IgnoreComment, Tokenizer, TokenizerOutput } from '../parser/tokenizer';
 import { Token } from '../parser/tokenizerTypes';
 import { AnalyzerFileInfo, ImportLookup } from './analyzerFileInfo';
 import * as AnalyzerNodeInfo from './analyzerNodeInfo';
@@ -95,7 +95,11 @@ class WriteableData {
     // the binder information hanging from it?
     parseTreeNeedsCleaning = false;
 
-    parseResults: ParseResults | undefined;
+    parserOutput: ParserOutput | undefined;
+    parsedFileContents: string | undefined;
+    tokenizerLines: TextRangeCollection<TextRange> | undefined;
+    tokenizerOutput: TokenizerOutput | undefined;
+
     moduleSymbolTable: SymbolTable | undefined;
 
     // Reentrancy check for binding.
@@ -106,6 +110,7 @@ class WriteableData {
     commentDiagnostics: Diagnostic[] = [];
     bindDiagnostics: Diagnostic[] = [];
     checkerDiagnostics: Diagnostic[] = [];
+    taskListDiagnostics: Diagnostic[] = [];
     typeIgnoreLines = new Map<number, IgnoreComment>();
     typeIgnoreAll: IgnoreComment | undefined;
     pyrightIgnoreLines = new Map<number, IgnoreComment>();
@@ -160,12 +165,13 @@ class WriteableData {
  commentDiagnostics=${this.commentDiagnostics?.length},
  bindDiagnostics=${this.bindDiagnostics?.length},
  checkerDiagnostics=${this.checkerDiagnostics?.length},
+ taskListDiagnostics=${this.taskListDiagnostics?.length},
  accumulatedDiagnostics=${this.accumulatedDiagnostics?.length},
  typeIgnoreLines=${this.typeIgnoreLines?.size},
  pyrightIgnoreLines=${this.pyrightIgnoreLines?.size},
  checkTime=${this.checkTime},
  clientDocumentContents=${this.clientDocumentContents?.length},
- parseResults=${this.parseResults?.parseTree.length}`;
+ parseResults=${this.parserOutput?.parseTree.length}`;
     }
 }
 
@@ -399,7 +405,10 @@ export class SourceFile {
     dropParseAndBindInfo(): void {
         this._fireFileDirtyEvent();
 
-        this._writableData.parseResults = undefined;
+        this._writableData.parserOutput = undefined;
+        this._writableData.tokenizerLines = undefined;
+        this._writableData.tokenizerOutput = undefined;
+        this._writableData.parsedFileContents = undefined;
         this._writableData.moduleSymbolTable = undefined;
         this._writableData.isBindingNeeded = true;
     }
@@ -421,10 +430,10 @@ export class SourceFile {
 
         // If the file contains a wildcard import or __all__ symbols,
         // we need to rebind because a dependent import may have changed.
-        if (this._writableData.parseResults) {
+        if (this._writableData.parserOutput) {
             if (
-                this._writableData.parseResults.containsWildcardImport ||
-                AnalyzerNodeInfo.getDunderAllInfo(this._writableData.parseResults.parseTree) !== undefined ||
+                this._writableData.parserOutput.containsWildcardImport ||
+                AnalyzerNodeInfo.getDunderAllInfo(this._writableData.parserOutput.parseTree) !== undefined ||
                 forceRebinding
             ) {
                 // We don't need to rebuild index data since wildcard
@@ -481,6 +490,10 @@ export class SourceFile {
         if (version === null) {
             this._writableData.clientDocumentVersion = undefined;
             this._writableData.clientDocumentContents = undefined;
+
+            // Since the file is no longer open, dump the tokenizer output
+            // so it doesn't consume memory.
+            this._writableData.tokenizerOutput = undefined;
         } else {
             this._writableData.clientDocumentVersion = version;
             this._writableData.clientDocumentContents = contents;
@@ -511,7 +524,7 @@ export class SourceFile {
 
     isParseRequired() {
         return (
-            !this._writableData.parseResults ||
+            !this._writableData.parserOutput ||
             this._writableData.analyzedFileContentsVersion !== this._writableData.fileContentsVersion
         );
     }
@@ -532,12 +545,33 @@ export class SourceFile {
         return this._writableData.isCheckingNeeded;
     }
 
-    getParseResults(): ParseResults | undefined {
-        if (!this.isParseRequired()) {
-            return this._writableData.parseResults;
+    getParseResults(): ParseFileResults | undefined {
+        if (this.isParseRequired()) {
+            return undefined;
         }
 
-        return undefined;
+        assert(this._writableData.parserOutput !== undefined && this._writableData.parsedFileContents !== undefined);
+
+        // If we've cached the tokenizer output, use the cached version.
+        // Otherwise re-tokenize the contents on demand.
+        const tokenizerOutput =
+            this._writableData.tokenizerOutput ?? this._tokenizeContents(this._writableData.parsedFileContents);
+
+        return {
+            parserOutput: this._writableData.parserOutput,
+            tokenizerOutput,
+            text: this._writableData.parsedFileContents,
+        };
+    }
+
+    getParserOutput(): ParserOutput | undefined {
+        if (this.isParseRequired()) {
+            return undefined;
+        }
+
+        assert(this._writableData.parserOutput !== undefined);
+
+        return this._writableData.parserOutput;
     }
 
     // Adds a new circular dependency for this file but only if
@@ -610,7 +644,7 @@ export class SourceFile {
 
             try {
                 // Parse the token stream, building the abstract syntax tree.
-                const parseResults = this._parseFile(
+                const parseFileResults = this._parseFile(
                     configOptions,
                     this._uri,
                     fileContents!,
@@ -618,19 +652,25 @@ export class SourceFile {
                     diagSink
                 );
 
-                assert(parseResults !== undefined && parseResults.tokenizerOutput !== undefined);
-                this._writableData.parseResults = parseResults;
-                this._writableData.typeIgnoreLines = this._writableData.parseResults.tokenizerOutput.typeIgnoreLines;
-                this._writableData.typeIgnoreAll = this._writableData.parseResults.tokenizerOutput.typeIgnoreAll;
-                this._writableData.pyrightIgnoreLines =
-                    this._writableData.parseResults.tokenizerOutput.pyrightIgnoreLines;
+                assert(parseFileResults !== undefined && parseFileResults.tokenizerOutput !== undefined);
+                this._writableData.parserOutput = parseFileResults.parserOutput;
+                this._writableData.tokenizerLines = parseFileResults.tokenizerOutput.lines;
+                this._writableData.parsedFileContents = fileContents;
+                this._writableData.typeIgnoreLines = parseFileResults.tokenizerOutput.typeIgnoreLines;
+                this._writableData.typeIgnoreAll = parseFileResults.tokenizerOutput.typeIgnoreAll;
+                this._writableData.pyrightIgnoreLines = parseFileResults.tokenizerOutput.pyrightIgnoreLines;
+
+                // Cache the tokenizer output only if this file is open.
+                if (this._writableData.clientDocumentContents !== undefined) {
+                    this._writableData.tokenizerOutput = parseFileResults.tokenizerOutput;
+                }
 
                 // Resolve imports.
                 const execEnvironment = configOptions.findExecEnvironment(this._uri);
                 timingStats.resolveImportsTime.timeOperation(() => {
                     const importResult = this._resolveImports(
                         importResolver,
-                        parseResults.importedModules,
+                        parseFileResults.parserOutput.importedModules,
                         execEnvironment
                     );
 
@@ -638,6 +678,13 @@ export class SourceFile {
                     this._writableData.builtinsImport = importResult.builtinsImportResult;
 
                     this._writableData.parseDiagnostics = diagSink.fetchAndClear();
+
+                    this._writableData.taskListDiagnostics = [];
+                    this._addTaskListDiagnostics(
+                        configOptions.taskListTokens,
+                        parseFileResults.tokenizerOutput,
+                        this._writableData.taskListDiagnostics
+                    );
                 });
 
                 // Is this file in a "strict" path?
@@ -647,8 +694,8 @@ export class SourceFile {
 
                 const commentDiags: CommentUtils.CommentDiagnostic[] = [];
                 this._diagnosticRuleSet = CommentUtils.getFileLevelDirectives(
-                    this._writableData.parseResults.tokenizerOutput.tokens,
-                    this._writableData.parseResults.tokenizerOutput.lines,
+                    parseFileResults.tokenizerOutput.tokens,
+                    parseFileResults.tokenizerOutput.lines,
                     configOptions.diagnosticRuleSet,
                     useStrict,
                     commentDiags
@@ -661,10 +708,7 @@ export class SourceFile {
                         new Diagnostic(
                             DiagnosticCategory.Error,
                             commentDiag.message,
-                            convertTextRangeToRange(
-                                commentDiag.range,
-                                this._writableData.parseResults!.tokenizerOutput.lines
-                            )
+                            convertTextRangeToRange(commentDiag.range, parseFileResults.tokenizerOutput.lines)
                         )
                     );
                 });
@@ -681,25 +725,30 @@ export class SourceFile {
                 );
 
                 // Create dummy parse results.
-                this._writableData.parseResults = {
-                    text: '',
+                this._writableData.parsedFileContents = '';
+
+                this._writableData.parserOutput = {
                     parseTree: ModuleNode.create({ start: 0, length: 0 }),
                     importedModules: [],
                     futureImports: new Set<string>(),
-                    tokenizerOutput: {
-                        tokens: new TextRangeCollection<Token>([]),
-                        lines: new TextRangeCollection<TextRange>([]),
-                        typeIgnoreAll: undefined,
-                        typeIgnoreLines: new Map<number, IgnoreComment>(),
-                        pyrightIgnoreLines: new Map<number, IgnoreComment>(),
-                        predominantEndOfLineSequence: '\n',
-                        hasPredominantTabSequence: false,
-                        predominantTabSequence: '    ',
-                        predominantSingleQuoteCharacter: "'",
-                    },
                     containsWildcardImport: false,
                     typingSymbolAliases: new Map<string, string>(),
                 };
+
+                this._writableData.tokenizerLines = new TextRangeCollection<TextRange>([]);
+
+                this._writableData.tokenizerOutput = {
+                    tokens: new TextRangeCollection<Token>([]),
+                    lines: this._writableData.tokenizerLines,
+                    typeIgnoreAll: undefined,
+                    typeIgnoreLines: new Map<number, IgnoreComment>(),
+                    pyrightIgnoreLines: new Map<number, IgnoreComment>(),
+                    predominantEndOfLineSequence: '\n',
+                    hasPredominantTabSequence: false,
+                    predominantTabSequence: '    ',
+                    predominantSingleQuoteCharacter: "'",
+                };
+
                 this._writableData.imports = undefined;
                 this._writableData.builtinsImport = undefined;
 
@@ -712,6 +761,7 @@ export class SourceFile {
                     getEmptyRange()
                 );
                 this._writableData.parseDiagnostics = diagSink.fetchAndClear();
+                this._writableData.taskListDiagnostics = diagSink.fetchAndClear();
 
                 // Do not rethrow the exception, swallow it here. Callers are not
                 // prepared to handle an exception.
@@ -738,7 +788,7 @@ export class SourceFile {
         assert(!this.isParseRequired(), 'Bind called before parsing');
         assert(this.isBindingRequired(), 'Bind called unnecessarily');
         assert(!this._writableData.isBindingInProgress, 'Bind called while binding in progress');
-        assert(this._writableData.parseResults !== undefined, 'Parse results not available');
+        assert(this._writableData.parserOutput !== undefined, 'Parse results not available');
 
         return this._logTracker.log(`binding: ${this._getPathForLogging(this._uri)}`, () => {
             try {
@@ -748,26 +798,26 @@ export class SourceFile {
 
                     const fileInfo = this._buildFileInfo(
                         configOptions,
-                        this._writableData.parseResults!.text,
+                        this._writableData.parsedFileContents!,
                         importLookup,
                         builtinsScope,
                         futureImports
                     );
-                    AnalyzerNodeInfo.setFileInfo(this._writableData.parseResults!.parseTree, fileInfo);
+                    AnalyzerNodeInfo.setFileInfo(this._writableData.parserOutput!.parseTree, fileInfo);
 
                     const binder = new Binder(fileInfo, configOptions.indexGenerationMode);
                     this._writableData.isBindingInProgress = true;
-                    binder.bindModule(this._writableData.parseResults!.parseTree);
+                    binder.bindModule(this._writableData.parserOutput!.parseTree);
 
                     // If we're in "test mode" (used for unit testing), run an additional
                     // "test walker" over the parse tree to validate its internal consistency.
                     if (configOptions.internalTestMode) {
                         const testWalker = new TestWalker();
-                        testWalker.walk(this._writableData.parseResults!.parseTree);
+                        testWalker.walk(this._writableData.parserOutput!.parseTree);
                     }
 
                     this._writableData.bindDiagnostics = fileInfo.diagnosticSink.fetchAndClear();
-                    const moduleScope = AnalyzerNodeInfo.getScope(this._writableData.parseResults!.parseTree);
+                    const moduleScope = AnalyzerNodeInfo.getScope(this._writableData.parserOutput!.parseTree);
                     assert(moduleScope !== undefined, 'Module scope not returned by binder');
                     this._writableData.moduleSymbolTable = moduleScope!.symbolTable;
                 });
@@ -812,13 +862,13 @@ export class SourceFile {
         importResolver: ImportResolver,
         evaluator: TypeEvaluator,
         sourceMapper: SourceMapper,
-        dependentFiles?: ParseResults[]
+        dependentFiles?: ParserOutput[]
     ) {
         assert(!this.isParseRequired(), 'Check called before parsing');
         assert(!this.isBindingRequired(), `Check called before binding: state=${this._writableData.debugPrint()}`);
         assert(!this._writableData.isBindingInProgress, 'Check called while binding in progress');
         assert(this.isCheckingRequired(), 'Check called unnecessarily');
-        assert(this._writableData.parseResults !== undefined, 'Parse results not available');
+        assert(this._writableData.parserOutput !== undefined, 'Parse results not available');
 
         return this._logTracker.log(`checking: ${this._getPathForLogging(this._uri)}`, () => {
             try {
@@ -827,14 +877,14 @@ export class SourceFile {
                     const checker = new Checker(
                         importResolver,
                         evaluator,
-                        this._writableData.parseResults!,
+                        this._writableData.parserOutput!,
                         sourceMapper,
                         dependentFiles
                     );
                     checker.check();
                     this._writableData.isCheckingNeeded = false;
 
-                    const fileInfo = AnalyzerNodeInfo.getFileInfo(this._writableData.parseResults!.parseTree)!;
+                    const fileInfo = AnalyzerNodeInfo.getFileInfo(this._writableData.parserOutput!.parseTree)!;
                     this._writableData.checkerDiagnostics = fileInfo.diagnosticSink.fetchAndClear();
                     this._writableData.checkTime = checkDuration.getDurationInMilliseconds();
                 });
@@ -908,6 +958,7 @@ export class SourceFile {
         appendArray(diagList, this._writableData.commentDiagnostics);
         appendArray(diagList, this._writableData.bindDiagnostics);
         appendArray(diagList, this._writableData.checkerDiagnostics);
+        appendArray(diagList, this._writableData.taskListDiagnostics);
 
         const prefilteredDiagList = diagList;
         const typeIgnoreLinesClone = new Map(this._writableData.typeIgnoreLines);
@@ -1018,11 +1069,7 @@ export class SourceFile {
             if (prefilteredErrorList.length === 0 && this._writableData.typeIgnoreAll !== undefined) {
                 const rangeStart = this._writableData.typeIgnoreAll.range.start;
                 const rangeEnd = rangeStart + this._writableData.typeIgnoreAll.range.length;
-                const range = convertOffsetsToRange(
-                    rangeStart,
-                    rangeEnd,
-                    this._writableData.parseResults!.tokenizerOutput.lines!
-                );
+                const range = convertOffsetsToRange(rangeStart, rangeEnd, this._writableData.tokenizerLines!);
 
                 if (!isUnreachableCodeRange(range) && this._diagnosticRuleSet.enableTypeIgnoreComments) {
                     unnecessaryTypeIgnoreDiags.push(
@@ -1032,14 +1079,10 @@ export class SourceFile {
             }
 
             typeIgnoreLinesClone.forEach((ignoreComment) => {
-                if (this._writableData.parseResults?.tokenizerOutput.lines) {
+                if (this._writableData.tokenizerLines!) {
                     const rangeStart = ignoreComment.range.start;
                     const rangeEnd = rangeStart + ignoreComment.range.length;
-                    const range = convertOffsetsToRange(
-                        rangeStart,
-                        rangeEnd,
-                        this._writableData.parseResults!.tokenizerOutput.lines!
-                    );
+                    const range = convertOffsetsToRange(rangeStart, rangeEnd, this._writableData.tokenizerLines!);
 
                     if (!isUnreachableCodeRange(range) && this._diagnosticRuleSet.enableTypeIgnoreComments) {
                         unnecessaryTypeIgnoreDiags.push(
@@ -1050,15 +1093,11 @@ export class SourceFile {
             });
 
             pyrightIgnoreLinesClone.forEach((ignoreComment) => {
-                if (this._writableData.parseResults?.tokenizerOutput.lines) {
+                if (this._writableData.tokenizerLines!) {
                     if (!ignoreComment.rulesList) {
                         const rangeStart = ignoreComment.range.start;
                         const rangeEnd = rangeStart + ignoreComment.range.length;
-                        const range = convertOffsetsToRange(
-                            rangeStart,
-                            rangeEnd,
-                            this._writableData.parseResults!.tokenizerOutput.lines!
-                        );
+                        const range = convertOffsetsToRange(rangeStart, rangeEnd, this._writableData.tokenizerLines!);
 
                         if (!isUnreachableCodeRange(range)) {
                             unnecessaryTypeIgnoreDiags.push(
@@ -1072,7 +1111,7 @@ export class SourceFile {
                             const range = convertOffsetsToRange(
                                 rangeStart,
                                 rangeEnd,
-                                this._writableData.parseResults!.tokenizerOutput.lines!
+                                this._writableData.tokenizerLines!
                             );
 
                             if (!isUnreachableCodeRange(range)) {
@@ -1123,9 +1162,6 @@ export class SourceFile {
                 )
             );
         }
-
-        // Add diagnostics for comments that match the task list tokens.
-        this._addTaskListDiagnostics(configOptions.taskListTokens, diagList);
 
         // If there is a "type: ignore" comment at the top of the file, clear
         // the diagnostic list of all error, warning, and information diagnostics.
@@ -1178,17 +1214,15 @@ export class SourceFile {
 
     // Get all task list diagnostics for the current file and add them
     // to the specified diagnostic list.
-    private _addTaskListDiagnostics(taskListTokens: TaskListToken[] | undefined, diagList: Diagnostic[]) {
+    private _addTaskListDiagnostics(
+        taskListTokens: TaskListToken[] | undefined,
+        tokenizerOutput: TokenizerOutput,
+        diagList: Diagnostic[]
+    ) {
         if (!taskListTokens || taskListTokens.length === 0 || !diagList) {
             return;
         }
 
-        // If we have no tokens, we're done.
-        if (!this._writableData.parseResults?.tokenizerOutput?.tokens) {
-            return;
-        }
-
-        const tokenizerOutput = this._writableData.parseResults.tokenizerOutput;
         for (let i = 0; i < tokenizerOutput.tokens.count; i++) {
             const token = tokenizerOutput.tokens.getItemAt(i);
 
@@ -1241,10 +1275,8 @@ export class SourceFile {
         builtinsScope: Scope | undefined,
         futureImports: Set<string>
     ) {
-        assert(this._writableData.parseResults !== undefined, 'Parse results not available');
-        const analysisDiagnostics = this.createTextRangeDiagnosticSink(
-            this._writableData.parseResults!.tokenizerOutput.lines
-        );
+        assert(this._writableData.parserOutput !== undefined, 'Parse results not available');
+        const analysisDiagnostics = this.createTextRangeDiagnosticSink(this._writableData.tokenizerLines!);
 
         const fileInfo: AnalyzerFileInfo = {
             importLookup,
@@ -1254,8 +1286,8 @@ export class SourceFile {
             executionEnvironment: configOptions.findExecEnvironment(this._uri),
             diagnosticRuleSet: this._diagnosticRuleSet,
             fileContents,
-            lines: this._writableData.parseResults!.tokenizerOutput.lines,
-            typingSymbolAliases: this._writableData.parseResults!.typingSymbolAliases,
+            lines: this._writableData.tokenizerLines!,
+            typingSymbolAliases: this._writableData.parserOutput!.typingSymbolAliases,
             definedConstants: configOptions.defineConstant,
             fileUri: this._uri,
             moduleName: this.getModuleName(),
@@ -1272,9 +1304,9 @@ export class SourceFile {
     }
 
     private _cleanParseTreeIfRequired() {
-        if (this._writableData.parseResults) {
+        if (this._writableData.parserOutput) {
             if (this._writableData.parseTreeNeedsCleaning) {
-                const cleanerWalker = new ParseTreeCleanerWalker(this._writableData.parseResults.parseTree);
+                const cleanerWalker = new ParseTreeCleanerWalker(this._writableData.parserOutput.parseTree);
                 cleanerWalker.clean();
                 this._writableData.parseTreeNeedsCleaning = false;
             }
@@ -1365,8 +1397,8 @@ export class SourceFile {
         fileContents: string,
         ipythonMode: IPythonMode,
         diagSink: DiagnosticSink
-    ) {
-        // Use the configuration options to determine the environment in which
+    ): ParseFileResults {
+        // Use the configuration options to determine the environment zin which
         // this source file will be executed.
         const execEnvironment = configOptions.findExecEnvironment(fileUri);
 
@@ -1381,6 +1413,23 @@ export class SourceFile {
         // Parse the token stream, building the abstract syntax tree.
         const parser = new Parser();
         return parser.parseSourceFile(fileContents, parseOptions, diagSink);
+    }
+
+    private _tokenizeContents(fileContents: string): TokenizerOutput {
+        const tokenizer = new Tokenizer();
+        const output = tokenizer.tokenize(fileContents);
+
+        // If the file is currently open, cache the tokenizer results.
+        if (this._writableData.clientDocumentContents !== undefined) {
+            this._writableData.tokenizerOutput = output;
+
+            // Replace the existing tokenizerLines with the newly-returned
+            // version. They should have the same contents, but we want to use
+            // the same object so the older object can be deallocated.
+            this._writableData.tokenizerLines = output.lines;
+        }
+
+        return output;
     }
 
     private _fireFileDirtyEvent() {

--- a/packages/pyright-internal/src/analyzer/sourceFileInfoUtils.ts
+++ b/packages/pyright-internal/src/analyzer/sourceFileInfoUtils.ts
@@ -90,7 +90,7 @@ function _parseAllOpenCells(program: ProgramView): void {
             continue;
         }
 
-        program.getParseResults(file.sourceFile.getUri());
+        program.getParserOutput(file.sourceFile.getUri());
         program.handleMemoryHighUsage();
     }
 }

--- a/packages/pyright-internal/src/analyzer/sourceMapper.ts
+++ b/packages/pyright-internal/src/analyzer/sourceMapper.ts
@@ -70,12 +70,12 @@ export class SourceMapper {
 
         return sourceFiles
             .filter(isDefined)
-            .map((sf) => sf.getParseResults()?.parseTree)
+            .map((sf) => sf.getParserOutput()?.parseTree)
             .filter(isDefined);
     }
 
     getModuleNode(fileUri: Uri): ModuleNode | undefined {
-        return this._boundSourceGetter(fileUri)?.sourceFile.getParseResults()?.parseTree;
+        return this._boundSourceGetter(fileUri)?.sourceFile.getParserOutput()?.parseTree;
     }
 
     findDeclarations(stubDecl: Declaration): Declaration[] {
@@ -350,7 +350,7 @@ export class SourceMapper {
 
         recursiveDeclCache.add(uniqueId);
 
-        const moduleNode = sourceFile.getParseResults()?.parseTree;
+        const moduleNode = sourceFile.getParserOutput()?.parseTree;
         if (!moduleNode) {
             // Don't bother deleting from the cache; we'll never get any info from this
             // file if it has no tree.
@@ -384,7 +384,7 @@ export class SourceMapper {
 
         recursiveDeclCache.add(uniqueId);
 
-        const moduleNode = sourceFile.getParseResults()?.parseTree;
+        const moduleNode = sourceFile.getParserOutput()?.parseTree;
         if (!moduleNode) {
             // Don't bother deleting from the cache; we'll never get any info from this
             // file if it has no tree.
@@ -412,7 +412,7 @@ export class SourceMapper {
         let classDecls: ClassOrFunctionOrVariableDeclaration[] = [];
 
         // fullClassName is period delimited, for example: 'OuterClass.InnerClass'
-        const parentNode = sourceFile.getParseResults()?.parseTree;
+        const parentNode = sourceFile.getParserOutput()?.parseTree;
         if (parentNode) {
             let classNameParts = fullClassName.split('.');
             if (classNameParts.length > 0) {
@@ -669,7 +669,7 @@ export class SourceMapper {
 
                 const sourceFiles = this._getSourceFiles(decl.uri);
                 for (const sourceFile of sourceFiles) {
-                    const moduleNode = sourceFile.getParseResults()?.parseTree;
+                    const moduleNode = sourceFile.getParserOutput()?.parseTree;
                     if (!moduleNode) {
                         continue;
                     }

--- a/packages/pyright-internal/src/analyzer/typeStubWriter.ts
+++ b/packages/pyright-internal/src/analyzer/typeStubWriter.ts
@@ -175,7 +175,7 @@ export class TypeStubWriter extends ParseTreeWalker {
         this._lineEnd = parseResults.tokenizerOutput.predominantEndOfLineSequence;
         this._tab = parseResults.tokenizerOutput.predominantTabSequence;
 
-        this.walk(parseResults.parseTree);
+        this.walk(parseResults.parserOutput.parseTree);
 
         this._writeFile();
     }

--- a/packages/pyright-internal/src/common/extensibility.ts
+++ b/packages/pyright-internal/src/common/extensibility.ts
@@ -18,7 +18,7 @@ import { TypeEvaluator } from '../analyzer/typeEvaluatorTypes';
 import { Diagnostic } from '../common/diagnostic';
 import { ServerSettings } from '../common/languageServerInterface';
 import { ParseNode } from '../parser/parseNodes';
-import { ParseResults } from '../parser/parser';
+import { ParseFileResults, ParserOutput } from '../parser/parser';
 import { ConfigOptions } from './configOptions';
 import { ConsoleInterface } from './console';
 import { ReadOnlyFileSystem } from './fileSystem';
@@ -85,7 +85,8 @@ export interface ProgramView {
 
     owns(uri: Uri): boolean;
     getSourceFileInfoList(): readonly SourceFileInfo[];
-    getParseResults(fileUri: Uri): ParseResults | undefined;
+    getParserOutput(fileUri: Uri): ParserOutput | undefined;
+    getParseResults(fileUri: Uri): ParseFileResults | undefined;
     getSourceFileInfo(fileUri: Uri): SourceFileInfo | undefined;
     getChainedUri(fileUri: Uri): Uri | undefined;
     getSourceMapper(fileUri: Uri, token: CancellationToken, mapCompiled?: boolean, preferStubs?: boolean): SourceMapper;

--- a/packages/pyright-internal/src/common/workspaceEditUtils.ts
+++ b/packages/pyright-internal/src/common/workspaceEditUtils.ts
@@ -27,8 +27,8 @@ import { ReadOnlyFileSystem } from './fileSystem';
 import { convertRangeToTextRange, convertTextRangeToRange } from './positionUtils';
 import { TextRange } from './textRange';
 import { TextRangeCollection } from './textRangeCollection';
-import { encodeUri } from './uri/uriUtils';
 import { Uri } from './uri/uri';
+import { encodeUri } from './uri/uriUtils';
 
 export function convertToTextEdits(editActions: TextEditAction[]): TextEdit[] {
     return editActions.map((editAction) => ({
@@ -187,7 +187,7 @@ export function generateWorkspaceEdit(
 
         edits.changes![encodeUri(fs, uri)] = [
             {
-                range: convertTextRangeToRange(parseResults.parseTree, parseResults.tokenizerOutput.lines),
+                range: convertTextRangeToRange(parseResults.parserOutput.parseTree, parseResults.tokenizerOutput.lines),
                 newText: final.getFileContent() ?? '',
             },
         ];

--- a/packages/pyright-internal/src/languageService/autoImporter.ts
+++ b/packages/pyright-internal/src/languageService/autoImporter.ts
@@ -36,7 +36,7 @@ import * as StringUtils from '../common/stringUtils';
 import { Position } from '../common/textRange';
 import { Uri } from '../common/uri/uri';
 import { ParseNodeType } from '../parser/parseNodes';
-import { ParseResults } from '../parser/parser';
+import { ParseFileResults } from '../parser/parser';
 import { CompletionMap } from './completionProvider';
 import { IndexAliasData } from './symbolIndexer';
 
@@ -165,13 +165,16 @@ export class AutoImporter {
     constructor(
         protected readonly execEnvironment: ExecutionEnvironment,
         protected readonly importResolver: ImportResolver,
-        protected readonly parseResults: ParseResults,
+        protected readonly parseResults: ParseFileResults,
         private readonly _invocationPosition: Position,
         private readonly _excludes: CompletionMap,
         protected readonly moduleSymbolMap: ModuleSymbolMap,
         protected readonly options: AutoImportOptions
     ) {
-        this._importStatements = getTopLevelImports(this.parseResults.parseTree, /* includeImplicitImports */ true);
+        this._importStatements = getTopLevelImports(
+            this.parseResults.parserOutput.parseTree,
+            /* includeImplicitImports */ true
+        );
     }
 
     getAutoImportCandidates(

--- a/packages/pyright-internal/src/languageService/callHierarchyProvider.ts
+++ b/packages/pyright-internal/src/languageService/callHierarchyProvider.ts
@@ -33,16 +33,16 @@ import { getSymbolKind } from '../common/lspUtils';
 import { convertOffsetsToRange } from '../common/positionUtils';
 import { ServiceKeys } from '../common/serviceKeys';
 import { Position, rangesAreEqual } from '../common/textRange';
+import { Uri } from '../common/uri/uri';
 import { encodeUri } from '../common/uri/uriUtils';
 import { ReferencesProvider, ReferencesResult } from '../languageService/referencesProvider';
 import { CallNode, MemberAccessNode, NameNode, ParseNode, ParseNodeType } from '../parser/parseNodes';
-import { ParseResults } from '../parser/parser';
+import { ParseFileResults } from '../parser/parser';
 import { DocumentSymbolCollector } from './documentSymbolCollector';
 import { canNavigateToFile } from './navigationUtils';
-import { Uri } from '../common/uri/uri';
 
 export class CallHierarchyProvider {
-    private readonly _parseResults: ParseResults | undefined;
+    private readonly _parseResults: ParseFileResults | undefined;
 
     constructor(
         private _program: ProgramView,
@@ -291,7 +291,7 @@ class FindOutgoingCallTreeWalker extends ParseTreeWalker {
     constructor(
         private _fs: ReadOnlyFileSystem,
         private _parseRoot: ParseNode,
-        private _parseResults: ParseResults,
+        private _parseResults: ParseFileResults,
         private _evaluator: TypeEvaluator,
         private _cancellationToken: CancellationToken
     ) {
@@ -423,7 +423,7 @@ class FindIncomingCallTreeWalker extends ParseTreeWalker {
     private readonly _declarations: Declaration[] = [];
 
     private readonly _usageProviders: SymbolUsageProvider[];
-    private readonly _parseResults: ParseResults;
+    private readonly _parseResults: ParseFileResults;
 
     constructor(
         private readonly _program: ProgramView,
@@ -446,7 +446,7 @@ class FindIncomingCallTreeWalker extends ParseTreeWalker {
     }
 
     findCalls(): CallHierarchyIncomingCall[] {
-        this.walk(this._parseResults.parseTree);
+        this.walk(this._parseResults.parserOutput.parseTree);
         return this._incomingCalls;
     }
 

--- a/packages/pyright-internal/src/languageService/completionProvider.ts
+++ b/packages/pyright-internal/src/languageService/completionProvider.ts
@@ -108,7 +108,7 @@ import {
     StringNode,
     TypeAnnotationNode,
 } from '../parser/parseNodes';
-import { ParseResults } from '../parser/parser';
+import { ParseFileResults } from '../parser/parser';
 import {
     FStringStartToken,
     OperatorToken,
@@ -278,7 +278,7 @@ export class CompletionProvider {
     private _stringLiteralContainer: StringToken | FStringStartToken | undefined = undefined;
 
     protected readonly execEnv: ExecutionEnvironment;
-    protected readonly parseResults: ParseResults;
+    protected readonly parseResults: ParseFileResults;
     protected readonly sourceMapper: SourceMapper;
 
     // If we're being asked to resolve a completion item, we run the
@@ -1087,7 +1087,7 @@ export class CompletionProvider {
             return undefined;
         }
 
-        let node = ParseTreeUtils.findNodeByOffset(this.parseResults.parseTree, offset);
+        let node = ParseTreeUtils.findNodeByOffset(this.parseResults.parserOutput.parseTree, offset);
 
         // See if we're inside a string literal or an f-string statement.
         const token = ParseTreeUtils.getTokenOverlapping(this.parseResults.tokenizerOutput.tokens, offset);
@@ -1130,7 +1130,7 @@ export class CompletionProvider {
                     sawComma = true;
                 }
 
-                const curNode = ParseTreeUtils.findNodeByOffset(this.parseResults.parseTree, curOffset);
+                const curNode = ParseTreeUtils.findNodeByOffset(this.parseResults.parserOutput.parseTree, curOffset);
                 if (curNode && curNode !== initialNode) {
                     if (ParseTreeUtils.getNodeDepth(curNode) > initialDepth) {
                         node = curNode;
@@ -1551,7 +1551,10 @@ export class CompletionProvider {
                     }
 
                     const previousOffset = TextRange.getEnd(prevToken);
-                    const previousNode = ParseTreeUtils.findNodeByOffset(this.parseResults.parseTree, previousOffset);
+                    const previousNode = ParseTreeUtils.findNodeByOffset(
+                        this.parseResults.parserOutput.parseTree,
+                        previousOffset
+                    );
                     if (
                         previousNode?.nodeType !== ParseNodeType.Error ||
                         previousNode.category !== ErrorExpressionCategory.MissingMemberAccessName
@@ -2769,7 +2772,7 @@ export class CompletionProvider {
             return completionMap;
         }
 
-        const symbolTable = AnalyzerNodeInfo.getScope(parseResults.parseTree)?.symbolTable;
+        const symbolTable = AnalyzerNodeInfo.getScope(parseResults.parserOutput.parseTree)?.symbolTable;
         if (!symbolTable) {
             return completionMap;
         }

--- a/packages/pyright-internal/src/languageService/definitionProvider.ts
+++ b/packages/pyright-internal/src/languageService/definitionProvider.ts
@@ -33,7 +33,7 @@ import { ServiceKeys } from '../common/serviceKeys';
 import { DocumentRange, Position, rangesAreEqual } from '../common/textRange';
 import { Uri } from '../common/uri/uri';
 import { ParseNode, ParseNodeType } from '../parser/parseNodes';
-import { ParseResults } from '../parser/parser';
+import { ParseFileResults } from '../parser/parser';
 
 export enum DefinitionFilter {
     All = 'all',
@@ -285,7 +285,7 @@ export class TypeDefinitionProvider extends DefinitionProviderBase {
     }
 }
 
-function _tryGetNode(parseResults: ParseResults | undefined, position: Position) {
+function _tryGetNode(parseResults: ParseFileResults | undefined, position: Position) {
     if (!parseResults) {
         return { node: undefined, offset: 0 };
     }
@@ -295,7 +295,7 @@ function _tryGetNode(parseResults: ParseResults | undefined, position: Position)
         return { node: undefined, offset: 0 };
     }
 
-    return { node: ParseTreeUtils.findNodeByOffset(parseResults.parseTree, offset), offset };
+    return { node: ParseTreeUtils.findNodeByOffset(parseResults.parserOutput.parseTree, offset), offset };
 }
 
 function _createModuleEntry(uri: Uri): DocumentRange {

--- a/packages/pyright-internal/src/languageService/documentHighlightProvider.ts
+++ b/packages/pyright-internal/src/languageService/documentHighlightProvider.ts
@@ -17,11 +17,11 @@ import { convertOffsetsToRange, convertPositionToOffset } from '../common/positi
 import { Position, TextRange } from '../common/textRange';
 import { Uri } from '../common/uri/uri';
 import { ParseNodeType } from '../parser/parseNodes';
-import { ParseResults } from '../parser/parser';
+import { ParseFileResults } from '../parser/parser';
 import { DocumentSymbolCollector } from './documentSymbolCollector';
 
 export class DocumentHighlightProvider {
-    private readonly _parseResults: ParseResults | undefined;
+    private readonly _parseResults: ParseFileResults | undefined;
 
     constructor(
         private _program: ProgramView,
@@ -43,7 +43,7 @@ export class DocumentHighlightProvider {
             return undefined;
         }
 
-        const node = ParseTreeUtils.findNodeByOffset(this._parseResults.parseTree, offset);
+        const node = ParseTreeUtils.findNodeByOffset(this._parseResults.parserOutput.parseTree, offset);
         if (node === undefined) {
             return undefined;
         }
@@ -56,7 +56,7 @@ export class DocumentHighlightProvider {
             this._program,
             node,
             this._token,
-            this._parseResults.parseTree,
+            this._parseResults.parserOutput.parseTree,
             {
                 treatModuleInImportAndFromImportSame: true,
                 useCase: ReferenceUseCase.References,

--- a/packages/pyright-internal/src/languageService/documentSymbolCollector.ts
+++ b/packages/pyright-internal/src/languageService/documentSymbolCollector.ts
@@ -216,7 +216,7 @@ export class DocumentSymbolCollector extends ParseTreeWalker {
             // Add declarations from files that implicitly import the target file.
             const implicitlyImportedBy = collectImportedByCells(program, sourceFileInfo);
             implicitlyImportedBy.forEach((implicitImport) => {
-                const parseTree = program.getParseResults(implicitImport.sourceFile.getUri())?.parseTree;
+                const parseTree = program.getParseResults(implicitImport.sourceFile.getUri())?.parserOutput.parseTree;
                 if (parseTree) {
                     const scope = AnalyzerNodeInfo.getScope(parseTree);
                     const symbol = scope?.lookUpSymbol(node.value);

--- a/packages/pyright-internal/src/languageService/documentSymbolProvider.ts
+++ b/packages/pyright-internal/src/languageService/documentSymbolProvider.ts
@@ -16,7 +16,7 @@ import { ProgramView } from '../common/extensibility';
 import { ReadOnlyFileSystem } from '../common/fileSystem';
 import { Uri } from '../common/uri/uri';
 import { encodeUri } from '../common/uri/uriUtils';
-import { ParseResults } from '../parser/parser';
+import { ParseFileResults } from '../parser/parser';
 import { IndexOptions, IndexSymbolData, SymbolIndexer } from './symbolIndexer';
 
 export function convertToFlatSymbols(
@@ -34,7 +34,7 @@ export function convertToFlatSymbols(
 }
 
 export class DocumentSymbolProvider {
-    private _parseResults: ParseResults | undefined;
+    private _parseResults: ParseFileResults | undefined;
 
     constructor(
         protected readonly program: ProgramView,
@@ -66,7 +66,7 @@ export class DocumentSymbolProvider {
             return symbolList;
         }
 
-        const fileInfo = getFileInfo(parseResults.parseTree);
+        const fileInfo = getFileInfo(parseResults.parserOutput.parseTree);
         if (!fileInfo) {
             return symbolList;
         }

--- a/packages/pyright-internal/src/languageService/hoverProvider.ts
+++ b/packages/pyright-internal/src/languageService/hoverProvider.ts
@@ -42,7 +42,7 @@ import { convertOffsetToPosition, convertPositionToOffset } from '../common/posi
 import { Position, Range, TextRange } from '../common/textRange';
 import { Uri } from '../common/uri/uri';
 import { ExpressionNode, NameNode, ParseNode, ParseNodeType, StringNode } from '../parser/parseNodes';
-import { ParseResults } from '../parser/parser';
+import { ParseFileResults } from '../parser/parser';
 import {
     getClassAndConstructorTypes,
     getConstructorTooltip,
@@ -152,7 +152,7 @@ export function getVariableTypeText(
 }
 
 export class HoverProvider {
-    private readonly _parseResults: ParseResults | undefined;
+    private readonly _parseResults: ParseFileResults | undefined;
     private readonly _sourceMapper: SourceMapper;
 
     constructor(
@@ -214,7 +214,7 @@ export class HoverProvider {
             return null;
         }
 
-        const node = ParseTreeUtils.findNodeByOffset(this._parseResults.parseTree, offset);
+        const node = ParseTreeUtils.findNodeByOffset(this._parseResults.parserOutput.parseTree, offset);
         if (node === undefined) {
             return null;
         }

--- a/packages/pyright-internal/src/languageService/importSorter.ts
+++ b/packages/pyright-internal/src/languageService/importSorter.ts
@@ -19,23 +19,22 @@ import {
 import { throwIfCancellationRequested } from '../common/cancellationUtils';
 import { TextEditAction } from '../common/editAction';
 import { convertOffsetToPosition } from '../common/positionUtils';
-import { Range } from '../common/textRange';
-import { TextRange } from '../common/textRange';
+import { Range, TextRange } from '../common/textRange';
 import { ImportAsNode, ImportFromAsNode, ImportFromNode, ParseNodeType } from '../parser/parseNodes';
-import { ParseResults } from '../parser/parser';
+import { ParseFileResults } from '../parser/parser';
 
 // We choose a line length that matches the default for the popular
 // "black" formatter used in many Python projects.
 const _maxLineLength = 88;
 
 export class ImportSorter {
-    constructor(private _parseResults: ParseResults, private _cancellationToken: CancellationToken) {}
+    constructor(private _parseResults: ParseFileResults, private _cancellationToken: CancellationToken) {}
 
     sort(): TextEditAction[] {
         throwIfCancellationRequested(this._cancellationToken);
 
         const actions: TextEditAction[] = [];
-        const importStatements = getTopLevelImports(this._parseResults.parseTree);
+        const importStatements = getTopLevelImports(this._parseResults.parserOutput.parseTree);
 
         const sortedStatements = importStatements.orderedImports
             .map((s) => s)

--- a/packages/pyright-internal/src/languageService/referencesProvider.ts
+++ b/packages/pyright-internal/src/languageService/referencesProvider.ts
@@ -29,7 +29,7 @@ import { ServiceKeys } from '../common/serviceKeys';
 import { DocumentRange, Position, TextRange, doesRangeContain } from '../common/textRange';
 import { Uri } from '../common/uri/uri';
 import { NameNode, ParseNode, ParseNodeType } from '../parser/parseNodes';
-import { ParseResults } from '../parser/parser';
+import { ParseFileResults } from '../parser/parser';
 import { CollectionResult, DocumentSymbolCollector } from './documentSymbolCollector';
 import { convertDocumentRangesToLocation } from './navigationUtils';
 
@@ -100,7 +100,7 @@ export class ReferencesResult {
 }
 
 export class FindReferencesTreeWalker {
-    private _parseResults: ParseResults | undefined;
+    private _parseResults: ParseFileResults | undefined;
 
     constructor(
         private _program: ProgramView,
@@ -111,13 +111,13 @@ export class FindReferencesTreeWalker {
         private readonly _createDocumentRange: (
             fileUri: Uri,
             result: CollectionResult,
-            parseResults: ParseResults
+            parseResults: ParseFileResults
         ) => DocumentRange = FindReferencesTreeWalker.createDocumentRange
     ) {
         this._parseResults = this._program.getParseResults(this._fileUri);
     }
 
-    findReferences(rootNode = this._parseResults?.parseTree) {
+    findReferences(rootNode = this._parseResults?.parserOutput.parseTree) {
         const results: DocumentRange[] = [];
         if (!this._parseResults) {
             return results;
@@ -147,7 +147,7 @@ export class FindReferencesTreeWalker {
         return results;
     }
 
-    static createDocumentRange(fileUri: Uri, result: CollectionResult, parseResults: ParseResults): DocumentRange {
+    static createDocumentRange(fileUri: Uri, result: CollectionResult, parseResults: ParseFileResults): DocumentRange {
         return {
             uri: fileUri,
             range: {
@@ -165,7 +165,7 @@ export class ReferencesProvider {
         private readonly _createDocumentRange?: (
             fileUri: Uri,
             result: CollectionResult,
-            parseResults: ParseResults
+            parseResults: ParseFileResults
         ) => DocumentRange,
         private readonly _convertToLocation?: (fs: ReadOnlyFileSystem, ranges: DocumentRange) => Location | undefined
     ) {
@@ -374,7 +374,7 @@ export class ReferencesProvider {
             return undefined;
         }
 
-        const node = ParseTreeUtils.findNodeByOffset(parseResults.parseTree, offset);
+        const node = ParseTreeUtils.findNodeByOffset(parseResults.parserOutput.parseTree, offset);
         if (node === undefined) {
             return undefined;
         }

--- a/packages/pyright-internal/src/languageService/renameProvider.ts
+++ b/packages/pyright-internal/src/languageService/renameProvider.ts
@@ -19,10 +19,10 @@ import { Position, Range } from '../common/textRange';
 import { Uri } from '../common/uri/uri';
 import { convertToWorkspaceEdit } from '../common/workspaceEditUtils';
 import { ReferencesProvider, ReferencesResult } from '../languageService/referencesProvider';
-import { ParseResults } from '../parser/parser';
+import { ParseFileResults } from '../parser/parser';
 
 export class RenameProvider {
-    private readonly _parseResults: ParseResults | undefined;
+    private readonly _parseResults: ParseFileResults | undefined;
 
     constructor(
         private _program: ProgramView,

--- a/packages/pyright-internal/src/languageService/signatureHelpProvider.ts
+++ b/packages/pyright-internal/src/languageService/signatureHelpProvider.ts
@@ -33,11 +33,11 @@ import { convertPositionToOffset } from '../common/positionUtils';
 import { Position } from '../common/textRange';
 import { Uri } from '../common/uri/uri';
 import { CallNode, NameNode, ParseNodeType } from '../parser/parseNodes';
-import { ParseResults } from '../parser/parser';
+import { ParseFileResults } from '../parser/parser';
 import { getDocumentationPartsForTypeAndDecl, getFunctionDocStringFromType } from './tooltipUtils';
 
 export class SignatureHelpProvider {
-    private readonly _parseResults: ParseResults | undefined;
+    private readonly _parseResults: ParseFileResults | undefined;
     private readonly _sourceMapper: SourceMapper;
 
     constructor(
@@ -73,7 +73,7 @@ export class SignatureHelpProvider {
             return undefined;
         }
 
-        let node = ParseTreeUtils.findNodeByOffset(this._parseResults.parseTree, offset);
+        let node = ParseTreeUtils.findNodeByOffset(this._parseResults.parserOutput.parseTree, offset);
 
         // See if we can get to a "better" node by backing up a few columns.
         // A "better" node is defined as one that's deeper than the current
@@ -90,7 +90,7 @@ export class SignatureHelpProvider {
             if (ch === ',' || ch === '(') {
                 break;
             }
-            const curNode = ParseTreeUtils.findNodeByOffset(this._parseResults.parseTree, curOffset);
+            const curNode = ParseTreeUtils.findNodeByOffset(this._parseResults.parserOutput.parseTree, curOffset);
             if (curNode && curNode !== initialNode) {
                 if (ParseTreeUtils.getNodeDepth(curNode) > initialDepth) {
                     node = curNode;

--- a/packages/pyright-internal/src/languageService/symbolIndexer.ts
+++ b/packages/pyright-internal/src/languageService/symbolIndexer.ts
@@ -18,7 +18,7 @@ import { convertOffsetsToRange, convertTextRangeToRange } from '../common/positi
 import { Range } from '../common/textRange';
 import { Uri } from '../common/uri/uri';
 import { ParseNodeType } from '../parser/parseNodes';
-import { ParseResults } from '../parser/parser';
+import { ParseFileResults } from '../parser/parser';
 import { convertSymbolKindToCompletionItemKind } from './autoImporter';
 
 export interface IndexOptions {
@@ -46,7 +46,7 @@ export interface IndexSymbolData {
 export class SymbolIndexer {
     static indexSymbols(
         fileInfo: AnalyzerFileInfo,
-        parseResults: ParseResults,
+        parseResults: ParseFileResults,
         indexOptions: IndexOptions,
         token: CancellationToken
     ): IndexSymbolData[] {
@@ -58,7 +58,14 @@ export class SymbolIndexer {
         //    __all__ to make sure we don't include too many symbols in the index.
 
         const indexSymbolData: IndexSymbolData[] = [];
-        collectSymbolIndexData(fileInfo, parseResults, parseResults.parseTree, indexOptions, indexSymbolData, token);
+        collectSymbolIndexData(
+            fileInfo,
+            parseResults,
+            parseResults.parserOutput.parseTree,
+            indexOptions,
+            indexSymbolData,
+            token
+        );
 
         return indexSymbolData;
     }
@@ -66,7 +73,7 @@ export class SymbolIndexer {
 
 function collectSymbolIndexData(
     fileInfo: AnalyzerFileInfo,
-    parseResults: ParseResults,
+    parseResults: ParseFileResults,
     node: AnalyzerNodeInfo.ScopedNode,
     indexOptions: IndexOptions,
     indexSymbolData: IndexSymbolData[],
@@ -118,7 +125,7 @@ function collectSymbolIndexData(
 
 function collectSymbolIndexDataForName(
     fileInfo: AnalyzerFileInfo,
-    parseResults: ParseResults,
+    parseResults: ParseFileResults,
     declaration: Declaration,
     indexOptions: IndexOptions,
     externallyVisible: boolean,

--- a/packages/pyright-internal/src/languageService/workspaceSymbolProvider.ts
+++ b/packages/pyright-internal/src/languageService/workspaceSymbolProvider.ts
@@ -64,7 +64,7 @@ export class WorkspaceSymbolProvider {
             return symbolList;
         }
 
-        const fileInfo = getFileInfo(parseResults.parseTree);
+        const fileInfo = getFileInfo(parseResults.parserOutput.parseTree);
         if (!fileInfo) {
             return symbolList;
         }

--- a/packages/pyright-internal/src/parser/parser.ts
+++ b/packages/pyright-internal/src/parser/parser.ts
@@ -178,14 +178,18 @@ export class ParseOptions {
     }
 }
 
-export interface ParseResults {
-    text: string;
+export interface ParserOutput {
     parseTree: ModuleNode;
     importedModules: ModuleImport[];
     futureImports: Set<string>;
-    tokenizerOutput: TokenizerOutput;
     containsWildcardImport: boolean;
     typingSymbolAliases: Map<string, string>;
+}
+
+export interface ParseFileResults {
+    text: string;
+    parserOutput: ParserOutput;
+    tokenizerOutput: TokenizerOutput;
 }
 
 export interface ParseExpressionTextResults {
@@ -238,7 +242,7 @@ export class Parser {
     private _typingImportAliases: string[] = [];
     private _typingSymbolAliases: Map<string, string> = new Map<string, string>();
 
-    parseSourceFile(fileContents: string, parseOptions: ParseOptions, diagSink: DiagnosticSink): ParseResults {
+    parseSourceFile(fileContents: string, parseOptions: ParseOptions, diagSink: DiagnosticSink): ParseFileResults {
         timingStats.tokenizeFileTime.timeOperation(() => {
             this._startNewParse(fileContents, 0, fileContents.length, parseOptions, diagSink);
         });
@@ -275,12 +279,14 @@ export class Parser {
         assert(this._tokenizerOutput !== undefined);
         return {
             text: fileContents,
-            parseTree: moduleNode,
-            importedModules: this._importedModules,
-            futureImports: this._futureImports,
+            parserOutput: {
+                parseTree: moduleNode,
+                importedModules: this._importedModules,
+                futureImports: this._futureImports,
+                containsWildcardImport: this._containsWildcardImport,
+                typingSymbolAliases: this._typingSymbolAliases,
+            },
             tokenizerOutput: this._tokenizerOutput!,
-            containsWildcardImport: this._containsWildcardImport,
-            typingSymbolAliases: this._typingSymbolAliases,
         };
     }
 

--- a/packages/pyright-internal/src/tests/chainedSourceFiles.test.ts
+++ b/packages/pyright-internal/src/tests/chainedSourceFiles.test.ts
@@ -19,13 +19,13 @@ import { normalizeSlashes } from '../common/pathUtils';
 import { convertOffsetsToRange, convertOffsetToPosition } from '../common/positionUtils';
 import { ServiceProvider } from '../common/serviceProvider';
 import { Uri } from '../common/uri/uri';
+import { UriEx } from '../common/uri/uriUtils';
 import { CompletionProvider } from '../languageService/completionProvider';
 import { parseTestData } from './harness/fourslash/fourSlashParser';
 import { TestAccessHost } from './harness/testAccessHost';
 import * as host from './harness/testHost';
 import { createFromFileSystem, distlibFolder, libFolder } from './harness/vfs/factory';
 import * as vfs from './harness/vfs/filesystem';
-import { UriEx } from '../common/uri/uriUtils';
 
 test('check chained files', () => {
     const code = `
@@ -48,7 +48,7 @@ test('check chained files', () => {
     const marker = data.markerPositions.get('marker')!;
     const markerUri = marker.fileUri;
 
-    const parseResult = service.getParseResult(markerUri)!;
+    const parseResult = service.getParseResults(markerUri)!;
     const result = new CompletionProvider(
         service.test_program,
         markerUri,
@@ -88,7 +88,7 @@ test('modify chained files', () => {
     // Make sure files are all realized.
     const marker = data.markerPositions.get('marker')!;
     const markerUri = marker.fileUri;
-    const parseResult = service.getParseResult(markerUri)!;
+    const parseResult = service.getParseResults(markerUri)!;
 
     // Close file in the middle of the chain
     service.setFileClosed(data.markerPositions.get('delete')!.fileUri);
@@ -138,7 +138,7 @@ test('modify chained files', async () => {
     const markerUri = marker.fileUri;
     const range = data.ranges.find((r) => r.marker === marker)!;
 
-    const parseResults = service.getParseResult(markerUri)!;
+    const parseResults = service.getParseResults(markerUri)!;
     analyze(service.test_program);
 
     // Initially, there should be no error.
@@ -187,7 +187,7 @@ test('chained files with 1000s of files', async () => {
     const markerUri = marker.fileUri;
     const range = data.ranges.find((r) => r.marker === marker)!;
 
-    const parseResults = service.getParseResult(markerUri)!;
+    const parseResults = service.getParseResults(markerUri)!;
     analyze(service.test_program);
 
     // There should be no error as it should find the foo1 in the first chained file.
@@ -217,7 +217,7 @@ test('imported by files', async () => {
     const markerUri = marker.fileUri;
     const range = data.ranges.find((r) => r.marker === marker)!;
 
-    const parseResults = service.getParseResult(markerUri)!;
+    const parseResults = service.getParseResults(markerUri)!;
     const diagnostics = await service.getDiagnosticsForRange(
         markerUri,
         convertOffsetsToRange(range.pos, range.end, parseResults.tokenizerOutput.lines),
@@ -251,7 +251,7 @@ test('re ordering cells', async () => {
     service.updateChainedUri(markerUri, bottomUri);
     analyze(service.test_program);
 
-    const parseResults = service.getParseResult(markerUri)!;
+    const parseResults = service.getParseResults(markerUri)!;
     const diagnostics = await service.getDiagnosticsForRange(
         markerUri,
         convertOffsetsToRange(range.pos, range.end, parseResults.tokenizerOutput.lines),

--- a/packages/pyright-internal/src/tests/importStatementUtils.test.ts
+++ b/packages/pyright-internal/src/tests/importStatementUtils.test.ts
@@ -493,8 +493,8 @@ test('resolve alias of not needed file', () => {
     state.openFile(marker.fileName);
 
     const markerUri = marker.fileUri;
-    const parseResults = state.workspace.service.getParseResult(markerUri)!;
-    const nameNode = findNodeByOffset(parseResults.parseTree, marker.position) as NameNode;
+    const parseResults = state.workspace.service.getParseResults(markerUri)!;
+    const nameNode = findNodeByOffset(parseResults.parserOutput.parseTree, marker.position) as NameNode;
     const aliasDecls = evaluator.getDeclarationsForNameNode(nameNode)!;
 
     // Unroot the file. we can't explicitly close the file since it will unload the file from test program.
@@ -532,7 +532,7 @@ function testAddition(
     const marker = state.getMarkerByName(markerName)!;
     const parseResults = state.program.getBoundSourceFile(marker!.fileUri)!.getParseResults()!;
 
-    const importStatement = getTopLevelImports(parseResults.parseTree).orderedImports.find(
+    const importStatement = getTopLevelImports(parseResults.parserOutput.parseTree).orderedImports.find(
         (i) => i.moduleName === moduleName
     )!;
     const edits = getTextEditsForAutoImportSymbolAddition(importNameInfo, importStatement, parseResults);
@@ -552,7 +552,7 @@ function testInsertions(
     const marker = state.getMarkerByName(markerName)!;
     const parseResults = state.program.getBoundSourceFile(marker!.fileUri)!.getParseResults()!;
 
-    const importStatements = getTopLevelImports(parseResults.parseTree);
+    const importStatements = getTopLevelImports(parseResults.parserOutput.parseTree);
     const edits = getTextEditsForAutoImportInsertions(
         importNameInfo,
         importStatements,

--- a/packages/pyright-internal/src/tests/ipythonMode.test.ts
+++ b/packages/pyright-internal/src/tests/ipythonMode.test.ts
@@ -12,9 +12,9 @@ import { CompletionItemKind, MarkupKind } from 'vscode-languageserver-types';
 import { DiagnosticRule } from '../common/diagnosticRules';
 import { TextRange } from '../common/textRange';
 import { TextRangeCollection } from '../common/textRangeCollection';
+import { LocMessage } from '../localization/localize';
 import { Comment, CommentType, Token } from '../parser/tokenizerTypes';
 import { parseAndGetTestState } from './harness/fourslash/testState';
-import { LocMessage } from '../localization/localize';
 
 test('regular mode', () => {
     const code = `

--- a/packages/pyright-internal/src/tests/parser.test.ts
+++ b/packages/pyright-internal/src/tests/parser.test.ts
@@ -19,18 +19,18 @@ import * as TestUtils from './testUtils';
 
 test('Empty', () => {
     const diagSink = new DiagnosticSink();
-    const parseResults = TestUtils.parseText('', diagSink);
+    const parserOutput = TestUtils.parseText('', diagSink).parserOutput;
 
     assert.equal(diagSink.fetchAndClear().length, 0);
-    assert.equal(parseResults.parseTree.statements.length, 0);
+    assert.equal(parserOutput.parseTree.statements.length, 0);
 });
 
 test('Sample1', () => {
     const diagSink = new DiagnosticSink();
-    const parseInfo = TestUtils.parseSampleFile('sample1.py', diagSink);
+    const parserOutput = TestUtils.parseSampleFile('sample1.py', diagSink).parserOutput;
 
     assert.equal(diagSink.fetchAndClear().length, 0);
-    assert.equal(parseInfo.parseResults.parseTree.statements.length, 4);
+    assert.equal(parserOutput.parseTree.statements.length, 4);
 });
 
 test('FStringEmptyTuple', () => {
@@ -60,13 +60,13 @@ test('SuiteExpectedColon3', () => {
 
 test('ExpressionWrappedInParens', () => {
     const diagSink = new DiagnosticSink();
-    const parseResults = TestUtils.parseText('(str)', diagSink);
+    const parserOutput = TestUtils.parseText('(str)', diagSink).parserOutput;
 
     assert.equal(diagSink.fetchAndClear().length, 0);
-    assert.equal(parseResults.parseTree.statements.length, 1);
-    assert.equal(parseResults.parseTree.statements[0].nodeType, ParseNodeType.StatementList);
+    assert.equal(parserOutput.parseTree.statements.length, 1);
+    assert.equal(parserOutput.parseTree.statements[0].nodeType, ParseNodeType.StatementList);
 
-    const statementList = parseResults.parseTree.statements[0] as StatementListNode;
+    const statementList = parserOutput.parseTree.statements[0] as StatementListNode;
     assert.equal(statementList.statements.length, 1);
 
     // length of node should include parens
@@ -101,27 +101,27 @@ test('ModuleName range', () => {
 
 test('ParserRecovery1', () => {
     const diagSink = new DiagnosticSink();
-    const parseResults = TestUtils.parseSampleFile('parserRecovery1.py', diagSink).parseResults;
+    const parseResults = TestUtils.parseSampleFile('parserRecovery1.py', diagSink);
 
-    const node = findNodeByOffset(parseResults.parseTree, parseResults.text.length - 2);
+    const node = findNodeByOffset(parseResults.parserOutput.parseTree, parseResults.text.length - 2);
     const functionNode = getFirstAncestorOrSelfOfKind(node, ParseNodeType.Function);
     assert.equal(functionNode!.parent!.nodeType, ParseNodeType.Module);
 });
 
 test('ParserRecovery2', () => {
     const diagSink = new DiagnosticSink();
-    const parseResults = TestUtils.parseSampleFile('parserRecovery2.py', diagSink).parseResults;
+    const parseResults = TestUtils.parseSampleFile('parserRecovery2.py', diagSink);
 
-    const node = findNodeByOffset(parseResults.parseTree, parseResults.text.length - 2);
+    const node = findNodeByOffset(parseResults.parserOutput.parseTree, parseResults.text.length - 2);
     const functionNode = getFirstAncestorOrSelfOfKind(node, ParseNodeType.Function);
     assert.equal(functionNode!.parent!.nodeType, ParseNodeType.Suite);
 });
 
 test('ParserRecovery3', () => {
     const diagSink = new DiagnosticSink();
-    const parseResults = TestUtils.parseSampleFile('parserRecovery3.py', diagSink).parseResults;
+    const parseResults = TestUtils.parseSampleFile('parserRecovery3.py', diagSink);
 
-    const node = findNodeByOffset(parseResults.parseTree, parseResults.text.length - 2);
+    const node = findNodeByOffset(parseResults.parserOutput.parseTree, parseResults.text.length - 2);
     const functionNode = getFirstAncestorOrSelfOfKind(node, ParseNodeType.Function);
     assert.equal(functionNode!.parent!.nodeType, ParseNodeType.Module);
 });

--- a/packages/pyright-internal/src/tests/signatureHelp.test.ts
+++ b/packages/pyright-internal/src/tests/signatureHelp.test.ts
@@ -77,7 +77,7 @@ function checkSignatureHelp(code: string, expects: boolean) {
     const state = parseAndGetTestState(code).state;
     const marker = state.getMarkerByName('marker');
 
-    const parseResults = state.workspace.service.getParseResult(marker.fileUri)!;
+    const parseResults = state.workspace.service.getParseResults(marker.fileUri)!;
     const position = convertOffsetToPosition(marker.position, parseResults.tokenizerOutput.lines);
 
     const actual = new SignatureHelpProvider(

--- a/packages/pyright-internal/src/tests/testStateUtils.ts
+++ b/packages/pyright-internal/src/tests/testStateUtils.ts
@@ -17,13 +17,13 @@ import { isArray } from '../common/core';
 import { assertNever } from '../common/debug';
 import { FileEditAction, FileEditActions } from '../common/editAction';
 import { TextRange, rangesAreEqual } from '../common/textRange';
+import { Uri } from '../common/uri/uri';
 import { isFile } from '../common/uri/uriUtils';
 import { applyTextEditsToString } from '../common/workspaceEditUtils';
 import { DocumentSymbolCollector } from '../languageService/documentSymbolCollector';
 import { NameNode } from '../parser/parseNodes';
 import { Range } from './harness/fourslash/fourSlashTypes';
 import { TestState } from './harness/fourslash/testState';
-import { Uri } from '../common/uri/uri';
 
 export function convertFileEditActionToString(edit: FileEditAction): string {
     return `'${edit.replacementText.replace(/\n/g, '!n!')}'@'${edit.fileUri}:(${edit.range.start.line},${
@@ -155,7 +155,7 @@ export function verifyReferencesAtPosition(
     const sourceFile = program.getBoundSourceFile(Uri.file(fileName, program.serviceProvider));
     assert(sourceFile);
 
-    const node = findNodeByOffset(sourceFile.getParseResults()!.parseTree, position);
+    const node = findNodeByOffset(sourceFile.getParseResults()!.parserOutput.parseTree, position);
     const decls = DocumentSymbolCollector.getDeclarationsForNode(
         program,
         node as NameNode,
@@ -169,7 +169,9 @@ export function verifyReferencesAtPosition(
             program,
             isArray(symbolNames) ? symbolNames : [symbolNames],
             decls,
-            program.getBoundSourceFile(Uri.file(rangeFileName, program.serviceProvider))!.getParseResults()!.parseTree,
+            program
+                .getBoundSourceFile(Uri.file(rangeFileName, program.serviceProvider))!
+                .getParseResults()!.parserOutput.parseTree,
             CancellationToken.None,
             {
                 treatModuleInImportAndFromImportSame: true,

--- a/packages/pyright-internal/src/tests/textEditUtil.test.ts
+++ b/packages/pyright-internal/src/tests/textEditUtil.test.ts
@@ -114,9 +114,9 @@ function verifyRemoveNodes(code: string) {
     const ranges = state.getRanges();
     const changeRanges = _getChangeRanges(ranges);
     for (const range of changeRanges) {
-        const parseResults = state.program.getParseResults(range.fileUri)!;
-        const node = findNodeByOffset(parseResults.parseTree, range.pos)!;
-        tracker.removeNodes({ node, parseResults });
+        const parseFileResults = state.program.getParseResults(range.fileUri)!;
+        const node = findNodeByOffset(parseFileResults.parserOutput.parseTree, range.pos)!;
+        tracker.removeNodes({ node, parseFileResults });
     }
 
     const edits = tracker.getEdits(CancellationToken.None);

--- a/packages/pyright-internal/src/tests/typeEvaluator1.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator1.test.ts
@@ -201,7 +201,7 @@ test('Builtins1', () => {
         'ellipsis',
     ];
 
-    const moduleScope = AnalyzerNodeInfo.getScope(analysisResults[0].parseResults!.parseTree)!;
+    const moduleScope = AnalyzerNodeInfo.getScope(analysisResults[0].parseResults!.parserOutput.parseTree)!;
     assert.notStrictEqual(moduleScope, undefined);
 
     const builtinsScope = moduleScope.parent!;


### PR DESCRIPTION
@rchiodo, this is an alternate approach to optimizing the tokenizer data structures. With this change, the tokens for a file are not cached in memory unless the file is currently open in the editor. They are recomputed on demand if/when needed. This should theoretically reduce the memory usage more than your proposed change. I think this change is less complex than yours — and therefore easier to maintain.

Could you please run your memory benchmarks on this branch to confirm the memory savings and quantify the savings relative to your proposed change? We can then use this data to inform which change is preferable.