### PR TITLE
Fixed setting diagnosticSeverityOverrides with .toml file 

### DIFF
--- a/packages/pyright-internal/src/analyzer/service.ts
+++ b/packages/pyright-internal/src/analyzer/service.ts
@@ -643,7 +643,7 @@ export class AnalyzerService {
 
         const configs = this._getExtendedConfigurations(configFilePath ?? pyprojectFilePath);
 
-        if (configs) {
+        if (configs && configs.length > 0) {
             for (const config of configs) {
                 configOptions.initializeFromJson(
                     config.configFileJsonObj,

--- a/packages/pyright-internal/src/tests/languageServer.test.ts
+++ b/packages/pyright-internal/src/tests/languageServer.test.ts
@@ -192,4 +192,47 @@ describe(`Basic language server tests`, () => {
         assert.equal(diagnostic.diagnostics[3].code, 'reportUnusedImport');
         assert.equal(diagnostic.diagnostics[5].code, 'reportUnusedImport');
     });
+
+    test('Diagnostic severity overrides test', async () => {
+        const code = `
+// @filename: test.py
+//// def test([|/*marker*/x|]): ...
+//// 
+// @filename: pyproject.toml
+//// 
+    `;
+        const settings = [
+            {
+                item: {
+                    scopeUri: `file://${normalizeSlashes(DEFAULT_WORKSPACE_ROOT, '/')}`,
+                    section: 'python.analysis',
+                },
+                value: {
+                    diagnosticSeverityOverrides: {
+                        reportUnknownParameterType: 'warning',
+                    },
+                },
+            },
+        ];
+
+        const info = await runLanguageServer(
+            DEFAULT_WORKSPACE_ROOT,
+            code,
+            /* callInitialize */ true,
+            settings,
+            undefined,
+            /* supportsBackgroundThread */ true
+        );
+
+        // get the file containing the marker that also contains our task list comments
+        await openFile(info, 'marker');
+
+        // Wait for the diagnostics to publish
+        const diagnostics = await waitForDiagnostics(info);
+        const diagnostic = diagnostics.find((d) => d.uri.includes('test.py'));
+        assert(diagnostic);
+
+        // Make sure the error has a special rule
+        assert.equal(diagnostic.diagnostics[0].code, 'reportUnknownParameterType');
+    });
 });


### PR DESCRIPTION
Address [pylance issue 6052](https://github.com/microsoft/pylance-release/issues/6052)

Fix when `config`.length === 0 and `applyDiagnosticOverrides `wont apply
