### PR TITLE
Fixed bug that results in a false positive error when using a TypeVar…

### DIFF
--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -1381,28 +1381,44 @@ export function createTypeEvaluator(
             return;
         }
 
-        if (flags & EvalFlags.NoTypeVarTuple) {
+        if ((flags & EvalFlags.NoTypeVarTuple) !== 0) {
             if (isVariadicTypeVar(typeResult.type) && !typeResult.type.isVariadicInUnion) {
                 addError(LocMessage.typeVarTupleContext(), node);
                 typeResult.type = UnknownType.create();
             }
         }
 
-        if (!isEffectivelyInstantiable(typeResult.type)) {
-            const isEmptyVariadic =
-                isClassInstance(typeResult.type) &&
-                ClassType.isTupleClass(typeResult.type) &&
-                typeResult.type.tupleTypeArguments?.length === 0;
-
-            const isEllipsis =
-                isClassInstance(typeResult.type) && ClassType.isBuiltIn(typeResult.type, ['EllipsisType', 'ellipsis']);
-
-            if (!isEmptyVariadic && !isEllipsis) {
-                addExpectedClassDiagnostic(typeResult.type, node);
-                typeResult.type = UnknownType.create();
-                typeResult.typeErrors = true;
-            }
+        if (isEffectivelyInstantiable(typeResult.type, {honorTypeVarBounds: true})) {
+            return;
         }
+
+        // Exempt ellipses.
+        if (isClassInstance(typeResult.type) && ClassType.isBuiltIn(typeResult.type, ['EllipsisType', 'ellipsis'])) {
+            return;
+        }
+
+        // Exempt empty tuples, which can be used for specializing a TypeVarTuple.
+        if (isClassInstance(typeResult.type) && typeResult.type.tupleTypeArguments?.length === 0) {
+            return;
+        }
+
+        const diag = new DiagnosticAddendum();
+        if (isUnion(typeResult.type)) {
+            doForEachSubtype(typeResult.type, (subtype) => {
+                if (!isEffectivelyInstantiable(subtype, {honorTypeVarBounds: true})) {
+                    diag.addMessage(LocAddendum.typeNotClass().format({ type: printType(subtype) }));
+                }
+            });
+        }
+
+        addDiagnostic(
+            DiagnosticRule.reportGeneralTypeIssues,
+            LocMessage.typeExpectedClass().format({ type: printType(typeResult.type) }) + diag.getString(),
+            node
+        );
+
+        typeResult.type = UnknownType.create();
+        typeResult.typeErrors = true;
     }
 
     function getTypeOfAwaitOperator(node: AwaitNode, flags: EvalFlags, inferenceContext?: InferenceContext) {
@@ -3285,23 +3301,6 @@ export function createTypeEvaluator(
         }
 
         return diagnostic;
-    }
-
-    function addExpectedClassDiagnostic(type: Type, node: ParseNode) {
-        const diag = new DiagnosticAddendum();
-        if (isUnion(type)) {
-            doForEachSubtype(type, (subtype) => {
-                if (!isEffectivelyInstantiable(subtype)) {
-                    diag.addMessage(LocAddendum.typeNotClass().format({ type: printType(subtype) }));
-                }
-            });
-        }
-
-        addDiagnostic(
-            DiagnosticRule.reportGeneralTypeIssues,
-            LocMessage.typeExpectedClass().format({ type: printType(type) }) + diag.getString(),
-            node
-        );
     }
 
     function assignTypeToNameNode(
@@ -14912,9 +14911,6 @@ export function createTypeEvaluator(
         let typeArg0Type = typeArgs[0].type;
         if (!validateTypeArg(typeArgs[0])) {
             typeArg0Type = UnknownType.create();
-        } else if (!isEffectivelyInstantiable(typeArg0Type)) {
-            addExpectedClassDiagnostic(typeArg0Type, typeArgs[0].node);
-            typeArg0Type = UnknownType.create();
         }
 
         let optionalType = combineTypes([typeArg0Type, noneTypeClass ?? UnknownType.create()]);
@@ -15655,9 +15651,6 @@ export function createTypeEvaluator(
                     allowVariadicTypeVar: fileInfo.diagnosticRuleSet.enableExperimentalFeatures,
                 })
             ) {
-                typeArgType = UnknownType.create();
-            } else if (!isEffectivelyInstantiable(typeArgType)) {
-                addExpectedClassDiagnostic(typeArgType, typeArg.node);
                 typeArgType = UnknownType.create();
             }
 

--- a/packages/pyright-internal/src/localization/package.nls.en-us.json
+++ b/packages/pyright-internal/src/localization/package.nls.en-us.json
@@ -503,7 +503,7 @@
         "typedDictSecondArgDict": "Expected dict or keyword parameter as second parameter",
         "typedDictSecondArgDictEntry": "Expected simple dictionary entry",
         "typedDictSet": "Could not assign item in TypedDict",
-        "typeExpectedClass": "Expected type expression but received \"{type}\"",
+        "typeExpectedClass": "Expected class but received \"{type}\"",
         "typeGuardArgCount": "Expected a single type argument after \"TypeGuard\" or \"TypeIs\"",
         "typeGuardParamCount": "User-defined type guard functions and methods must have at least one input parameter",
         "typeIsReturnType": "Return type of TypeIs (\"{returnType}\") is not consistent with value parameter type (\"{type}\")",

--- a/packages/pyright-internal/src/tests/samples/classes1.py
+++ b/packages/pyright-internal/src/tests/samples/classes1.py
@@ -6,6 +6,7 @@ from typing import Any, TypeVar
 
 
 T = TypeVar("T")
+T2 = TypeVar("T2", bound=type[Any])
 
 
 class A:
@@ -77,3 +78,10 @@ class L(type[T]):
 def func2(cls: type[T]):
     class M(cls):
         pass
+
+
+def func3(cls: T2) -> T2:
+    class M(cls):
+        pass
+    
+    return M


### PR DESCRIPTION
… with an upper bound of `type` as a base class in a `class` statement. This addresses #8313.