### PR TITLE
Modified heuristics in `T is None` type narrowing logic to handle Typ…

### DIFF
--- a/packages/pyright-internal/src/analyzer/typeGuards.ts
+++ b/packages/pyright-internal/src/analyzer/typeGuards.ts
@@ -1060,39 +1060,50 @@ function narrowTypeForIsNone(evaluator: TypeEvaluator, type: Type, isPositiveTes
         /* options */ undefined,
         (subtype, unexpandedSubtype) => {
             if (isAnyOrUnknown(subtype)) {
-                // We need to assume that "Any" is always both None and not None,
-                // so it matches regardless of whether the test is positive or negative.
+                // Assume that "Any" is always both None and not None, so it matches
+                // regardless of whether the test is positive or negative.
                 return subtype;
             }
 
-            // If this is a TypeVar that isn't constrained, use the unexpanded
-            // TypeVar. For all other cases (including constrained TypeVars),
-            // use the expanded subtype.
-            const adjustedSubtype =
-                isTypeVar(unexpandedSubtype) && !TypeVarType.hasConstraints(unexpandedSubtype)
-                    ? unexpandedSubtype
-                    : subtype;
+            let useExpandedSubtype = false;
+            if (isTypeVar(unexpandedSubtype) && !TypeVarType.isSelf(unexpandedSubtype)) {
+                // If the TypeVar has value constraints and one or more of them
+                // are possibly compatible with None, use the expanded subtypes.
+                if (
+                    unexpandedSubtype.shared.constraints.some((constraint) => {
+                        return evaluator.assignType(constraint, evaluator.getNoneType());
+                    })
+                ) {
+                    useExpandedSubtype = true;
+                }
 
-            // See if it's a match for object.
-            if (isClassInstance(subtype) && ClassType.isBuiltIn(subtype, 'object')) {
+                // If the TypeVar han an explicit bound that is possibly compatible
+                // with None (e.g. "T: int | None"), use the expanded subtypes.
+                if (
+                    unexpandedSubtype.shared.boundType &&
+                    evaluator.assignType(unexpandedSubtype.shared.boundType, evaluator.getNoneType())
+                ) {
+                    useExpandedSubtype = true;
+                }
+            }
+
+            const adjustedSubtype = useExpandedSubtype ? subtype : unexpandedSubtype;
+
+            // Is it an exact match for None?
+            if (isNoneInstance(subtype)) {
+                resultIncludesNoneSubtype = true;
+                return isPositiveTest ? adjustedSubtype : undefined;
+            }
+
+            // Is it potentially None?
+            if (evaluator.assignType(subtype, evaluator.getNoneType())) {
                 resultIncludesNoneSubtype = true;
                 return isPositiveTest
                     ? addConditionToType(evaluator.getNoneType(), subtype.props?.condition)
                     : adjustedSubtype;
             }
 
-            // See if it's a match for None.
-            if (isNoneInstance(subtype) === isPositiveTest) {
-                resultIncludesNoneSubtype = true;
-
-                if (isTypeVar(adjustedSubtype) && adjustedSubtype.shared.isSynthesizedSelf) {
-                    return adjustedSubtype;
-                }
-
-                return subtype;
-            }
-
-            return undefined;
+            return isPositiveTest ? undefined : adjustedSubtype;
         }
     );
 

--- a/packages/pyright-internal/src/tests/samples/literalString3.py
+++ b/packages/pyright-internal/src/tests/samples/literalString3.py
@@ -1,7 +1,7 @@
 # This sample tests the case where a LiteralString is used as the bound
 # of a TypeVar.
 
-from typing import Generic, TypeVar, LiteralString
+from typing import Generic, LiteralString, TypeVar
 
 T = TypeVar("T")
 T_LS = TypeVar("T_LS", bound=LiteralString)
@@ -20,7 +20,7 @@ def func2(x: T_LS | None, default: T_LS) -> ClassA[T_LS]:
     if x is None:
         x = default
 
-    reveal_type(x, expected_text="T_LS@func2 | LiteralString*")
+    reveal_type(x, expected_text="T_LS@func2")
     out = func1(x)
-    reveal_type(out, expected_text="ClassA[T_LS@func2 | str*]")
+    reveal_type(out, expected_text="ClassA[T_LS@func2]")
     return out

--- a/packages/pyright-internal/src/tests/samples/typeNarrowingIsNone1.py
+++ b/packages/pyright-internal/src/tests/samples/typeNarrowingIsNone1.py
@@ -93,6 +93,16 @@ def func8(x: _T3) -> _T3:
     return x
 
 
+_T4 = TypeVar("_T4")
+
+
+def func9(value: type[_T4] | None):
+    if value is None:
+        reveal_type(value, expected_text="None")
+    else:
+        reveal_type(value, expected_text="type[_T4@func9]")
+
+
 class A:
     def __init__(self, parent: Self | None) -> None:
         self.parent = parent


### PR DESCRIPTION
…eVars with no bounds better. The previous logic was arguably correct, but it produced results that were unexpected by some users. This addresses #8575.