### PR TITLE
Changed behavior of logic that converts a class to a callable when th…

### DIFF
--- a/packages/pyright-internal/src/analyzer/constructors.ts
+++ b/packages/pyright-internal/src/analyzer/constructors.ts
@@ -35,6 +35,7 @@ import {
     isTupleClass,
     lookUpClassMember,
     mapSubtypes,
+    rescopeConstructorClassTypeVars,
     selfSpecializeClass,
     specializeTupleClass,
     transformPossibleRecursiveTypeAlias,
@@ -961,7 +962,7 @@ function createFunctionFromNewMethod(
         convertedNew.details.flags &= ~(FunctionTypeFlags.StaticMethod | FunctionTypeFlags.ConstructorMethod);
         convertedNew.details.constructorTypeVarScopeId = getTypeVarScopeId(classType);
 
-        return convertedNew;
+        return rescopeConstructorClassTypeVars(convertedNew, '__new__');
     };
 
     if (isFunction(newType)) {
@@ -1062,7 +1063,7 @@ function createFunctionFromInitMethod(
         convertedInit.details.flags &= ~FunctionTypeFlags.StaticMethod;
         convertedInit.details.constructorTypeVarScopeId = getTypeVarScopeId(classType);
 
-        return convertedInit;
+        return rescopeConstructorClassTypeVars(convertedInit, '__init__');
     }
 
     if (isFunction(initType)) {

--- a/packages/pyright-internal/src/analyzer/dataClasses.ts
+++ b/packages/pyright-internal/src/analyzer/dataClasses.ts
@@ -87,9 +87,15 @@ export function synthesizeDataClassMethods(
 
     const classTypeVar = synthesizeTypeVarForSelfCls(classType, /* isClsParam */ true);
     const newType = FunctionType.createSynthesizedInstance('__new__', FunctionTypeFlags.ConstructorMethod);
-    newType.details.constructorTypeVarScopeId = classType.details.typeVarScopeId;
+    if (classType.details.typeVarScopeId) {
+        newType.details.typeVarScopeId = classType.details.typeVarScopeId + '-new';
+        newType.details.constructorTypeVarScopeId = classType.details.typeVarScopeId;
+    }
     const initType = FunctionType.createSynthesizedInstance('__init__');
-    initType.details.constructorTypeVarScopeId = classType.details.typeVarScopeId;
+    if (classType.details.typeVarScopeId) {
+        initType.details.typeVarScopeId = classType.details.typeVarScopeId + '-init';
+        initType.details.constructorTypeVarScopeId = classType.details.typeVarScopeId;
+    }
 
     // Generate both a __new__ and an __init__ method. The parameters of the
     // __new__ method are based on field definitions for NamedTuple classes,
@@ -784,6 +790,7 @@ function getConverterInputType(
     const targetFunction = FunctionType.createSynthesizedInstance('');
     targetFunction.details.typeVarScopeId = typeVar.scopeId;
     targetFunction.details.declaredReturnType = fieldType;
+    targetFunction.details.typeParameters.push(typeVar);
     FunctionType.addParameter(targetFunction, {
         category: ParameterCategory.Simple,
         name: '__input',

--- a/packages/pyright-internal/src/analyzer/namedTuples.ts
+++ b/packages/pyright-internal/src/analyzer/namedTuples.ts
@@ -142,7 +142,10 @@ export function createNamedTupleType(
     if (ParseTreeUtils.isAssignmentToDefaultsFollowingNamedTuple(errorNode)) {
         constructorType.details.flags |= FunctionTypeFlags.DisableDefaultChecks;
     }
-    constructorType.details.typeVarScopeId = classType.details.typeVarScopeId;
+    if (classType.details.typeVarScopeId) {
+        constructorType.details.typeVarScopeId = classType.details.typeVarScopeId + '_new';
+        constructorType.details.constructorTypeVarScopeId = classType.details.typeVarScopeId;
+    }
     FunctionType.addParameter(constructorType, {
         category: ParameterCategory.Simple,
         name: 'cls',
@@ -377,7 +380,10 @@ export function createNamedTupleType(
     FunctionType.addParameter(initType, selfParameter);
     FunctionType.addDefaultParameters(initType);
     initType.details.declaredReturnType = evaluator.getNoneType();
-    initType.details.constructorTypeVarScopeId = classType.details.typeVarScopeId;
+    if (classType.details.typeVarScopeId) {
+        initType.details.typeVarScopeId = classType.details.typeVarScopeId + '_init';
+        initType.details.constructorTypeVarScopeId = classType.details.typeVarScopeId;
+    }
 
     classFields.set('__new__', Symbol.createWithType(SymbolFlags.ClassMember, constructorType));
     classFields.set('__init__', Symbol.createWithType(SymbolFlags.ClassMember, initType));

--- a/packages/pyright-internal/src/analyzer/typedDicts.ts
+++ b/packages/pyright-internal/src/analyzer/typedDicts.ts
@@ -279,7 +279,10 @@ export function synthesizeTypedDictClassMethods(
     });
     FunctionType.addDefaultParameters(newType);
     newType.details.declaredReturnType = ClassType.cloneAsInstance(classType);
-    newType.details.constructorTypeVarScopeId = classType.details.typeVarScopeId;
+    if (classType.details.typeVarScopeId) {
+        newType.details.typeVarScopeId = classType.details.typeVarScopeId + '_new';
+        newType.details.constructorTypeVarScopeId = classType.details.typeVarScopeId;
+    }
 
     // Synthesize an __init__ method with two overrides.
     const initOverride1 = FunctionType.createSynthesizedInstance('__init__', FunctionTypeFlags.Overloaded);
@@ -290,7 +293,10 @@ export function synthesizeTypedDictClassMethods(
         hasDeclaredType: true,
     });
     initOverride1.details.declaredReturnType = evaluator.getNoneType();
-    initOverride1.details.constructorTypeVarScopeId = classType.details.typeVarScopeId;
+    if (classType.details.typeVarScopeId) {
+        initOverride1.details.typeVarScopeId = classType.details.typeVarScopeId + '_init';
+        initOverride1.details.constructorTypeVarScopeId = classType.details.typeVarScopeId;
+    }
 
     // The first parameter must be positional-only.
     FunctionType.addParameter(initOverride1, {

--- a/packages/pyright-internal/src/tests/samples/constructorCallable2.py
+++ b/packages/pyright-internal/src/tests/samples/constructorCallable2.py
@@ -128,7 +128,7 @@ class Class8(Generic[T]):
 
 
 r8 = accepts_callable(Class8)
-reveal_type(r8, expected_text="(x: T@Class8, y: list[T@Class8]) -> Class8[T@Class8]")
+reveal_type(r8, expected_text="(x: T@__new__, y: list[T@__new__]) -> Class8[T@__new__]")
 reveal_type(r8("", [""]), expected_text="Class8[str]")
 
 


### PR DESCRIPTION
…e `__init__` or `__new__` method contain class-scoped type variables. These type variables are now rescoped to be function-scoped type parameters when converting to a callable. This is more consistent with the type specification.