### PR TITLE
Fixed bug that results in a false positive `reportUnnecessaryComparis…

### DIFF
--- a/packages/pyright-internal/src/analyzer/checker.ts
+++ b/packages/pyright-internal/src/analyzer/checker.ts
@@ -1868,7 +1868,7 @@ export class Checker extends ParseTreeWalker {
 
         const exprTypeResult = this._evaluator.getTypeOfExpression(expression);
         let isExprFunction = true;
-        let isCoroutine = false;
+        let isCoroutine = true;
 
         doForEachSubtype(exprTypeResult.type, (subtype) => {
             subtype = this._evaluator.makeTopLevelTypeVarsConcrete(subtype);
@@ -1877,8 +1877,8 @@ export class Checker extends ParseTreeWalker {
                 isExprFunction = false;
             }
 
-            if (isClassInstance(subtype) && ClassType.isBuiltIn(subtype, 'Coroutine')) {
-                isCoroutine = true;
+            if (!isClassInstance(subtype) || !ClassType.isBuiltIn(subtype, 'Coroutine')) {
+                isCoroutine = false;
             }
         });
 

--- a/packages/pyright-internal/src/tests/samples/comparison2.py
+++ b/packages/pyright-internal/src/tests/samples/comparison2.py
@@ -2,12 +2,11 @@
 # when applied to functions that appear within a conditional expression.
 
 
-from typing import Any
+from typing import Any, Coroutine
 from dataclasses import dataclass
 
 
-def cond() -> bool:
-    ...
+def cond() -> bool: ...
 
 
 # This should generate a diagnostic when reportUnnecessaryComparison is enabled.
@@ -76,4 +75,13 @@ async def func4() -> bool:
 async def func5() -> None:
     # This should generate an error if reportUnnecessaryComparison is enabled.
     if func4():
+        pass
+
+
+def func6() -> Coroutine[Any, Any, int] | None: ...
+
+
+def func7():
+    coro = func6()
+    if coro:
         pass


### PR DESCRIPTION
…on` when a variable is used in a conditional expression and its type is a union that includes a `Coroutine` and a non-coroutine. This addresses #7881.