### PR TITLE
Fixed a bug that results in an incorrect "inconsistent overload" erro…

### DIFF
--- a/packages/pyright-internal/src/analyzer/checker.ts
+++ b/packages/pyright-internal/src/analyzer/checker.ts
@@ -959,6 +959,7 @@ export class Checker extends ParseTreeWalker {
                 } else {
                     const liveScopes = ParseTreeUtils.getTypeVarScopesForNode(node);
                     declaredReturnType = updateTypeWithInternalTypeVars(declaredReturnType, liveScopes);
+                    declaredReturnType = this._evaluator.stripTypeGuard(declaredReturnType);
 
                     let diagAddendum = new DiagnosticAddendum();
                     let returnTypeMatches = false;
@@ -968,9 +969,7 @@ export class Checker extends ParseTreeWalker {
                             declaredReturnType,
                             returnType,
                             diagAddendum,
-                            /* destTypeVarContext */ new TypeVarContext(),
-                            /* srcTypeVarContext */ undefined,
-                            AssignTypeFlags.AllowBoolTypeGuard
+                            /* destTypeVarContext */ new TypeVarContext()
                         )
                     ) {
                         returnTypeMatches = true;
@@ -993,18 +992,10 @@ export class Checker extends ParseTreeWalker {
                             }
 
                             if (!typeVarContext.isEmpty()) {
-                                const adjustedReturnType = applySolvedTypeVars(declaredReturnType, typeVarContext);
+                                let adjustedReturnType = applySolvedTypeVars(declaredReturnType, typeVarContext);
+                                adjustedReturnType = this._evaluator.stripTypeGuard(adjustedReturnType);
 
-                                if (
-                                    this._evaluator.assignType(
-                                        adjustedReturnType,
-                                        returnType,
-                                        diagAddendum,
-                                        /* destTypeVarContext */ undefined,
-                                        /* srcTypeVarContext */ undefined,
-                                        AssignTypeFlags.AllowBoolTypeGuard
-                                    )
-                                ) {
+                                if (this._evaluator.assignType(adjustedReturnType, returnType, diagAddendum)) {
                                     returnTypeMatches = true;
                                 }
                             }

--- a/packages/pyright-internal/src/analyzer/typeEvaluatorTypes.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluatorTypes.ts
@@ -506,6 +506,7 @@ export interface TypeEvaluator {
     stripLiteralValue: (type: Type) => Type;
     removeTruthinessFromType: (type: Type) => Type;
     removeFalsinessFromType: (type: Type) => Type;
+    stripTypeGuard: (type: Type) => Type;
 
     getExpectedType: (node: ExpressionNode) => ExpectedTypeResult | undefined;
     verifyRaiseExceptionType: (node: RaiseNode) => void;

--- a/packages/pyright-internal/src/analyzer/typeUtils.ts
+++ b/packages/pyright-internal/src/analyzer/typeUtils.ts
@@ -203,9 +203,6 @@ export const enum AssignTypeFlags {
     // For function types, skip the return type check.
     SkipReturnTypeCheck = 1 << 6,
 
-    // Allow bool values to be assigned to TypeGuard[x] types.
-    AllowBoolTypeGuard = 1 << 7,
-
     // In most cases, literals are stripped when assigning to a
     // type variable. This overrides the standard behavior.
     RetainLiteralsForTypeVar = 1 << 8,

--- a/packages/pyright-internal/src/tests/samples/typeGuard2.py
+++ b/packages/pyright-internal/src/tests/samples/typeGuard2.py
@@ -43,7 +43,7 @@ def overloaded_filter(
 
 
 x1 = cb1(1)
-reveal_type(x1, expected_text="bool")
+reveal_type(x1, expected_text="TypeGuard[int]")
 
 sf1 = simple_filter([], cb1)
 reveal_type(sf1, expected_text="list[object]")

--- a/packages/pyright-internal/src/tests/samples/typeIs1.py
+++ b/packages/pyright-internal/src/tests/samples/typeIs1.py
@@ -2,7 +2,17 @@
 
 # pyright: reportMissingModuleSource=false
 
-from typing import Any, Callable, Collection, Literal, Mapping, Sequence, TypeVar, Union
+from typing import (
+    Any,
+    Callable,
+    Collection,
+    Literal,
+    Mapping,
+    Sequence,
+    TypeVar,
+    Union,
+    overload,
+)
 
 from typing_extensions import TypeIs
 
@@ -146,3 +156,19 @@ def func9(val: Collection[object]) -> None:
         reveal_type(val, expected_text="list[int]")
     else:
         reveal_type(val, expected_text="Collection[object]")
+
+
+@overload
+def func10(v: tuple[int | str, ...], b: Literal[False]) -> TypeIs[tuple[str, ...]]:
+    ...
+
+
+@overload
+def func10(
+    v: tuple[int | str, ...], b: Literal[True] = True
+) -> TypeIs[tuple[int, ...]]:
+    ...
+
+
+def func10(v: tuple[int | str, ...], b: bool = True) -> bool:
+    ...


### PR DESCRIPTION
…r when the overloads return `TypeIs` or `TypeGuard` and the implementation returns `bool`. This addresses #8521.