### PR TITLE
Fixed a bug that results in a false positive `reportOverlappingOverlo…

### DIFF
--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -25004,20 +25004,22 @@ export function createTypeEvaluator(
 
         // Is an additional specialization step required?
         if (doSpecializationStep) {
-            assignType(
-                specializedSrcType,
-                specializedDestType,
-                /* diag */ undefined,
-                srcTypeVarContext,
-                destTypeVarContext,
-                (flags ^ AssignTypeFlags.ReverseTypeVarMatching) | AssignTypeFlags.RetainLiteralsForTypeVar,
-                recursionCount
-            );
-
-            if ((flags & AssignTypeFlags.ReverseTypeVarMatching) === 0) {
-                specializedDestType = applySolvedTypeVars(destType, destTypeVarContext);
-            } else {
-                specializedSrcType = applySolvedTypeVars(srcType, srcTypeVarContext);
+            if (
+                assignType(
+                    specializedSrcType,
+                    specializedDestType,
+                    /* diag */ undefined,
+                    srcTypeVarContext,
+                    destTypeVarContext,
+                    (flags ^ AssignTypeFlags.ReverseTypeVarMatching) | AssignTypeFlags.RetainLiteralsForTypeVar,
+                    recursionCount
+                )
+            ) {
+                if ((flags & AssignTypeFlags.ReverseTypeVarMatching) === 0) {
+                    specializedDestType = applySolvedTypeVars(destType, destTypeVarContext);
+                } else {
+                    specializedSrcType = applySolvedTypeVars(srcType, srcTypeVarContext);
+                }
             }
         }
 

--- a/packages/pyright-internal/src/tests/samples/overload5.py
+++ b/packages/pyright-internal/src/tests/samples/overload5.py
@@ -1,7 +1,23 @@
 # This sample tests the type checker's detection of overlapping
 # overload declarations.
 
-from typing import Any, AnyStr, Generic, Literal, Protocol, Sequence, TypeVar, overload
+from typing import (
+    Any,
+    AnyStr,
+    Callable,
+    Concatenate,
+    Generic,
+    Literal,
+    ParamSpec,
+    Protocol,
+    Sequence,
+    TypeVar,
+    overload,
+)
+
+_T1 = TypeVar("_T1")
+_T2 = TypeVar("_T2")
+_P = ParamSpec("_P")
 
 
 @overload
@@ -98,10 +114,6 @@ def func5(a: float, b: float = 3.4, *c: int, d: float = 4.5) -> str:
 
 def func5(*args: Any, **kwargs: Any) -> Any:
     pass
-
-
-_T1 = TypeVar("_T1")
-_T2 = TypeVar("_T2")
 
 
 class GenericClass(Generic[_T1, _T2]):
@@ -394,3 +406,17 @@ def func22(self, p1: int | list[int], /) -> int:
 
 def func22(self, p1: str | int | set[int] | list[int], /) -> str | int:
     return ""
+
+
+@overload
+def func23(f: Callable[Concatenate[_T1, _P], _T2]) -> int:
+    ...
+
+
+@overload
+def func23(f: Callable[_P, _T2]) -> int:
+    ...
+
+
+def func23(f: Any) -> int:
+    return 1


### PR DESCRIPTION
…ad` error in certain cases involving `ParamSpec` and `Concatenate`. This addresses #8389.