### PR TITLE
Fixed recent regression that affected unannotated `__call__` methods …

### DIFF
--- a/packages/pyright-internal/src/tests/samples/metaclass7.py
+++ b/packages/pyright-internal/src/tests/samples/metaclass7.py
@@ -5,6 +5,9 @@
 # pyright: reportIncompatibleMethodOverride=false
 
 
+from typing import Any, Self
+
+
 class MetaClass1(type):
     def __call__(cls, **kwargs):
         return object.__new__(**kwargs)
@@ -33,7 +36,7 @@ reveal_type(v2, expected_text="NoReturn")
 
 
 class MetaClass3(type):
-    def __call__(cls, *args, **kwargs):
+    def __call__(cls, *args, **kwargs) -> Any:
         return super().__call__(*args, **kwargs)
 
 
@@ -44,3 +47,17 @@ class Class3(metaclass=MetaClass3):
 
 v3 = Class3()
 reveal_type(v3, expected_text="Any")
+
+
+class MetaClass4(type):
+    def __call__(cls, *args, **kwargs):
+        return super().__call__(*args, **kwargs)
+
+
+class Class4(metaclass=MetaClass4):
+    def __new__(cls, *args, **kwargs) -> Self:
+        return super().__new__(cls, *args, **kwargs)
+
+
+v4 = Class4()
+reveal_type(v4, expected_text="Class4")


### PR DESCRIPTION
…in a metaclass. This change aligns pyright's behavior to the typing spec. It addresses #7717.