### PR TITLE
Fixed bug that causes a "bare" `type` (with no type argument) or `typ…

### DIFF
--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -2239,7 +2239,7 @@ export function createTypeEvaluator(
 
         // If this is a type[Any] or type[Unknown], allow any other members.
         if (isClassInstance(objectType) && ClassType.isBuiltIn(objectType, 'type') && objectType.includeSubclasses) {
-            if ((flags & MemberAccessFlags.SkipTypeBaseClass) === 0) {
+            if ((flags & (MemberAccessFlags.SkipTypeBaseClass | MemberAccessFlags.SkipAttributeAccessOverride)) === 0) {
                 const typeArg =
                     objectType.typeArguments && objectType.typeArguments.length >= 1
                         ? objectType.typeArguments[0]

--- a/packages/pyright-internal/src/tests/samples/type1.py
+++ b/packages/pyright-internal/src/tests/samples/type1.py
@@ -124,3 +124,12 @@ def func7(v: type):
 class Class1(Generic[T]):
     def method1(self, v: type) -> type[T]:
         return v
+
+
+class Class2:
+    x1: type
+    x2: type[Any]
+
+
+reveal_type(Class2.x1, expected_text="type")
+reveal_type(Class2.x2, expected_text="type[Any]")


### PR DESCRIPTION
…e[Any]` to be treated as a possible descriptor object. This addresses #8136.