### PR TITLE
Fixed a bug that results in incorrect type narrowing when using `isin…

### DIFF
--- a/packages/pyright-internal/src/tests/samples/typeNarrowingIsinstance1.py
+++ b/packages/pyright-internal/src/tests/samples/typeNarrowingIsinstance1.py
@@ -1,7 +1,17 @@
 # This sample exercises the type analyzer's isinstance type narrowing logic.
 
 from types import NoneType
-from typing import Any, Generic, Iterable, Iterator, Protocol, Sized, TypeVar, Union, runtime_checkable
+from typing import (
+    Any,
+    Generic,
+    Iterable,
+    Iterator,
+    Protocol,
+    Sized,
+    TypeVar,
+    Union,
+    runtime_checkable,
+)
 
 S = TypeVar("S")
 T = TypeVar("T")
@@ -233,3 +243,21 @@ def func13(x: object | type[object]) -> None:
 def func14(x: Iterable[T]):
     if isinstance(x, Iterator):
         reveal_type(x, expected_text="Iterator[T@func14]")
+
+
+class Base15(Generic[T]):
+    value: T
+
+
+class Child15(Base15[int]):
+    value: int
+
+
+def func15(x: Base15[T]):
+    if isinstance(x, Child15):
+        # This should generate an error. It's here just to ensure that
+        # this code branch isn't marked unreachable.
+        reveal_type(x, expected_text="Never")
+
+        reveal_type(x, expected_text="Child15")
+        reveal_type(x.value, expected_text="int")

--- a/packages/pyright-internal/src/tests/typeEvaluator1.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator1.test.ts
@@ -288,12 +288,6 @@ test('TypeNarrowing7', () => {
     TestUtils.validateResults(analysisResults, 0);
 });
 
-test('TypeNarrowingIsinstance1', () => {
-    const analysisResults = TestUtils.typeAnalyzeSampleFiles(['typeNarrowingIsinstance1.py']);
-
-    TestUtils.validateResults(analysisResults, 8);
-});
-
 test('TypeNarrowingAssert1', () => {
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['typeNarrowingAssert1.py']);
 
@@ -370,6 +364,12 @@ test('TypeNarrowingEnum2', () => {
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['typeNarrowingEnum2.py']);
 
     TestUtils.validateResults(analysisResults, 2);
+});
+
+test('TypeNarrowingIsinstance1', () => {
+    const analysisResults = TestUtils.typeAnalyzeSampleFiles(['typeNarrowingIsinstance1.py']);
+
+    TestUtils.validateResults(analysisResults, 9);
 });
 
 test('TypeNarrowingIsinstance2', () => {


### PR DESCRIPTION
…stance` with an instance of a generic class as the first argument and a concrete subclass as the filter type. This addresses #8672.