### PR TITLE
Fixed bug that can result in a false negative when a function return …

### DIFF
--- a/packages/pyright-internal/src/analyzer/checker.ts
+++ b/packages/pyright-internal/src/analyzer/checker.ts
@@ -4840,6 +4840,9 @@ export class Checker extends ParseTreeWalker {
             if (declaredReturnType) {
                 this._reportUnknownReturnResult(node, declaredReturnType);
                 this._validateReturnTypeIsNotContravariant(declaredReturnType, returnAnnotation);
+
+                const liveScopes = ParseTreeUtils.getTypeVarScopesForNode(node);
+                declaredReturnType = updateTypeWithInternalTypeVars(declaredReturnType, liveScopes);
             }
 
             // Wrap the declared type in a generator type if the function is a generator.

--- a/packages/pyright-internal/src/tests/samples/returnTypes1.py
+++ b/packages/pyright-internal/src/tests/samples/returnTypes1.py
@@ -1,5 +1,10 @@
 # This sample tests basic return type analysis and error reporting.
 
+from typing import TypeVar
+
+
+T = TypeVar("T")
+
 
 def func1(a: int, b: int) -> int:
     c = float(a + b)
@@ -25,3 +30,13 @@ func2(3, 5)
 def func3() -> bool:
     "Doc strings are allowed"
     ...
+
+
+# This should not produce any error because not all paths return an int.
+def func4() -> int:
+    pass
+
+
+# This should not produce any error because not all paths return a T.
+def func5(x: T) -> T:
+    pass

--- a/packages/pyright-internal/src/tests/typeEvaluator1.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator1.test.ts
@@ -555,7 +555,7 @@ test('TypeNarrowingLocalConst1', () => {
 test('ReturnTypes1', () => {
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['returnTypes1.py']);
 
-    TestUtils.validateResults(analysisResults, 2);
+    TestUtils.validateResults(analysisResults, 4);
 });
 
 test('ReturnTypes2', () => {


### PR DESCRIPTION
…type is a TypeVar and the function falls through and implicitly returns a `None`.