### PR TITLE
Changed behavior of pyright to match the latest typing spec when it e…

### DIFF
--- a/packages/pyright-internal/src/analyzer/enums.ts
+++ b/packages/pyright-internal/src/analyzer/enums.ts
@@ -310,13 +310,6 @@ export function transformTypeForEnumMember(
 
     const primaryDecl = decls[0];
 
-    // In ".py" files, the transform applies only to members that are
-    // assigned within the class. In stub files, it applies to most variables
-    // even if they are not assigned. This unfortunate convention means
-    // there is no way in a stub to specify both enum members and instance
-    // variables used within each enum instance. Unless/until there is
-    // a change to this convention and all type checkers and stubs adopt
-    // it, we're stuck with this limitation.
     let isMemberOfEnumeration = false;
     let isUnpackedTuple = false;
     let valueTypeExprNode: ExpressionNode | undefined;
@@ -342,13 +335,6 @@ export function transformTypeForEnumMember(
         isMemberOfEnumeration = true;
         isUnpackedTuple = true;
         valueTypeExprNode = nameNode.parent.parent.rightExpression;
-    } else if (
-        getFileInfo(nameNode).isStubFile &&
-        nameNode.parent?.nodeType === ParseNodeType.TypeAnnotation &&
-        nameNode.parent.valueExpression === nameNode
-    ) {
-        isMemberOfEnumeration = true;
-        declaredTypeNode = nameNode.parent.typeAnnotation;
     }
 
     // The spec specifically excludes names that start and end with a single underscore.


### PR DESCRIPTION
…ncounters an attribute with a type annotation within an `Enum` class body in a stub. These are now treated as non-member attributes rather than members. Typeshed stubs have been updated to conform to the new standard. This addresses #8061.