### PR TITLE
Fixed bug in pattern matching for `Callable()` in the negative (fall-…

### DIFF
--- a/packages/pyright-internal/src/tests/samples/matchClass6.py
+++ b/packages/pyright-internal/src/tests/samples/matchClass6.py
@@ -1,7 +1,7 @@
 # This sample tests the case where `Callable()` is used as a class pattern.
 
 from collections.abc import Callable
-from typing import Any, TypeVar
+from typing import Any, Protocol, TypeVar
 
 T = TypeVar("T")
 
@@ -38,3 +38,28 @@ def func5(obj: Any):
         case Callable():
             reveal_type(obj, expected_text="(...) -> Any")
             return obj()
+
+
+def func6(obj: Callable[[], None]):
+    match obj:
+        case Callable():
+            reveal_type(obj, expected_text="() -> None")
+            return obj()
+
+        case x:
+            reveal_type(obj, expected_text="Never")
+
+
+class CallableProto(Protocol):
+    def __call__(self) -> None:
+        pass
+
+
+def func7(obj: CallableProto):
+    match obj:
+        case Callable():
+            reveal_type(obj, expected_text="CallableProto")
+            return obj()
+
+        case x:
+            reveal_type(obj, expected_text="Never")


### PR DESCRIPTION
…through) case. This addresses #8160.