### PR TITLE
Skip unnecessary py.typed file exist checks.

### DIFF
--- a/packages/pyright-internal/src/analyzer/importResolver.ts
+++ b/packages/pyright-internal/src/analyzer/importResolver.ts
@@ -26,7 +26,7 @@ import { isIdentifierChar, isIdentifierStartChar } from '../parser/characters';
 import { ImplicitImport, ImportResult, ImportType } from './importResult';
 import { getDirectoryLeadingDotsPointsTo } from './importStatementUtils';
 import { ImportPath, ParentDirectoryCache } from './parentDirectoryCache';
-import { PyTypedInfo, getPyTypedInfoUnsafe } from './pyTypedUtils';
+import { PyTypedInfo, getPyTypedInfoForPyTypedFile } from './pyTypedUtils';
 import * as PythonPathUtils from './pythonPathUtils';
 import * as SymbolNameUtils from './symbolNameUtils';
 import { isDunderName } from './symbolNameUtils';
@@ -2709,7 +2709,7 @@ export class ImportResolver {
             return undefined;
         }
 
-        return getPyTypedInfoUnsafe(this.fileSystem, filePath.pytypedUri);
+        return getPyTypedInfoForPyTypedFile(this.fileSystem, filePath.pytypedUri);
     }
 
     private _resolveNativeModuleStub(

--- a/packages/pyright-internal/src/analyzer/importResolver.ts
+++ b/packages/pyright-internal/src/analyzer/importResolver.ts
@@ -2709,7 +2709,7 @@ export class ImportResolver {
             return undefined;
         }
 
-        return getPyTypedInfoUnsafe(this.fileSystem, filePath);
+        return getPyTypedInfoUnsafe(this.fileSystem, filePath.pytypedUri);
     }
 
     private _resolveNativeModuleStub(

--- a/packages/pyright-internal/src/analyzer/importResolver.ts
+++ b/packages/pyright-internal/src/analyzer/importResolver.ts
@@ -16,8 +16,8 @@ import { Host } from '../common/host';
 import { stubsSuffix } from '../common/pathConsts';
 import { stripFileExtension } from '../common/pathUtils';
 import { PythonVersion, pythonVersion3_0 } from '../common/pythonVersion';
-import { ServiceProvider } from '../common/serviceProvider';
 import { ServiceKeys } from '../common/serviceKeys';
+import { ServiceProvider } from '../common/serviceProvider';
 import * as StringUtils from '../common/stringUtils';
 import { equateStringsCaseInsensitive } from '../common/stringUtils';
 import { Uri } from '../common/uri/uri';
@@ -26,7 +26,7 @@ import { isIdentifierChar, isIdentifierStartChar } from '../parser/characters';
 import { ImplicitImport, ImportResult, ImportType } from './importResult';
 import { getDirectoryLeadingDotsPointsTo } from './importStatementUtils';
 import { ImportPath, ParentDirectoryCache } from './parentDirectoryCache';
-import { PyTypedInfo, getPyTypedInfo } from './pyTypedUtils';
+import { PyTypedInfo, getPyTypedInfoUnsafe } from './pyTypedUtils';
 import * as PythonPathUtils from './pythonPathUtils';
 import * as SymbolNameUtils from './symbolNameUtils';
 import { isDunderName } from './symbolNameUtils';
@@ -2708,7 +2708,8 @@ export class ImportResolver {
         if (!this.fileExistsCached(filePath.pytypedUri)) {
             return undefined;
         }
-        return getPyTypedInfo(this.fileSystem, filePath);
+
+        return getPyTypedInfoUnsafe(this.fileSystem, filePath);
     }
 
     private _resolveNativeModuleStub(

--- a/packages/pyright-internal/src/analyzer/pyTypedUtils.ts
+++ b/packages/pyright-internal/src/analyzer/pyTypedUtils.ts
@@ -36,6 +36,10 @@ export function getPyTypedInfo(fileSystem: FileSystem, dirPath: Uri): PyTypedInf
  * Retrieves information about a py.typed file. The pyTypedPath provided must be a valid path.
  */
 export function getPyTypedInfoForPyTypedFile(fileSystem: FileSystem, pyTypedPath: Uri) {
+    // This function intentionally doesn't check whether the given py.typed path exists or not,
+    // as filesystem access is expensive if done repeatedly.
+    // The caller should verify the file's validity before calling this method and use a cache if possible
+    // to avoid high filesystem access costs.
     let isPartiallyTyped = false;
 
     // Read the contents of the file as text.

--- a/packages/pyright-internal/src/analyzer/pyTypedUtils.ts
+++ b/packages/pyright-internal/src/analyzer/pyTypedUtils.ts
@@ -16,6 +16,9 @@ export interface PyTypedInfo {
     isPartiallyTyped: boolean;
 }
 
+/**
+ * Retrieves information about a py.typed file, if it exists, under the given path.
+ */
 export function getPyTypedInfo(fileSystem: FileSystem, dirPath: Uri): PyTypedInfo | undefined {
     if (!fileSystem.existsSync(dirPath) || !isDirectory(fileSystem, dirPath)) {
         return undefined;
@@ -26,10 +29,13 @@ export function getPyTypedInfo(fileSystem: FileSystem, dirPath: Uri): PyTypedInf
         return undefined;
     }
 
-    return getPyTypedInfoUnsafe(fileSystem, pyTypedPath);
+    return getPyTypedInfoForPyTypedFile(fileSystem, pyTypedPath);
 }
 
-export function getPyTypedInfoUnsafe(fileSystem: FileSystem, pyTypedPath: Uri) {
+/**
+ * Retrieves information about a py.typed file. The pyTypedPath provided must be a valid path.
+ */
+export function getPyTypedInfoForPyTypedFile(fileSystem: FileSystem, pyTypedPath: Uri) {
     let isPartiallyTyped = false;
 
     // Read the contents of the file as text.

--- a/packages/pyright-internal/src/analyzer/pyTypedUtils.ts
+++ b/packages/pyright-internal/src/analyzer/pyTypedUtils.ts
@@ -21,12 +21,17 @@ export function getPyTypedInfo(fileSystem: FileSystem, dirPath: Uri): PyTypedInf
         return undefined;
     }
 
-    let isPartiallyTyped = false;
     const pyTypedPath = dirPath.pytypedUri;
 
     if (!fileSystem.existsSync(pyTypedPath) || !isFile(fileSystem, pyTypedPath)) {
         return undefined;
     }
+
+    return getPyTypedInfoUnsafe(fileSystem, pyTypedPath);
+}
+
+export function getPyTypedInfoUnsafe(fileSystem: FileSystem, pyTypedPath: Uri) {
+    let isPartiallyTyped = false;
 
     // Read the contents of the file as text.
     const fileStats = fileSystem.statSync(pyTypedPath);

--- a/packages/pyright-internal/src/analyzer/pyTypedUtils.ts
+++ b/packages/pyright-internal/src/analyzer/pyTypedUtils.ts
@@ -16,9 +16,9 @@ export interface PyTypedInfo {
     isPartiallyTyped: boolean;
 }
 
-/**
- * Retrieves information about a py.typed file, if it exists, under the given path.
- */
+//
+// Retrieves information about a py.typed file, if it exists, under the given path.
+//
 export function getPyTypedInfo(fileSystem: FileSystem, dirPath: Uri): PyTypedInfo | undefined {
     if (!fileSystem.existsSync(dirPath) || !isDirectory(fileSystem, dirPath)) {
         return undefined;
@@ -32,9 +32,9 @@ export function getPyTypedInfo(fileSystem: FileSystem, dirPath: Uri): PyTypedInf
     return getPyTypedInfoForPyTypedFile(fileSystem, pyTypedPath);
 }
 
-/**
- * Retrieves information about a py.typed file. The pyTypedPath provided must be a valid path.
- */
+//
+// Retrieves information about a py.typed file. The pyTypedPath provided must be a valid path.
+//
 export function getPyTypedInfoForPyTypedFile(fileSystem: FileSystem, pyTypedPath: Uri) {
     // This function intentionally doesn't check whether the given py.typed path exists or not,
     // as filesystem access is expensive if done repeatedly.

--- a/packages/pyright-internal/src/analyzer/pyTypedUtils.ts
+++ b/packages/pyright-internal/src/analyzer/pyTypedUtils.ts
@@ -22,7 +22,6 @@ export function getPyTypedInfo(fileSystem: FileSystem, dirPath: Uri): PyTypedInf
     }
 
     const pyTypedPath = dirPath.pytypedUri;
-
     if (!fileSystem.existsSync(pyTypedPath) || !isFile(fileSystem, pyTypedPath)) {
         return undefined;
     }


### PR DESCRIPTION
In `importResolver`, it already checks if a `py.typed` file exists before calling `getPyTypedInfo`, using the file system cache, so there's no need to recheck it inside `getPyTypedInfo`. This minor improvement results in a 500~1000ms speed boost for certain cases where the `py.typed` file is checked across many folders, such as in `indexer`. 

It would be beneficial to extend the cache to the file system itself so all code could benefit from it, but for now, the improvement is specific to the `importResolver`, where the cache exists.

![image](https://github.com/microsoft/pyright/assets/1333179/e5dda039-1767-499f-9e1c-685daf125aea)

vs

![image](https://github.com/microsoft/pyright/assets/1333179/4cdfc7fb-142d-4d1d-985c-aa744303e020)
