### PR TITLE
Fix crash when imports are not resolved

### DIFF
--- a/packages/pyright-internal/src/analyzer/importStatementUtils.ts
+++ b/packages/pyright-internal/src/analyzer/importStatementUtils.ts
@@ -646,7 +646,7 @@ function _processImportNode(node: ImportNode, localImports: ImportStatements, fo
         localImports.orderedImports.push(localImport);
 
         // Add it to the map.
-        if (resolvedPath) {
+        if (resolvedPath && !resolvedPath.isEmpty()) {
             // Don't overwrite existing import or import from statements
             // because we always want to prefer 'import from' over 'import'
             // in the map.
@@ -692,7 +692,7 @@ function _processImportFromNode(
     localImports.orderedImports.push(localImport);
 
     // Add it to the map.
-    if (resolvedPath) {
+    if (resolvedPath && !resolvedPath.isEmpty()) {
         const prevEntry = localImports.mapByFilePath.get(resolvedPath.key);
         // Overwrite existing import statements because we always want to prefer
         // 'import from' over 'import'. Also, overwrite existing 'import from' if

--- a/packages/pyright-internal/src/analyzer/packageTypeVerifier.ts
+++ b/packages/pyright-internal/src/analyzer/packageTypeVerifier.ts
@@ -1489,7 +1489,7 @@ export class PackageTypeVerifier {
                 ? resolvedPath.getDirectory()
                 : importResult.packageDirectory ?? Uri.empty();
             let isModuleSingleFile = false;
-            if (resolvedPath && stripFileExtension(resolvedPath.fileName) !== '__init__') {
+            if (resolvedPath && !resolvedPath.isEmpty() && stripFileExtension(resolvedPath.fileName) !== '__init__') {
                 isModuleSingleFile = true;
             }
 

--- a/packages/pyright-internal/src/analyzer/program.ts
+++ b/packages/pyright-internal/src/analyzer/program.ts
@@ -1803,7 +1803,7 @@ export class Program {
 
             if (importResult.isImportFound && !importResult.isNativeLib && importResult.resolvedUris.length > 0) {
                 const resolvedPath = importResult.resolvedUris[importResult.resolvedUris.length - 1];
-                if (resolvedPath) {
+                if (!resolvedPath.isEmpty()) {
                     // See if the source file already exists in the program.
                     sourceFileInfo = this.getSourceFileInfo(resolvedPath);
 


### PR DESCRIPTION
We're seeing this in our telemetry data as this crash here:

Error: Debug Failure. False expression.</br>at assert <a href='https://github.com/microsoft/pyrx/blob/ca5e67fa6216de93b79bafb18ff86985899d66e6/packages/pyright/packages/pyright-internal/src/analyzer/program.ts#L1498'>pyright-internal/src/analyzer/program.ts:1498:8</a></br>at _addToSourceFileListAndMap <a href='https://github.com/microsoft/pyrx/blob/ca5e67fa6216de93b79bafb18ff86985899d66e6/packages/pyright/packages/pyright-internal/src/analyzer/program.ts#L362'>pyright-internal/src/analyzer/program.ts:362:13</a></br>at addTrackedFile <a href='https://github.com/microsoft/pyrx/blob/ca5e67fa6216de93b79bafb18ff86985899d66e6/packages/pyright/packages/pyright-internal/src/analyzer/program.ts#L1802'>pyright-internal/src/analyzer/program.ts:1802:29</a></br>at callback <a href='https://github.com/microsoft/pyrx/blob/ca5e67fa6216de93b79bafb18ff86985899d66e6/packages/pyright/packages/pyright-internal/src/common/timing.ts#L40'>pyright-internal/src/common/timing.ts:40:19</a></br>at importLookup <a href='https://github.com/microsoft/pyrx/blob/ca5e67fa6216de93b79bafb18ff86985899d66e6/packages/pyright/packages/pyright-internal/src/analyzer/typeEvaluator.ts#L2983'>pyright-internal/src/analyzer/typeEvaluator.ts:2983:29</a></br>at getTypeOfModule <a href='https://github.com/microsoft/pyrx/blob/ca5e67fa6216de93b79bafb18ff86985899d66e6/packages/pyright/packages/pyright-internal/src/analyzer/typeEvaluator.ts#L2978'>pyright-internal/src/analyzer/typeEvaluator.ts:2978:15</a></br>at getTypeshedType <a href='https://github.com/microsoft/pyrx/blob/ca5e67fa6216de93b79bafb18ff86985899d66e6/packages/pyright/packages/pyright-internal/src/analyzer/typeEvaluator.ts#L957'>pyright-internal/src/analyzer/typeEvaluator.ts:957:28</a></br>at initializedBasicTypes <a href='https://github.com/microsoft/pyrx/blob/ca5e67fa6216de93b79bafb18ff86985899d66e6/packages/pyright/packages/pyright-internal/src/analyzer/typeEvaluator.ts#L17279'>pyright-internal/src/analyzer/typeEvaluator.ts:17279:8</a></br>at callback <a href='https://github.com/microsoft/pyrx/blob/ca5e67fa6216de93b79bafb18ff86985899d66e6/packages/pyright/packages/pyright-internal/src/common/timing.ts#L40'>pyright-internal/src/common/timing.ts:40:19</a></br>at getTypeOfFunction <a href='https://github.com/microsoft/pyrx/blob/ca5e67fa6216de93b79bafb18ff86985899d66e6/packages/pyright/packages/pyright-internal/src/analyzer/checker.ts#L407'>pyright-internal/src/analyzer/checker.ts:407:51</a></br>at visitFunction <a href='https://github.com/microsoft/pyrx/blob/ca5e67fa6216de93b79bafb18ff86985899d66e6/packages/pyright/packages/pyright-internal/src/analyzer/parseTreeWalker.ts#L442'>pyright-internal/src/analyzer/parseTreeWalker.ts:442:28</a></br>at visit <a href='https://github.com/microsoft/pyrx/blob/ca5e67fa6216de93b79bafb18ff86985899d66e6/packages/pyright/packages/pyright-internal/src/analyzer/parseTreeWalker.ts#L933'>pyright-internal/src/analyzer/parseTreeWalker.ts:933:20</a></br>at visitNode <a href='https://github.com/microsoft/pyrx/blob/ca5e67fa6216de93b79bafb18ff86985899d66e6/packages/pyright/packages/pyright-internal/src/analyzer/parseTreeWalker.ts#L915'>pyright-internal/src/analyzer/parseTreeWalker.ts:915:36</a></br>at walk <a href='https://github.com/microsoft/pyrx/blob/ca5e67fa6216de93b79bafb18ff86985899d66e6/packages/pyright/packages/pyright-internal/src/analyzer/checker.ts#L280'>pyright-internal/src/analyzer/checker.ts:280:18</a></br>at walk <a href='https://github.com/microsoft/pyrx/blob/ca5e67fa6216de93b79bafb18ff86985899d66e6/packages/pyright/packages/pyright-internal/src/analyzer/checker.ts#L2784'>pyright-internal/src/analyzer/checker.ts:2784:17</a></br>at _walkStatementsAndReportUnreachable <a href='https://github.com/microsoft/pyrx/blob/ca5e67fa6216de93b79bafb18ff86985899d66e6/packages/pyright/packages/pyright-internal/src/analyzer/checker.ts#L261'>pyright-internal/src/analyzer/checker.ts:261:13</a></br>    at callback <a href='https://github.com/microsoft/pyrx/blob/ca5e67fa6216de93b79bafb18ff86985899d66e6/packages/pyright/packages/pyright-internal/src/common/timing.ts#L40'>pyright-internal/src/common/timing.ts:40:19</a></br>at callback <a href='https://github.com/microsoft/pyrx/blob/ca5e67fa6216de93b79bafb18ff86985899d66e6/packages/pyright/packages/pyright-internal/src/common/logTracker.ts#L61'>pyright-internal/src/common/logTracker.ts:61:19</a></br>at log <a href='https://github.com/microsoft/pyrx/blob/ca5e67fa6216de93b79bafb18ff86985899d66e6/packages/pyright/packages/pyright-internal/src/analyzer/sourceFile.ts#L823'>pyright-internal/src/analyzer/sourceFile.ts:823:32</a></br>at callback <a href='https://github.com/microsoft/pyrx/blob/ca5e67fa6216de93b79bafb18ff86985899d66e6/packages/pyright/packages/pyright-internal/src/common/logTracker.ts#L61'>pyright-internal/src/common/logTracker.ts:61:19</a></br>at log <a href='https://github.com/microsoft/pyrx/blob/ca5e67fa6216de93b79bafb18ff86985899d66e6/packages/pyright/packages/pyright-internal/src/analyzer/program.ts#L1874'>pyright-internal/src/analyzer/program.ts:1874:32</a></br>at _checkTypes <a href='https://github.com/microsoft/pyrx/blob/ca5e67fa6216de93b79bafb18ff86985899d66e6/packages/pyright/packages/pyright-internal/src/analyzer/program.ts#L1998'>pyright-internal/src/analyzer/program.ts:1998:25</a></br>at callback <a href='https://github.com/microsoft/pyrx/blob/ca5e67fa6216de93b79bafb18ff86985899d66e6/packages/pyright/packages/pyright-internal/src/common/logTracker.ts#L61'>pyright-internal/src/common/logTracker.ts:61:19</a></br>at log <a href='https://github.com/microsoft/pyrx/blob/ca5e67fa6216de93b79bafb18ff86985899d66e6/packages/pyright/packages/pyright-internal/src/analyzer/program.ts#L1874'>pyright-internal/src/analyzer/program.ts:1874:32</a></br>at callback <a href='https://github.com/microsoft/pyrx/blob/ca5e67fa6216de93b79bafb18ff86985899d66e6/packages/pyright/packages/pyright-internal/src/analyzer/typeEvaluator.ts#L626'>pyright-internal/src/analyzer/typeEvaluator.ts:626:19</a></br>at callback <a href='https://github.com/microsoft/pyrx/blob/ca5e67fa6216de93b79bafb18ff86985899d66e6/packages/pyright/packages/pyright-internal/src/common/timing.ts#L40'>pyright-internal/src/common/timing.ts:40:19</a></br>at runWithCancellationToken <a href='https://github.com/microsoft/pyrx/blob/ca5e67fa6216de93b79bafb18ff86985899d66e6/packages/pyright/packages/pyright-internal/src/analyzer/program.ts#L1027'>pyright-internal/src/analyzer/program.ts:1027:40</a></br>

Which I believe is caused by the invalid check for empty.