### PR TITLE
Add note about VS code's locale being used first

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -436,3 +436,5 @@ LC_MESSAGES="en-us"
 LANG="zh-cn"
 LANGUAGE="fr"
 ```
+
+Please note that when running in VS Code, VS Code's locale takes precedence. Setting these environment variables only applies when using Pyright outside of VS code.


### PR DESCRIPTION
In response to https://github.com/microsoft/pyright/issues/7873