### PR TITLE
Fixed bug in protocol matching that results in a false positive when …

### DIFF
--- a/packages/pyright-internal/src/tests/samples/protocol49.py
+++ b/packages/pyright-internal/src/tests/samples/protocol49.py
@@ -1,0 +1,21 @@
+# This sample tests the case where a protocol is matched against a
+# dataclass. Dataclass fields need to act as if they are instance
+# members rather than class members, which means a callable stored
+# in a dataclass member should not be bound to the dataclass itself.
+
+from dataclasses import dataclass
+from typing import Callable, Protocol
+
+
+class HasA(Protocol):
+    @property
+    def a(self) -> Callable[[int], int]: ...
+
+
+@dataclass
+class A:
+    a: Callable[[int], int]
+
+
+def func1(a: A):
+    has_a: HasA = a

--- a/packages/pyright-internal/src/tests/typeEvaluator2.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator2.test.ts
@@ -1417,6 +1417,12 @@ test('Protocol48', () => {
     TestUtils.validateResults(analysisResults, 0);
 });
 
+test('Protocol49', () => {
+    const analysisResults = TestUtils.typeAnalyzeSampleFiles(['protocol49.py']);
+
+    TestUtils.validateResults(analysisResults, 0);
+});
+
 test('ProtocolExplicit1', () => {
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['protocolExplicit1.py']);
 


### PR DESCRIPTION
…the subject object is a dataclass that contains a callable. It should be considered an instance member in this case, so it should not be bound to the class. This addresses #7735.