### PR TITLE
Fixed a bug that results in a false negative when a generic function …

### DIFF
--- a/packages/pyright-internal/src/tests/samples/solver10.py
+++ b/packages/pyright-internal/src/tests/samples/solver10.py
@@ -17,9 +17,9 @@ def extend_if(xs: list[_T], ys: list[tuple[_T, bool]]) -> list[_T]:
 extend_if(["foo"], [("bar", True), ("baz", True)])
 
 
-def Return(value: _T) -> Callable[[_T], None]:
+def func1(value: _T) -> Callable[[_T], None]:
     ...
 
 
-def func1() -> Callable[[bool], None]:
-    return Return(True)
+def func2() -> Callable[[bool], None]:
+    return func1(True)

--- a/packages/pyright-internal/src/tests/samples/solver34.py
+++ b/packages/pyright-internal/src/tests/samples/solver34.py
@@ -1,0 +1,21 @@
+# This sample tests the case where a generic function returns a Callable type
+# that is specialized with unsolved type variables.
+
+from collections.abc import Container
+from typing import TypeVar, Callable
+
+
+T = TypeVar("T")
+VT = TypeVar("VT")
+
+
+def func1(container: Container[T]) -> Callable[[T], bool]: ...
+
+
+def func2(a: T, b: Container[VT]) -> T:
+    cmp = func1(b)
+
+    # This should generate an error.
+    cmp(a)
+
+    return a

--- a/packages/pyright-internal/src/tests/typeEvaluator2.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator2.test.ts
@@ -747,6 +747,12 @@ test('Solver33', () => {
     TestUtils.validateResults(analysisResults, 0);
 });
 
+test('Solver34', () => {
+    const analysisResults = TestUtils.typeAnalyzeSampleFiles(['solver34.py']);
+
+    TestUtils.validateResults(analysisResults, 1);
+});
+
 test('SolverScoring1', () => {
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['solverScoring1.py']);
 


### PR DESCRIPTION
…returns a Callable type that is specialized to include a live (in-scope) type variable. This addresses #7542.