### PR TITLE
Fix severity overrides being skipped when there's a pyrightconfig.json

### DIFF
--- a/packages/pyright-internal/src/analyzer/service.ts
+++ b/packages/pyright-internal/src/analyzer/service.ts
@@ -640,6 +640,7 @@ export class AnalyzerService {
         configOptions.disableTaggedHints = !!commandLineOptions.disableTaggedHints;
 
         configOptions.initializeTypeCheckingMode(commandLineOptions.typeCheckingMode ?? 'standard');
+        configOptions.applyDiagnosticOverrides(commandLineOptions.diagnosticSeverityOverrides);
 
         const configs = this._getExtendedConfigurations(configFilePath ?? pyprojectFilePath);
 
@@ -653,8 +654,6 @@ export class AnalyzerService {
                     commandLineOptions
                 );
             }
-        } else {
-            configOptions.applyDiagnosticOverrides(commandLineOptions.diagnosticSeverityOverrides);
         }
 
         // If no include paths were provided, assume that all files within

--- a/packages/pyright-internal/src/tests/harness/fourslash/testStateUtils.ts
+++ b/packages/pyright-internal/src/tests/harness/fourslash/testStateUtils.ts
@@ -16,7 +16,11 @@ import { getStringComparer } from '../../../common/stringUtils';
 import * as vfs from '../vfs/filesystem';
 import { FourSlashData, FourSlashFile, GlobalMetadataOptionNames, Marker, MetadataOptionNames } from './fourSlashTypes';
 
-export function createVfsInfoFromFourSlashData(projectRoot: string, testData: FourSlashData) {
+export function createVfsInfoFromFourSlashData(
+    projectRoot: string,
+    testData: FourSlashData,
+    ignoreRawConfigJson = false
+) {
     const metaProjectRoot = testData.globalOptions[GlobalMetadataOptionNames.projectRoot];
     projectRoot = metaProjectRoot ? combinePaths(projectRoot, metaProjectRoot) : projectRoot;
 
@@ -28,7 +32,7 @@ export function createVfsInfoFromFourSlashData(projectRoot: string, testData: Fo
 
     for (const file of testData.files) {
         // if one of file is configuration file, set config options from the given json
-        if (isConfig(file, ignoreCase)) {
+        if (isConfig(file, ignoreCase) && !ignoreRawConfigJson) {
             try {
                 rawConfigJson = JSONC.parse(file.content);
             } catch (e: any) {

--- a/packages/pyright-internal/src/tests/lsp/languageServer.ts
+++ b/packages/pyright-internal/src/tests/lsp/languageServer.ts
@@ -135,7 +135,8 @@ class TestServer extends PyrightServer {
     constructor(
         connection: Connection,
         fs: FileSystem,
-        private readonly _supportsBackgroundAnalysis: boolean | undefined
+        private readonly _supportsBackgroundAnalysis: boolean | undefined,
+        private readonly _name: string
     ) {
         super(connection, _supportsBackgroundAnalysis ? 1 : 0, fs);
     }
@@ -190,7 +191,7 @@ async function runServer(
         // Create a host so we can control the file system for the PyrightServer.
         const disposables: Disposable[] = [];
         const host = createTestHost(testServerData);
-        const server = new TestServer(connection, host.fs, testServerData.backgroundAnalysis);
+        const server = new TestServer(connection, host.fs, testServerData.backgroundAnalysis, testServerData.testName);
 
         // Listen for the test messages from the client. These messages
         // are how the test code queries the state of the server.
@@ -325,7 +326,7 @@ class ServerStateManager {
             if (serverIndex >= 0) {
                 try {
                     instance.disposables[serverIndex].dispose();
-                    instance.disposables = instance.disposables.splice(serverIndex, 1);
+                    instance.disposables.splice(serverIndex, 1);
                 } catch (e) {
                     // Dispose failures don't matter.
                 }

--- a/packages/pyright-internal/src/tests/lsp/languageServerTestUtils.ts
+++ b/packages/pyright-internal/src/tests/lsp/languageServerTestUtils.ts
@@ -211,7 +211,7 @@ export function createFileSystem(projectRoot: string, testData: FourSlashData, o
         mountedPaths.set(bundledStubsFolder, bundledStubsFolderPathTestServer);
     }
 
-    const vfsInfo = createVfsInfoFromFourSlashData(projectRoot, testData);
+    const vfsInfo = createVfsInfoFromFourSlashData(projectRoot, testData, /* ignoreRawConfigJson */ true);
     return createFromFileSystem(
         optionalHost ?? host.HOST,
         vfsInfo.ignoreCase,


### PR DESCRIPTION
In these two issues, the severity override being set in the user's settings.json is not being applied:

https://github.com/microsoft/pylance-release/issues/6087
https://github.com/microsoft/pylance-release/issues/6085

The reason for this was the commandline settings were never being applied when there's a pyrightconfig.json. I modified the logic to apply the command line options first and then let the pyrightconfig.json files to override those values.

I also found an issue in the test code that prevented the LSP tests from cleaning up server instances.