### PR TITLE
Added error check for an enum attribute with a "naked" `Final` attrib…

### DIFF
--- a/packages/pyright-internal/src/analyzer/checker.ts
+++ b/packages/pyright-internal/src/analyzer/checker.ts
@@ -5071,6 +5071,15 @@ export class Checker extends ParseTreeWalker {
                 return;
             }
 
+            // Look for an enum attribute annotated with "Final".
+            if (decls[0].isFinal) {
+                this._evaluator.addDiagnostic(
+                    DiagnosticRule.reportGeneralTypeIssues,
+                    LocMessage.enumMemberTypeAnnotation(),
+                    decls[0].node
+                );
+            }
+
             const declNode = decls[0].node;
             const assignedValueType = symbolType.priv.literalValue.itemType;
             const assignmentNode = ParseTreeUtils.getParentNodeOfType<AssignmentNode>(

--- a/packages/pyright-internal/src/tests/samples/enum12.py
+++ b/packages/pyright-internal/src/tests/samples/enum12.py
@@ -3,12 +3,15 @@
 # type checkers should flag such conditions as errors.
 
 from enum import Enum
-from typing import Callable
+from typing import Callable, Final
 
 
 class Enum1(Enum):
     # This should generate an error.
-    MEMBER: int = 1
+    MEMBER_1: int = 1
+
+    # This should generate an error.
+    MEMBER_2: Final = 3
 
     _NON_MEMBER_: int = 3
 

--- a/packages/pyright-internal/src/tests/typeEvaluator3.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator3.test.ts
@@ -1019,7 +1019,7 @@ test('Enum11', () => {
 test('Enum12', () => {
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['enum12.py']);
 
-    TestUtils.validateResults(analysisResults, 1);
+    TestUtils.validateResults(analysisResults, 2);
 });
 
 test('EnumAuto1', () => {


### PR DESCRIPTION
…ute. This should be considered invalid. This addresses #8543.