### PR TITLE
Fixed bug in the `functools.partial` logic that results in incorrect …

### DIFF
--- a/packages/pyright-internal/src/analyzer/constructorTransform.ts
+++ b/packages/pyright-internal/src/analyzer/constructorTransform.ts
@@ -362,7 +362,7 @@ function applyPartialTransformToFunction(
                 }
             } else {
                 const paramName = matchingParam.param.name!;
-                const paramType = FunctionType.getEffectiveParamType(origFunctionType, matchingParam.index);
+                const paramType = matchingParam.type;
 
                 if (paramMap.has(paramName)) {
                     if (errorNode) {

--- a/packages/pyright-internal/src/tests/samples/partial6.py
+++ b/packages/pyright-internal/src/tests/samples/partial6.py
@@ -1,0 +1,26 @@
+# This sample tests functools.partial with an unpacked TypedDict in the
+# **kwargs annotation.
+
+from functools import partial
+from typing import TypedDict, Unpack
+
+
+class DC1(TypedDict, total=False):
+    x: str
+    y: int
+
+
+def test1(**kwargs: Unpack[DC1]) -> None:
+    ...
+
+
+test1_partial = partial(test1, x="")
+
+# This should generate an error.
+test1_partial(x=1)
+
+# This should generate an error.
+test1_partial(y="")
+
+test1_partial(x="")
+test1_partial(y=1)

--- a/packages/pyright-internal/src/tests/typeEvaluator8.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator8.test.ts
@@ -749,6 +749,12 @@ test('Partial5', () => {
     TestUtils.validateResults(analysisResults, 3);
 });
 
+test('Partial6', () => {
+    const analysisResults = TestUtils.typeAnalyzeSampleFiles(['partial6.py']);
+
+    TestUtils.validateResults(analysisResults, 2);
+});
+
 test('TotalOrdering1', () => {
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['totalOrdering1.py']);
 


### PR DESCRIPTION
…handling of an unpacked TypedDict when used with a `**kwargs` parameter. This addresses #8617.