### PR TITLE
Fixed regression that results in a false positive when an `Annotated`…

### DIFF
--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -7614,7 +7614,7 @@ export function createTypeEvaluator(
 
     function getTypeArgs(node: IndexNode, flags: EvalFlags, options?: GetTypeArgsOptions): TypeResultWithNode[] {
         const typeArgs: TypeResultWithNode[] = [];
-        let adjFlags = flags;
+        let adjFlags = flags | EvalFlags.NoConvertSpecialForm;
 
         if (options?.isFinalAnnotation) {
             adjFlags |= EvalFlags.NoClassVar | EvalFlags.NoFinal;

--- a/packages/pyright-internal/src/tests/samples/annotated1.py
+++ b/packages/pyright-internal/src/tests/samples/annotated1.py
@@ -1,8 +1,8 @@
 # This sample tests handling of the Python 3.9 "Annotated" feature
 # described in PEP 593.
 
-from typing import Annotated, TypeVar, ClassVar, Final
 from dataclasses import InitVar, dataclass
+from typing import Annotated, ClassVar, Final, TypeVar
 
 
 class struct2:
@@ -96,3 +96,6 @@ def func4():
 
 
 reveal_type(func4(), expected_text="type[Annotated]")
+
+x9 = list[Annotated[int, ""]]()
+reveal_type(x9, expected_text="list[int]")

--- a/packages/pyright-internal/src/tests/typeEvaluator7.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator7.test.ts
@@ -832,7 +832,7 @@ test('Annotated1', () => {
 
     configOptions.defaultPythonVersion = pythonVersion3_8;
     const analysisResults38 = TestUtils.typeAnalyzeSampleFiles(['annotated1.py'], configOptions);
-    TestUtils.validateResults(analysisResults38, 32);
+    TestUtils.validateResults(analysisResults38, 34);
 
     configOptions.defaultPythonVersion = pythonVersion3_11;
     const analysisResults39 = TestUtils.typeAnalyzeSampleFiles(['annotated1.py'], configOptions);


### PR DESCRIPTION
… type is used in a type argument within a specialized type on the LHS of a call expression, such as `list[Annotated[int, ""]]()`. This addresses #8454.