### PR TITLE
Modified heuristics in `T is None` type narrowing logic to handle Typ…

### DIFF
--- a/packages/pyright-internal/src/tests/samples/literalString3.py
+++ b/packages/pyright-internal/src/tests/samples/literalString3.py
@@ -1,7 +1,7 @@
 # This sample tests the case where a LiteralString is used as the bound
 # of a TypeVar.
 
-from typing import Generic, TypeVar, LiteralString
+from typing import Generic, LiteralString, TypeVar
 
 T = TypeVar("T")
 T_LS = TypeVar("T_LS", bound=LiteralString)
@@ -20,7 +20,7 @@ def func2(x: T_LS | None, default: T_LS) -> ClassA[T_LS]:
     if x is None:
         x = default
 
-    reveal_type(x, expected_text="T_LS@func2 | LiteralString*")
+    reveal_type(x, expected_text="T_LS@func2")
     out = func1(x)
-    reveal_type(out, expected_text="ClassA[T_LS@func2 | str*]")
+    reveal_type(out, expected_text="ClassA[T_LS@func2]")
     return out

--- a/packages/pyright-internal/src/tests/samples/typeNarrowingIsNone1.py
+++ b/packages/pyright-internal/src/tests/samples/typeNarrowingIsNone1.py
@@ -93,6 +93,16 @@ def func8(x: _T3) -> _T3:
     return x
 
 
+_T4 = TypeVar("_T4")
+
+
+def func9(value: type[_T4] | None):
+    if value is None:
+        reveal_type(value, expected_text="None")
+    else:
+        reveal_type(value, expected_text="type[_T4@func9]")
+
+
 class A:
     def __init__(self, parent: Self | None) -> None:
         self.parent = parent


### PR DESCRIPTION
…eVars with no bounds better. The previous logic was arguably correct, but it produced results that were unexpected by some users. This addresses #8575.