### PR TITLE
Fixed bug that results in incorrect type `isinstance` or `issubclass`…

### DIFF
--- a/packages/pyright-internal/src/analyzer/typeGuards.ts
+++ b/packages/pyright-internal/src/analyzer/typeGuards.ts
@@ -1764,7 +1764,11 @@ function narrowTypeForIsInstanceInternal(
 
     const filteredType = evaluator.mapSubtypesExpandTypeVars(
         expandedTypes,
-        /* options */ undefined,
+        {
+            expandCallback: (type) => {
+                return evaluator.expandPromotionTypes(errorNode, type);
+            },
+        },
         (subtype, unexpandedSubtype) => {
             // If we fail to filter anything in the negative case, we need to decide
             // whether to retain the original TypeVar or replace it with its specialized

--- a/packages/pyright-internal/src/tests/samples/isinstance2.py
+++ b/packages/pyright-internal/src/tests/samples/isinstance2.py
@@ -4,7 +4,7 @@
 
 # pyright: reportUnnecessaryIsInstance=true
 
-from typing import Union
+from typing import TypeVar, Union
 
 # This should generate an error because "dummy" can't be resolved.
 # The symbol Document should have an unknown type.
@@ -33,3 +33,13 @@ def func3(obj: float):
         reveal_type(obj, expected_text="float")
     else:
         reveal_type(obj, expected_text="int")
+
+
+T = TypeVar("T", bound=float)
+
+
+def func4(t: type[T]):
+    if issubclass(t, float):
+        reveal_type(t, expected_text="type[float]*")
+    else:
+        reveal_type(t, expected_text="type[int]*")


### PR DESCRIPTION
… type narrowing when using a type variable with an upper bound that includes a promotion type. This addresses #8238.