### PR TITLE
Fix `stubPath`'s default value in schema

### DIFF
--- a/packages/vscode-pyright/schemas/pyrightconfig.schema.json
+++ b/packages/vscode-pyright/schemas/pyrightconfig.schema.json
@@ -577,7 +577,7 @@
     "stubPath": {
       "type": "string",
       "title": "Path to directory containing custom type stub files",
-      "default": "",
+      "default": "./typings",
       "examples": [
         "src/typestubs"
       ],


### PR DESCRIPTION
The default value of `./typings` was first introduced [5 years ago](https://github.com/microsoft/pyright/commit/1f3ed05adcbb834cc557c6e60e6f64d5d9bd5a73), yet the schema has not been updated accordingly ever since.