### PR TITLE
Don't use Uri.Empty for default workspace.

### DIFF
--- a/packages/pyright-internal/src/analyzer/service.ts
+++ b/packages/pyright-internal/src/analyzer/service.ts
@@ -518,7 +518,7 @@ export class AnalyzerService {
             ? optionRoot
             : isString(optionRoot)
             ? Uri.file(optionRoot, this.serviceProvider, /* checkRelative */ true)
-            : Uri.empty();
+            : Uri.file('<default workspace root>', this.serviceProvider);
 
         const executionRoot = this.fs.realCasePath(executionRootUri);
         let projectRoot = executionRoot;

--- a/packages/pyright-internal/src/analyzer/service.ts
+++ b/packages/pyright-internal/src/analyzer/service.ts
@@ -518,7 +518,7 @@ export class AnalyzerService {
             ? optionRoot
             : isString(optionRoot)
             ? Uri.file(optionRoot, this.serviceProvider, /* checkRelative */ true)
-            : Uri.file('<default workspace root>', this.serviceProvider);
+            : Uri.defaultWorkspace(this.serviceProvider);
 
         const executionRoot = this.fs.realCasePath(executionRootUri);
         let projectRoot = executionRoot;

--- a/packages/pyright-internal/src/common/uri/uri.ts
+++ b/packages/pyright-internal/src/common/uri/uri.ts
@@ -8,15 +8,15 @@
 
 import { URI, Utils } from 'vscode-uri';
 import { CaseSensitivityDetector } from '../caseSensitivityDetector';
+import { isArray } from '../core';
 import { combinePaths, isRootedDiskPath, normalizeSlashes } from '../pathUtils';
+import { ServiceKeys } from '../serviceKeys';
 import { ServiceKey } from '../serviceProvider';
+import { JsonObjType } from './baseUri';
+import { ConstantUri } from './constantUri';
+import { EmptyUri } from './emptyUri';
 import { FileUri, FileUriSchema } from './fileUri';
 import { WebUri } from './webUri';
-import { EmptyUri } from './emptyUri';
-import { JsonObjType } from './baseUri';
-import { isArray } from '../core';
-import { ServiceKeys } from '../serviceKeys';
-import { ConstantUri } from './constantUri';
 
 export const enum UriKinds {
     file,
@@ -232,6 +232,13 @@ export namespace Uri {
 
     export function empty(): Uri {
         return EmptyUri.instance;
+    }
+
+    export function defaultWorkspace(serviceProvider: IServiceProvider): Uri;
+    export function defaultWorkspace(caseSensitivityDetector: CaseSensitivityDetector): Uri;
+    export function defaultWorkspace(arg: IServiceProvider | CaseSensitivityDetector): Uri {
+        arg = CaseSensitivityDetector.is(arg) ? arg : arg.get(ServiceKeys.caseSensitivityDetector);
+        return Uri.file('/<default workspace root>/', arg);
     }
 
     export function fromJsonObj(jsonObj: JsonObjType) {

--- a/packages/pyright-internal/src/tests/config.test.ts
+++ b/packages/pyright-internal/src/tests/config.test.ts
@@ -355,3 +355,19 @@ test('verify can serialize config options', () => {
     assert.deepEqual(config, deserialized);
     assert.ok(deserialized.findExecEnvironment(UriEx.file('foo/bar.py')));
 });
+
+test('extra paths on undefined execution root/default workspace', () => {
+    const nullConsole = new NullConsole();
+    const service = createAnalyzer(nullConsole);
+    const commandLineOptions = new CommandLineOptions(undefined, /* fromVsCodeExtension */ false);
+    commandLineOptions.extraPaths = ['/extraPaths'];
+
+    service.setOptions(commandLineOptions);
+    const configOptions = service.test_getConfigOptions(commandLineOptions);
+
+    const expectedExtraPaths = [Uri.file('/extraPaths', service.serviceProvider)];
+    assert.deepStrictEqual(
+        configOptions.defaultExtraPaths?.map((u) => u.getFilePath()),
+        expectedExtraPaths.map((u) => u.getFilePath())
+    );
+});


### PR DESCRIPTION
fixes https://github.com/microsoft/pylance-release/issues/5740

It broke due to this change https://github.com/microsoft/pyrx/pull/4878

During this update, we modified how Uri handles case sensitivity, identifying a specific problem where an `EmptyUri` was defaulting to case sensitivity: false. 

However, `EmptyUri` implemented functions like resolvePaths/combinePaths that ended up using incorrect case sensitivity.  To address this, we changed how `EmptyUri` behaves and changed the default workspace not to use `EmptyUri`. However, it appears that we missed its usage in this spot.