### PR TITLE
Fixed bug in `isinstance` type narrowing if the second argument is `o…

### DIFF
--- a/packages/pyright-internal/src/analyzer/typeGuards.ts
+++ b/packages/pyright-internal/src/analyzer/typeGuards.ts
@@ -1842,8 +1842,12 @@ function narrowTypeForIsInstanceInternal(
                 if (isInstantiableClass(subtype) || isSubtypeMetaclass) {
                     // Handle the special case of isinstance(x, metaclass).
                     const includesMetaclassType = filterTypes.some((classType) => isInstantiableMetaclass(classType));
+                    const includesObject = filterTypes.some(
+                        (classType) => isInstantiableClass(classType) && ClassType.isBuiltIn(classType, 'object')
+                    );
+
                     if (isPositiveTest) {
-                        return includesMetaclassType ? negativeFallback : undefined;
+                        return includesMetaclassType || includesObject ? negativeFallback : undefined;
                     } else {
                         return includesMetaclassType ? undefined : negativeFallback;
                     }

--- a/packages/pyright-internal/src/tests/samples/typeNarrowingIsinstance1.py
+++ b/packages/pyright-internal/src/tests/samples/typeNarrowingIsinstance1.py
@@ -223,3 +223,8 @@ def func12(x: TA3) -> None:
         reveal_type(x, expected_text="dict[str, str | list[TA3] | dict[str, TA3]]")
     else:
         reveal_type(x, expected_text="str | list[str | list[TA3] | dict[str, TA3]]")
+
+
+def func13(x: object | type[object]) -> None:
+    if isinstance(x, object):
+        reveal_type(x, expected_text="object | type[object]")


### PR DESCRIPTION
…bject` and the first argument is a `type` instance. This addresses #8520.