### PR TITLE
Fixed bug in type narrowing logic for sequence pattern matching when …

### DIFF
--- a/packages/pyright-internal/src/analyzer/typeUtils.ts
+++ b/packages/pyright-internal/src/analyzer/typeUtils.ts
@@ -1364,6 +1364,17 @@ export function isMaybeDescriptorInstance(type: Type, requireSetter = false): bo
     return true;
 }
 
+export function isTupleGradualForm(type: Type) {
+    return (
+        isClassInstance(type) &&
+        isTupleClass(type) &&
+        type.tupleTypeArguments &&
+        type.tupleTypeArguments.length === 1 &&
+        isAnyOrUnknown(type.tupleTypeArguments[0].type) &&
+        type.tupleTypeArguments[0].isUnbounded
+    );
+}
+
 export function isTupleClass(type: ClassType) {
     return ClassType.isBuiltIn(type, 'tuple');
 }

--- a/packages/pyright-internal/src/tests/samples/matchSequence1.py
+++ b/packages/pyright-internal/src/tests/samples/matchSequence1.py
@@ -1,6 +1,8 @@
 # This sample tests type checking for match statements (as
 # described in PEP 634) that contain sequence patterns.
 
+# pyright: reportMissingModuleSource=false
+
 from enum import Enum
 from typing import (
     Any,
@@ -15,8 +17,9 @@ from typing import (
     TypeVar,
     Union,
 )
+from typing_extensions import TypeVarTuple, Unpack
 
-from typing_extensions import Unpack  # pyright: ignore[reportMissingModuleSource]
+Ts = TypeVarTuple("Ts")
 
 
 def test_unknown(value_to_match):
@@ -585,3 +588,10 @@ def test_unbounded_tuple_5(subj: tuple[int, Unpack[tuple[str, ...]]]):
             reveal_type(rest, expected_text="list[str]")
         case x:
             reveal_type(x, expected_text="Never")
+
+
+def test_variadic_tuple(subj: tuple[int, Unpack[Ts]]) -> tuple[Unpack[Ts]]:
+    match subj:
+        case _, *rest:
+            reveal_type(rest, expected_text="list[Unknown]")
+            return (*rest,)

--- a/packages/pyright-internal/src/tests/samples/tuple1.py
+++ b/packages/pyright-internal/src/tests/samples/tuple1.py
@@ -281,3 +281,8 @@ def func20(v: tuple[Never]):
     x2: tuple[Never] = ()
 
     x3: tuple[Never] = v
+
+
+def func21(x: tuple[Any, ...], *args: *Ts) -> tuple[*Ts]:
+    args = x
+    return args


### PR DESCRIPTION
…a "star" entry in the pattern captures a TypeVarTuple. The resulting type should be `Unknown` rather than the unpacked TypeVarTuple.

Fixed bug that results in a false positive when assigning type `tuple[Any, ...]` to `tuple[*TS]`. This should be allowed because `tuple[Any, ...]` is a gradual form that is assignable to all tuple types.

This addresses #8357.