### PR TITLE
Fixed bug that results in a false positive when using a two-argument …

### DIFF
--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -8587,15 +8587,23 @@ export function createTypeEvaluator(
 
             let bindToSelfType: ClassType | TypeVarType | undefined;
             if (bindToType) {
-                bindToSelfType = TypeBase.cloneForCondition(
-                    TypeVarType.cloneAsBound(
-                        synthesizeTypeVarForSelfCls(
-                            ClassType.cloneIncludeSubclasses(bindToType, /* includeSubclasses */ false),
-                            /* isClsParam */ false
-                        )
-                    ),
-                    bindToType.props?.condition
-                );
+                if (node.d.args.length > 1) {
+                    // If this is a two-argument form of super(), use the
+                    // bindToType evaluated from the arguments.
+                    bindToSelfType = convertToInstance(bindToType);
+                } else {
+                    // If this is a zero-argument form of super(), synthesize
+                    // a Self type to bind to.
+                    bindToSelfType = TypeBase.cloneForCondition(
+                        TypeVarType.cloneAsBound(
+                            synthesizeTypeVarForSelfCls(
+                                ClassType.cloneIncludeSubclasses(bindToType, /* includeSubclasses */ false),
+                                /* isClsParam */ false
+                            )
+                        ),
+                        bindToType.props?.condition
+                    );
+                }
             }
 
             const type = resultIsInstance ? convertToInstance(resultType, /* includeSubclasses */ false) : resultType;

--- a/packages/pyright-internal/src/tests/samples/super2.py
+++ b/packages/pyright-internal/src/tests/samples/super2.py
@@ -3,11 +3,13 @@
 
 from typing import TypeVar
 
-
 T = TypeVar("T", bound="A")
 
 
 class A:
+    def __init__(self, **kw: object) -> None:
+        pass
+
     @classmethod
     def factory(cls: type[T]) -> T:
         return cls()
@@ -26,7 +28,11 @@ b1 = B.factory()
 reveal_type(b1, expected_text="B")
 
 b2 = B.factoryB()
-reveal_type(b2, expected_text="B")
+reveal_type(b2, expected_text="B*")
+
+
+def test_a(cls: type[T]) -> T:
+    return super(A, cls).__new__(cls)
 
 
 class C:


### PR DESCRIPTION
…form of `super()` outside of a class. This addresses #8604.