### PR TITLE
Fixed bug that produces incorrect output when converting to a textual…

### DIFF
--- a/packages/pyright-internal/src/analyzer/typeUtils.ts
+++ b/packages/pyright-internal/src/analyzer/typeUtils.ts
@@ -2548,7 +2548,7 @@ export function convertToInstantiable(type: Type, includeSubclasses = true): Typ
         return type.cached.instantiableType;
     }
 
-    let result = mapSubtypes(type, (subtype) => {
+    const result = mapSubtypes(type, (subtype) => {
         switch (subtype.category) {
             case TypeCategory.Class: {
                 return ClassType.cloneAsInstantiable(subtype, includeSubclasses);
@@ -2565,21 +2565,6 @@ export function convertToInstantiable(type: Type, includeSubclasses = true): Typ
 
         return subtype;
     });
-
-    // Copy over any type alias information.
-    if (type.typeAliasInfo && type !== result) {
-        result = TypeBase.cloneForTypeAlias(
-            result,
-            type.typeAliasInfo.name,
-            type.typeAliasInfo.fullName,
-            type.typeAliasInfo.moduleName,
-            type.typeAliasInfo.fileUri,
-            type.typeAliasInfo.typeVarScopeId,
-            type.typeAliasInfo.isPep695Syntax,
-            type.typeAliasInfo.typeParameters,
-            type.typeAliasInfo.typeArguments
-        );
-    }
 
     if (type !== result) {
         // Cache the converted value for next time.

--- a/packages/pyright-internal/src/analyzer/types.ts
+++ b/packages/pyright-internal/src/analyzer/types.ts
@@ -251,6 +251,10 @@ export namespace TypeBase {
                 newInstance.instantiableNestingLevel === undefined ? 1 : newInstance.instantiableNestingLevel;
         }
 
+        // Remove type alias information because the type will no longer match
+        // that of the type alias definition.
+        delete newInstance.typeAliasInfo;
+
         // Should we cache it for next time?
         if (cache) {
             if (!type.cached) {

--- a/packages/pyright-internal/src/tests/samples/recursiveTypeAlias4.py
+++ b/packages/pyright-internal/src/tests/samples/recursiveTypeAlias4.py
@@ -19,12 +19,12 @@ def f2(args: JSONStructured):
     if isinstance(args, list):
         reveal_type(
             args,
-            expected_text="list[str | float | int | bool | JSONArray | dict[str, JSONType] | None]",
+            expected_text="list[str | float | int | bool | list[JSONType] | dict[str, JSONType] | None]",
         )
     else:
         reveal_type(
             args,
-            expected_text="dict[str, str | float | int | bool | list[JSONType] | JSONObject | None]",
+            expected_text="dict[str, str | float | int | bool | list[JSONType] | dict[str, JSONType] | None]",
         )
         dargs: JSONObject = args
 
@@ -34,12 +34,12 @@ def f3(args: JSONStructured):
     if isinstance(args, dict):
         reveal_type(
             args,
-            expected_text="dict[str, str | float | int | bool | list[JSONType] | JSONObject | None]",
+            expected_text="dict[str, str | float | int | bool | list[JSONType] | dict[str, JSONType] | None]",
         )
     else:
         reveal_type(
             args,
-            expected_text="list[str | float | int | bool | JSONArray | dict[str, JSONType] | None]",
+            expected_text="list[str | float | int | bool | list[JSONType] | dict[str, JSONType] | None]",
         )
         largs: JSONArray = args
 

--- a/packages/pyright-internal/src/tests/samples/typeAlias1.py
+++ b/packages/pyright-internal/src/tests/samples/typeAlias1.py
@@ -38,7 +38,15 @@ v5: list[Alias1] = []
 
 
 Alias2 = int | str
+Alias3 = int
+Alias4 = type[int]
 
 
 def func1(x: Alias2):
     reveal_type(type(x), expected_text="type[int] | type[str]")
+
+
+def func2(v2: type[Alias2], v3: type[Alias3], v4: type[Alias4]):
+    reveal_type(v2, expected_text="type[int] | type[str]")
+    reveal_type(v3, expected_text="type[int]")
+    reveal_type(v4, expected_text="type[type[int]]")


### PR DESCRIPTION
… representation the type `type[Foo]` where `Foo` is a type alias. This addresses #7806.