### PR TITLE
Fixed a bug that results in incorrect type evaluation when a sequence…

### DIFF
--- a/packages/pyright-internal/src/analyzer/patternMatching.ts
+++ b/packages/pyright-internal/src/analyzer/patternMatching.ts
@@ -1290,7 +1290,7 @@ function getSequencePatternInfo(
                             typeArgs.splice(tupleIndeterminateIndex, 0, typeArgs[tupleIndeterminateIndex]);
                         }
 
-                        if (typeArgs.length > patternEntryCount) {
+                        if (typeArgs.length > patternEntryCount && patternStarEntryIndex === undefined) {
                             typeArgs.splice(tupleIndeterminateIndex, 1);
                         }
                     }

--- a/packages/pyright-internal/src/tests/samples/matchSequence1.py
+++ b/packages/pyright-internal/src/tests/samples/matchSequence1.py
@@ -479,3 +479,12 @@ def test_unbounded_tuple(
             reveal_type(x, expected_text="int")
             reveal_type(y, expected_text="str")
             reveal_type(z, expected_text="complex")
+
+
+def test_unbounded_tuple_2(subj: tuple[int, str, Unpack[tuple[range, ...]]]) -> None:
+    match subj:
+        case [1, *ts1]:
+            reveal_type(ts1, expected_text="list[str | range]")
+
+        case [1, "", *ts2]:
+            reveal_type(ts2, expected_text="list[range]")


### PR DESCRIPTION
… pattern in a `match` statement includes a `*` element and the subject includes a tuple with an element with indeterminate length. This addresses #7613.