### PR TITLE
Fixed a bug that results in a false positive error when bidirectional…

### DIFF
--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -13215,10 +13215,10 @@ export function createTypeEvaluator(
                 node,
                 keyTypes,
                 valueTypes,
-                    /* forceStrictInference */ true,
-                    /* isValueTypeInvariant */ true,
-                    /* expectedKeyType */ undefined,
-                    /* expectedValueType */ undefined,
+                /* forceStrictInference */ true,
+                /* isValueTypeInvariant */ true,
+                /* expectedKeyType */ undefined,
+                /* expectedValueType */ undefined,
                 expectedTypedDictEntries,
                 expectedDiagAddendum
             );
@@ -13306,7 +13306,7 @@ export function createTypeEvaluator(
             node,
             keyTypes,
             valueTypes,
-                /* forceStrictInference */ true,
+            /* forceStrictInference */ true,
             isValueTypeInvariant,
             expectedKeyType,
             expectedValueType,
@@ -13359,10 +13359,10 @@ export function createTypeEvaluator(
             node,
             keyTypeResults,
             valueTypeResults,
-                /* forceStrictInference */ hasExpectedType,
-                /* isValueTypeInvariant */ false
+            /* forceStrictInference */ hasExpectedType,
+            /* isValueTypeInvariant */ false
         );
-        
+
         if (keyValueResult.isIncomplete) {
             isIncomplete = true;
         }

--- a/packages/pyright-internal/src/tests/samples/dictionary2.py
+++ b/packages/pyright-internal/src/tests/samples/dictionary2.py
@@ -1,14 +1,34 @@
 # This sample tests dictionary inference logic.
 
-from typing import Mapping
+from typing import Mapping, TypeAlias, TypeVar
+
+T = TypeVar("T")
 
 
-def f(mapping: Mapping[str | bytes, int]):
+def func1(mapping: Mapping[str | bytes, int]):
     return mapping
 
 
-f({"x": 1})
-f({b"x": 1})
+func1({"x": 1})
+func1({b"x": 1})
 
 # This should generate an error.
-f({3: 1})
+func1({3: 1})
+
+
+RecursiveMapping: TypeAlias = (
+    int | Mapping[int, "RecursiveMapping"] | Mapping[str, "RecursiveMapping"]
+)
+
+
+class HasName:
+    name: str | None
+
+
+def func2(x: T | None) -> T:
+    assert x is not None
+    return x
+
+
+def func3(v: list[HasName]) -> RecursiveMapping:
+    return {func2(x.name): 1 for x in v}


### PR DESCRIPTION
… type inference is used for a dictionary comprehension when the expected type is a union. This addresses #7741.