### PR TITLE
Fixed bug that caused first argument of `cast` method on `memoryview`…

### DIFF
--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -9669,7 +9669,10 @@ export function createTypeEvaluator(
         inferenceContext: InferenceContext | undefined
     ): CallResult {
         // Handle the 'cast' call as a special case.
-        if (FunctionType.isBuiltIn(expandedCallType.priv.overloads[0], 'cast') && argList.length === 2) {
+        if (
+            FunctionType.isBuiltIn(expandedCallType.priv.overloads[0], ['typing.cast', 'typing_extensions.cast']) &&
+            argList.length === 2
+        ) {
             return { returnType: evaluateCastCall(argList, errorNode) };
         }
 
@@ -11411,7 +11414,14 @@ export function createTypeEvaluator(
 
         // Special-case a few built-in calls that are often used for
         // casting or checking for unknown types.
-        if (FunctionType.isBuiltIn(type, ['cast', 'isinstance', 'issubclass'])) {
+        if (
+            FunctionType.isBuiltIn(type, [
+                'typing.cast',
+                'typing_extensions.cast',
+                'builtins.isinstance',
+                'builtins.issubclass',
+            ])
+        ) {
             skipUnknownArgCheck = true;
         }
 

--- a/packages/pyright-internal/src/analyzer/types.ts
+++ b/packages/pyright-internal/src/analyzer/types.ts
@@ -1087,9 +1087,11 @@ export namespace ClassType {
 
         if (className !== undefined) {
             const classArray = Array.isArray(className) ? className : [className];
-            return (
-                classArray.some((name) => name === classType.shared.name) ||
-                classArray.some((name) => name === classType.priv.aliasName)
+            return classArray.some(
+                (name) =>
+                    name === classType.shared.name ||
+                    name === classType.shared.fullName ||
+                    name === classType.priv.aliasName
             );
         }
 
@@ -2179,7 +2181,7 @@ export namespace FunctionType {
 
         if (name !== undefined) {
             const functionArray = Array.isArray(name) ? name : [name];
-            return functionArray.some((name) => name === type.shared.name);
+            return functionArray.some((name) => name === type.shared.name || name === type.shared.fullName);
         }
 
         return true;


### PR DESCRIPTION
… object to be treated as a type expression. Pyright was confusing this method with `typing.cast`. This addresses #8649.