### PR TITLE
Added support for using `Literal` and various other special forms in …

### DIFF
--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -20376,7 +20376,8 @@ export function createTypeEvaluator(
         signatureTracker: UniqueSignatureTracker | undefined
     ): TypeResult {
         if (arg.typeResult) {
-            return { type: arg.typeResult.type, isIncomplete: arg.typeResult.isIncomplete };
+            const type = arg.typeResult.type?.specialForm ?? arg.typeResult.type;
+            return { type, isIncomplete: arg.typeResult.isIncomplete };
         }
 
         if (!arg.valueExpression) {
@@ -23733,8 +23734,19 @@ export function createTypeEvaluator(
                     return true;
                 }
 
-                if (
-                    !isSpecialFormClass(expandedSrcType, flags) &&
+                if (isSpecialFormClass(expandedSrcType, flags)) {
+                    if (destType.specialForm) {
+                        return assignType(
+                            destType.specialForm,
+                            expandedSrcType,
+                            diag,
+                            destTypeVarContext,
+                            srcTypeVarContext,
+                            flags,
+                            recursionCount
+                        );
+                    }
+                } else if (
                     assignClass(
                         destType,
                         expandedSrcType,

--- a/packages/pyright-internal/src/tests/samples/specialForm2.py
+++ b/packages/pyright-internal/src/tests/samples/specialForm2.py
@@ -51,3 +51,6 @@ func1(TypeGuard)
 func1(Annotated)
 func1(Union[int, str])
 func1(int | str)
+
+
+{Literal[1]: "literal"}[Literal[1]]


### PR DESCRIPTION
…a value expression. This addresses #7547.