### PR TITLE
Changed the handling of `Enum` subclasses that explicitly override `v…

### DIFF
--- a/packages/pyright-internal/src/analyzer/enums.ts
+++ b/packages/pyright-internal/src/analyzer/enums.ts
@@ -544,6 +544,13 @@ export function getTypeOfEnumMember(
     const literalValue = classType.literalValue;
 
     if (memberName === 'name' || memberName === '_name_') {
+        // Does the class explicitly override this member? Or it it using the
+        // standard behavior provided by the "Enum" class?
+        const memberInfo = lookUpClassMember(classType, memberName);
+        if (memberInfo && isClass(memberInfo.classType) && !ClassType.isBuiltIn(memberInfo.classType, 'Enum')) {
+            return undefined;
+        }
+
         const strClass = evaluator.getBuiltInType(errorNode, 'str');
         if (!isInstantiableClass(strClass)) {
             return undefined;
@@ -579,6 +586,13 @@ export function getTypeOfEnumMember(
     const valueType = getEnumDeclaredValueType(evaluator, classType);
 
     if (memberName === 'value' || memberName === '_value_') {
+        // Does the class explicitly override this member? Or it it using the
+        // standard behavior provided by the "Enum" class?
+        const memberInfo = lookUpClassMember(classType, memberName);
+        if (memberInfo && isClass(memberInfo.classType) && !ClassType.isBuiltIn(memberInfo.classType, 'Enum')) {
+            return undefined;
+        }
+
         // If the enum class has a custom metaclass, it may implement some
         // "magic" that computes different values for the "_value_" attribute.
         // This occurs, for example, in the django TextChoices class. If we

--- a/packages/pyright-internal/src/tests/samples/enum1.py
+++ b/packages/pyright-internal/src/tests/samples/enum1.py
@@ -263,3 +263,29 @@ reveal_type(TestEnum20.B.value, expected_text="Literal[2]")
 reveal_type(TestEnum20.A.A.A, expected_text="Literal[TestEnum20.A]")
 reveal_type(TestEnum20.A.B.A, expected_text="Literal[TestEnum20.A]")
 reveal_type(TestEnum20.A.B, expected_text="Literal[TestEnum20.B]")
+
+
+class TestEnum21Base(Enum, metaclass=CustomEnumMeta1):
+    @property
+    def value(self) -> str:
+        return "test"
+
+
+class TestEnum21(TestEnum21Base):
+    A = 1
+
+
+reveal_type(TestEnum21.A.value, expected_text="str")
+
+
+class TestEnum22Base(Enum):
+    @property
+    def value(self) -> str:
+        return "test"
+
+
+class TestEnum22(TestEnum22Base):
+    A = 1
+
+
+reveal_type(TestEnum22.A.value, expected_text="str")


### PR DESCRIPTION
…alue` or `name` to avoid using the special-case logic for computing these types. This is done regardless of whether the class uses a custom metaclass. This addresses #7939.