### PR TITLE
Fixed a bug that results in incorrect type evaluation for a variable …

### DIFF
--- a/packages/pyright-internal/src/analyzer/scope.ts
+++ b/packages/pyright-internal/src/analyzer/scope.ts
@@ -62,6 +62,10 @@ export interface SymbolWithScope {
     // scopes because they are "executed" immediately as
     // part of the scope in which they are contained.
     isBeyondExecutionScope: boolean;
+
+    // The symbol was accessed through a nonlocal or global binding.
+    usesNonlocalBinding: boolean;
+    usesGlobalBinding: boolean;
 }
 
 export interface GlobalScopeResult {
@@ -73,6 +77,8 @@ export interface LookupSymbolOptions {
     isOutsideCallerModule?: boolean;
     isBeyondExecutionScope?: boolean;
     useProxyScope?: boolean;
+    usesNonlocalBinding?: boolean;
+    usesGlobalBinding?: boolean;
 }
 
 export class Scope {
@@ -163,6 +169,8 @@ export class Scope {
                     isOutsideCallerModule: !!options?.isOutsideCallerModule,
                     isBeyondExecutionScope: !!options?.isBeyondExecutionScope,
                     scope: effectiveScope,
+                    usesNonlocalBinding: !!options?.usesNonlocalBinding,
+                    usesGlobalBinding: !!options?.usesGlobalBinding,
                 };
             }
         }
@@ -170,7 +178,8 @@ export class Scope {
         let parentScope: Scope | undefined;
         let isNextScopeBeyondExecutionScope = options?.isBeyondExecutionScope || this.isIndependentlyExecutable();
 
-        if (this.notLocalBindings.get(name) === NameBindingType.Global) {
+        const notLocalBinding = this.notLocalBindings.get(name);
+        if (notLocalBinding === NameBindingType.Global) {
             const globalScopeResult = this.getGlobalScope();
             if (globalScopeResult.scope !== this) {
                 parentScope = globalScopeResult.scope;
@@ -189,6 +198,8 @@ export class Scope {
             return parentScope.lookUpSymbolRecursive(name, {
                 isOutsideCallerModule: !!options?.isOutsideCallerModule || this.type === ScopeType.Module,
                 isBeyondExecutionScope: isNextScopeBeyondExecutionScope,
+                usesNonlocalBinding: notLocalBinding === NameBindingType.Nonlocal || !!options?.usesNonlocalBinding,
+                usesGlobalBinding: notLocalBinding === NameBindingType.Global || !!options?.usesGlobalBinding,
             });
         }
 

--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -4621,6 +4621,12 @@ export function createTypeEvaluator(
         symbolWithScope: SymbolWithScope,
         effectiveType: Type
     ): FlowNodeTypeResult | undefined {
+        // This function applies only to captured variables, not those that
+        // are accessed via an explicit nonlocal or global binding.
+        if (symbolWithScope.usesGlobalBinding || symbolWithScope.usesNonlocalBinding) {
+            return undefined;
+        }
+
         // This function applies only to variables, parameters, and imports, not to other
         // types of symbols.
         const decls = symbolWithScope.symbol.getDeclarations();

--- a/packages/pyright-internal/src/tests/samples/capturedVariable1.py
+++ b/packages/pyright-internal/src/tests/samples/capturedVariable1.py
@@ -133,3 +133,14 @@ def func11(foo: list[int] | None):
 
         def inner() -> list[int]:
             return [x for x in foo]
+
+
+def func12() -> None:
+    counter = 0
+
+    def inner() -> None:
+        nonlocal counter
+        reveal_type(counter, expected_text="int")
+        counter += 1
+
+    inner()


### PR DESCRIPTION
…that uses a nonlocal or global binding within an inner scope. Such a variable should never honor the narrowed type from the outer scope. This addresses #7838.