### PR TITLE
Allow `Final` and `ClassVar` to be combined in both directions within…

### DIFF
--- a/packages/pyright-internal/src/tests/samples/dataclass17.py
+++ b/packages/pyright-internal/src/tests/samples/dataclass17.py
@@ -11,6 +11,7 @@ class A:
     b: Final[str] = ""
     c: ClassVar[Final[int]] = 0
     d: ClassVar[Final] = 0
+    e: Final[ClassVar[int]] = 0
 
 
 a = A(1)
@@ -29,3 +30,6 @@ A.c = 0
 
 # This should generate an error.
 A.d = 0
+
+# This should generate an error.
+A.e = 0

--- a/packages/pyright-internal/src/tests/typeEvaluator4.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator4.test.ts
@@ -363,7 +363,7 @@ test('DataClass16', () => {
 test('DataClass17', () => {
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['dataclass17.py']);
 
-    TestUtils.validateResults(analysisResults, 5);
+    TestUtils.validateResults(analysisResults, 6);
 });
 
 test('DataClassReplace1', () => {


### PR DESCRIPTION
… a dataclass. Previously, the `Final` qualifier needed to be the outermost. This addresses #8676.