### PR TITLE
Fix issue with cwd not being used to find the python interpreter paths

### DIFF
--- a/packages/pyright-internal/src/common/fullAccessHost.ts
+++ b/packages/pyright-internal/src/common/fullAccessHost.ts
@@ -235,10 +235,8 @@ export class FullAccessHost extends LimitedAccessHost {
         try {
             const commandLineArgs: string[] = ['-c', extractSys];
             importFailureInfo.push(`Executing interpreter: '${interpreterPath}'`);
-            const temp = this.serviceProvider.get(ServiceKeys.tempFile).mktmpdir();
             const execOutput = child_process.execFileSync(interpreterPath, commandLineArgs, {
                 encoding: 'utf8',
-                cwd: temp.getFilePath(),
             });
             const caseDetector = this.serviceProvider.get(ServiceKeys.caseSensitivityDetector);
 
@@ -253,8 +251,7 @@ export class FullAccessHost extends LimitedAccessHost {
                         // Skip non-existent paths and broken zips/eggs.
                         if (
                             this.serviceProvider.fs().existsSync(normalizedUri) &&
-                            isDirectory(this.serviceProvider.fs(), normalizedUri) &&
-                            !normalizedUri.equals(temp)
+                            isDirectory(this.serviceProvider.fs(), normalizedUri)
                         ) {
                             result.paths.push(normalizedUri);
                         } else {


### PR DESCRIPTION
Addresses https://github.com/microsoft/pylance-release/issues/6113

It seems it's not necessary to remove the cwd for the sys or os modules. They can't be overridden by local versions and our existing code already excluded the cwd when finding other modules.

I tested this by:
- Creating an `os` folder and putting an `__init__.py` in it.
- Creating a `sys` folder and putting an `__init__.py` in it
- Running python, importing sys and os and trying to call the function in the `__init__.py`
- Neither would load my version
- Creating a `json` folder and putting an `__init__.py` in it.
- Python would load this json module though


Our interpreter search code is this:

```python
import sys
import os, os.path
normalize = lambda p: os.path.normcase(os.path.normpath(p))
cwd = normalize(os.getcwd())
orig_sys_path = [p for p in sys.path if p != ""]
sys.path[:] = [p for p in sys.path if p != "" and normalize(p) != cwd]
json.dump(dict(path=orig_sys_path, prefix=sys.prefix), sys.stdout)
```

Running that code does not load the custom json module though.