### PR TITLE
Discard `TypeEvaluator` if cancellation leaves partially-constructed function type in cache

### DIFF
--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -14510,8 +14510,8 @@ export function createTypeEvaluator(
             return { type: functionType, isIncomplete, typeErrors };
         } catch (e) {
             if (OperationCanceledException.is(e)) {
-                // If the work was canceled before the class types were updated, the
-                // class type in the type cache is in an invalid, partially-constructed state.
+                // If the work was canceled before the function type was updated, the
+                // function type in the type cache is in an invalid, partially-constructed state.
                 e.isTypeCacheInvalid = true;
             }
 
@@ -18291,8 +18291,8 @@ export function createTypeEvaluator(
             return functionType;
         } catch (e) {
             if (OperationCanceledException.is(e)) {
-                // If the work was canceled before the class types were updated, the
-                // class type in the type cache is in an invalid, partially-constructed state.
+                // If the work was canceled before the function type was updated, the
+                // function type in the type cache is in an invalid, partially-constructed state.
                 e.isTypeCacheInvalid = true;
             }
 

--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -14513,7 +14513,6 @@ export function createTypeEvaluator(
                 // If the work was canceled before the class types were updated, the
                 // class type in the type cache is in an invalid, partially-constructed state.
                 e.isTypeCacheInvalid = true;
-                console.log('Saw cancellation exception in getTypeOfLambdaWithExpectedType');
             }
 
             throw e;
@@ -18295,7 +18294,6 @@ export function createTypeEvaluator(
                 // If the work was canceled before the class types were updated, the
                 // class type in the type cache is in an invalid, partially-constructed state.
                 e.isTypeCacheInvalid = true;
-                console.log('Saw cancellation exception in getTypeOfFunctionPredecorated');
             }
 
             throw e;


### PR DESCRIPTION
This is the function equivalent of the class cancellation fix in https://github.com/microsoft/pyright/pull/5786.

If `getTypeOfFunctionDecorated` or `getTypeOfLambdaWithExpectedType` are cancelled before they complete, which would leave a partially evaluated function type in the type cache, we now set `isTypeCacheInvalid` to `true` on the `OperationCanceledException`. This will cause `Program._runEvaluatorWithCancellationToken` to discard the `TypeEvaluator` and create a new instance.

I believe this will address https://github.com/microsoft/pylance-release/issues/4295.