### PR TITLE
Fixed a bug that leads to a false negative when an unparenthesized as…

### DIFF
--- a/packages/pyright-internal/src/parser/parser.ts
+++ b/packages/pyright-internal/src/parser/parser.ts
@@ -4138,7 +4138,7 @@ export class Parser {
             if (this._consumeTokenIfOperator(OperatorType.Power)) {
                 doubleStarExpression = this._parseExpression(/* allowUnpack */ false);
             } else {
-                keyExpression = this._parseTestOrStarExpression(/* allowAssignmentExpression */ true);
+                keyExpression = this._parseTestOrStarExpression(/* allowAssignmentExpression */ false);
 
                 if (this._consumeTokenIfType(TokenType.Colon)) {
                     valueExpression = this._parseTestExpression(/* allowAssignmentExpression */ false);

--- a/packages/pyright-internal/src/tests/samples/assignmentExpr2.py
+++ b/packages/pyright-internal/src/tests/samples/assignmentExpr2.py
@@ -53,3 +53,15 @@ def func2():
 def func3():
     # This should generate an error.
     yield from y := [1]
+
+def func4():
+    # This should generate an error.
+    v1 = {x := 'a': 0}
+
+    v2 = {(x := 'a'): 0}
+
+    # This should generate an error.
+    v3 = {x := 'a': i for i in range(4)}
+
+    v4 = {(x := 'a'): i for i in range(4)}
+

--- a/packages/pyright-internal/src/tests/typeEvaluator4.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator4.test.ts
@@ -111,7 +111,7 @@ test('AssignmentExpr1', () => {
 
 test('AssignmentExpr2', () => {
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['assignmentExpr2.py']);
-    TestUtils.validateResults(analysisResults, 6);
+    TestUtils.validateResults(analysisResults, 8);
 });
 
 test('AssignmentExpr3', () => {


### PR DESCRIPTION
…signment expression is used in a dictionary key within a dictionary expression or comprehension. This addresses #7694.