### PR TITLE
Changed behavior of constructor call evaluation when `__new__` evalua…

### DIFF
--- a/packages/pyright-internal/src/analyzer/constructors.ts
+++ b/packages/pyright-internal/src/analyzer/constructors.ts
@@ -292,9 +292,17 @@ function validateNewAndInitMethods(
 
     let initMethodTypeResult: TypeResult | undefined;
 
-    // Validate __init__ if it's present. Skip if the __new__ method produced errors.
+    // If there were errors evaluating the __new__ method, assume that __new__
+    // returns the class instance and proceed accordingly. This may produce
+    // false positives in some cases, but it will prevent false negatives
+    // if the __init__ method also produces type errors (perhaps unrelated
+    // to the errors in the __new__ method).
+    if (argumentErrors) {
+        initMethodTypeResult = { type: convertToInstance(type) };
+    }
+
+    // Validate __init__ if it's present.
     if (
-        !argumentErrors &&
         !isNever(newMethodReturnType) &&
         !shouldSkipInitEvaluation(evaluator, type, newMethodReturnType) &&
         isClassInstance(newMethodReturnType)

--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -13177,7 +13177,7 @@ export function createTypeEvaluator(
             if (isEffectivelyInstantiable(specializedType)) {
                 classType.details.baseClasses.push(specializedType);
             } else {
-                addExpectedClassDiagnostic(typeArg.type, argList[1].valueExpression || errorNode);
+                classType.details.baseClasses.push(UnknownType.create());
             }
         });
 

--- a/packages/pyright-internal/src/tests/samples/newType2.py
+++ b/packages/pyright-internal/src/tests/samples/newType2.py
@@ -13,13 +13,16 @@ class A(X1): ...
 class B(X2, A): ...
 
 
-# This should generate an error because the first arg is not a string.
+# This should generate two errors (one for `__new__` and one for `__init__`)
+# because the first arg is not a string.
 X3 = type(34, (object,))
 
-# This should generate an error because the second arg is not a tuple of class types.
+# This should generate two errors (one for `__new__` and one for `__init__`)
+# because the second arg is not a tuple of class types.
 X4 = type("X4", 34)
 
-# This should generate an error because the second arg is not a tuple of class types.
+# This should generate two errors (one for `__new__` and one for `__init__`)
+# because the second arg is not a tuple of class types.
 X5 = type("X5", (3,))
 
 

--- a/packages/pyright-internal/src/tests/typeEvaluator2.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator2.test.ts
@@ -266,7 +266,7 @@ test('NewType1', () => {
 test('NewType2', () => {
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['newType2.py']);
 
-    TestUtils.validateResults(analysisResults, 4);
+    TestUtils.validateResults(analysisResults, 6);
 });
 
 test('NewType3', () => {


### PR DESCRIPTION
…tion results in type evaluation errors. Previously, pyright skipped the `__init__` evaluation in this case. It now proceeds to evaluate `__init__`, potentially generating redundant errors. This addresses #8026.