### PR TITLE
Changed union creation logic to retain (rather than elide) redundant …

### DIFF
--- a/packages/pyright-internal/src/analyzer/constraintSolver.ts
+++ b/packages/pyright-internal/src/analyzer/constraintSolver.ts
@@ -497,15 +497,13 @@ export function assignTypeToTypeVar(
                         (destType as TypeVarType).details.boundType !== undefined &&
                         isClassInstance(objectType)
                     ) {
-                        newNarrowTypeBound = combineTypes(
-                            [curSolvedNarrowTypeBound, objectType],
-                            maxSubtypeCountForTypeVarNarrowBound
-                        );
+                        newNarrowTypeBound = combineTypes([curSolvedNarrowTypeBound, objectType], {
+                            maxSubtypeCount: maxSubtypeCountForTypeVarNarrowBound,
+                        });
                     } else {
-                        newNarrowTypeBound = combineTypes(
-                            [curSolvedNarrowTypeBound, adjSrcType],
-                            maxSubtypeCountForTypeVarNarrowBound
-                        );
+                        newNarrowTypeBound = combineTypes([curSolvedNarrowTypeBound, adjSrcType], {
+                            maxSubtypeCount: maxSubtypeCountForTypeVarNarrowBound,
+                        });
                     }
                 }
             }

--- a/packages/pyright-internal/src/analyzer/constructors.ts
+++ b/packages/pyright-internal/src/analyzer/constructors.ts
@@ -607,7 +607,7 @@ function validateInitMethod(
 
                 return applyExpectedSubtypeForConstructor(evaluator, type, expectedSubType, typeVarContext);
             },
-            /* sortSubtypes */ true
+            { sortSubtypes: true }
         );
 
         if (isNever(returnType) || argumentErrors) {

--- a/packages/pyright-internal/src/analyzer/operations.ts
+++ b/packages/pyright-internal/src/analyzer/operations.ts
@@ -656,7 +656,7 @@ export function getTypeOfBinaryOperation(
                 flags | EvalFlags.InstantiableType
             );
 
-            let newUnion = combineTypes([adjustedLeftType, adjustedRightType]);
+            let newUnion = combineTypes([adjustedLeftType, adjustedRightType], { skipElideRedundantLiterals: true });
 
             const unionClass = evaluator.getUnionClassType();
             if (unionClass && isInstantiableClass(unionClass)) {

--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -11325,7 +11325,7 @@ export function createTypeEvaluator(
 
                         return undefined;
                     },
-                    /* sortSubtypes */ true
+                    { sortSubtypes: true }
                 );
 
                 if (isClassInstance(filteredType)) {
@@ -14077,7 +14077,7 @@ export function createTypeEvaluator(
                 (builtInClassName === 'set' && fileInfo.diagnosticRuleSet.strictSetInference) ||
                 hasExpectedType
             ) {
-                inferredEntryType = combineTypes(entryTypes, maxSubtypesForInferredType);
+                inferredEntryType = combineTypes(entryTypes, { maxSubtypeCount: maxSubtypesForInferredType });
             } else {
                 // Is the list or set homogeneous? If so, use stricter rules. Otherwise relax the rules.
                 inferredEntryType = areTypesSame(entryTypes, { ignorePseudoGeneric: true })
@@ -15069,7 +15069,7 @@ export function createTypeEvaluator(
             literalTypes.push(type);
         }
 
-        let result = combineTypes(literalTypes);
+        let result = combineTypes(literalTypes, { skipElideRedundantLiterals: true });
 
         if (isUnion(result) && unionTypeClass && isInstantiableClass(unionTypeClass)) {
             result = TypeBase.cloneAsSpecialForm(result, ClassType.cloneAsInstance(unionTypeClass));
@@ -15714,7 +15714,7 @@ export function createTypeEvaluator(
             addDiagnostic(DiagnosticRule.reportInvalidTypeArguments, LocMessage.unionTypeArgCount(), errorNode);
         }
 
-        let unionType = combineTypes(types);
+        let unionType = combineTypes(types, { skipElideRedundantLiterals: true });
         if (unionTypeClass && isInstantiableClass(unionTypeClass)) {
             unionType = TypeBase.cloneAsSpecialForm(unionType, ClassType.cloneAsInstance(unionTypeClass));
         }


### PR DESCRIPTION
…literals in some cases. In particular, for type expressions that explicitly include literals along with their non-literal counterpart like `Literal[1] | int`. Retaining these redundant subtypes can be useful for language server features like completion suggestions. This addresses #8392.