### PR TITLE
Share heap usage numbers to support cache cleanup in VS code

### DIFF
--- a/packages/pyright-internal/src/analyzer/cacheManager.ts
+++ b/packages/pyright-internal/src/analyzer/cacheManager.ts
@@ -8,7 +8,7 @@
  * if memory usage approaches the max heap space.
  */
 
-import { HeapInfo } from 'v8';
+import type { HeapInfo } from 'v8';
 import { Worker } from 'worker_threads';
 import { AnalysisRequest } from '../backgroundAnalysisBase';
 import { ConsoleInterface } from '../common/console';
@@ -55,6 +55,8 @@ export class CacheManager {
         if (msg.requestType === 'cacheUsageBuffer') {
             const index = parseInt(msg.data || '0');
             const buffer = msg.sharedUsageBuffer;
+            // Index of zero is reserved for the main thread so if
+            // the index isn't passed, don't save the shared buffer.
             if (buffer && index) {
                 this._sharedUsageBuffer = buffer;
                 this._sharedUsagePosition = index;

--- a/packages/pyright-internal/src/analyzer/cacheManager.ts
+++ b/packages/pyright-internal/src/analyzer/cacheManager.ts
@@ -8,6 +8,9 @@
  * if memory usage approaches the max heap space.
  */
 
+import { HeapInfo } from 'v8';
+import { Worker } from 'worker_threads';
+import { AnalysisRequest } from '../backgroundAnalysisBase';
 import { ConsoleInterface } from '../common/console';
 import { fail } from '../common/debug';
 import { getHeapStatistics } from '../common/memUtils';
@@ -24,10 +27,39 @@ export interface CacheOwner {
 export class CacheManager {
     private _pausedCount = 0;
     private readonly _cacheOwners: CacheOwner[] = [];
+    private _sharedUsageBuffer: SharedArrayBuffer | undefined;
+    private _sharedUsagePosition = 0;
     private _lastHeapStats = Date.now();
 
+    constructor(private readonly _maxWorkers: number = 0) {}
     registerCacheOwner(provider: CacheOwner) {
         this._cacheOwners.push(provider);
+    }
+
+    addWorker(index: number, worker: Worker) {
+        // Send the sharedArrayBuffer to the worker so it can be used
+        // to keep track of heap usage on all threads.
+        const buffer = this._getSharedUsageBuffer();
+        if (buffer) {
+            // The SharedArrayBuffer needs to be separate from data in order for it
+            // to be marshalled correctly.
+            worker.postMessage({ requestType: 'cacheUsageBuffer', sharedUsageBuffer: buffer, data: index.toString() });
+            worker.on('exit', () => {
+                const view = new Float64Array(buffer);
+                view[index] = 0;
+            });
+        }
+    }
+
+    handleCachedUsageBufferMessage(msg: AnalysisRequest) {
+        if (msg.requestType === 'cacheUsageBuffer') {
+            const index = parseInt(msg.data || '0');
+            const buffer = msg.sharedUsageBuffer;
+            if (buffer && index) {
+                this._sharedUsageBuffer = buffer;
+                this._sharedUsagePosition = index;
+            }
+        }
     }
 
     unregisterCacheOwner(provider: CacheOwner) {
@@ -82,6 +114,7 @@ export class CacheManager {
     // Returns a ratio of used bytes to total bytes.
     getUsedHeapRatio(console?: ConsoleInterface) {
         const heapStats = getHeapStatistics();
+        let usage = this._getTotalHeapUsage(heapStats);
 
         if (console && Date.now() - this._lastHeapStats > 1000) {
             // This can fill up the user's console, so we only do it once per second.
@@ -90,17 +123,49 @@ export class CacheManager {
                 `Heap stats: ` +
                     `total_heap_size=${this._convertToMB(heapStats.total_heap_size)}, ` +
                     `used_heap_size=${this._convertToMB(heapStats.used_heap_size)}, ` +
+                    `cross_worker_used_heap_size=${this._convertToMB(usage)}, ` +
                     `total_physical_size=${this._convertToMB(heapStats.total_physical_size)}, ` +
                     `total_available_size=${this._convertToMB(heapStats.total_available_size)}, ` +
                     `heap_size_limit=${this._convertToMB(heapStats.heap_size_limit)}`
             );
         }
 
-        return heapStats.used_heap_size / heapStats.heap_size_limit;
+        // Total usage seems to be off by about 5%, so we'll add that back in
+        // to make the ratio more accurate. (200MB at 4GB)
+        usage += usage * 0.05;
+
+        return usage / heapStats.heap_size_limit;
     }
 
     private _convertToMB(bytes: number) {
         return `${Math.round(bytes / (1024 * 1024))}MB`;
+    }
+
+    private _getSharedUsageBuffer() {
+        try {
+            if (!this._sharedUsageBuffer && this._maxWorkers > 0) {
+                // Allocate enough space for the workers and the main thread.
+                this._sharedUsageBuffer = new SharedArrayBuffer(8 * (this._maxWorkers + 1));
+            }
+
+            return this._sharedUsageBuffer;
+        } catch {
+            // SharedArrayBuffer is not supported.
+            return undefined;
+        }
+    }
+
+    private _getTotalHeapUsage(heapStats: HeapInfo): number {
+        // If the SharedArrayBuffer is supported, we'll use it to to get usage
+        // from other threads and add that to our own
+        const buffer = this._getSharedUsageBuffer();
+        if (buffer) {
+            const view = new Float64Array(buffer);
+            view[this._sharedUsagePosition] = heapStats.used_heap_size;
+            return view.reduce((a, b) => a + b, 0);
+        }
+
+        return heapStats.used_heap_size;
     }
 }
 

--- a/packages/pyright-internal/src/backgroundAnalysis.ts
+++ b/packages/pyright-internal/src/backgroundAnalysis.ts
@@ -10,7 +10,7 @@ import { Worker } from 'worker_threads';
 
 import { ImportResolver } from './analyzer/importResolver';
 import { BackgroundAnalysisBase, BackgroundAnalysisRunnerBase } from './backgroundAnalysisBase';
-import { BackgroundThreadIndex, InitializationData } from './backgroundThreadBase';
+import { InitializationData } from './backgroundThreadBase';
 import { getCancellationFolderName } from './common/cancellationUtils';
 import { ConfigOptions } from './common/configOptions';
 import { FullAccessHost } from './common/fullAccessHost';
@@ -19,14 +19,16 @@ import { ServiceProvider } from './common/serviceProvider';
 import { getRootUri } from './common/uri/uriUtils';
 
 export class BackgroundAnalysis extends BackgroundAnalysisBase {
-    constructor(serviceProvider: ServiceProvider, workerIndex = BackgroundThreadIndex) {
+    private static _workerIndex = 0;
+
+    constructor(serviceProvider: ServiceProvider) {
         super(serviceProvider.console());
 
         const initialData: InitializationData = {
             rootUri: getRootUri(serviceProvider)?.toString() ?? '',
             cancellationFolderName: getCancellationFolderName(),
             runner: undefined,
-            workerIndex,
+            workerIndex: ++BackgroundAnalysis._workerIndex,
         };
 
         // this will load this same file in BG thread and start listener
@@ -34,7 +36,7 @@ export class BackgroundAnalysis extends BackgroundAnalysisBase {
         this.setup(worker);
 
         // Tell the cacheManager we have a worker that needs to share data.
-        serviceProvider.cacheManager()?.addWorker(workerIndex, worker);
+        serviceProvider.cacheManager()?.addWorker(initialData.workerIndex, worker);
     }
 }
 

--- a/packages/pyright-internal/src/backgroundAnalysisBase.ts
+++ b/packages/pyright-internal/src/backgroundAnalysisBase.ts
@@ -326,6 +326,10 @@ export abstract class BackgroundAnalysisRunnerBase extends BackgroundThreadBase 
 
     protected onMessage(msg: AnalysisRequest) {
         switch (msg.requestType) {
+            case 'cacheUsageBuffer': {
+                this.serviceProvider.cacheManager()?.handleCachedUsageBufferMessage(msg);
+                break;
+            }
             case 'analyze': {
                 const port = msg.port!;
                 const data = deserialize(msg.data);
@@ -740,12 +744,14 @@ export type AnalysisRequestKind =
     | 'setImportResolver'
     | 'shutdown'
     | 'addInterimFile'
-    | 'analyzeFile';
+    | 'analyzeFile'
+    | 'cacheUsageBuffer';
 
 export interface AnalysisRequest {
     requestType: AnalysisRequestKind;
     data: string | null;
     port?: MessagePort | undefined;
+    sharedUsageBuffer?: SharedArrayBuffer;
 }
 
 export type AnalysisResponseKind = 'log' | 'analysisResult' | 'analysisPaused' | 'analysisDone';

--- a/packages/pyright-internal/src/backgroundThreadBase.ts
+++ b/packages/pyright-internal/src/backgroundThreadBase.ts
@@ -8,6 +8,7 @@
 
 import { MessagePort, parentPort, TransferListItem } from 'worker_threads';
 
+import { CacheManager } from './analyzer/cacheManager';
 import { OperationCanceledException, setCancellationFolderName } from './common/cancellationUtils';
 import { ConfigOptions } from './common/configOptions';
 import { ConsoleInterface, LogLevel } from './common/console';
@@ -15,9 +16,9 @@ import { isThenable } from './common/core';
 import * as debug from './common/debug';
 import { PythonVersion } from './common/pythonVersion';
 import { createFromRealFileSystem, RealTempFile } from './common/realFileSystem';
+import { ServiceKeys } from './common/serviceKeys';
 import { ServiceProvider } from './common/serviceProvider';
 import './common/serviceProviderExtensions';
-import { ServiceKeys } from './common/serviceKeys';
 import { Uri } from './common/uri/uri';
 
 export class BackgroundConsole implements ConsoleInterface {
@@ -74,6 +75,9 @@ export class BackgroundThreadBase {
                     this.getConsole()
                 )
             );
+        }
+        if (!this._serviceProvider.tryGet(ServiceKeys.cacheManager)) {
+            this._serviceProvider.add(ServiceKeys.cacheManager, new CacheManager());
         }
 
         // Stash the base directory into a global variable.
@@ -237,11 +241,14 @@ export function getBackgroundWaiter<T>(port: MessagePort, deserializer = deseria
     });
 }
 
+export const BackgroundThreadIndex = 1;
+
 export interface InitializationData {
     rootUri: string;
     cancellationFolderName: string | undefined;
     runner: string | undefined;
     title?: string;
+    workerIndex: number;
 }
 
 export interface RequestResponse {

--- a/packages/pyright-internal/src/backgroundThreadBase.ts
+++ b/packages/pyright-internal/src/backgroundThreadBase.ts
@@ -241,8 +241,6 @@ export function getBackgroundWaiter<T>(port: MessagePort, deserializer = deseria
     });
 }
 
-export const BackgroundThreadIndex = 1;
-
 export interface InitializationData {
     rootUri: string;
     cancellationFolderName: string | undefined;

--- a/packages/pyright-internal/src/common/serviceProviderExtensions.ts
+++ b/packages/pyright-internal/src/common/serviceProviderExtensions.ts
@@ -25,6 +25,7 @@ declare module './serviceProvider' {
         tmp(): TempFile | undefined;
         sourceFileFactory(): ISourceFileFactory;
         partialStubs(): SupportPartialStubs;
+        cacheManager(): CacheManager | undefined;
     }
 }
 
@@ -73,6 +74,11 @@ ServiceProvider.prototype.tmp = function () {
 ServiceProvider.prototype.sourceFileFactory = function () {
     const result = this.tryGet(ServiceKeys.sourceFileFactory);
     return result || DefaultSourceFileFactory;
+};
+
+ServiceProvider.prototype.cacheManager = function () {
+    const result = this.tryGet(ServiceKeys.cacheManager);
+    return result;
 };
 
 const DefaultSourceFileFactory: ISourceFileFactory = {

--- a/packages/pyright-internal/src/nodeMain.ts
+++ b/packages/pyright-internal/src/nodeMain.ts
@@ -11,9 +11,9 @@ import { ServiceProvider } from './common/serviceProvider';
 import { run } from './nodeServer';
 import { PyrightServer } from './server';
 
-export function main() {
+export function main(maxWorkers: number) {
     run(
-        (conn) => new PyrightServer(conn),
+        (conn) => new PyrightServer(conn, maxWorkers),
         () => {
             const runner = new BackgroundAnalysisRunner(new ServiceProvider());
             runner.start();

--- a/packages/pyright-internal/src/server.ts
+++ b/packages/pyright-internal/src/server.ts
@@ -22,9 +22,10 @@ import { isPythonBinary } from './analyzer/pythonPathUtils';
 import { BackgroundAnalysis } from './backgroundAnalysis';
 import { BackgroundAnalysisBase } from './backgroundAnalysisBase';
 import { CommandController } from './commands/commandController';
+import { getCancellationFolderName } from './common/cancellationUtils';
 import { ConfigOptions, SignatureDisplayType } from './common/configOptions';
 import { ConsoleWithLogLevel, LogLevel, convertLogLevel } from './common/console';
-import { isDefined, isString } from './common/core';
+import { isDebugMode, isDefined, isString } from './common/core';
 import { resolvePathWithEnvVariables } from './common/envVarUtils';
 import { FileBasedCancellationProvider } from './common/fileBasedCancellationUtils';
 import { FileSystem } from './common/fileSystem';
@@ -215,11 +216,11 @@ export class PyrightServer extends LanguageServerBase {
     }
 
     createBackgroundAnalysis(serviceId: string): BackgroundAnalysisBase | undefined {
-        // if (isDebugMode() || !getCancellationFolderName()) {
-        //     // Don't do background analysis if we're in debug mode or an old client
-        //     // is used where cancellation is not supported.
-        //     return undefined;
-        // }
+        if (isDebugMode() || !getCancellationFolderName()) {
+            // Don't do background analysis if we're in debug mode or an old client
+            // is used where cancellation is not supported.
+            return undefined;
+        }
 
         return new BackgroundAnalysis(this.serverOptions.serviceProvider);
     }

--- a/packages/pyright-internal/src/tests/cacheManager.test.ts
+++ b/packages/pyright-internal/src/tests/cacheManager.test.ts
@@ -8,6 +8,7 @@
 
 import assert from 'assert';
 
+import { Worker } from 'worker_threads';
 import { CacheManager, CacheOwner } from '../analyzer/cacheManager';
 
 test('basic', () => {
@@ -67,6 +68,44 @@ test('multiple owners', () => {
 
     manager.unregisterCacheOwner(mock2);
     assert.strictEqual(manager.getCacheUsage(), 0);
+});
+
+test('Shared memory', async () => {
+    const manager = new CacheManager(/* maxWorkers */ 1);
+
+    // Without the .js output from Jest, we need to generate a non module worker. Use a string
+    // to do so. This means the worker can't use the CacheManager, but it just needs to
+    // listen for the sharedArrayBuffer message.
+    const workerSource = `
+const { parentPort } = require('worker_threads');
+parentPort.on('message', (msg) => {
+if (msg.requestType === 'cacheUsageBuffer') {
+    const buffer = msg.sharedUsageBuffer;
+    const view = new Float64Array(buffer);
+    view[1] = 50 * 1024 * 1024 * 1024; // Make this super huge, 50GB to make sure usage is over 100%
+    parentPort.postMessage('done');
+    }
+});
+`;
+    const worker = new Worker(workerSource, { eval: true });
+    worker.on('error', (err) => {
+        throw err;
+    });
+    manager.addWorker(1, worker);
+
+    // Wait for the worker to post a message back to us.
+    await new Promise<void>((resolve, reject) => {
+        worker.on('message', (msg: string) => {
+            if (msg === 'done') {
+                resolve();
+            }
+        });
+    });
+
+    // Get the heap usage and verify it's more than 100%
+    const usage = manager.getUsedHeapRatio();
+    worker.terminate();
+    assert(usage > 1);
 });
 
 class MockCacheOwner implements CacheOwner {

--- a/packages/pyright-internal/src/tests/lsp/languageServer.ts
+++ b/packages/pyright-internal/src/tests/lsp/languageServer.ts
@@ -137,7 +137,7 @@ class TestServer extends PyrightServer {
         fs: FileSystem,
         private readonly _supportsBackgroundAnalysis: boolean | undefined
     ) {
-        super(connection, fs);
+        super(connection, _supportsBackgroundAnalysis ? 1 : 0, fs);
     }
 
     test_onDidChangeWatchedFiles(params: any) {

--- a/packages/pyright/src/langserver.ts
+++ b/packages/pyright/src/langserver.ts
@@ -1,3 +1,4 @@
 import { main } from 'pyright-internal/nodeMain';
 
-main();
+// Command line version doesn't use any worker threads.
+main(/* maxWorkers */ 0);

--- a/packages/vscode-pyright/src/server.ts
+++ b/packages/vscode-pyright/src/server.ts
@@ -2,4 +2,5 @@ import { main } from 'pyright-internal/nodeMain';
 
 Error.stackTraceLimit = 256;
 
-main();
+// VS Code version of the server has one background thread.
+main(/* maxWorkers */ 1);


### PR DESCRIPTION
VS code uses pointer compression which seems to share the heap with all the worker threads. This means the `getHeapStatistics` function is not returning the correct amount of memory in use for a thread.

This change shares this number with the other threads so they can take total usage into account when deciding whether or not to clean up the heap.