### PR TITLE
Changed the behavior for eliding literals from a union when the non-l…

### DIFF
--- a/packages/pyright-internal/src/analyzer/types.ts
+++ b/packages/pyright-internal/src/analyzer/types.ts
@@ -3521,26 +3521,23 @@ function _addTypeIfUnique(unionType: UnionType, typeToAdd: UnionableType) {
             }
         }
 
-        // If the typeToAdd is a literal value and there's already
-        // a non-literal type that matches, don't add the literal value.
         if (isClassInstance(type) && isClassInstance(typeToAdd)) {
-            if (isSameWithoutLiteralValue(type, typeToAdd)) {
-                if (type.literalValue === undefined) {
-                    return;
-                }
-            }
-
             // If we're adding Literal[False] or Literal[True] to its
             // opposite, combine them into a non-literal 'bool' type.
-            if (
-                ClassType.isBuiltIn(type, 'bool') &&
-                !type.condition &&
-                ClassType.isBuiltIn(typeToAdd, 'bool') &&
-                !typeToAdd.condition
-            ) {
-                if (typeToAdd.literalValue !== undefined && !typeToAdd.literalValue === type.literalValue) {
-                    unionType.subtypes[i] = ClassType.cloneWithLiteral(type, /* value */ undefined);
-                    return;
+            if (ClassType.isBuiltIn(type, 'bool') && !type.condition) {
+                if (ClassType.isBuiltIn(typeToAdd, 'bool') && !typeToAdd.condition) {
+                    if (typeToAdd.literalValue !== undefined && !typeToAdd.literalValue === type.literalValue) {
+                        unionType.subtypes[i] = ClassType.cloneWithLiteral(type, /* value */ undefined);
+                        return;
+                    }
+                }
+
+                // If we're adding Literal[False] or Literal[True] and there's
+                // already a 'bool', don't add the redundant types.
+                if (isSameWithoutLiteralValue(type, typeToAdd)) {
+                    if (type.literalValue === undefined) {
+                        return;
+                    }
                 }
             }
 

--- a/packages/pyright-internal/src/tests/samples/loop10.py
+++ b/packages/pyright-internal/src/tests/samples/loop10.py
@@ -7,5 +7,5 @@ def fibonacci():
     while True:
         yield a
         a, b = b, a + b
-        reveal_type(a, expected_text="int")
+        reveal_type(a, expected_text="int | Literal[1]")
         reveal_type(b, expected_text="int")

--- a/packages/pyright-internal/src/tests/samples/loop33.py
+++ b/packages/pyright-internal/src/tests/samples/loop33.py
@@ -6,4 +6,4 @@ for x in range(1):
     for y in range(1):
         count += 1
 
-reveal_type(count, expected_text="int")
+reveal_type(count, expected_text="int | Literal[0]")

--- a/packages/pyright-internal/src/tests/samples/loop48.py
+++ b/packages/pyright-internal/src/tests/samples/loop48.py
@@ -11,9 +11,9 @@ class ClassA:
         self.x = 0
 
         for _ in range(1, 10):
-            self.x = reveal_type(self.x, expected_text="int") + 1
+            self.x = reveal_type(self.x, expected_text="int | Literal[0]") + 1
 
-        reveal_type(self.x, expected_text="int")
+        reveal_type(self.x, expected_text="int | Literal[0]")
 
     def method2(self) -> None:
         self.x = 0
@@ -21,4 +21,4 @@ class ClassA:
         for _ in range(1, 10):
             self.x += 1
 
-        reveal_type(self.x, expected_text="int")
+        reveal_type(self.x, expected_text="int | Literal[0]")

--- a/packages/pyright-internal/src/tests/samples/matchClass1.py
+++ b/packages/pyright-internal/src/tests/samples/matchClass1.py
@@ -151,8 +151,8 @@ def test_union(
 ) -> TInt | Literal[3] | float | str:
     match value_to_match:
         case int() as a1:
-            reveal_type(a1, expected_text="int* | int")
-            reveal_type(value_to_match, expected_text="int* | int")
+            reveal_type(a1, expected_text="int* | int | Literal[3]")
+            reveal_type(value_to_match, expected_text="int* | int | Literal[3]")
 
         case float() as a2:
             reveal_type(a2, expected_text="float")

--- a/packages/pyright-internal/src/tests/samples/typeNarrowing6.py
+++ b/packages/pyright-internal/src/tests/samples/typeNarrowing6.py
@@ -23,5 +23,5 @@ def func1(a: bool):
     if a:
         foo2 = Class2()
 
-    reveal_type(foo2.val1, expected_text="int")
-    reveal_type(foo2.val2.val0, expected_text="int")
+    reveal_type(foo2.val1, expected_text="int | Literal[0]")
+    reveal_type(foo2.val2.val0, expected_text="int | Literal[4]")

--- a/packages/pyright-internal/src/tests/samples/typeNarrowingIn1.py
+++ b/packages/pyright-internal/src/tests/samples/typeNarrowingIn1.py
@@ -51,7 +51,7 @@ def func1(x: int | str | None, y: Literal[1, 2, "b"], b: int):
         reveal_type(x, expected_text="Literal[1] | None")
 
     if x in (1, b, "a"):
-        reveal_type(x, expected_text="int | Literal['a']")
+        reveal_type(x, expected_text="int | Literal['a', 1, 2]")
 
     if y in (1, b, "a"):
         reveal_type(y, expected_text="Literal[1, 2]")


### PR DESCRIPTION
…iteral subtype is also present. This is still done for `bool` literals but not for other literal subtypes. This preserves more information in the union, which can be useful for completion suggestions.