### PR TITLE
Added logic to expand promotion types for `float` and `complex` when …

### DIFF
--- a/packages/pyright-internal/src/analyzer/constructors.ts
+++ b/packages/pyright-internal/src/analyzer/constructors.ts
@@ -122,6 +122,12 @@ export function validateConstructorArguments(
     inferenceContext: InferenceContext | undefined,
     signatureTracker: UniqueSignatureTracker | undefined
 ): CallResult {
+    // If this is a "float" or "complex" constructor call, do not include
+    // the associated promotions.
+    if (!type.includeSubclasses && type.includePromotions) {
+        type = ClassType.cloneRemoveTypePromotions(type);
+    }
+
     const metaclassResult = validateMetaclassCall(
         evaluator,
         errorNode,

--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -5226,6 +5226,11 @@ export function createTypeEvaluator(
             baseType = makeTopLevelTypeVarsConcrete(baseType);
         }
 
+        // Do union expansion for promotion types. Exclude bytes here because
+        // this creates too much noise. Users who want stricter checks for bytes
+        // can use "disableBytesTypePromotions".
+        baseType = expandPromotionTypes(node, baseType, /* excludeBytes */ true);
+
         switch (baseType.category) {
             case TypeCategory.Any:
             case TypeCategory.Unknown:


### PR DESCRIPTION
…these types are used in a member access expression (i.e. the LHS of a "dot" operator).