### PR TITLE
Fixed bug that results in parameter types being converted to `Any` wh…

### DIFF
--- a/packages/pyright-internal/src/analyzer/constraintSolver.ts
+++ b/packages/pyright-internal/src/analyzer/constraintSolver.ts
@@ -326,10 +326,7 @@ export function assignTypeToTypeVar(
                 )
             ) {
                 // The srcType is narrower than the current wideTypeBound, so replace it.
-                // If it's Any, don't replace it because Any is the narrowest type already.
-                if (!isAnyOrUnknown(curWideTypeBound)) {
-                    newWideTypeBound = adjSrcType;
-                }
+                newWideTypeBound = adjSrcType;
             } else if (
                 !evaluator.assignType(
                     adjSrcType,

--- a/packages/pyright-internal/src/analyzer/constructors.ts
+++ b/packages/pyright-internal/src/analyzer/constructors.ts
@@ -1087,8 +1087,6 @@ function createFunctionFromInitMethod(
 
         const convertedInit = FunctionType.clone(boundInit);
         convertedInit.details.declaredReturnType = boundInit.strippedFirstParamType ?? selfType ?? objectType;
-        convertedInit.details.name = '';
-        convertedInit.details.fullName = '';
 
         if (convertedInit.specializedTypes) {
             convertedInit.specializedTypes.returnType = selfType ?? objectType;

--- a/packages/pyright-internal/src/tests/samples/constructorCallable1.py
+++ b/packages/pyright-internal/src/tests/samples/constructorCallable1.py
@@ -135,3 +135,15 @@ def func3(t: type[object]):
     reveal_type(
         cast_to_callable(t), expected_text="(*args: Any, **kwargs: Any) -> object"
     )
+
+
+@dataclass
+class G:
+    value: int
+
+
+def func4(c: Callable[[T1], T2]) -> Callable[[T1], T2]:
+    return c
+
+
+reveal_type(func4(G), expected_text="(int) -> G")


### PR DESCRIPTION
…en converting a `NewType` or dataclass constructor to a callable. This addresses #8116.