### PR TITLE
Fixed bug that results in incorrect type evaluation of a function tha…

### DIFF
--- a/packages/pyright-internal/src/analyzer/typeUtils.ts
+++ b/packages/pyright-internal/src/analyzer/typeUtils.ts
@@ -3298,6 +3298,8 @@ export function convertTypeToParamSpecValue(type: Type): FunctionType {
             newFunction.details.typeVarScopeId = newFunction.details.higherOrderTypeVarScopeIds.pop();
         }
 
+        newFunction.details.constructorTypeVarScopeId = type.details.constructorTypeVarScopeId;
+
         return newFunction;
     }
 
@@ -3336,6 +3338,7 @@ export function convertParamSpecValueToType(type: FunctionType): Type {
 
     FunctionType.addHigherOrderTypeVarScopeIds(functionType, withoutParamSpec.details.typeVarScopeId);
     FunctionType.addHigherOrderTypeVarScopeIds(functionType, withoutParamSpec.details.higherOrderTypeVarScopeIds);
+    functionType.details.constructorTypeVarScopeId = withoutParamSpec.details.constructorTypeVarScopeId;
 
     withoutParamSpec.details.parameters.forEach((entry, index) => {
         FunctionType.addParameter(functionType, {

--- a/packages/pyright-internal/src/analyzer/types.ts
+++ b/packages/pyright-internal/src/analyzer/types.ts
@@ -1764,6 +1764,7 @@ export namespace FunctionType {
 
         FunctionType.addHigherOrderTypeVarScopeIds(newFunction, paramSpecValue.details.typeVarScopeId);
         FunctionType.addHigherOrderTypeVarScopeIds(newFunction, paramSpecValue.details.higherOrderTypeVarScopeIds);
+        newFunction.details.constructorTypeVarScopeId = paramSpecValue.details.constructorTypeVarScopeId;
 
         if (!newFunction.details.methodClass && paramSpecValue.details.methodClass) {
             newFunction.details.methodClass = paramSpecValue.details.methodClass;

--- a/packages/pyright-internal/src/tests/samples/constructor30.py
+++ b/packages/pyright-internal/src/tests/samples/constructor30.py
@@ -29,3 +29,11 @@ def func1(t: type[TA]) -> TA: ...
 
 b = B(func1, A)
 reveal_type(b, expected_text="B[(t: type[A]), A]")
+
+
+class C(Generic[TA]):
+    def __init__(self, _type: type[TA]) -> None: ...
+
+
+c = B(C, A)
+reveal_type(c, expected_text="B[(_type: type[A]), C[A]]")


### PR DESCRIPTION
…t accepts a Callable[P, T] and is passed a class object whose constructor needs to be converted to a callable. This addresses #8170.