### PR TITLE
Changed the type of the `__doc__` attribute for a module to always be…

### DIFF
--- a/packages/pyright-internal/src/analyzer/binder.ts
+++ b/packages/pyright-internal/src/analyzer/binder.ts
@@ -286,16 +286,7 @@ export class Binder extends ParseTreeWalker {
                 this._addImplicitSymbolToCurrentScope('__dict__', node, 'Dict[str, Any]');
                 this._addImplicitSymbolToCurrentScope('__annotations__', node, 'Dict[str, Any]');
                 this._addImplicitSymbolToCurrentScope('__builtins__', node, 'Any');
-
-                // If there is a static docstring provided in the module, assume
-                // that the type of `__doc__` is `str` rather than `str | None`. This
-                // doesn't apply to stub files.
-                const moduleDocString = ParseTreeUtils.getDocString(node.statements);
-                this._addImplicitSymbolToCurrentScope(
-                    '__doc__',
-                    node,
-                    !this._fileInfo.isStubFile && moduleDocString ? 'str' : 'str | None'
-                );
+                this._addImplicitSymbolToCurrentScope('__doc__', node, 'str | None');
 
                 // Create a start node for the module.
                 this._currentFlowNode = this._createStartFlowNode();


### PR DESCRIPTION
… `str | None`. Previously, pyright changed its declared type to `str` if a docstring was present in the module, but this is incorrect because it's a writable value and can be set to `None`. This addresses #8388.