### PR TITLE
Fixed issues with the `reportInconsistentConstructor`. It produced fa…

### DIFF
--- a/packages/pyright-internal/src/analyzer/checker.ts
+++ b/packages/pyright-internal/src/analyzer/checker.ts
@@ -171,7 +171,6 @@ import {
     EnumLiteral,
     FunctionParam,
     FunctionType,
-    FunctionTypeFlags,
     OverloadedFunctionType,
     Type,
     TypeBase,
@@ -5663,18 +5662,6 @@ export class Checker extends ParseTreeWalker {
         if (FunctionType.hasDefaultParameters(initMemberType) || FunctionType.hasDefaultParameters(newMemberType)) {
             return;
         }
-
-        // We'll set the "SkipArgsKwargs" flag for pragmatic reasons since __new__
-        // often has an *args and/or **kwargs. We'll also set the ParamSpecValue
-        // because we don't care about the return type for this check.
-        initMemberType = FunctionType.cloneWithNewFlags(
-            initMemberType,
-            initMemberType.shared.flags | FunctionTypeFlags.GradualCallableForm | FunctionTypeFlags.ParamSpecValue
-        );
-        newMemberType = FunctionType.cloneWithNewFlags(
-            newMemberType,
-            initMemberType.shared.flags | FunctionTypeFlags.GradualCallableForm | FunctionTypeFlags.ParamSpecValue
-        );
 
         if (
             !this._evaluator.assignType(

--- a/packages/pyright-internal/src/tests/samples/inconsistentConstructor1.py
+++ b/packages/pyright-internal/src/tests/samples/inconsistentConstructor1.py
@@ -1,5 +1,7 @@
 # This sample tests the reportInconsistentConstructor diagnostic check.
 
+from typing import Any, Self
+
 
 class Parent1:
     def __init__(self, a: int) -> None:
@@ -20,4 +22,21 @@ class Parent2:
 class Child2(Parent2):
     # This should generate an error if reportInconsistentConstructor is enabled.
     def __new__(cls, b: str):
+        ...
+
+
+class Class3:
+    def __new__(cls, *args: object, **kwargs: object) -> Self:
+        ...
+
+    # This should generate an error if reportInconsistentConstructor is enabled.
+    def __init__(self, a: int) -> None:
+        ...
+
+
+class Class4:
+    def __new__(cls, *args: Any, **kwargs: Any) -> Self:
+        ...
+
+    def __init__(self, a: int) -> None:
         ...

--- a/packages/pyright-internal/src/tests/typeEvaluator6.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator6.test.ts
@@ -807,7 +807,7 @@ test('InconsistentConstructor1', () => {
     // Enable it as an error.
     configOptions.diagnosticRuleSet.reportInconsistentConstructor = 'error';
     analysisResults = TestUtils.typeAnalyzeSampleFiles(['inconsistentConstructor1.py'], configOptions);
-    TestUtils.validateResults(analysisResults, 2);
+    TestUtils.validateResults(analysisResults, 3);
 });
 
 test('ClassGetItem1', () => {


### PR DESCRIPTION
…lse negatives in some cases and produced bad error messages in other cases. This addresses #8501 and #8500.