### PR TITLE
varaiables -> variables typo fix for English and Korean translations.

### DIFF
--- a/packages/pyright-internal/src/localization/package.nls.en-us.json
+++ b/packages/pyright-internal/src/localization/package.nls.en-us.json
@@ -239,7 +239,7 @@
         "inconsistentIndent": "Unindent amount does not match previous indent",
         "initMustReturnNone": "Return type of \"__init__\" must be None",
         "inconsistentTabs": "Inconsistent use of tabs and spaces in indentation",
-        "initMethodSelfParamTypeVar": "Type annotation for \"self\" parameter of \"__init__\" method cannot contain class-scoped type varaiables",
+        "initMethodSelfParamTypeVar": "Type annotation for \"self\" parameter of \"__init__\" method cannot contain class-scoped type variables",
         "initSubclassClsParam": "__init_subclass__ override should take a \"cls\" parameter",
         "initSubclassCallFailed": "Incorrect keyword arguments for __init_subclass__ method",
         "initVarNotAllowed": "\"InitVar\" is not allowed in this context",

--- a/packages/pyright-internal/src/localization/package.nls.ko.json
+++ b/packages/pyright-internal/src/localization/package.nls.ko.json
@@ -252,7 +252,7 @@
         "incompatibleMethodOverride": "\"{name}\" 메서드가 호환되지 않는 방식으로 \"{className}\" 클래스를 재정의합니다.",
         "inconsistentIndent": "들여쓰기하지 않은 양이 이전 들여쓰기와 일치하지 않습니다.",
         "inconsistentTabs": "들여쓰기에서 탭 및 공백의 일관성 없는 사용",
-        "initMethodSelfParamTypeVar": "\"__init__\" 메서드의 \"self\" 매개 변수의 형식 주석에는 클래스 범위 형식 varaiable을 포함할 수 없음",
+        "initMethodSelfParamTypeVar": "\"__init__\" 메서드의 \"self\" 매개 변수의 형식 주석에는 클래스 범위 형식 variable을 포함할 수 없음",
         "initMustReturnNone": "\"__init__\"의 반환 형식은 None이어야 합니다.",
         "initSubclassCallFailed": "__init_subclass__ 메서드의 키워드 인수가 잘못됨",
         "initSubclassClsParam": "__init_subclass__ 재정의는 \"cls\" 매개 변수를 사용해야 합니다.",


### PR DESCRIPTION
I noticed this typo when I encountered this error.