### PR TITLE
Fixed regression that results in incorrect type evaluation for annota…

### DIFF
--- a/packages/pyright-internal/src/analyzer/constraintSolver.ts
+++ b/packages/pyright-internal/src/analyzer/constraintSolver.ts
@@ -537,7 +537,7 @@ export function assignTypeToTypeVar(
                         adjWideTypeBound,
                         newNarrowTypeBound,
                         diag?.createAddendum(),
-                        typeVarContext,
+                        /* destTypeVarContext */ undefined,
                         /* srcTypeVarContext */ undefined,
                         AssignTypeFlags.IgnoreTypeVarScope,
                         recursionCount

--- a/packages/pyright-internal/src/tests/samples/protocol50.py
+++ b/packages/pyright-internal/src/tests/samples/protocol50.py
@@ -1,0 +1,18 @@
+# This sample tests the case where a protocol is used as a type argument
+# for itself.
+
+from typing import Generic, Protocol, TypeVar
+
+V_co = TypeVar("V_co", covariant=True)
+
+
+class Proto1(Generic[V_co]):
+    def f(self, /) -> V_co: ...
+
+
+class Proto2(Protocol[V_co]):
+    def f(self, /) -> V_co: ...
+
+
+def func1(v0: Proto1[Proto1[object]]):
+    v2: Proto2[Proto2[object]] = v0

--- a/packages/pyright-internal/src/tests/typeEvaluator7.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator7.test.ts
@@ -575,6 +575,12 @@ test('Protocol49', () => {
     TestUtils.validateResults(analysisResults, 0);
 });
 
+test('Protocol50', () => {
+    const analysisResults = TestUtils.typeAnalyzeSampleFiles(['protocol50.py']);
+
+    TestUtils.validateResults(analysisResults, 0);
+});
+
 test('ProtocolExplicit1', () => {
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['protocolExplicit1.py']);
 


### PR DESCRIPTION
…tions that involve nested protocols (such as `P[P[T]]`). This addresses #6767.