### PR TITLE
Fixed a bug that results in an incorrect "inconsistent overload" erro…

### DIFF
--- a/packages/pyright-internal/src/tests/samples/typeGuard2.py
+++ b/packages/pyright-internal/src/tests/samples/typeGuard2.py
@@ -43,7 +43,7 @@ def overloaded_filter(
 
 
 x1 = cb1(1)
-reveal_type(x1, expected_text="bool")
+reveal_type(x1, expected_text="TypeGuard[int]")
 
 sf1 = simple_filter([], cb1)
 reveal_type(sf1, expected_text="list[object]")

--- a/packages/pyright-internal/src/tests/samples/typeIs1.py
+++ b/packages/pyright-internal/src/tests/samples/typeIs1.py
@@ -2,7 +2,17 @@
 
 # pyright: reportMissingModuleSource=false
 
-from typing import Any, Callable, Collection, Literal, Mapping, Sequence, TypeVar, Union
+from typing import (
+    Any,
+    Callable,
+    Collection,
+    Literal,
+    Mapping,
+    Sequence,
+    TypeVar,
+    Union,
+    overload,
+)
 
 from typing_extensions import TypeIs
 
@@ -146,3 +156,19 @@ def func9(val: Collection[object]) -> None:
         reveal_type(val, expected_text="list[int]")
     else:
         reveal_type(val, expected_text="Collection[object]")
+
+
+@overload
+def func10(v: tuple[int | str, ...], b: Literal[False]) -> TypeIs[tuple[str, ...]]:
+    ...
+
+
+@overload
+def func10(
+    v: tuple[int | str, ...], b: Literal[True] = True
+) -> TypeIs[tuple[int, ...]]:
+    ...
+
+
+def func10(v: tuple[int | str, ...], b: bool = True) -> bool:
+    ...


### PR DESCRIPTION
…r when the overloads return `TypeIs` or `TypeGuard` and the implementation returns `bool`. This addresses #8521.