### PR TITLE
Fixed bug that results in incorrect type narrowing for `isinstance` o…

### DIFF
--- a/packages/pyright-internal/src/analyzer/codeFlowEngine.ts
+++ b/packages/pyright-internal/src/analyzer/codeFlowEngine.ts
@@ -1482,9 +1482,12 @@ export function getCodeFlowEngine(
                             const arg1Expr = testExpression.arguments[1].valueExpression;
                             const arg1Type = evaluator.getTypeOfExpression(
                                 arg1Expr,
-                                EvaluatorFlags.EvaluateStringLiteralAsType |
+                                EvaluatorFlags.AllowMissingTypeArgs |
+                                    EvaluatorFlags.EvaluateStringLiteralAsType |
                                     EvaluatorFlags.DisallowParamSpec |
-                                    EvaluatorFlags.DisallowTypeVarTuple
+                                    EvaluatorFlags.DisallowTypeVarTuple |
+                                    EvaluatorFlags.DisallowFinal |
+                                    EvaluatorFlags.DoNotSpecialize
                             ).type;
 
                             if (isInstantiableClass(arg1Type)) {

--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -11965,7 +11965,8 @@ export function createTypeEvaluator(
                       EvaluatorFlags.EvaluateStringLiteralAsType |
                       EvaluatorFlags.DisallowParamSpec |
                       EvaluatorFlags.DisallowTypeVarTuple |
-                      EvaluatorFlags.DisallowFinal
+                      EvaluatorFlags.DisallowFinal |
+                      EvaluatorFlags.DoNotSpecialize
                     : EvaluatorFlags.DoNotSpecialize | EvaluatorFlags.DisallowFinal;
                 const exprTypeResult = getTypeOfExpression(
                     argParam.argument.valueExpression,

--- a/packages/pyright-internal/src/analyzer/typeGuards.ts
+++ b/packages/pyright-internal/src/analyzer/typeGuards.ts
@@ -73,6 +73,7 @@ import {
     getSpecializedTupleType,
     getTypeCondition,
     getTypeVarScopeId,
+    getUnknownTypeForCallable,
     isInstantiableMetaclass,
     isLiteralType,
     isLiteralTypeOrUnion,
@@ -630,7 +631,9 @@ export function getTypeNarrowingCallback(
                         EvaluatorFlags.AllowMissingTypeArgs |
                             EvaluatorFlags.EvaluateStringLiteralAsType |
                             EvaluatorFlags.DisallowParamSpec |
-                            EvaluatorFlags.DisallowTypeVarTuple
+                            EvaluatorFlags.DisallowTypeVarTuple |
+                            EvaluatorFlags.DisallowFinal |
+                            EvaluatorFlags.DoNotSpecialize
                     );
                     const arg1Type = arg1TypeResult.type;
 
@@ -1150,6 +1153,14 @@ function getIsInstanceClassTypes(argType: Type): (ClassType | TypeVarType | Func
     // undefined if any of the types are not valid.
     const addClassTypesToList = (types: Type[]) => {
         types.forEach((subtype) => {
+            if (isClass(subtype)) {
+                subtype = specializeWithUnknownTypeArgs(subtype);
+
+                if (isInstantiableClass(subtype) && ClassType.isBuiltIn(subtype, 'Callable')) {
+                    subtype = convertToInstantiable(getUnknownTypeForCallable());
+                }
+            }
+
             if (isInstantiableClass(subtype) || (isTypeVar(subtype) && TypeBase.isInstantiable(subtype))) {
                 classTypeList.push(subtype);
             } else if (isNoneTypeClass(subtype)) {
@@ -1430,6 +1441,7 @@ function narrowTypeForIsInstanceInternal(
                                 ) {
                                     if (
                                         !filterType.typeArguments ||
+                                        !filterType.isTypeArgumentExplicit ||
                                         !ClassType.isSameGenericClass(concreteVarType, filterType)
                                     ) {
                                         const typeVarContext = new TypeVarContext(getTypeVarScopeId(filterType));
@@ -1452,7 +1464,7 @@ function narrowTypeForIsInstanceInternal(
                                             specializedFilterType = applySolvedTypeVars(
                                                 unspecializedFilterType,
                                                 typeVarContext,
-                                                { unknownIfNotFound: true }
+                                                { unknownIfNotFound: true, useUnknownOverDefault: true }
                                             ) as ClassType;
                                         }
                                     }

--- a/packages/pyright-internal/src/analyzer/typeUtils.ts
+++ b/packages/pyright-internal/src/analyzer/typeUtils.ts
@@ -243,6 +243,7 @@ export const enum AssignTypeFlags {
 
 export interface ApplyTypeVarOptions {
     unknownIfNotFound?: boolean;
+    useUnknownOverDefault?: boolean;
     unknownExemptTypeVars?: TypeVarType[];
     useNarrowBoundOnly?: boolean;
     eliminateUnsolvedInUnions?: boolean;
@@ -1101,6 +1102,17 @@ export function specializeWithDefaultTypeArgs(type: ClassType): ClassType {
 export function specializeWithUnknownTypeArgs(type: ClassType): ClassType {
     if (type.details.typeParameters.length === 0) {
         return type;
+    }
+
+    if (isTupleClass(type)) {
+        return ClassType.cloneIncludeSubclasses(
+            specializeTupleClass(
+                type,
+                [{ type: UnknownType.create(), isUnbounded: true }],
+                /* isTypeArgumentExplicit */ false
+            ),
+            !!type.includeSubclasses
+        );
     }
 
     return ClassType.cloneForSpecialization(
@@ -4264,7 +4276,9 @@ class ApplySolvedTypeVarsTransformer extends TypeVarTransformer {
                             }
 
                             if (this._options.unknownIfNotFound) {
-                                return specializeWithDefaultTypeArgs(subtype);
+                                return this._options.useUnknownOverDefault
+                                    ? specializeWithUnknownTypeArgs(subtype)
+                                    : specializeWithDefaultTypeArgs(subtype);
                             }
                         }
 
@@ -4295,7 +4309,7 @@ class ApplySolvedTypeVarsTransformer extends TypeVarTransformer {
 
             if (useDefaultOrUnknown) {
                 // Use the default value if there is one.
-                if (typeVar.details.isDefaultExplicit) {
+                if (typeVar.details.isDefaultExplicit && !this._options.useUnknownOverDefault) {
                     return this._solveDefaultType(typeVar.details.defaultType, recursionCount);
                 }
 
@@ -4421,7 +4435,7 @@ class ApplySolvedTypeVarsTransformer extends TypeVarTransformer {
 
         if (useDefaultOrUnknown) {
             // Use the default value if there is one.
-            if (paramSpec.details.isDefaultExplicit) {
+            if (paramSpec.details.isDefaultExplicit && !this._options.useUnknownOverDefault) {
                 return convertTypeToParamSpecValue(
                     this._solveDefaultType(paramSpec.details.defaultType, recursionCount)
                 );

--- a/packages/pyright-internal/src/tests/samples/typeNarrowingIsinstance20.py
+++ b/packages/pyright-internal/src/tests/samples/typeNarrowingIsinstance20.py
@@ -1,0 +1,16 @@
+# This sample tests the case where an isinstance type narrowing is used
+# with a generic class with a type parameter that has a default value.
+
+from typing import Generic
+from typing_extensions import TypeVar  # pyright: ignore[reportMissingModuleSource]
+
+
+T = TypeVar("T", bound=int, default=int)
+
+
+class ClassA(Generic[T]): ...
+
+
+def func1(obj: object):
+    if isinstance(obj, ClassA):
+        reveal_type(obj, expected_text="ClassA[Unknown]")

--- a/packages/pyright-internal/src/tests/typeEvaluator1.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator1.test.ts
@@ -472,6 +472,12 @@ test('TypeNarrowingIsinstance19', () => {
     TestUtils.validateResults(analysisResults, 0);
 });
 
+test('TypeNarrowingIsinstance20', () => {
+    const analysisResults = TestUtils.typeAnalyzeSampleFiles(['typeNarrowingIsinstance20.py']);
+
+    TestUtils.validateResults(analysisResults, 0);
+});
+
 test('TypeNarrowingTupleLength1', () => {
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['typeNarrowingTupleLength1.py']);
 


### PR DESCRIPTION
…r `issubclass` type guard when the filter is a generic class whose type parameter has a default value.

This addresses #7860.