### PR TITLE
Changed bidirectional type inference for calls that have an expected …

### DIFF
--- a/packages/pyright-internal/src/tests/samples/call16.py
+++ b/packages/pyright-internal/src/tests/samples/call16.py
@@ -1,0 +1,34 @@
+# This sample tests a case of bidirectional type inference for calls
+# that involves a union in the expected type.
+
+# pyright: strict
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Generic, TypeVar
+
+T_co = TypeVar("T_co", covariant=True)
+E_co = TypeVar("E_co", covariant=True)
+F = TypeVar("F")
+
+
+class Ok(Generic[T_co]):
+    def or_else(self, op: object) -> Ok[T_co]:
+        ...
+
+
+class Err(Generic[E_co]):
+    def or_else(self, op: Callable[[E_co], Result[T_co, F]]) -> Result[T_co, F]:
+        ...
+
+
+Result = Ok[T_co] | Err[E_co]
+
+
+def inner(func: Callable[[E_co], Err[F]], r: Result[T_co, E_co]) -> Result[T_co, F]:
+    match r:
+        case Ok():
+            return r.or_else(func)
+        case Err():
+            return r.or_else(func)

--- a/packages/pyright-internal/src/tests/typeEvaluator1.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator1.test.ts
@@ -864,6 +864,12 @@ test('Call15', () => {
     TestUtils.validateResults(analysisResults, 6);
 });
 
+test('Call16', () => {
+    const analysisResults = TestUtils.typeAnalyzeSampleFiles(['call16.py']);
+
+    TestUtils.validateResults(analysisResults, 0);
+});
+
 test('Function1', () => {
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['function1.py']);
 


### PR DESCRIPTION
…type that includes a union to first attempt to solve using constraints from the full union before falling back to individual subtypes in the union. This restores the behavior prior to 1.1.372. It addresses #8449.