### PR TITLE
Did a cleanup pass on the code that accesses the param types. Some co…

### DIFF
--- a/packages/pyright-internal/src/analyzer/constructorTransform.ts
+++ b/packages/pyright-internal/src/analyzer/constructorTransform.ts
@@ -236,7 +236,7 @@ function applyPartialTransformToFunction(
                 paramListDetails.params[argIndex].kind === ParamKind.Keyword
             ) {
                 if (paramListDetails.argsIndex !== undefined) {
-                    const paramType = FunctionType.getEffectiveParamType(
+                    const paramType = FunctionType.getParamType(
                         origFunctionType,
                         paramListDetails.params[paramListDetails.argsIndex].index
                     );
@@ -284,7 +284,7 @@ function applyPartialTransformToFunction(
                     argumentErrors = true;
                 }
             } else {
-                const paramType = FunctionType.getEffectiveParamType(origFunctionType, argIndex);
+                const paramType = FunctionType.getParamType(origFunctionType, argIndex);
                 const diag = new DiagnosticAddendum();
                 const paramName = paramListDetails.params[argIndex].param.name ?? '';
 
@@ -331,7 +331,7 @@ function applyPartialTransformToFunction(
                     }
                     argumentErrors = true;
                 } else {
-                    const paramType = FunctionType.getEffectiveParamType(
+                    const paramType = FunctionType.getParamType(
                         origFunctionType,
                         paramListDetails.params[paramListDetails.kwargsIndex].index
                     );
@@ -413,15 +413,15 @@ function applyPartialTransformToFunction(
     // Create a new parameter list that omits parameters that have been
     // populated already.
     const updatedParamList: FunctionParam[] = specializedFunctionType.shared.parameters.map((param, index) => {
-        const specializedParam: FunctionParam = { ...param };
-        specializedParam.type = FunctionType.getEffectiveParamType(specializedFunctionType, index);
+        const newType = FunctionType.getParamType(specializedFunctionType, index);
 
         // If it's a keyword parameter that has been assigned a value through
         // the "partial" mechanism, mark it has having a default value.
+        let newDefaultType = FunctionType.getParamDefaultType(specializedFunctionType, index);
         if (param.name && paramMap.get(param.name)) {
-            specializedParam.defaultType = AnyType.create(/* isEllipsis */ true);
+            newDefaultType = AnyType.create(/* isEllipsis */ true);
         }
-        return specializedParam;
+        return FunctionParam.create(param.category, newType, param.flags, param.name, newDefaultType);
     });
     const unassignedParamList = updatedParamList.filter((param) => {
         if (param.category === ParamCategory.KwargsDict) {

--- a/packages/pyright-internal/src/analyzer/constructors.ts
+++ b/packages/pyright-internal/src/analyzer/constructors.ts
@@ -824,7 +824,7 @@ function createFunctionFromNewMethod(
                 return false;
             }
 
-            const paramType = FunctionType.getEffectiveParamType(newSubtype, index);
+            const paramType = FunctionType.getParamType(newSubtype, index);
             const typeVars = getTypeVarArgsRecursive(paramType);
             return typeVars.some((typeVar) => typeVar.priv.scopeId === getTypeVarScopeId(classType));
         });
@@ -953,7 +953,7 @@ function createFunctionFromInitMethod(
                 const typeVarsInParams: TypeVarType[] = [];
 
                 convertedInit.shared.parameters.forEach((param, index) => {
-                    const paramType = FunctionType.getEffectiveParamType(convertedInit, index);
+                    const paramType = FunctionType.getParamType(convertedInit, index);
                     addTypeVarsToListIfUnique(typeVarsInParams, getTypeVarArgsRecursive(paramType));
                 });
 

--- a/packages/pyright-internal/src/analyzer/functionTransform.ts
+++ b/packages/pyright-internal/src/analyzer/functionTransform.ts
@@ -91,7 +91,7 @@ function applyTotalOrderingTransform(
         firstMemberType.shared.parameters.length >= 2 &&
         FunctionParam.isTypeDeclared(firstMemberType.shared.parameters[1])
     ) {
-        operandType = firstMemberType.shared.parameters[1].type;
+        operandType = FunctionType.getParamType(firstMemberType, 1);
     }
 
     // If there was no provided operand type, fall back to object.

--- a/packages/pyright-internal/src/analyzer/properties.ts
+++ b/packages/pyright-internal/src/analyzer/properties.ts
@@ -314,7 +314,7 @@ function addGetMethodToPropertySymbolTable(evaluator: TypeEvaluator, propertyObj
         FunctionParam.create(ParamCategory.Simple, AnyType.create(), FunctionParamFlags.TypeDeclared, 'self')
     );
 
-    const objType = fget.shared.parameters.length > 0 ? FunctionType.getEffectiveParamType(fget, 0) : AnyType.create();
+    const objType = fget.shared.parameters.length > 0 ? FunctionType.getParamType(fget, 0) : AnyType.create();
 
     FunctionType.addParam(
         getFunction2,
@@ -358,7 +358,7 @@ function addSetMethodToPropertySymbolTable(evaluator: TypeEvaluator, propertyObj
         FunctionParam.create(ParamCategory.Simple, AnyType.create(), FunctionParamFlags.TypeDeclared, 'self')
     );
 
-    let objType = fset.shared.parameters.length > 0 ? FunctionType.getEffectiveParamType(fset, 0) : AnyType.create();
+    let objType = fset.shared.parameters.length > 0 ? FunctionType.getParamType(fset, 0) : AnyType.create();
     if (isTypeVar(objType) && TypeVarType.isSelf(objType)) {
         objType = evaluator.makeTopLevelTypeVarsConcrete(objType);
     }
@@ -388,7 +388,7 @@ function addSetMethodToPropertySymbolTable(evaluator: TypeEvaluator, propertyObj
         fset.shared.parameters[1].category === ParamCategory.Simple &&
         fset.shared.parameters[1].name
     ) {
-        setParamType = fset.shared.parameters[1].type;
+        setParamType = FunctionType.getParamType(fset, 1);
     }
     FunctionType.addParam(
         setFunction,
@@ -413,7 +413,7 @@ function addDelMethodToPropertySymbolTable(evaluator: TypeEvaluator, propertyObj
     delFunction.shared.deprecatedMessage = fdel.shared.deprecatedMessage;
     delFunction.shared.methodClass = fdel.shared.methodClass;
 
-    let objType = fdel.shared.parameters.length > 0 ? FunctionType.getEffectiveParamType(fdel, 0) : AnyType.create();
+    let objType = fdel.shared.parameters.length > 0 ? FunctionType.getParamType(fdel, 0) : AnyType.create();
 
     if (isTypeVar(objType) && TypeVarType.isSelf(objType)) {
         objType = evaluator.makeTopLevelTypeVarsConcrete(objType);

--- a/packages/pyright-internal/src/analyzer/typeWalker.ts
+++ b/packages/pyright-internal/src/analyzer/typeWalker.ts
@@ -140,7 +140,7 @@ export class TypeWalker {
         for (let i = 0; i < type.shared.parameters.length; i++) {
             // Ignore parameters such as "*" that have no name.
             if (type.shared.parameters[i].name) {
-                const paramType = FunctionType.getEffectiveParamType(type, i);
+                const paramType = FunctionType.getParamType(type, i);
                 this.walk(paramType);
                 if (this._isWalkCanceled) {
                     break;

--- a/packages/pyright-internal/src/languageService/completionProvider.ts
+++ b/packages/pyright-internal/src/languageService/completionProvider.ts
@@ -2051,7 +2051,7 @@ export class CompletionProvider {
                 return undefined;
             }
 
-            const paramType = type.shared.parameters[paramIndex].type;
+            const paramType = FunctionType.getParamType(type, paramIndex);
             this._addLiteralValuesForTargetType(paramType, priorWord, priorText, postText, completionMap);
             return undefined;
         });
@@ -2144,7 +2144,7 @@ export class CompletionProvider {
                     signature.shared.parameters.length >= 1 &&
                     signature.shared.parameters[0].category === ParamCategory.Simple
                 ) {
-                    typesToCombine.push(FunctionType.getEffectiveParamType(signature, 0));
+                    typesToCombine.push(FunctionType.getParamType(signature, 0));
                 }
             });
 

--- a/packages/pyright-internal/src/tests/samples/paramSpec4.py
+++ b/packages/pyright-internal/src/tests/samples/paramSpec4.py
@@ -159,7 +159,7 @@ assert_type(y1, A[int, [int]])
 reveal_type(y1, expected_text="A[int, (q: int, /)]")
 
 
-# This should generaet an error because Concatenate is not
+# This should generate an error because Concatenate is not
 # allowed in this context.
 def func11(func: Concatenate[int, ...]) -> None:
     # This should generate an error because Concatenate is not


### PR DESCRIPTION
…de paths were not using the appropriate accessor functions, so they were ignoring specialized param types and using the unspecialized (declared) type instead.