### PR TITLE
Fixed a bug that results in incorrect type evaluation when a global (…

### DIFF
--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -4648,6 +4648,19 @@ export function createTypeEvaluator(
             return undefined;
         }
 
+        // If the symbol is a non-final variable in the global scope, it is not
+        // eligible because it could be modified by other modules.
+        if (
+            !decls.every(
+                (decl) =>
+                    decl.type !== DeclarationType.Variable ||
+                    decl.isFinal ||
+                    ScopeUtils.getScopeForNode(decl.node)?.type !== ScopeType.Module
+            )
+        ) {
+            return undefined;
+        }
+
         // If the symbol is a variable captured by an inner function
         // or lambda, see if we can infer the type from the outer scope.
         const scopeHierarchy = ScopeUtils.getScopeHierarchy(node, symbolWithScope.scope);

--- a/packages/pyright-internal/src/tests/samples/capturedVariable1.py
+++ b/packages/pyright-internal/src/tests/samples/capturedVariable1.py
@@ -4,31 +4,39 @@
 from typing import NoReturn, Optional
 
 
-def get_optional_int() -> Optional[int]:
-    ...
+def get_optional_int() -> Optional[int]: ...
 
 
-v1 = get_optional_int()
-if v1 is not None:
-    lambda: v1 + 5
+v0 = get_optional_int()
+if v0 is not None:
+    # This should generate an error because v0 is
+    # a global variable and could be reassigned
+    # outside of this module.
+    lambda: v0 + 5
 
-v2 = get_optional_int()
-if v2 is not None:
-    # This should generate an error because v2
-    # is reassigned after capture.
-    lambda: v2 + 5
-v2 = None
 
-v3 = get_optional_int()
-if v3 is not None:
-    lambda: v3 + 5
-else:
-    v3 = None
+def func0():
+    v1 = get_optional_int()
+    if v1 is not None:
+        lambda: v1 + 5
 
-# This should generate an error because v4 is
-# not bound prior to the capture.
-lambda: v4 + 5
-v4 = get_optional_int()
+    v2 = get_optional_int()
+    if v2 is not None:
+        # This should generate an error because v2
+        # is reassigned after capture.
+        lambda: v2 + 5
+    v2 = None
+
+    v3 = get_optional_int()
+    if v3 is not None:
+        lambda: v3 + 5
+    else:
+        v3 = None
+
+    # This should generate an error because v4 is
+    # not bound prior to the capture.
+    lambda: v4 + 5
+    v4 = get_optional_int()
 
 
 def func1(v1: Optional[int]):
@@ -92,8 +100,7 @@ def func7():
         v1: Optional[int] = 3
 
 
-def func8() -> NoReturn:
-    ...
+def func8() -> NoReturn: ...
 
 
 def func9(x: str | None):

--- a/packages/pyright-internal/src/tests/samples/nameBinding5.py
+++ b/packages/pyright-internal/src/tests/samples/nameBinding5.py
@@ -18,7 +18,7 @@ def func_b() -> None:
     b = "a"
 
     class A:
-        reveal_type(b, expected_text="Literal[0]")
+        reveal_type(b, expected_text="int")
         b = "b"
         reveal_type(b, expected_text="str")
 

--- a/packages/pyright-internal/src/tests/samples/unbound6.py
+++ b/packages/pyright-internal/src/tests/samples/unbound6.py
@@ -1,12 +1,27 @@
 # This sample tests the case where a variable in an outer scope is captured
 # by inner scopes and is potentially unbound.
 
-if 1 + 1 > 3:
-    y = 0
 
+def func1():
+    if 1 + 1 > 3:
+        y = 0
 
-class A:
-    def method1(self):
+    class A:
+        def method1(self):
+            # This should generate a "possibly unbound" error.
+            print(y)
+
+            def inner():
+                # This should generate a "possibly unbound" error.
+                print(y)
+
+            # This should generate a "possibly unbound" error.
+            v = lambda: y
+
+            # This should generate a "possibly unbound" error.
+            x = [m + y for m in range(3)]
+
+    def func1(self):
         # This should generate a "possibly unbound" error.
         print(y)
 
@@ -20,30 +35,23 @@ class A:
         # This should generate a "possibly unbound" error.
         x = [m + y for m in range(3)]
 
+    # The code below should not generate any errors because
+    # z is assigned a value later.
+    if 1 + 1 > 3:
+        z = 0
 
-def func1(self):
-    # This should generate a "possibly unbound" error.
-    print(y)
+    class B:
+        def method1(self):
+            print(z)
 
-    def inner():
-        # This should generate a "possibly unbound" error.
-        print(y)
+            def inner():
+                print(z)
 
-    # This should generate a "possibly unbound" error.
-    v = lambda: y
+            v = lambda: z
 
-    # This should generate a "possibly unbound" error.
-    x = [m + y for m in range(3)]
+            x = [m + z for m in range(3)]
 
-
-# The code below should not generate any errors because
-# z is assigned a value later.
-if 1 + 1 > 3:
-    z = 0
-
-
-class B:
-    def method1(self):
+    def func2(self):
         print(z)
 
         def inner():
@@ -53,16 +61,4 @@ class B:
 
         x = [m + z for m in range(3)]
 
-
-def func2(self):
-    print(z)
-
-    def inner():
-        print(z)
-
-    v = lambda: z
-
-    x = [m + z for m in range(3)]
-
-
-z = 0
+    z = 0

--- a/packages/pyright-internal/src/tests/typeEvaluator1.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator1.test.ts
@@ -1070,7 +1070,7 @@ test('CodeFlow8', () => {
 test('CapturedVariable1', () => {
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['capturedVariable1.py']);
 
-    TestUtils.validateResults(analysisResults, 5);
+    TestUtils.validateResults(analysisResults, 6);
 });
 
 test('CapturedVariable2', () => {


### PR DESCRIPTION
…module-scoped) variable is captured within an inner scope and the variable is not modified anywhere below the inner scope. It's possible in this case for the variable to be modified by code outside of the module. This addresses #7780.