### PR TITLE
Changed behavior of conversion from class constructor to callable to …

### DIFF
--- a/packages/pyright-internal/src/tests/samples/constructorCallable2.py
+++ b/packages/pyright-internal/src/tests/samples/constructorCallable2.py
@@ -120,3 +120,23 @@ reveal_type(
 
 reveal_type(r7(0), expected_text="Class7[int]")
 reveal_type(r7(""), expected_text="Class7[str]")
+
+
+class Class8(Generic[T]):
+    def __new__(cls, x: T, y: list[T]) -> Self:
+        return super().__new__(cls)
+
+
+r8 = accepts_callable(Class8)
+reveal_type(r8, expected_text="(x: T@Class8, y: list[T@Class8]) -> Class8[T@Class8]")
+reveal_type(r8("", [""]), expected_text="Class8[str]")
+
+
+class Class9:
+    def __init__(self, x: list[T], y: list[T]) -> None:
+        pass
+
+
+r9 = accepts_callable(Class9)
+reveal_type(r9, expected_text="(x: list[T@__init__], y: list[T@__init__]) -> Class9")
+reveal_type(r9([""], [""]), expected_text="Class9")

--- a/packages/pyright-internal/src/tests/samples/genericType14.py
+++ b/packages/pyright-internal/src/tests/samples/genericType14.py
@@ -11,7 +11,7 @@ V = TypeVar("V")
 @dataclass
 class Registry(Generic[K, V]):
     key: K
-    value: dict[str, V] = field(default_factory=dict)
+    value: dict[str, V] = field(default_factory=dict[str, V])
 
 
 class Base:


### PR DESCRIPTION
…conform to honor return type of the `__new__` method. This addresses #7687.