### PR TITLE
Fixed bug that results in a false positive error when a covariant typ…

### DIFF
--- a/packages/pyright-internal/src/analyzer/checker.ts
+++ b/packages/pyright-internal/src/analyzer/checker.ts
@@ -602,6 +602,7 @@ export class Checker extends ParseTreeWalker {
                     if (
                         containingClassNode &&
                         isTypeVar(paramType) &&
+                        paramType.priv.scopeType === TypeVarScopeType.Class &&
                         paramType.shared.declaredVariance === Variance.Covariant &&
                         !paramType.shared.isSynthesized &&
                         !exemptMethods.some((name) => name === functionTypeResult.functionType.shared.name)

--- a/packages/pyright-internal/src/tests/samples/typeVar4.py
+++ b/packages/pyright-internal/src/tests/samples/typeVar4.py
@@ -9,7 +9,7 @@ _T_co = TypeVar("_T_co", covariant=True)
 _T_contra = TypeVar("_T_contra", contravariant=True)
 
 
-class Foo(Generic[_T, _T_co, _T_contra]):
+class ClassA(Generic[_T, _T_co, _T_contra]):
     def func1(self, a: _T):
         pass
 
@@ -53,3 +53,11 @@ class Foo(Generic[_T, _T_co, _T_contra]):
 
     def func11(self) -> list[_T_contra]:
         return []
+
+
+class ClassB:
+    def func1(self, a: _T_co) -> _T_co:
+        return a
+
+    def func2(self, a: _T_contra) -> _T_contra:
+        return a


### PR DESCRIPTION
…e variable that is scoped to a method is used in a parameter annotation. This addresses #8614.