### PR TITLE
Simplify editable install docs

### DIFF
--- a/docs/import-resolution.md
+++ b/docs/import-resolution.md
@@ -42,23 +42,21 @@ Pyright uses the following mechanisms (in priority order) to determine which Pyt
 
 ### Editable installs
 
-[PEP 660](https://peps.python.org/pep-0660/) enables build backends (e.g. setuptools) to use import hooks to direct the [import machinery](https://docs.python.org/3/reference/import.html) to the package’s source files rather than putting the path to those files in a `.pth` file. Import hooks can provide an editable installation that is a more accurate representation of your real installation. However, because resolving module locations using an import hook requires executing Python code, they are not usable by Pyright and other static analysis tools. Therefore, if your editable install is configured to use import hooks, Pyright will be unable to find the corresponding source files.
+If you want to use static analysis tools with an editable install, you should configure the editable install to use `.pth` files that contain file paths rather than executable lines (prefixed with `import`) that install import hooks. See your package manager’s documentation for details on how to do this. We have provided some basic information for common package managers below.
 
-If you want to use static analysis tools with an editable install, you should configure the editable install to use `.pth` files that contain file paths rather than executable lines (prefixed with `import`) that install import hooks. See your build backend’s documentation for details on how to do this. We have provided some basic information for common build backends below.
+Import hooks can provide an editable installation that is a more accurate representation of your real installation. However, because resolving module locations using an import hook requires executing Python code, they are not usable by Pyright and other static analysis tools. Therefore, if your editable install is configured to use import hooks, Pyright will be unable to find the corresponding source files.
 
-#### Setuptools
-Setuptools currently supports two ways to request:
-[“compat mode”](https://setuptools.pypa.io/en/latest/userguide/development_mode.html#legacy-behavior)
-where a `.pth` file will be used -- a config setting and an environment variable. Another
-option is [“strict mode”](https://setuptools.pypa.io/en/latest/userguide/development_mode.html#strict-editable-installs)
-which uses symlinks instead.
+#### pip / setuptools
+`pip` (`setuptools`) supports two ways to avoid import hooks:
+- [compat mode](https://setuptools.pypa.io/en/latest/userguide/development_mode.html#legacy-behavior)
+- [strict mode](https://setuptools.pypa.io/en/latest/userguide/development_mode.html#strict-editable-installs)
 
-#### Hatch/Hatchling
-[Hatchling](https://hatch.pypa.io/latest/config/build/#dev-mode) uses `.pth` files by
+#### Hatch / Hatchling
+[Hatchling](https://hatch.pypa.io/latest/config/build/#dev-mode) uses path-based `.pth` files by
 default. It will only use import hooks if you set `dev-mode-exact` to `true`.
 
 #### PDM
-[PDM](https://pdm.fming.dev/latest/pyproject/build/#editable-build-backend) uses `.pth`
+[PDM](https://pdm.fming.dev/latest/pyproject/build/#editable-build-backend) uses path-based `.pth`
 files by default. It will only use import hooks if you set `editable-backend` to
 `"editables"`.
 


### PR DESCRIPTION
While handling [a recent Pylance issue](https://github.com/microsoft/pylance-release/issues/5732), I realized that I buried the lede when writing the editable install docs. The first paragraph was all technical background info. The second paragraph told you how to fix the issue that likely brought you to the docs.

I've reorganized and simplified the text. I also added the word `pip` to the `setuptools` section. I'm hoping that this new text will be more helpful to typical users.