### PR TITLE
Fixed bug in logic that validates subtyping relationships between `Ty…

### DIFF
--- a/packages/pyright-internal/src/tests/samples/overload12.py
+++ b/packages/pyright-internal/src/tests/samples/overload12.py
@@ -1,10 +1,10 @@
 # This sample tests overload matching in cases where the match
 # is ambiguous due to an Any or Unknown argument.
 
+# pyright: reportMissingModuleSource=false
+
 from typing import Any, Generic, Literal, TypeVar, overload
-from typing_extensions import (  # pyright: ignore[reportMissingModuleSource]
-    LiteralString,
-)
+from typing_extensions import LiteralString, TypeIs
 
 _T = TypeVar("_T")
 
@@ -338,3 +338,22 @@ def func19(a: ClassC, b: list, c: Any):
     my_list2: list[int] = []
     v1 = a.method1("hi", my_list2)
     reveal_type(v1, expected_text="float")
+
+
+@overload
+def overload11(x: str) -> TypeIs[str]:
+    ...
+
+
+@overload
+def overload11(x: int) -> TypeIs[int]:
+    ...
+
+
+def overload11(x: Any) -> Any:
+    return True
+
+
+def func20(val: Any):
+    if overload11(val):
+        reveal_type(val, expected_text="Any")

--- a/packages/pyright-internal/src/tests/samples/typeIs1.py
+++ b/packages/pyright-internal/src/tests/samples/typeIs1.py
@@ -1,7 +1,10 @@
 # This sample tests the TypeIs form.
 
+# pyright: reportMissingModuleSource=false
+
 from typing import Any, Callable, Collection, Literal, Mapping, Sequence, TypeVar, Union
-from typing_extensions import TypeIs  # pyright: ignore[reportMissingModuleSource]
+
+from typing_extensions import TypeIs
 
 
 def is_str1(val: Union[str, int]) -> TypeIs[str]:

--- a/packages/pyright-internal/src/tests/samples/typeIs2.py
+++ b/packages/pyright-internal/src/tests/samples/typeIs2.py
@@ -1,0 +1,36 @@
+# This sample tests the subtyping relationships between TypeIs, TypeGuard,
+# and bool.
+
+# pyright: reportMissingModuleSource=false
+
+from typing import Callable
+
+from typing_extensions import TypeGuard, TypeIs
+
+TypeIsInt = Callable[..., TypeIs[int]]
+TypeIsFloat = Callable[..., TypeIs[float]]
+BoolReturn = Callable[..., bool]
+TypeGuardInt = Callable[..., TypeGuard[int]]
+
+
+def func1(v1: TypeIsInt, v2: TypeIsFloat, v3: BoolReturn, v4: TypeGuardInt):
+    a1: TypeIsInt = v1
+    a2: TypeIsInt = v2 # Should generate an error
+    a3: TypeIsInt = v3 # Should generate an error
+    a4: TypeIsInt = v4 # Should generate an error
+
+    b1: TypeIsFloat = v1 # Should generate an error
+    b2: TypeIsFloat = v2
+    b3: TypeIsFloat = v3 # Should generate an error
+    b4: TypeIsFloat = v4 # Should generate an error
+
+    c1: BoolReturn = v1
+    c2: BoolReturn = v2
+    c3: BoolReturn = v3
+    c4: BoolReturn = v4
+
+    d1: TypeGuardInt = v1 # Should generate an error
+    d2: TypeGuardInt = v2 # Should generate an error
+    d3: TypeGuardInt = v3 # Should generate an error
+    d4: TypeGuardInt = v4
+

--- a/packages/pyright-internal/src/tests/typeEvaluator6.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator6.test.ts
@@ -128,6 +128,11 @@ test('TypeIs1', () => {
     TestUtils.validateResults(analysisResults, 2);
 });
 
+test('TypeIs2', () => {
+    const analysisResults = TestUtils.typeAnalyzeSampleFiles(['typeIs2.py']);
+    TestUtils.validateResults(analysisResults, 9);
+});
+
 test('Never1', () => {
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['never1.py']);
 


### PR DESCRIPTION
…peIs[T]`, `TypeGuard[T]` and `bool` when used in a return type of a callable. This addresses #8521.