### PR TITLE
Fixed inconsistent behavior when evaluating a binary expression with …

### DIFF
--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -1861,9 +1861,12 @@ export function createTypeEvaluator(
                     return isUnboundedTupleClass(tupleBaseClass) || tupleBaseClass.priv.tupleTypeArguments.length === 0;
                 }
 
-                // Check for Literal[False] and Literal[True].
-                if (ClassType.isBuiltIn(type, 'bool') && type.priv.literalValue !== undefined) {
-                    return type.priv.literalValue === false;
+                // Check for bool, int, str and bytes literals that are never falsy.
+                if (
+                    type.priv.literalValue !== undefined &&
+                    ClassType.isBuiltIn(type, ['bool', 'int', 'str', 'bytes'])
+                ) {
+                    return !type.priv.literalValue || type.priv.literalValue === BigInt(0);
                 }
 
                 // If this is a protocol class, don't make any assumptions about the absence
@@ -1949,14 +1952,12 @@ export function createTypeEvaluator(
                     return false;
                 }
 
-                // Check for Literal[False], Literal[0], Literal[""].
+                // Check for bool, int, str and bytes literals that are never falsy.
                 if (
-                    type.priv.literalValue === false ||
-                    type.priv.literalValue === 0 ||
-                    type.priv.literalValue === BigInt(0) ||
-                    type.priv.literalValue === ''
+                    type.priv.literalValue !== undefined &&
+                    ClassType.isBuiltIn(type, ['bool', 'int', 'str', 'bytes'])
                 ) {
-                    return false;
+                    return !!type.priv.literalValue && type.priv.literalValue !== BigInt(0);
                 }
 
                 // If this is a protocol class, don't make any assumptions about the absence

--- a/packages/pyright-internal/src/tests/samples/final3.py
+++ b/packages/pyright-internal/src/tests/samples/final3.py
@@ -234,3 +234,15 @@ v8: Annotated[Final, "meta"] = 1
 
 # This should generate an error
 v8 = 2
+
+v9: Final = 2 or "2"
+reveal_type(v9, expected_text="Literal[2]")
+
+v10: Final = 0 or "2"
+reveal_type(v10, expected_text="Literal['2']")
+
+v11: Final = b"" and True
+reveal_type(v11, expected_text='Literal[b""]')
+
+v12: Final = b"2" and True
+reveal_type(v12, expected_text="Literal[True]")


### PR DESCRIPTION
…an `or` or `and` operator when the LHS evaluates to a literal `int`, `str`, `bytes` or `bool` type. This addresses #8417.