### PR TITLE
Fixed bug that results in a false negative if a `__set__` descriptor …

### DIFF
--- a/packages/pyright-internal/src/analyzer/checker.ts
+++ b/packages/pyright-internal/src/analyzer/checker.ts
@@ -1501,7 +1501,7 @@ export class Checker extends ParseTreeWalker {
     }
 
     override visitMemberAccess(node: MemberAccessNode) {
-        const typeResult = this._evaluator.getTypeResult(node);
+        const typeResult = this._evaluator.getTypeResult(node.d.member);
         const type = typeResult?.type ?? UnknownType.create();
 
         const leftExprType = this._evaluator.getType(node.d.leftExpr);
@@ -4224,7 +4224,7 @@ export class Checker extends ParseTreeWalker {
         }
 
         if (errorMessage) {
-            this._reportDeprecatedDiagnostic(node, errorMessage, info.deprecationMessage);
+            this._reportDeprecatedDiagnostic(node, errorMessage, info.deprecatedMessage);
         }
     }
 
@@ -4362,24 +4362,13 @@ export class Checker extends ParseTreeWalker {
                 ) {
                     if (this._fileInfo.executionEnvironment.pythonVersion.isGreaterOrEqualTo(deprecatedForm.version)) {
                         if (!deprecatedForm.typingImportOnly || isImportFromTyping) {
-                            if (this._fileInfo.diagnosticRuleSet.reportDeprecated === 'none') {
-                                this._evaluator.addDeprecated(
-                                    LocMessage.deprecatedType().format({
-                                        version: deprecatedForm.version.toString(),
-                                        replacement: deprecatedForm.replacementText,
-                                    }),
-                                    node
-                                );
-                            } else {
-                                this._evaluator.addDiagnostic(
-                                    DiagnosticRule.reportDeprecated,
-                                    LocMessage.deprecatedType().format({
-                                        version: deprecatedForm.version.toString(),
-                                        replacement: deprecatedForm.replacementText,
-                                    }),
-                                    node
-                                );
-                            }
+                            this._reportDeprecatedDiagnostic(
+                                node,
+                                LocMessage.deprecatedType().format({
+                                    version: deprecatedForm.version.toString(),
+                                    replacement: deprecatedForm.replacementText,
+                                })
+                            );
                         }
                     }
                 }

--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -3487,6 +3487,7 @@ export function createTypeEvaluator(
             memberResultToCache = {
                 ...resultToCache,
                 type: updateTypeWithExternalTypeVars(resultToCache.type, [enclosingClass.shared.typeVarScopeId]),
+                memberAccessDeprecationInfo: setTypeResult.memberAccessDeprecationInfo,
             };
         }
         writeTypeCache(target.d.member, memberResultToCache, EvalFlags.None);
@@ -6256,7 +6257,7 @@ export function createTypeEvaluator(
             const overloadUsed = callResult.overloadsUsedForCall[0];
             if (overloadUsed.shared.deprecatedMessage) {
                 deprecationInfo = {
-                    deprecationMessage: overloadUsed.shared.deprecatedMessage,
+                    deprecatedMessage: overloadUsed.shared.deprecatedMessage,
                     accessType: ClassType.isPropertyClass(concreteMemberType) ? 'property' : 'descriptor',
                     accessMethod: usage.method,
                 };

--- a/packages/pyright-internal/src/analyzer/typeEvaluatorTypes.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluatorTypes.ts
@@ -251,7 +251,7 @@ export interface TypeResultWithNode extends TypeResult {
 export interface MemberAccessDeprecationInfo {
     accessType: 'property' | 'descriptor';
     accessMethod: 'get' | 'set' | 'del';
-    deprecationMessage: string;
+    deprecatedMessage: string;
 }
 
 export interface EvaluatorUsage {

--- a/packages/pyright-internal/src/tests/checker.test.ts
+++ b/packages/pyright-internal/src/tests/checker.test.ts
@@ -568,11 +568,11 @@ test('Deprecated4', () => {
     const configOptions = new ConfigOptions(Uri.empty());
 
     const analysisResults1 = TestUtils.typeAnalyzeSampleFiles(['deprecated4.py'], configOptions);
-    TestUtils.validateResults(analysisResults1, 0, 0, 0, undefined, undefined, 6);
+    TestUtils.validateResults(analysisResults1, 0, 0, 0, undefined, undefined, 7);
 
     configOptions.diagnosticRuleSet.reportDeprecated = 'error';
     const analysisResults2 = TestUtils.typeAnalyzeSampleFiles(['deprecated4.py'], configOptions);
-    TestUtils.validateResults(analysisResults2, 6);
+    TestUtils.validateResults(analysisResults2, 7);
 });
 
 test('Deprecated5', () => {

--- a/packages/pyright-internal/src/tests/samples/deprecated4.py
+++ b/packages/pyright-internal/src/tests/samples/deprecated4.py
@@ -1,6 +1,7 @@
 # This sample tests the handling of deprecated properties and decorators.
 
 from typing import overload
+
 from typing_extensions import deprecated  # pyright: ignore[reportMissingModuleSource]
 
 
@@ -46,6 +47,9 @@ v2 = a.v2
 
 # This should generate an error if reportDeprecated is enabled.
 a.v2 = ""
+
+# This should generate an error if reportDeprecated is enabled.
+a.v2 += ""
 
 # This should generate an error if reportDeprecated is enabled.
 del a.v2


### PR DESCRIPTION
…method is marked deprecated and is implicitly accessed using an augmented assignment operator, as in `a.x += 1`.