### PR TITLE
Fixed type evaluation of old-style (pre-PEP 695) type alias that alia…

### DIFF
--- a/packages/pyright-internal/src/tests/samples/typeAlias3.py
+++ b/packages/pyright-internal/src/tests/samples/typeAlias3.py
@@ -2,13 +2,14 @@
 # partially-specialized classes that can be further
 # specialized.
 
-# pyright: strict
+# pyright: reportMissingModuleSource=false
 
-from typing import Callable, Generic, Optional, TypeVar
-from typing_extensions import ParamSpec  # pyright: ignore[reportMissingModuleSource]
+from typing import Callable, Generic, Optional
+from typing_extensions import ParamSpec, TypeVar
 
 T = TypeVar("T")
 P = ParamSpec("P")
+TStr = TypeVar("TStr", default=str)
 
 ValidationResult = tuple[bool, Optional[T]]
 
@@ -22,13 +23,28 @@ class ClassA(Generic[T]):
         ...
 
 
-TypeAliasA = ClassA[T]
+TypeAliasA1 = ClassA[T]
 
 a1 = ClassA(3.0)
 reveal_type(a1, expected_text="ClassA[float]")
 
-a2 = TypeAliasA(3.0)
-reveal_type(a2, expected_text="ClassA[float]")
+a2 = TypeAliasA1(3)
+reveal_type(a2, expected_text="ClassA[Unknown]")
+
+a3 = TypeAliasA1[int](3)
+reveal_type(a3, expected_text="ClassA[int]")
+
+
+TypeAliasA2 = ClassA[TStr]
+
+# This should generate an error.
+b1 = TypeAliasA2(1)
+
+b2 = TypeAliasA2("")
+reveal_type(b2, expected_text="ClassA[str]")
+
+b3 = TypeAliasA2[float](1.0)
+reveal_type(b3, expected_text="ClassA[float]")
 
 Func = Callable[P, T]
 AnyFunc = Func[P, int]

--- a/packages/pyright-internal/src/tests/typeEvaluator3.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator3.test.ts
@@ -602,7 +602,7 @@ test('TypeAlias2', () => {
 test('TypeAlias3', () => {
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['typeAlias3.py']);
 
-    TestUtils.validateResults(analysisResults, 0);
+    TestUtils.validateResults(analysisResults, 1);
 });
 
 test('TypeAlias4', () => {


### PR DESCRIPTION
…ses a generic class when it is used as a direct constructor call. This addresses #8337.