### PR TITLE
Log type evals perf when option is on

### DIFF
--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -583,7 +583,13 @@ interface CodeFlowAnalyzerCacheEntry {
     codeFlowAnalyzer: CodeFlowAnalyzer;
 }
 
-export function createTypeEvaluator(importLookup: ImportLookup, evaluatorOptions: EvaluatorOptions): TypeEvaluator {
+type LogWrapper = <T extends (...args: any[]) => any>(func: T) => (...args: Parameters<T>) => ReturnType<T>;
+
+export function createTypeEvaluator(
+    importLookup: ImportLookup,
+    evaluatorOptions: EvaluatorOptions,
+    wrapWithLogger: LogWrapper
+): TypeEvaluator {
     const symbolResolutionStack: SymbolResolutionStackEntry[] = [];
     const asymmetricAccessorAssignmentCache = new Set<number>();
     const speculativeTypeTracker = new SpeculativeTypeTracker();
@@ -21825,7 +21831,7 @@ export function createTypeEvaluator(importLookup: ImportLookup, evaluatorOptions
         return UnknownType.create();
     }
 
-    function getFunctionInferredReturnType(type: FunctionType, args?: ValidateArgTypeParams[]) {
+    function _getFunctionInferredReturnType(type: FunctionType, args?: ValidateArgTypeParams[]) {
         let returnType: Type | undefined;
         let isIncomplete = false;
         const analyzeUnannotatedFunctions = true;
@@ -26928,6 +26934,9 @@ export function createTypeEvaluator(importLookup: ImportLookup, evaluatorOptions
             });
         });
     }
+
+    // Track these apis internal usages when logging is on. otherwise, it should be noop.
+    const getFunctionInferredReturnType = wrapWithLogger(_getFunctionInferredReturnType);
 
     const evaluatorInterface: TypeEvaluator = {
         runWithCancellationToken,

--- a/packages/pyright-internal/src/analyzer/typeEvaluatorWithTracker.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluatorWithTracker.ts
@@ -55,11 +55,14 @@ export function createTypeEvaluatorWithTracker(
 
     // Wrap all functions with either a logger or a timer.
     importLookup = wrapWithLogger(importLookup);
-    const evaluator = createTypeEvaluator(importLookup, evaluatorOptions);
+    const evaluator = createTypeEvaluator(importLookup, evaluatorOptions, wrapWithLogger);
+
+    // Track these apis external usages when logging is on. otherwise, it should be noop.
     const keys = Object.keys(evaluator);
     keys.forEach((k) => {
         const entry = (evaluator as any)[k];
-        if (typeof entry === 'function') {
+        if (typeof entry === 'function' && entry.name) {
+            // Only wrap functions that aren't wrapped already.
             (evaluator as any)[k] = wrapWithLogger(entry);
         }
     });


### PR DESCRIPTION
this log is controlled by 3 debugging options.

```
   "python.analysis.logLevel": "Trace",
  "python.analysis.logTypeEvaluationTime": true,
  "python.analysis.typeEvaluationTimeThreshold": 5000,
```

when investigating an issue like https://github.com/microsoft/pyright/issues/7159, one can set the options, and get logs like below

```
evaluateTypesForStatement ...
  getTypeOfBoundMember ...
    _getFunctionInferredReturnType ...
      getTypeOfExpression ...
        validateCallArguments ...
          useSpeculativeMode ...
            validateCallArguments ...
              _getFunctionInferredReturnType ...
                getTypeOfExpression ...
                  validateCallArguments ...
                    useSpeculativeMode ...
                      validateCallArguments ...
                        _getFunctionInferredReturnType ...
                          getTypeOfExpression ...
                            getTypeOfExpression ...
                              evaluateTypeForSubnode ...
                                evaluateTypesForStatement ...
                                  evaluateTypeForSubnode ...
                                    evaluateTypesForStatement ...
                                      _getFunctionInferredReturnType ...
                                        evaluateTypeForSubnode ...
                                          evaluateTypesForStatement ...
                                            evaluateTypeForSubnode ...
                                              evaluateTypesForStatement ...
                                                useSpeculativeMode ...
                                                  validateCallArguments ["dict([(('algebraic', True), se <shortened> " (..sympy.core.assumptions_generated) [42:21]] (9006ms)
                                                useSpeculativeMode (9282ms)
                                              evaluateTypesForStatement ["full_implications" (..sympy.core.assumptions_generated) [42:1]] (9283ms)
                                            evaluateTypeForSubnode ["full_implications" (..sympy.core.assumptions_generated) [42:1]] (9283ms)
                                          evaluateTypesForStatement ["_assume_rules" (..sympy.core.assumptions) [225:5]] (9302ms)
                                        evaluateTypeForSubnode ["_assume_rules" (..sympy.core.assumptions) [225:5]] (9302ms)
                                      _getFunctionInferredReturnType [Function '_load_pre_generated_assumption_rules' (sympy.core.assumptions)] (9305ms)
                                    evaluateTypesForStatement ["_assume_rules" (..sympy.core.assumptions) [298:1]] (9306ms)
                                  evaluateTypeForSubnode ["_assume_rules" (..sympy.core.assumptions) [298:1]] (9306ms)
                                evaluateTypesForStatement ["_assume_defined" (..sympy.core.assumptions) [299:1]] (9336ms)
                              evaluateTypeForSubnode ["_assume_defined" (..sympy.core.assumptions) [299:1]] (9336ms)
                            getTypeOfExpression ["_assume_defined.add" (..sympy.core.assumptions) [300:1]] (9336ms)
                          getTypeOfExpression ["StdFactKB" (..sympy.core.symbol) [315:26]] (9339ms)
                        _getFunctionInferredReturnType [Function '__xnew__' (sympy.core.symbol)] (9343ms)
                      validateCallArguments ["staticmethod" (..sympy.core.symbol) [298:6]] (9344ms)
                    useSpeculativeMode (9344ms)
                  validateCallArguments ["staticmethod" (..sympy.core.symbol) [298:6]] (9344ms)
                getTypeOfExpression ["Symbol.__xnew__" (..sympy.core.symbol) [347:16]] (9344ms)
              _getFunctionInferredReturnType [Function '__xnew_cached_' (sympy.core.symbol)] (9345ms)
            validateCallArguments ["staticmethod" (..sympy.core.symbol) [344:6]] (9345ms)
          useSpeculativeMode (9346ms)
        validateCallArguments ["staticmethod" (..sympy.core.symbol) [344:6]] (9346ms)
      getTypeOfExpression ["Symbol.__xnew_cached_" (..sympy.core.symbol) [296:16]] (9403ms)
    _getFunctionInferredReturnType [Function '__new__' (sympy.core.symbol)] (9405ms)
  getTypeOfBoundMember [Class 'Symbol' (sympy.core.symbol)] (9405ms)
evaluateTypesForStatement [Assignment (..Foo) [3:1]] (9406ms)
```

from there, one can see the bottleneck is this `validateCallArguments ["dict([(('algebraic', True), se <shortened> " (..sympy.core.assumptions_generated) [42:21]] (9006ms)`

and code is reaching there to infer `return type` of `_getFunctionInferredReturnType [Function '_load_pre_generated_assumption_rules' (sympy.core.assumptions)] (9305ms)`

if one opens that file in editor, he will see from `inlay hint` (from `pylance`), its type is `FactRules`

![image](https://github.com/microsoft/pyright/assets/1333179/5d7e24f8-c837-46bc-9a55-c705e64b1800)

if return type annotation is explicitly added to `_load_pre_generated_assumption_rules` (such as double clicking inlay hint `-> FactRules`), one can see the perf issue goes away and can confirm using the log

```
evaluateTypesForStatement ...
  getTypeOfBoundMember ...
    _getFunctionInferredReturnType ...
      getTypeOfExpression ["Symbol.__xnew_cached_" (..sympy.core.symbol) [296:16]] (82ms)
    _getFunctionInferredReturnType [Function '__new__' (sympy.core.symbol)] (84ms)
  getTypeOfBoundMember [Class 'Symbol' (sympy.core.symbol)] (84ms)
evaluateTypesForStatement [Assignment (..Foo) [3:1]] (84ms)
```

basically, this can provide a way to find out which symbols require explicitly type annotation to improve type eval performance (rather than blindly adding type annotations in random places).

it could be used by users and update upstream or used by package owner to find out which symbols are critical to have type annotations.