### PR TITLE
Improved consistency of unreachable code. Previously, unreachable cod…

### DIFF
--- a/packages/pyright-internal/src/tests/samples/constrainedTypeVar13.py
+++ b/packages/pyright-internal/src/tests/samples/constrainedTypeVar13.py
@@ -49,21 +49,21 @@ class Class1(Generic[_T1, _T2, _T3, _P, Unpack[_Ts]]):
             # This should generate an error.
             return [0]
 
-        if cond:
+        if cond or 3 > 2:
             if isinstance(val1, str):
                 # This should generate an error.
                 return [0]
             else:
                 return [0]
 
-        if cond:
+        if cond or 3 > 2:
             if isinstance(val3, B):
                 return [B()]
             else:
                 # This should generate an error.
                 return [C()]
 
-        if cond:
+        if cond or 3 > 2:
             if not isinstance(val3, B) and not isinstance(val3, C):
                 return [A()]
 

--- a/packages/pyright-internal/src/tests/samples/tryExcept4.py
+++ b/packages/pyright-internal/src/tests/samples/tryExcept4.py
@@ -1,7 +1,10 @@
 # This sample validates that the exception type provided
 # within a raise statement is valid.
 
-a: bool = True
+from random import random
+
+
+a: bool = True if random() > 0.5 else False
 
 
 class CustomException1(BaseException):
@@ -11,10 +14,10 @@ class CustomException1(BaseException):
 
 # This should generate an error because CustomException1
 # requires an argument to instantiate.
-if a:
+if a or 2 > 1:
     raise CustomException1
 
-if a:
+if a or 2 > 1:
     raise CustomException1(3)
 
 
@@ -24,5 +27,5 @@ class CustomException2:
 
 # This should generate an error because
 # the exception doesn't derive from BaseException.
-if a:
+if a or 2 > 1:
     raise CustomException2

--- a/packages/pyright-internal/src/tests/samples/unreachable1.py
+++ b/packages/pyright-internal/src/tests/samples/unreachable1.py
@@ -1,8 +1,8 @@
 # This sample tests the detection and reporting of unreachable code.
 
-from abc import abstractmethod
 import os
 import sys
+from abc import abstractmethod
 from typing import NoReturn
 
 
@@ -109,3 +109,19 @@ def func10():
     return
     # This should be marked unreachable.
     b = e.errno
+
+
+def func11(obj: str) -> list:
+    if isinstance(obj, str):
+        return []
+    else:
+        # This should be marked as unreachable.
+        return obj
+
+
+def func12(obj: str) -> list:
+    if isinstance(obj, str):
+        return []
+
+    # This should be marked as unreachable.
+    return obj

--- a/packages/pyright-internal/src/tests/typeEvaluator1.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator1.test.ts
@@ -26,7 +26,7 @@ import * as TestUtils from './testUtils';
 test('Unreachable1', () => {
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['unreachable1.py']);
 
-    TestUtils.validateResults(analysisResults, 0, 0, 2, 1, 4);
+    TestUtils.validateResults(analysisResults, 0, 0, 2, 1, 6);
 });
 
 test('Builtins1', () => {


### PR DESCRIPTION
…e was not supported for `if` or `else` suites when the condition type was narrowed to `Never`. This addresses https://github.com/microsoft/pylance-release/issues/6028.