### PR TITLE
Fixed bug that results in inconsistent type narrowing on assignment b…

### DIFF
--- a/packages/pyright-internal/src/analyzer/typeEvaluatorTypes.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluatorTypes.ts
@@ -205,6 +205,10 @@ export interface TypeResult<T extends Type = Type> {
     // corresponding __getattr__?
     isAsymmetricAccessor?: boolean;
 
+    // For member access operations that are 'set', this is the narrowed
+    // type when considering the declared type of the member.
+    narrowedTypeForSet?: Type | undefined;
+
     // Is the type wrapped in a "Required", "NotRequired" or "ReadOnly" class?
     isRequired?: boolean;
     isNotRequired?: boolean;
@@ -411,6 +415,10 @@ export interface ClassMemberLookup {
     // Is member a descriptor object that is asymmetric with respect
     // to __get__ and __set__ types?
     isAsymmetricAccessor: boolean;
+
+    // For member access operations that are 'set', this is the narrowed
+    // type when considering the declared type of the member.
+    narrowedTypeForSet?: Type;
 
     // Deprecation messages related to magic methods invoked via the member access.
     memberAccessDeprecationInfo?: MemberAccessDeprecationInfo;

--- a/packages/pyright-internal/src/tests/samples/assignment1.py
+++ b/packages/pyright-internal/src/tests/samples/assignment1.py
@@ -1,8 +1,10 @@
 # This sample tests the type checker's handling of
 # member assignments.
 
+from not_present import NotPresentClass  # type: ignore
 
-class Foo:
+
+class ClassA:
     def __init__(self):
         self.string_list: list[str] = []
 
@@ -10,7 +12,7 @@ class Foo:
         return ""
 
 
-a = Foo()
+a = ClassA()
 
 a.string_list = ["yep"]
 
@@ -46,13 +48,25 @@ a.do_something = lambda: "hello"
 a.do_something = lambda x: 1
 
 
-Foo.do_something = patch2
+ClassA.do_something = patch2
 
 # This should generate an error because of a param count mismatch
-Foo.do_something = patch1
+ClassA.do_something = patch1
 
 
-class Class1:
+class ClassB:
     # This should generate an error because assignment expressions
     # can't be used within a class.
     [(j := i) for i in range(5)]
+
+
+class ClassC:
+    def __init__(self):
+        self.x = NotPresentClass  # type: int
+        self.y: int
+        self.y = NotPresentClass
+        self.z: int = NotPresentClass
+
+        reveal_type(self.x, expected_text="Unknown | int")
+        reveal_type(self.y, expected_text="Unknown | int")
+        reveal_type(self.z, expected_text="Unknown | int")


### PR DESCRIPTION
…ased on whether the assignment occurs within the same statement that includes the (declared) type annotation for the variable and whether the type annotation is provided as a type comment. This addresses #7537.