### PR TITLE
Unify behavior between `pyrightconfig.json` and `pyproject.toml`

### DIFF
--- a/packages/pyright-internal/src/analyzer/service.ts
+++ b/packages/pyright-internal/src/analyzer/service.ts
@@ -643,7 +643,7 @@ export class AnalyzerService {
             });
         }
 
-        if (!configFilePath && commandLineOptions.executionRoot) {
+        if (!(configFilePath || pyprojectFilePath) && commandLineOptions.executionRoot) {
             if (commandLineOptions.includeFileSpecs.length === 0) {
                 // If no config file was found and there are no explicit include
                 // paths specified, assume the caller wants to include all source

--- a/packages/pyright-internal/src/analyzer/service.ts
+++ b/packages/pyright-internal/src/analyzer/service.ts
@@ -643,7 +643,9 @@ export class AnalyzerService {
             });
         }
 
-        if (!(configFilePath || pyprojectFilePath) && commandLineOptions.executionRoot) {
+        const configs = this._getExtendedConfigurations(configFilePath ?? pyprojectFilePath);
+
+        if (!configs && commandLineOptions.executionRoot) {
             if (commandLineOptions.includeFileSpecs.length === 0) {
                 // If no config file was found and there are no explicit include
                 // paths specified, assume the caller wants to include all source
@@ -662,8 +664,6 @@ export class AnalyzerService {
         configOptions.disableTaggedHints = !!commandLineOptions.disableTaggedHints;
 
         configOptions.initializeTypeCheckingMode(commandLineOptions.typeCheckingMode ?? 'standard');
-
-        const configs = this._getExtendedConfigurations(configFilePath ?? pyprojectFilePath);
 
         if (configs) {
             for (const config of configs) {

--- a/packages/pyright-internal/src/common/configOptions.ts
+++ b/packages/pyright-internal/src/common/configOptions.ts
@@ -1128,7 +1128,7 @@ export class ConfigOptions {
         // Read the "include" entry.
         if (configObj.include !== undefined) {
             if (!Array.isArray(configObj.include)) {
-                console.error(`Config "include" entry must must contain an array.`);
+                console.error(`Config "include" entry must contain an array.`);
             } else {
                 this.include = [];
                 const filesList = configObj.include as string[];


### PR DESCRIPTION
Resolved #8102

Basically, there is a check here
https://github.com/microsoft/pyright/blob/238f70049f47dccd16d06bc0fd795a189cf0ae8d/packages/pyright-internal/src/analyzer/service.ts#L646-L660
which initializes include and exclude if no `pyrightconfig.json` is found. Note it does not check for `pyproject.toml`.

Later if neither config defined an include or exclude they also get initialized, and `autoExcludeVenv` gets set.
https://github.com/microsoft/pyright/blob/238f70049f47dccd16d06bc0fd795a189cf0ae8d/packages/pyright-internal/src/analyzer/service.ts#L689-L698

However, in the case of `pyproject.toml`, because exclude has already been set, `autoExcludeVenv` does not get set, leading to a difference in behavior between `pyrightconfig.json` and `pyproject.toml`.

This adds an extra check for `pyproject.toml` to avoid this.
