### PR TITLE
Fixed bug that results in incorrect type narrowing for `isinstance` o…

### DIFF
--- a/packages/pyright-internal/src/analyzer/codeFlowEngine.ts
+++ b/packages/pyright-internal/src/analyzer/codeFlowEngine.ts
@@ -1482,9 +1482,12 @@ export function getCodeFlowEngine(
                             const arg1Expr = testExpression.arguments[1].valueExpression;
                             const arg1Type = evaluator.getTypeOfExpression(
                                 arg1Expr,
-                                EvaluatorFlags.EvaluateStringLiteralAsType |
+                                EvaluatorFlags.AllowMissingTypeArgs |
+                                    EvaluatorFlags.EvaluateStringLiteralAsType |
                                     EvaluatorFlags.DisallowParamSpec |
-                                    EvaluatorFlags.DisallowTypeVarTuple
+                                    EvaluatorFlags.DisallowTypeVarTuple |
+                                    EvaluatorFlags.DisallowFinal |
+                                    EvaluatorFlags.DoNotSpecialize
                             ).type;
 
                             if (isInstantiableClass(arg1Type)) {

--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -11965,7 +11965,8 @@ export function createTypeEvaluator(
                       EvaluatorFlags.EvaluateStringLiteralAsType |
                       EvaluatorFlags.DisallowParamSpec |
                       EvaluatorFlags.DisallowTypeVarTuple |
-                      EvaluatorFlags.DisallowFinal
+                      EvaluatorFlags.DisallowFinal |
+                      EvaluatorFlags.DoNotSpecialize
                     : EvaluatorFlags.DoNotSpecialize | EvaluatorFlags.DisallowFinal;
                 const exprTypeResult = getTypeOfExpression(
                     argParam.argument.valueExpression,

--- a/packages/pyright-internal/src/tests/samples/typeNarrowingIsinstance20.py
+++ b/packages/pyright-internal/src/tests/samples/typeNarrowingIsinstance20.py
@@ -1,0 +1,16 @@
+# This sample tests the case where an isinstance type narrowing is used
+# with a generic class with a type parameter that has a default value.
+
+from typing import Generic
+from typing_extensions import TypeVar  # pyright: ignore[reportMissingModuleSource]
+
+
+T = TypeVar("T", bound=int, default=int)
+
+
+class ClassA(Generic[T]): ...
+
+
+def func1(obj: object):
+    if isinstance(obj, ClassA):
+        reveal_type(obj, expected_text="ClassA[Unknown]")

--- a/packages/pyright-internal/src/tests/typeEvaluator1.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator1.test.ts
@@ -472,6 +472,12 @@ test('TypeNarrowingIsinstance19', () => {
     TestUtils.validateResults(analysisResults, 0);
 });
 
+test('TypeNarrowingIsinstance20', () => {
+    const analysisResults = TestUtils.typeAnalyzeSampleFiles(['typeNarrowingIsinstance20.py']);
+
+    TestUtils.validateResults(analysisResults, 0);
+});
+
 test('TypeNarrowingTupleLength1', () => {
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['typeNarrowingTupleLength1.py']);
 


### PR DESCRIPTION
…r `issubclass` type guard when the filter is a generic class whose type parameter has a default value.

This addresses #7860.