### PR TITLE
Follow-up pull from Pylance

### DIFF
--- a/packages/pyright-internal/src/common/uri/uri.ts
+++ b/packages/pyright-internal/src/common/uri/uri.ts
@@ -234,11 +234,14 @@ export namespace Uri {
         return EmptyUri.instance;
     }
 
+    export const DefaultWorkspaceRootComponent = '<default workspace root>';
+    export const DefaultWorkspaceRootPath = `/${DefaultWorkspaceRootComponent}`;
+
     export function defaultWorkspace(serviceProvider: IServiceProvider): Uri;
     export function defaultWorkspace(caseSensitivityDetector: CaseSensitivityDetector): Uri;
     export function defaultWorkspace(arg: IServiceProvider | CaseSensitivityDetector): Uri {
         arg = CaseSensitivityDetector.is(arg) ? arg : arg.get(ServiceKeys.caseSensitivityDetector);
-        return Uri.file('/<default workspace root>/', arg);
+        return Uri.file(DefaultWorkspaceRootPath, arg);
     }
 
     export function fromJsonObj(jsonObj: JsonObjType) {

--- a/packages/pyright-internal/src/tests/harness/vfs/pathValidation.ts
+++ b/packages/pyright-internal/src/tests/harness/vfs/pathValidation.ts
@@ -8,6 +8,7 @@ import { sep } from 'path';
 
 import * as pu from '../../../common/pathUtils';
 import { createIOError } from '../utils';
+import { Uri } from '../../../common/uri/uri';
 
 const invalidRootComponentRegExp = getInvalidRootComponentRegExp();
 const invalidNavigableComponentRegExp = /[:*?"<>|]/;
@@ -127,7 +128,7 @@ function validateComponents(components: string[], flags: ValidationFlags, hasTra
         return false;
     }
     for (let i = 1; i < components.length; i++) {
-        if (invalidComponentRegExp.test(components[i])) {
+        if (invalidComponentRegExp.test(components[i]) && components[i] !== Uri.DefaultWorkspaceRootComponent) {
             return false;
         }
     }


### PR DESCRIPTION
Follow-up to https://github.com/microsoft/pyright/pull/7761

- Test change to consider paths rooted with `<default workspace root>` to be valid.