### PR TITLE
Fixed a bug that resulted in an infinite loop when a function that us…

### DIFF
--- a/packages/pyright-internal/src/analyzer/checker.ts
+++ b/packages/pyright-internal/src/analyzer/checker.ts
@@ -5028,11 +5028,27 @@ export class Checker extends ParseTreeWalker {
                     ];
 
                     if (newMemberTypeResult) {
-                        this._evaluator.validateCallArguments(errorNode, argList, newMemberTypeResult);
+                        this._evaluator.validateCallArguments(
+                            errorNode,
+                            argList,
+                            newMemberTypeResult,
+                            /* typeVarContext */ undefined,
+                            /* skipUnknownArgCheck */ undefined,
+                            /* inferenceContext */ undefined,
+                            /* signatureTracker */ undefined
+                        );
                     }
 
                     if (initMemberTypeResult) {
-                        this._evaluator.validateCallArguments(errorNode, argList, initMemberTypeResult);
+                        this._evaluator.validateCallArguments(
+                            errorNode,
+                            argList,
+                            initMemberTypeResult,
+                            /* typeVarContext */ undefined,
+                            /* skipUnknownArgCheck */ undefined,
+                            /* inferenceContext */ undefined,
+                            /* signatureTracker */ undefined
+                        );
                     }
                 }
             } else if (declaredValueType) {

--- a/packages/pyright-internal/src/analyzer/codeFlowEngine.ts
+++ b/packages/pyright-internal/src/analyzer/codeFlowEngine.ts
@@ -1687,9 +1687,10 @@ export function getCodeFlowEngine(
                                 node,
                                 node.arguments,
                                 { type: callSubtype, isIncomplete: callTypeResult.isIncomplete },
-                                undefined /* typeVarContext */,
-                                false /* skipUnknownArgCheck */,
-                                undefined /* expectedType */
+                                /* typeVarContext */ undefined,
+                                /* skipUnknownArgCheck */ false,
+                                /* inferenceContext */ undefined,
+                                /* signatureTracker */ undefined
                             );
 
                             if (callResult.returnType && isNever(callResult.returnType)) {

--- a/packages/pyright-internal/src/analyzer/decorators.ts
+++ b/packages/pyright-internal/src/analyzer/decorators.ts
@@ -432,7 +432,9 @@ function getTypeOfDecorator(evaluator: TypeEvaluator, node: DecoratorNode, funct
         argList,
         decoratorTypeResult,
         /* typeVarContext */ undefined,
-        /* skipUnknownArgCheck */ true
+        /* skipUnknownArgCheck */ true,
+        /* inferenceContext */ undefined,
+        /* signatureTracker */ undefined
     );
 
     evaluator.setTypeResultForNode(node, {

--- a/packages/pyright-internal/src/analyzer/typeEvaluatorTypes.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluatorTypes.ts
@@ -38,7 +38,7 @@ import * as DeclarationUtils from './declarationUtils';
 import { SymbolWithScope } from './scope';
 import { Symbol } from './symbol';
 import { PrintTypeFlags } from './typePrinter';
-import { AssignTypeFlags, ClassMember, InferenceContext, MemberAccessFlags } from './typeUtils';
+import { AssignTypeFlags, ClassMember, InferenceContext, MemberAccessFlags, UniqueSignatureTracker } from './typeUtils';
 import { TypeVarContext } from './typeVarContext';
 import {
     AnyType,
@@ -496,7 +496,8 @@ export interface TypeEvaluator {
         typeResult: TypeResult<OverloadedFunctionType>,
         typeVarContext: TypeVarContext | undefined,
         skipUnknownArgCheck: boolean,
-        inferenceContext: InferenceContext | undefined
+        inferenceContext: InferenceContext | undefined,
+        signatureTracker: UniqueSignatureTracker | undefined
     ) => CallResult;
     validateInitSubclassArgs: (node: ClassNode, classType: ClassType) => void;
 
@@ -532,7 +533,11 @@ export interface TypeEvaluator {
         emitNotIterableError?: boolean
     ) => TypeResult | undefined;
     getGetterTypeFromProperty: (propertyClass: ClassType, inferTypeIfNeeded: boolean) => Type | undefined;
-    getTypeOfArgument: (arg: FunctionArgument) => TypeResult;
+    getTypeOfArgument: (
+        arg: FunctionArgument,
+        inferenceContext: InferenceContext | undefined,
+        signatureTracker: UniqueSignatureTracker | undefined
+    ) => TypeResult;
     markNamesAccessed: (node: ParseNode, names: string[]) => void;
     expandPromotionTypes: (node: ParseNode, type: Type) => Type;
     makeTopLevelTypeVarsConcrete: (type: Type, makeParamSpecsConcrete?: boolean) => Type;
@@ -617,9 +622,10 @@ export interface TypeEvaluator {
         errorNode: ExpressionNode,
         argList: FunctionArgument[],
         callTypeResult: TypeResult,
-        typeVarContext?: TypeVarContext,
-        skipUnknownArgCheck?: boolean,
-        inferenceContext?: InferenceContext
+        typeVarContext: TypeVarContext | undefined,
+        skipUnknownArgCheck: boolean | undefined,
+        inferenceContext: InferenceContext | undefined,
+        signatureTracker: UniqueSignatureTracker | undefined
     ) => CallResult;
     validateTypeArg: (argResult: TypeResultWithNode, options?: ValidateTypeArgsOptions) => boolean;
     assignTypeToExpression: (

--- a/packages/pyright-internal/src/analyzer/typeUtils.ts
+++ b/packages/pyright-internal/src/analyzer/typeUtils.ts
@@ -254,7 +254,6 @@ export interface ApplyTypeVarOptions {
 export interface InferenceContext {
     expectedType: Type;
     isTypeIncomplete?: boolean;
-    signatureTracker?: UniqueSignatureTracker;
 }
 
 export interface RequiresSpecializationOptions {
@@ -405,32 +404,19 @@ export function isBuiltInDeprecatedType(type: Type) {
     return false;
 }
 
-export function makeInferenceContext(
-    expectedType: undefined,
-    isTypeIncomplete?: boolean,
-    signatureTracker?: UniqueSignatureTracker
-): undefined;
-export function makeInferenceContext(
-    expectedType: Type,
-    isTypeIncomplete?: boolean,
-    signatureTracker?: UniqueSignatureTracker
-): InferenceContext;
-export function makeInferenceContext(
-    expectedType: Type | undefined,
-    isTypeIncomplete?: boolean,
-    signatureTracker?: UniqueSignatureTracker
-): InferenceContext | undefined;
+export function makeInferenceContext(expectedType: undefined, isTypeIncomplete?: boolean): undefined;
+export function makeInferenceContext(expectedType: Type, isTypeIncomplete?: boolean): InferenceContext;
+export function makeInferenceContext(expectedType?: Type, isTypeIncomplete?: boolean): InferenceContext | undefined;
 
 export function makeInferenceContext(
     expectedType: Type | undefined,
-    isTypeIncomplete?: boolean,
-    signatureTracker?: UniqueSignatureTracker
+    isTypeIncomplete?: boolean
 ): InferenceContext | undefined {
     if (!expectedType) {
         return undefined;
     }
 
-    return { expectedType, isTypeIncomplete, signatureTracker };
+    return { expectedType, isTypeIncomplete };
 }
 
 // Calls a callback for each subtype and combines the results


### PR DESCRIPTION
…es an `*args: *Ts` parameter is passed as an argument to itself. This partially addresses #7141.