### PR TITLE
Fixed recent regression that results in a false positive error when a…

### DIFF
--- a/packages/pyright-internal/src/analyzer/constraintSolver.ts
+++ b/packages/pyright-internal/src/analyzer/constraintSolver.ts
@@ -944,6 +944,7 @@ function assignTypeToParamSpec(
             newFunction.details.docString = srcType.details.docString;
             newFunction.details.deprecatedMessage = srcType.details.deprecatedMessage;
             newFunction.details.paramSpec = srcType.details.paramSpec;
+            newFunction.details.methodClass = srcType.details.methodClass;
 
             let updateContextWithNewFunction = false;
 

--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -25433,6 +25433,7 @@ export function createTypeEvaluator(importLookup: ImportLookup, evaluatorOptions
                     remainingFunction.details.typeVarScopeId = effectiveSrcType.details.typeVarScopeId;
                     remainingFunction.details.constructorTypeVarScopeId =
                         effectiveSrcType.details.constructorTypeVarScopeId;
+                    remainingFunction.details.methodClass = effectiveSrcType.details.methodClass;
                     remainingParams.forEach((param) => {
                         FunctionType.addParameter(remainingFunction, param);
                     });

--- a/packages/pyright-internal/src/analyzer/types.ts
+++ b/packages/pyright-internal/src/analyzer/types.ts
@@ -1821,6 +1821,7 @@ export namespace FunctionType {
             FunctionType.addHigherOrderTypeVarScopeIds(newFunction, paramSpecValue.details.higherOrderTypeVarScopeIds);
 
             newFunction.details.paramSpec = paramSpecValue.details.paramSpec;
+            newFunction.details.methodClass = paramSpecValue.details.methodClass;
         }
 
         return newFunction;

--- a/packages/pyright-internal/src/tests/samples/property18.py
+++ b/packages/pyright-internal/src/tests/samples/property18.py
@@ -1,0 +1,21 @@
+# This sample tests the case where a @property decorator is applied to
+# a method that has been previously decorated.
+
+from typing import ParamSpec, TypeVar, Callable
+
+P = ParamSpec("P")
+R = TypeVar("R")
+
+
+def deco1(func: Callable[P, R]) -> Callable[P, R]: ...
+
+
+class ClassA:
+    @property
+    @deco1
+    def prop(self) -> int:
+        return 1
+
+
+a = ClassA()
+reveal_type(a.prop, expected_text="int")

--- a/packages/pyright-internal/src/tests/typeEvaluator1.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator1.test.ts
@@ -1189,6 +1189,12 @@ test('Property17', () => {
     TestUtils.validateResults(analysisResults, 0);
 });
 
+test('Property18', () => {
+    const analysisResults = TestUtils.typeAnalyzeSampleFiles(['property18.py']);
+
+    TestUtils.validateResults(analysisResults, 0);
+});
+
 test('Operator1', () => {
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['operator1.py']);
 


### PR DESCRIPTION
…pplying a `@property` decorator to a method that has already had a decorator applied to it. This addresses #7667.