### PR TITLE
Modified handling of annotated `self` parameter in `__init__` method …

### DIFF
--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -11303,13 +11303,10 @@ export function createTypeEvaluator(importLookup: ImportLookup, evaluatorOptions
                 }
             }
 
-            // Some typeshed stubs use specialized type annotations in the "self" parameter
-            // of an overloaded __init__ method to specify which specialized type should
-            // be constructed. Although this isn't part of the official Python spec, other
-            // type checkers appear to honor it.
+            // The type annotation for the "self" parameter in an __init__ method to
+            // can incluence the type being constructed.
             if (
                 type.details.name === '__init__' &&
-                FunctionType.isOverloaded(type) &&
                 type.strippedFirstParamType &&
                 type.boundToType &&
                 isClassInstance(type.strippedFirstParamType) &&

--- a/packages/pyright-internal/src/tests/samples/constructor6.py
+++ b/packages/pyright-internal/src/tests/samples/constructor6.py
@@ -9,26 +9,21 @@ _T = TypeVar("_T", bound=Optional[str])
 
 class TextField(Generic[_T]):
     @overload
-    def __init__(self: "TextField[str]", *, null: Literal[False] = ...) -> None:
-        ...
+    def __init__(self: "TextField[str]", *, null: Literal[False] = ...) -> None: ...
 
     @overload
     def __init__(
         self: "TextField[Optional[str]]",
         *,
         null: Literal[True] = ...,
-    ) -> None:
-        ...
+    ) -> None: ...
 
     @overload
-    def __init__(self, *, null: bool = ...) -> None:
-        ...
+    def __init__(self, *, null: bool = ...) -> None: ...
 
-    def __init__(self, *, null: bool = ...) -> None:
-        ...
+    def __init__(self, *, null: bool = ...) -> None: ...
 
-    def __get__(self: "TextField[_T]", instance: Any, owner: Any) -> _T:
-        ...
+    def __get__(self: "TextField[_T]", instance: Any, owner: Any) -> _T: ...
 
 
 def foo(a: bool):
@@ -37,8 +32,7 @@ def foo(a: bool):
     reveal_type(TextField(null=a), expected_text="TextField[Unknown]")
 
 
-class Model:
-    ...
+class Model: ...
 
 
 _T1 = TypeVar("_T1", bound="Optional[Model]")
@@ -49,17 +43,14 @@ class ForeignKey(Generic[_T1]):
     @overload
     def __init__(
         self: "ForeignKey[_T2]", to: Type[_T2], *, null: Literal[False] = ...
-    ) -> None:
-        ...
+    ) -> None: ...
 
     @overload
     def __init__(
         self: "ForeignKey[Optional[_T2]]", to: Type[_T2], *, null: Literal[True]
-    ) -> None:
-        ...
+    ) -> None: ...
 
-    def __init__(self, to: Type[_T2], *, null: bool = False) -> None:
-        ...
+    def __init__(self, to: Type[_T2], *, null: bool = False) -> None: ...
 
 
 class Author(Model):
@@ -68,3 +59,23 @@ class Author(Model):
 
 reveal_type(ForeignKey(Author, null=False), expected_text="ForeignKey[Author]")
 reveal_type(ForeignKey(Author, null=True), expected_text="ForeignKey[Author | None]")
+
+
+_T3 = TypeVar("_T3")
+_T4 = TypeVar("_T4")
+_S1 = TypeVar("_S1")
+_S2 = TypeVar("_S2")
+
+
+class Class1(Generic[_T3, _T4]):
+    def __init__(self: "Class1[_S1, _S2]", value1: _S1, value2: _S2) -> None: ...
+
+
+reveal_type(Class1(0, ""), expected_text="Class1[int, str]")
+
+
+class Class2(Generic[_T3, _T4]):
+    def __init__(self: "Class2[_S2, _S1]", value1: _S1, value2: _S2) -> None: ...
+
+
+reveal_type(Class2(0, ""), expected_text="Class2[str, int]")


### PR DESCRIPTION
…when evaluating constructor call so pyright conforms to the latest typing spec. This addresses #7682.