### PR TITLE
Add Installation Instructions for PyCharm

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -16,6 +16,9 @@ Sublime text users can install the [LSP-pyright](https://github.com/sublimelsp/L
 #### Emacs
 Emacs users can install [eglot](https://github.com/joaotavora/eglot) or [lsp-mode](https://github.com/emacs-lsp/lsp-mode) with [lsp-pyright](https://github.com/emacs-lsp/lsp-pyright).
 
+#### PyCharm
+PyCharm users can install [pyright-for-pycharm](https://github.com/InSyncWithFoo/pyright-for-pycharm) if they're using community edition, or [pyright-langserver-for-pycharm](https://github.com/InSyncWithFoo/pyright-langserver-for-pycharm) if they're using professional edition. The later makes use of PyCharm's experimental [LSP API](https://plugins.jetbrains.com/docs/intellij/language-server-protocol.html).
+
 ### Command-line
 
 #### Python Package


### PR DESCRIPTION
There exist two Pyright extensions for PyCharm. One simply runs the CLI, and routes error messages into PyCharm, while the later actually uses the LSP API. The former only exists because usage of LSP API is limited to professional edition users. Both come from the same creator.

This adds notes in the documentation to these two plugins, since the lack of a PyCharm plugin initially made it quite difficult for engineers on my team to get effective live type-checking.