### PR TITLE
Fixed recent regression that results in incorrect `isinstance` type n…

### DIFF
--- a/packages/pyright-internal/src/analyzer/typeGuards.ts
+++ b/packages/pyright-internal/src/analyzer/typeGuards.ts
@@ -1222,9 +1222,15 @@ export function isIsinstanceFilterSuperclass(
     }
 
     if (isInstanceCheck) {
+        // We convert both types to instances in case they are protocol
+        // classes. A protocol class isn't allowed to be assigned to
+        // type[T], so this would otherwise fail.
         if (
             ClassType.isProtocolClass(concreteFilterType) &&
-            evaluator.assignType(concreteFilterType, concreteVarType)
+            evaluator.assignType(
+                ClassType.cloneAsInstance(concreteFilterType),
+                ClassType.cloneAsInstance(concreteVarType)
+            )
         ) {
             return true;
         }
@@ -1251,7 +1257,13 @@ export function isIsinstanceFilterSubclass(
     }
 
     if (isInstanceCheck) {
-        if (ClassType.isProtocolClass(varType) && evaluator.assignType(varType, concreteFilterType)) {
+        // We convert both types to instances in case they are protocol
+        // classes. A protocol class isn't allowed to be assigned to
+        // type[T], so this would otherwise fail.
+        if (
+            ClassType.isProtocolClass(varType) &&
+            evaluator.assignType(ClassType.cloneAsInstance(varType), ClassType.cloneAsInstance(concreteFilterType))
+        ) {
             return true;
         }
     }
@@ -1410,8 +1422,8 @@ function narrowTypeForIsInstanceInternal(
                     } else if (filterIsSubclass) {
                         if (
                             evaluator.assignType(
-                                concreteVarType,
-                                concreteFilterType,
+                                convertToInstance(concreteVarType),
+                                convertToInstance(concreteFilterType),
                                 /* diag */ undefined,
                                 /* destTypeVarContext */ undefined,
                                 /* srcTypeVarContext */ undefined,
@@ -1444,8 +1456,8 @@ function narrowTypeForIsInstanceInternal(
                                         if (
                                             addConstraintsForExpectedType(
                                                 evaluator,
-                                                unspecializedFilterType,
-                                                concreteVarType,
+                                                convertToInstance(unspecializedFilterType),
+                                                convertToInstance(concreteVarType),
                                                 typeVarContext,
                                                 /* liveTypeVarScopes */ undefined,
                                                 errorNode.start

--- a/packages/pyright-internal/src/tests/samples/typeNarrowingIsinstance1.py
+++ b/packages/pyright-internal/src/tests/samples/typeNarrowingIsinstance1.py
@@ -1,7 +1,7 @@
 # This sample exercises the type analyzer's isinstance type narrowing logic.
 
 from types import NoneType
-from typing import Any, Generic, Protocol, Sized, TypeVar, Union, runtime_checkable
+from typing import Any, Generic, Iterable, Iterator, Protocol, Sized, TypeVar, Union, runtime_checkable
 
 S = TypeVar("S")
 T = TypeVar("T")
@@ -228,3 +228,8 @@ def func12(x: TA3) -> None:
 def func13(x: object | type[object]) -> None:
     if isinstance(x, object):
         reveal_type(x, expected_text="object | type[object]")
+
+
+def func14(x: Iterable[T]):
+    if isinstance(x, Iterator):
+        reveal_type(x, expected_text="Iterator[T@func14]")


### PR DESCRIPTION
…arrowing when the filter class and the type are both protocols. This addresses #8518.