### PR TITLE
Changed behavior to no longer exempt unguarded access to not-required…

### DIFF
--- a/packages/pyright-internal/src/analyzer/parseTreeUtils.ts
+++ b/packages/pyright-internal/src/analyzer/parseTreeUtils.ts
@@ -1423,37 +1423,6 @@ export function isWithinLoop(node: ParseNode): boolean {
     return false;
 }
 
-export function isWithinTryBlock(node: ParseNode, treatWithAsTryBlock = false): boolean {
-    let curNode: ParseNode | undefined = node;
-    let prevNode: ParseNode | undefined;
-
-    while (curNode) {
-        switch (curNode.nodeType) {
-            case ParseNodeType.Try: {
-                return curNode.trySuite === prevNode;
-            }
-
-            case ParseNodeType.With: {
-                if (treatWithAsTryBlock && curNode.suite === prevNode) {
-                    return true;
-                }
-                break;
-            }
-
-            case ParseNodeType.Function:
-            case ParseNodeType.Module:
-            case ParseNodeType.Class: {
-                return false;
-            }
-        }
-
-        prevNode = curNode;
-        curNode = curNode.parent;
-    }
-
-    return false;
-}
-
 export function isWithinAssertExpression(node: ParseNode): boolean {
     let curNode: ParseNode | undefined = node;
     let prevNode: ParseNode | undefined;

--- a/packages/pyright-internal/src/analyzer/typedDicts.ts
+++ b/packages/pyright-internal/src/analyzer/typedDicts.ts
@@ -1465,14 +1465,12 @@ export function getTypeOfIndexedTypedDict(
                 allDiagsInvolveNotRequiredKeys = false;
                 return UnknownType.create();
             } else if (!(entry.isRequired || entry.isProvided) && usage.method === 'get') {
-                if (!ParseTreeUtils.isWithinTryBlock(node, /* treatWithAsTryBlock */ true)) {
-                    diag.addMessage(
-                        LocAddendum.keyNotRequired().format({
-                            name: entryName,
-                            type: evaluator.printType(baseType),
-                        })
-                    );
-                }
+                diag.addMessage(
+                    LocAddendum.keyNotRequired().format({
+                        name: entryName,
+                        type: evaluator.printType(baseType),
+                    })
+                );
             } else if (entry.isReadOnly && usage.method !== 'get') {
                 diag.addMessage(
                     LocAddendum.keyReadOnly().format({


### PR DESCRIPTION
… TypedDict member within a `try` or `with` block. Previously, such errors were exempt, but this is inconsistent with other type checks in pyright which eschew the practice of using exception handling for normal code flow. This addresses #7714.