### PR TITLE
Fixed bug that can result in incorrect evaluation of a traditional (p…

### DIFF
--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -4606,7 +4606,7 @@ export function createTypeEvaluator(
 
         // Isinstance treats traditional (non-PEP 695) type aliases that are unions
         // as tuples of classes rather than unions.
-        if ((flags & EvalFlags.IsinstanceParam) !== 0) {
+        if ((flags & EvalFlags.IsinstanceArg) !== 0) {
             if (isUnion(type) && type.typeAliasInfo && !type.typeAliasInfo.isPep695Syntax) {
                 return type;
             }
@@ -12059,13 +12059,7 @@ export function createTypeEvaluator(
                 argType = argParam.argType;
             } else {
                 const flags = argParam.isinstanceParam
-                    ? EvalFlags.AllowMissingTypeArgs |
-                      EvalFlags.StrLiteralAsType |
-                      EvalFlags.NoParamSpec |
-                      EvalFlags.NoTypeVarTuple |
-                      EvalFlags.NoFinal |
-                      EvalFlags.NoSpecialize |
-                      EvalFlags.IsinstanceParam
+                    ? EvalFlags.IsInstanceArgDefaults
                     : EvalFlags.NoFinal | EvalFlags.NoSpecialize;
                 const exprTypeResult = getTypeOfExpression(
                     argParam.argument.valueExpression,

--- a/packages/pyright-internal/src/analyzer/typeEvaluatorTypes.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluatorTypes.ts
@@ -160,7 +160,7 @@ export const enum EvalFlags {
 
     // Interpret the expression using the specialized behaviors associated
     // with the second argument to isinstance and issubclass calls.
-    IsinstanceParam = 1 << 29,
+    IsinstanceArg = 1 << 29,
 
     // Defaults used for evaluating the LHS of a call expression.
     CallBaseDefaults = NoSpecialize,
@@ -170,6 +170,16 @@ export const enum EvalFlags {
 
     // Defaults used for evaluating the LHS of a member access expression.
     MemberAccessBaseDefaults = NoSpecialize,
+
+    // Defaults used for evaluating the second argument of an 'isinstance'
+    // or 'issubclass' call.
+    IsInstanceArgDefaults = AllowMissingTypeArgs |
+        StrLiteralAsType |
+        NoParamSpec |
+        NoTypeVarTuple |
+        NoFinal |
+        NoSpecialize |
+        IsinstanceArg,
 }
 
 export interface TypeResult<T extends Type = Type> {

--- a/packages/pyright-internal/src/analyzer/typeGuards.ts
+++ b/packages/pyright-internal/src/analyzer/typeGuards.ts
@@ -627,15 +627,7 @@ export function getTypeNarrowingCallback(
                     (callType.details.builtInName === 'isinstance' || callType.details.builtInName === 'issubclass')
                 ) {
                     const isInstanceCheck = callType.details.builtInName === 'isinstance';
-                    const arg1TypeResult = evaluator.getTypeOfExpression(
-                        arg1Expr,
-                        EvalFlags.AllowMissingTypeArgs |
-                            EvalFlags.StrLiteralAsType |
-                            EvalFlags.NoParamSpec |
-                            EvalFlags.NoTypeVarTuple |
-                            EvalFlags.NoFinal |
-                            EvalFlags.NoSpecialize
-                    );
+                    const arg1TypeResult = evaluator.getTypeOfExpression(arg1Expr, EvalFlags.IsInstanceArgDefaults);
                     const arg1Type = arg1TypeResult.type;
 
                     const classTypeList = getIsInstanceClassTypes(evaluator, arg1Type);


### PR DESCRIPTION
…re-PEP 695) type alias the defines a union which is later used as the second argument to an `isinstance` or `issubclass` call. This addresses #8358.