### PR TITLE
Fixed a bug that results in incorrect type narrowing in the negative …

### DIFF
--- a/packages/pyright-internal/src/analyzer/patternMatching.ts
+++ b/packages/pyright-internal/src/analyzer/patternMatching.ts
@@ -738,19 +738,9 @@ function narrowTypeBasedOnClassPattern(
 
                 if (pattern.arguments.length === 0) {
                     if (isClass(classInstance) && isClass(subjectSubtypeExpanded)) {
-                        if (ClassType.isDerivedFrom(subjectSubtypeExpanded, classInstance)) {
-                            // We know that this match will always succeed, so we can
-                            // eliminate this subtype.
-                            return undefined;
-                        }
-
-                        // Handle LiteralString as a special case.
-                        if (
-                            ClassType.isBuiltIn(classInstance, 'str') &&
-                            ClassType.isBuiltIn(subjectSubtypeExpanded, 'LiteralString')
-                        ) {
-                            return undefined;
-                        }
+                        // We know that this match will always succeed, so we can
+                        // eliminate this subtype.
+                        return undefined;
                     }
 
                     return subjectSubtypeExpanded;

--- a/packages/pyright-internal/src/tests/samples/matchClass1.py
+++ b/packages/pyright-internal/src/tests/samples/matchClass1.py
@@ -495,3 +495,16 @@ def func21(subj: object):
         # This should generate an error because Proto2 isn't runtime checkable.
         case Proto2():
             pass
+
+
+class Impl1:
+    x: int
+
+
+def func22(subj: Proto1 | int):
+    match subj:
+        case Proto1():
+            reveal_type(subj, expected_text="Proto1")
+
+        case _:
+            reveal_type(subj, expected_text="int")


### PR DESCRIPTION
…(fall-through) case when a `match` statement includes a class pattern with a runtime-checkable protocol class. This addresses #7823.