### PR TITLE
Fixed bug that results in a false positive error when using a TypeVar…

### DIFF
--- a/packages/pyright-internal/src/localization/package.nls.en-us.json
+++ b/packages/pyright-internal/src/localization/package.nls.en-us.json
@@ -503,7 +503,7 @@
         "typedDictSecondArgDict": "Expected dict or keyword parameter as second parameter",
         "typedDictSecondArgDictEntry": "Expected simple dictionary entry",
         "typedDictSet": "Could not assign item in TypedDict",
-        "typeExpectedClass": "Expected type expression but received \"{type}\"",
+        "typeExpectedClass": "Expected class but received \"{type}\"",
         "typeGuardArgCount": "Expected a single type argument after \"TypeGuard\" or \"TypeIs\"",
         "typeGuardParamCount": "User-defined type guard functions and methods must have at least one input parameter",
         "typeIsReturnType": "Return type of TypeIs (\"{returnType}\") is not consistent with value parameter type (\"{type}\")",

--- a/packages/pyright-internal/src/tests/samples/classes1.py
+++ b/packages/pyright-internal/src/tests/samples/classes1.py
@@ -6,6 +6,7 @@ from typing import Any, TypeVar
 
 
 T = TypeVar("T")
+T2 = TypeVar("T2", bound=type[Any])
 
 
 class A:
@@ -77,3 +78,10 @@ class L(type[T]):
 def func2(cls: type[T]):
     class M(cls):
         pass
+
+
+def func3(cls: T2) -> T2:
+    class M(cls):
+        pass
+    
+    return M


### PR DESCRIPTION
… with an upper bound of `type` as a base class in a `class` statement. This addresses #8313.