### PR TITLE
Fixed bug that results in a warning if the `self` parameter in an `__…

### DIFF
--- a/packages/pyright-internal/src/analyzer/checker.ts
+++ b/packages/pyright-internal/src/analyzer/checker.ts
@@ -7313,7 +7313,9 @@ export class Checker extends ParseTreeWalker {
 
             if (
                 typeVars.some(
-                    (typeVar) => typeVar.priv.scopeId === functionType.shared.methodClass?.shared.typeVarScopeId
+                    (typeVar) =>
+                        typeVar.priv.scopeId === functionType.shared.methodClass?.shared.typeVarScopeId &&
+                        !typeVar.shared.isSynthesizedSelf
                 )
             ) {
                 this._evaluator.addDiagnostic(


### PR DESCRIPTION
…init__` method is given an explicit `Self` annotation. This addresses #8532.