### PR TITLE
Make python interpreter execution more secure

### DIFF
--- a/packages/pyright-internal/src/common/fileSystem.ts
+++ b/packages/pyright-internal/src/common/fileSystem.ts
@@ -85,6 +85,7 @@ export interface TempFile {
     // The directory returned by tmpdir must exist and be the same each time tmpdir is called.
     tmpdir(): Uri;
     tmpfile(options?: TmpfileOptions): Uri;
+    mktmpdir(): Uri;
 }
 
 export namespace FileSystem {

--- a/packages/pyright-internal/src/common/realFileSystem.ts
+++ b/packages/pyright-internal/src/common/realFileSystem.ts
@@ -515,6 +515,11 @@ export class RealTempFile implements TempFile, CaseSensitivityDetector {
         return Uri.file(f.name, this);
     }
 
+    mktmpdir(): Uri {
+        const d = tmp.dirSync();
+        return Uri.file(d.name, this);
+    }
+
     dispose(): void {
         try {
             this._tmpdir?.removeCallback();

--- a/packages/pyright-internal/src/tests/harness/vfs/filesystem.ts
+++ b/packages/pyright-internal/src/tests/harness/vfs/filesystem.ts
@@ -9,16 +9,16 @@
 /* eslint-disable no-dupe-class-members */
 import { Dirent, ReadStream, WriteStream } from 'fs';
 
+import { CaseSensitivityDetector } from '../../../common/caseSensitivityDetector';
 import { FileSystem, MkDirOptions, TempFile, TmpfileOptions } from '../../../common/fileSystem';
 import { FileWatcher, FileWatcherEventHandler, FileWatcherEventType } from '../../../common/fileWatcher';
 import * as pathUtil from '../../../common/pathUtils';
 import { compareStringsCaseInsensitive, compareStringsCaseSensitive } from '../../../common/stringUtils';
+import { FileUriSchema } from '../../../common/uri/fileUri';
+import { Uri } from '../../../common/uri/uri';
 import { bufferFrom, createIOError } from '../utils';
 import { Metadata, SortedMap, closeIterator, getIterator, nextResult } from './../utils';
 import { ValidationFlags, validate } from './pathValidation';
-import { FileUriSchema } from '../../../common/uri/fileUri';
-import { Uri } from '../../../common/uri/uri';
-import { CaseSensitivityDetector } from '../../../common/caseSensitivityDetector';
 
 export const MODULE_PATH = pathUtil.normalizeSlashes('/');
 
@@ -373,6 +373,11 @@ export class TestFileSystem implements FileSystem, TempFile, CaseSensitivityDete
         const path = this.tmpdir().combinePaths(name);
         this.writeFileSync(path, '');
         return path;
+    }
+
+    mktmpdir(): Uri {
+        this.mkdirpSync('/tmp/1');
+        return Uri.parse('file:///tmp/1', this);
     }
 
     realCasePath(path: Uri): Uri {


### PR DESCRIPTION
Pyrx internal issue: https://github.com/microsoft/pyrx/issues/5287

The FullAccessHost currently runs the python interpreter from whatever directory Pylance was started from. This could potentially cause issues if that directory happens have overridden some of the stdlib modules.

This change makes the FullAccessHost run python with either the '-I' flag or forces it to run in a temp folder.