### PR TITLE
Fixed bug that results in false positive when evaluating the call to …

### DIFF
--- a/packages/pyright-internal/src/analyzer/constraintSolver.ts
+++ b/packages/pyright-internal/src/analyzer/constraintSolver.ts
@@ -101,7 +101,7 @@ export function assignTypeToTypeVar(
 
     let isTypeVarInScope = true;
     const isInvariant = (flags & AssignTypeFlags.EnforceInvariance) !== 0;
-    const isContravariant = (flags & AssignTypeFlags.ReverseTypeVarMatching) !== 0;
+    const isContravariant = (flags & AssignTypeFlags.ReverseTypeVarMatching) !== 0 && !isInvariant;
 
     // If the TypeVar doesn't have a scope ID, then it's being used
     // outside of a valid TypeVar scope. This will be reported as a

--- a/packages/pyright-internal/src/tests/samples/solverLiteral1.py
+++ b/packages/pyright-internal/src/tests/samples/solverLiteral1.py
@@ -31,15 +31,13 @@ def func2() -> TA1[bool]:
     return func1(True)
 
 
-def func3(value: _T) -> Callable[[_T], None]:
-    ...
+def func3(value: _T) -> Callable[[_T], None]: ...
 
 
 x: Callable[[tuple[bool]], None] = func3((True,))
 
 
-def func4(v: _T, f: Callable[[_T], None]):
-    ...
+def func4(v: _T, f: Callable[[_T], None]): ...
 
 
 def func5(v: Literal[1, 2], f: Callable[[Literal[1, 2]], None]):
@@ -51,9 +49,20 @@ class ClassB(Generic[_S, _T]):
     right: _T
 
 
-def func6(s: _S, t: _T) -> ClassB[_S, _T]:
-    ...
+def func6(s: _S, t: _T) -> ClassB[_S, _T]: ...
 
 
 def func7(t: _T, f: Callable[[ClassB[_T, Literal[2]]], None]) -> None:
     return f(func6(t, 2))
+
+
+def func8(a: _T, b: Callable[[list[_T]], None]) -> _T:
+    return a
+
+
+def func9(v: Callable[[list[int]], None]):
+    func8(b=v, a=1)
+
+    # This should also type check without error, but it doesn't currently.
+    # See issue #8048.
+    # func8(a=1, b=v)


### PR DESCRIPTION
…a generic function that involves a type variable used in both a covariant and contravariant (or invariant) position and both literal and non-literal types are involved. This addresses part of #6207.