### PR TITLE
Fixed bug that results in incorrect type evaluation in cases where a …

### DIFF
--- a/packages/pyright-internal/src/analyzer/constraintSolver.ts
+++ b/packages/pyright-internal/src/analyzer/constraintSolver.ts
@@ -940,7 +940,7 @@ function assignTypeToParamSpec(
             });
             newFunction.details.typeVarScopeId = srcType.details.typeVarScopeId;
             newFunction.details.constructorTypeVarScopeId = srcType.details.constructorTypeVarScopeId;
-            newFunction.details.paramSpecTypeVarScopeId = srcType.details.paramSpecTypeVarScopeId;
+            FunctionType.addHigherOrderTypeVarScopeIds(newFunction, srcType.details.higherOrderTypeVarScopeIds);
             newFunction.details.docString = srcType.details.docString;
             newFunction.details.deprecatedMessage = srcType.details.deprecatedMessage;
             newFunction.details.paramSpec = srcType.details.paramSpec;

--- a/packages/pyright-internal/src/analyzer/typeVarContext.ts
+++ b/packages/pyright-internal/src/analyzer/typeVarContext.ts
@@ -23,7 +23,6 @@ import {
     TypeCategory,
     TypeVarScopeId,
     TypeVarType,
-    WildcardTypeVarScopeId,
 } from './types';
 
 // The maximum number of signature contexts that can be associated
@@ -410,7 +409,7 @@ export class TypeVarContext {
         return (
             scopeId !== undefined &&
             this._solveForScopes !== undefined &&
-            this._solveForScopes.some((s) => s === scopeId || s === WildcardTypeVarScopeId)
+            this._solveForScopes.some((s) => s === scopeId)
         );
     }
 

--- a/packages/pyright-internal/src/tests/samples/solver7.py
+++ b/packages/pyright-internal/src/tests/samples/solver7.py
@@ -7,7 +7,8 @@
 
 # pyright: strict
 
-from typing import Generic, TypeVar
+from typing import Generic, Iterator, TypeVar
+from contextlib import contextmanager
 
 _A = TypeVar("_A")
 _B = TypeVar("_B")
@@ -31,3 +32,13 @@ a1 = ClassA(27)
 
 reveal_type(a1.value_a, expected_text="int")
 reveal_type(a1.value_b, expected_text="str")
+
+
+@contextmanager
+def func1(default: _A | None = None) -> Iterator[_A | str]:
+    yield ""
+
+
+def func2():
+    with func1() as y:
+        reveal_type(y, expected_text="str")


### PR DESCRIPTION
…generic function returns a callable, and the function is called with a higher-order generic function as an argument. This addresses #7386.