### PR TITLE
Added a check for the case where a frozen dataclass overrides a field…

### DIFF
--- a/packages/pyright-internal/src/analyzer/dataClasses.ts
+++ b/packages/pyright-internal/src/analyzer/dataClasses.ts
@@ -386,6 +386,14 @@ export function synthesizeDataClassMethods(
                             dataClassEntry.hasDefault = true;
                             dataClassEntry.defaultValueExpression = oldEntry.defaultValueExpression;
                             hasDefaultValue = true;
+
+                            // Warn the user of this case because it can result in type errors if the
+                            // default value is incompatible with the new type.
+                            evaluator.addDiagnostic(
+                                DiagnosticRule.reportGeneralTypeIssues,
+                                LocMessage.dataClassFieldInheritedDefault().format({ fieldName: variableName }),
+                                variableNameNode
+                            );
                         }
 
                         fullDataClassEntries[insertIndex] = dataClassEntry;

--- a/packages/pyright-internal/src/localization/localize.ts
+++ b/packages/pyright-internal/src/localization/localize.ts
@@ -351,6 +351,8 @@ export namespace Localizer {
             new ParameterizedString<{ funcName: string; fieldType: string; fieldName: string }>(
                 getRawString('Diagnostic.dataClassConverterOverloads')
             );
+        export const dataClassFieldInheritedDefault = () =>
+            new ParameterizedString<{ fieldName: string }>(getRawString('Diagnostic.dataClassFieldInheritedDefault'));
         export const dataClassFieldWithDefault = () => getRawString('Diagnostic.dataClassFieldWithDefault');
         export const dataClassFieldWithoutAnnotation = () => getRawString('Diagnostic.dataClassFieldWithoutAnnotation');
         export const dataClassFieldWithPrivateName = () => getRawString('Diagnostic.dataClassFieldWithPrivateName');

--- a/packages/pyright-internal/src/localization/package.nls.en-us.json
+++ b/packages/pyright-internal/src/localization/package.nls.en-us.json
@@ -89,6 +89,7 @@
         "dataClassBaseClassNotFrozen": "A frozen class cannot inherit from a class that is not frozen",
         "dataClassConverterFunction": "Argument of type \"{argType}\" is not a valid converter for field \"{fieldName}\" of type \"{fieldType}\"",
         "dataClassConverterOverloads": "No overloads of \"{funcName}\" are valid converters for field \"{fieldName}\" of type \"{fieldType}\"",
+        "dataClassFieldInheritedDefault": "\"{fieldName}\" overrides a field of the same name but is missing a default value",
         "dataClassFieldWithDefault": "Fields without default values cannot appear after fields with default values",
         "dataClassFieldWithoutAnnotation": "Dataclass field without type annotation will cause runtime exception",
         "dataClassFieldWithPrivateName": "Dataclass field cannot use private name",

--- a/packages/pyright-internal/src/tests/samples/dataclass4.py
+++ b/packages/pyright-internal/src/tests/samples/dataclass4.py
@@ -6,16 +6,13 @@
 from dataclasses import dataclass, field
 
 
-class C1:
-    ...
+class C1: ...
 
 
-class C2:
-    ...
+class C2: ...
 
 
-class C3:
-    ...
+class C3: ...
 
 
 @dataclass
@@ -74,6 +71,9 @@ class DC6:
 
 @dataclass
 class DC7(DC6):
+    # This should generate an error because it is overriding
+    # a field with a default value, but it doesn't have a
+    # default value.
     a: int
 
     # This should generate an error because the default
@@ -88,6 +88,9 @@ class DC8:
 
 @dataclass
 class DC9(DC8):
+    # This should generate an error because it is overriding
+    # a field with a default value, but it doesn't have a
+    # default value.
     a: int
 
     # This should generate an error because the default

--- a/packages/pyright-internal/src/tests/samples/dataclass6.py
+++ b/packages/pyright-internal/src/tests/samples/dataclass6.py
@@ -23,7 +23,7 @@ class ParentA:
 
 @dataclass
 class ChildA(ParentA):
-    prop_2: str
+    prop_2: str = "bye"
 
 
 test = ChildA(prop_2="test", prop_4="hi")

--- a/packages/pyright-internal/src/tests/typeEvaluator4.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator4.test.ts
@@ -606,7 +606,7 @@ test('DataClass3', () => {
 test('DataClass4', () => {
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['dataclass4.py']);
 
-    TestUtils.validateResults(analysisResults, 4);
+    TestUtils.validateResults(analysisResults, 6);
 });
 
 test('DataClass5', () => {


### PR DESCRIPTION
… from its parent class but doesn't provide a default value (where its parent does). This can result in a type violation if the parent's default value is not compatible with the child's (covariant) field type. This addresses #7702.