### PR TITLE
Renamed "external" and "internal" type vars to "free" and "bound" res…

### DIFF
--- a/packages/pyright-internal/src/analyzer/constraintSolver.ts
+++ b/packages/pyright-internal/src/analyzer/constraintSolver.ts
@@ -118,7 +118,7 @@ export function assignTypeToTypeVar(
         return false;
     }
 
-    if (TypeVarType.hasInternalScopeId(destType) && !destType.priv.isUnificationVar) {
+    if (TypeVarType.isBound(destType) && !destType.priv.isUnificationVar) {
         // Handle Any as a source.
         if (isAnyOrUnknown(srcType) || (isClass(srcType) && ClassType.derivesFromAnyOrUnknown(srcType))) {
             return true;

--- a/packages/pyright-internal/src/analyzer/protocols.ts
+++ b/packages/pyright-internal/src/analyzer/protocols.ts
@@ -327,8 +327,8 @@ function assignClassToProtocolInternal(
                 /* isClsType */ false
             );
 
-            if (TypeVarType.hasInternalScopeId(synthCond.typeVar)) {
-                selfType = TypeVarType.cloneWithInternalScopeId(selfType);
+            if (TypeVarType.isBound(synthCond.typeVar)) {
+                selfType = TypeVarType.cloneAsBound(selfType);
             }
         } else {
             selfType = srcType;


### PR DESCRIPTION
…pectively. This terminology is more reflective of their true meaning. No functional change.