### PR TITLE
Changed the behavior when invoking constructor for `type[T]` where `T…

### DIFF
--- a/packages/pyright-internal/src/analyzer/constructors.ts
+++ b/packages/pyright-internal/src/analyzer/constructors.ts
@@ -637,14 +637,12 @@ function validateFallbackConstructorCall(
 
     // It's OK if the argument list consists only of `*args` and `**kwargs`.
     if (argList.length > 0 && argList.some((arg) => arg.argumentCategory === ArgumentCategory.Simple)) {
-        if (!type.includeSubclasses) {
-            evaluator.addDiagnostic(
-                DiagnosticRule.reportCallIssue,
-                LocMessage.constructorNoArgs().format({ type: type.aliasName || type.details.name }),
-                errorNode
-            );
-            reportedErrors = true;
-        }
+        evaluator.addDiagnostic(
+            DiagnosticRule.reportCallIssue,
+            LocMessage.constructorNoArgs().format({ type: type.aliasName || type.details.name }),
+            errorNode
+        );
+        reportedErrors = true;
     }
 
     if (!inferenceContext && type.typeArguments) {

--- a/packages/pyright-internal/src/tests/samples/constructor13.py
+++ b/packages/pyright-internal/src/tests/samples/constructor13.py
@@ -11,5 +11,7 @@ class Foo(Generic[T]):
         val = self.method1()
         reveal_type(val(), expected_text="T@Foo")
 
-    def method1(self) -> type[T]:
-        ...
+        # This should generate an error.
+        val(1)
+
+    def method1(self) -> type[T]: ...

--- a/packages/pyright-internal/src/tests/samples/constructor21.py
+++ b/packages/pyright-internal/src/tests/samples/constructor21.py
@@ -13,7 +13,7 @@ T_A = TypeVar("T_A", bound=ClassA)
 
 
 def func1(cls: type[T_A]) -> T_A:
-    # This should generate an error
+    # This should generate an error.
     y = cls()
 
     x = cls(1, "")
@@ -25,6 +25,7 @@ _T = TypeVar("_T")
 
 
 def func2(cls: type[_T]) -> _T:
+    # This should generate an error.
     y = cls(1, "")
 
     x = cls()

--- a/packages/pyright-internal/src/tests/typeEvaluator3.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator3.test.ts
@@ -1572,7 +1572,7 @@ test('Constructor12', () => {
 test('Constructor13', () => {
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['constructor13.py']);
 
-    TestUtils.validateResults(analysisResults, 0);
+    TestUtils.validateResults(analysisResults, 1);
 });
 
 test('Constructor14', () => {
@@ -1620,7 +1620,7 @@ test('Constructor20', () => {
 test('Constructor21', () => {
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['constructor21.py']);
 
-    TestUtils.validateResults(analysisResults, 1);
+    TestUtils.validateResults(analysisResults, 2);
 });
 
 test('Constructor22', () => {


### PR DESCRIPTION
…` is a TypeVar with no explicit upper bound (and therefore has an implicit upper bound of `object`). According to the newly-clarified typing spec, this should enforce the constructor signature of `object`.