### PR TITLE
Modified OverloadedFunctionType interface in preparation for a follow…

### DIFF
--- a/packages/pyright-internal/src/analyzer/constructorTransform.ts
+++ b/packages/pyright-internal/src/analyzer/constructorTransform.ts
@@ -139,10 +139,11 @@ function applyPartialTransform(
 
     if (isOverloadedFunction(origFunctionType)) {
         const applicableOverloads: FunctionType[] = [];
+        const overloads = OverloadedFunctionType.getOverloads(origFunctionType);
         let sawArgErrors = false;
 
         // Apply the partial transform to each of the functions in the overload.
-        OverloadedFunctionType.getOverloads(origFunctionType).forEach((overload) => {
+        overloads.forEach((overload) => {
             // Apply the transform to this overload, but don't report errors.
             const transformResult = applyPartialTransformToFunction(
                 evaluator,
@@ -162,11 +163,11 @@ function applyPartialTransform(
         });
 
         if (applicableOverloads.length === 0) {
-            if (sawArgErrors) {
+            if (sawArgErrors && overloads.length > 0) {
                 evaluator.addDiagnostic(
                     DiagnosticRule.reportCallIssue,
                     LocMessage.noOverload().format({
-                        name: origFunctionType.priv.overloads[0].shared.name,
+                        name: overloads[0].shared.name,
                     }),
                     errorNode
                 );

--- a/packages/pyright-internal/src/analyzer/constructors.ts
+++ b/packages/pyright-internal/src/analyzer/constructors.ts
@@ -855,7 +855,7 @@ function createFunctionFromNewMethod(
     }
 
     const newOverloads: FunctionType[] = [];
-    newType.priv.overloads.forEach((overload) => {
+    OverloadedFunctionType.getOverloads(newType).forEach((overload) => {
         const converted = convertNewToConstructor(overload);
         if (converted) {
             newOverloads.push(converted);
@@ -985,7 +985,7 @@ function createFunctionFromInitMethod(
     }
 
     const initOverloads: FunctionType[] = [];
-    initType.priv.overloads.forEach((overload) => {
+    OverloadedFunctionType.getOverloads(initType).forEach((overload) => {
         const converted = convertInitToConstructor(overload);
         if (converted) {
             initOverloads.push(converted);

--- a/packages/pyright-internal/src/analyzer/decorators.ts
+++ b/packages/pyright-internal/src/analyzer/decorators.ts
@@ -509,7 +509,10 @@ export function addOverloadsToFunctionType(evaluator: TypeEvaluator, node: Funct
                     } else if (isOverloadedFunction(prevDeclDeclTypeInfo.decoratedType)) {
                         // If the previous declaration was itself an overloaded function,
                         // copy the entries from it.
-                        appendArray(overloadedTypes, prevDeclDeclTypeInfo.decoratedType.priv.overloads);
+                        appendArray(
+                            overloadedTypes,
+                            OverloadedFunctionType.getOverloads(prevDeclDeclTypeInfo.decoratedType)
+                        );
                     }
                 }
             }

--- a/packages/pyright-internal/src/analyzer/packageTypeVerifier.ts
+++ b/packages/pyright-internal/src/analyzer/packageTypeVerifier.ts
@@ -49,6 +49,7 @@ import {
     isTypeSame,
     isUnknown,
     ModuleType,
+    OverloadedFunctionType,
     Type,
     TypeBase,
     TypeCategory,
@@ -832,7 +833,7 @@ export class PackageTypeVerifier {
             }
 
             case TypeCategory.OverloadedFunction: {
-                for (const overload of type.priv.overloads) {
+                for (const overload of OverloadedFunctionType.getOverloads(type)) {
                     knownStatus = this._updateKnownStatusIfWorse(
                         knownStatus,
                         this._getSymbolTypeKnownStatus(
@@ -1346,7 +1347,7 @@ export class PackageTypeVerifier {
             }
 
             case TypeCategory.OverloadedFunction: {
-                for (const overload of type.priv.overloads) {
+                for (const overload of OverloadedFunctionType.getOverloads(type)) {
                     knownStatus = this._updateKnownStatusIfWorse(
                         knownStatus,
                         this._getTypeKnownStatus(report, overload, publicSymbols, diag.createAddendum())

--- a/packages/pyright-internal/src/analyzer/sourceMapper.ts
+++ b/packages/pyright-internal/src/analyzer/sourceMapper.ts
@@ -21,15 +21,15 @@ import {
     ClassDeclaration,
     Declaration,
     FunctionDeclaration,
-    ParamDeclaration,
-    SpecialBuiltInClassDeclaration,
-    VariableDeclaration,
     isAliasDeclaration,
     isClassDeclaration,
     isFunctionDeclaration,
     isParamDeclaration,
     isSpecialBuiltInClassDeclaration,
     isVariableDeclaration,
+    ParamDeclaration,
+    SpecialBuiltInClassDeclaration,
+    VariableDeclaration,
 } from './declaration';
 import { ImportResolver } from './importResolver';
 import { SourceFile } from './sourceFile';
@@ -38,7 +38,7 @@ import { isUserCode } from './sourceFileInfoUtils';
 import { buildImportTree } from './sourceMapperUtils';
 import { TypeEvaluator } from './typeEvaluatorTypes';
 import { lookUpClassMember } from './typeUtils';
-import { ClassType, isFunction, isInstantiableClass, isOverloadedFunction } from './types';
+import { ClassType, isFunction, isInstantiableClass, isOverloadedFunction, OverloadedFunctionType } from './types';
 
 type ClassOrFunctionOrVariableDeclaration =
     | ClassDeclaration
@@ -521,7 +521,8 @@ export class SourceMapper {
             if (isFunction(type) && type.shared.declaration) {
                 this._addClassOrFunctionDeclarations(type.shared.declaration, result, recursiveDeclCache);
             } else if (isOverloadedFunction(type)) {
-                for (const overloadDecl of type.priv.overloads.map((o) => o.shared.declaration).filter(isDefined)) {
+                const overloads = OverloadedFunctionType.getOverloads(type);
+                for (const overloadDecl of overloads.map((o) => o.shared.declaration).filter(isDefined)) {
                     this._addClassOrFunctionDeclarations(overloadDecl, result, recursiveDeclCache);
                 }
             } else if (isInstantiableClass(type)) {

--- a/packages/pyright-internal/src/analyzer/tracePrinter.ts
+++ b/packages/pyright-internal/src/analyzer/tracePrinter.ts
@@ -17,7 +17,7 @@ import * as AnalyzerNodeInfo from './analyzerNodeInfo';
 import { Declaration, DeclarationType } from './declaration';
 import * as ParseTreeUtils from './parseTreeUtils';
 import { Symbol } from './symbol';
-import { Type, TypeBase, TypeCategory } from './types';
+import { OverloadedFunctionType, Type, TypeBase, TypeCategory } from './types';
 
 export type PrintableType = ParseNode | Declaration | Symbol | Type | undefined;
 
@@ -78,7 +78,9 @@ export function createTracePrinter(roots: Uri[]): TracePrinter {
                     return `Never ${wrap(type.props?.typeAliasInfo?.fullName)}`;
 
                 case TypeCategory.OverloadedFunction:
-                    return `OverloadedFunction [${type.priv.overloads.map((o) => wrap(printType(o), '"')).join(',')}]`;
+                    return `OverloadedFunction [${OverloadedFunctionType.getOverloads(type)
+                        .map((o) => wrap(printType(o), '"'))
+                        .join(',')}]`;
 
                 case TypeCategory.TypeVar:
                     return `TypeVar '${type.shared.name}' ${wrap(type.props?.typeAliasInfo?.fullName)}`;

--- a/packages/pyright-internal/src/analyzer/typePrinter.ts
+++ b/packages/pyright-internal/src/analyzer/typePrinter.ts
@@ -1394,7 +1394,7 @@ class UniqueNameMap {
                 }
 
                 case TypeCategory.OverloadedFunction: {
-                    type.priv.overloads.forEach((overload) => {
+                    OverloadedFunctionType.getOverloads(type).forEach((overload) => {
                         this.build(overload, recursionTypes, recursionCount);
                     });
                     break;

--- a/packages/pyright-internal/src/analyzer/typeWalker.ts
+++ b/packages/pyright-internal/src/analyzer/typeWalker.ts
@@ -157,11 +157,17 @@ export class TypeWalker {
     }
 
     visitOverloadedFunction(type: OverloadedFunctionType): void {
-        for (const overload of type.priv.overloads) {
+        const overloads = OverloadedFunctionType.getOverloads(type);
+        for (const overload of overloads) {
             this.walk(overload);
             if (this._isWalkCanceled) {
                 break;
             }
+        }
+
+        const impl = OverloadedFunctionType.getImplementation(type);
+        if (impl) {
+            this.walk(impl);
         }
     }
 

--- a/packages/pyright-internal/src/analyzer/types.ts
+++ b/packages/pyright-internal/src/analyzer/types.ts
@@ -2252,7 +2252,8 @@ export namespace FunctionType {
 }
 
 export interface OverloadedFunctionDetailsPriv {
-    overloads: FunctionType[];
+    // eslint-disable-next-line @typescript-eslint/naming-convention
+    _overloads: FunctionType[];
 }
 
 export interface OverloadedFunctionType extends TypeBase<TypeCategory.OverloadedFunction> {
@@ -2268,7 +2269,7 @@ export namespace OverloadedFunctionType {
             cached: undefined,
             shared: undefined,
             priv: {
-                overloads: [],
+                _overloads: [],
             },
         };
 
@@ -2282,15 +2283,15 @@ export namespace OverloadedFunctionType {
     // Adds a new overload or an implementation.
     export function addOverload(type: OverloadedFunctionType, functionType: FunctionType) {
         functionType.priv.overloaded = type;
-        type.priv.overloads.push(functionType);
+        type.priv._overloads.push(functionType);
     }
 
     export function getOverloads(type: OverloadedFunctionType): FunctionType[] {
-        return type.priv.overloads.filter((func) => FunctionType.isOverloaded(func));
+        return type.priv._overloads.filter((func) => FunctionType.isOverloaded(func));
     }
 
     export function getImplementation(type: OverloadedFunctionType): FunctionType | undefined {
-        return type.priv.overloads.find((func) => !FunctionType.isOverloaded(func));
+        return type.priv._overloads.find((func) => !FunctionType.isOverloaded(func));
     }
 }
 
@@ -3342,14 +3343,14 @@ export function isTypeSame(type1: Type, type2: Type, options: TypeSameOptions = 
         case TypeCategory.OverloadedFunction: {
             // Make sure the overload counts match.
             const functionType2 = type2 as OverloadedFunctionType;
-            if (type1.priv.overloads.length !== functionType2.priv.overloads.length) {
+            if (type1.priv._overloads.length !== functionType2.priv._overloads.length) {
                 return false;
             }
 
             // We assume here that overloaded functions always appear
             // in the same order from one analysis pass to another.
-            for (let i = 0; i < type1.priv.overloads.length; i++) {
-                if (!isTypeSame(type1.priv.overloads[i], functionType2.priv.overloads[i], options, recursionCount)) {
+            for (let i = 0; i < type1.priv._overloads.length; i++) {
+                if (!isTypeSame(type1.priv._overloads[i], functionType2.priv._overloads[i], options, recursionCount)) {
                     return false;
                 }
             }

--- a/packages/pyright-internal/src/languageService/definitionProvider.ts
+++ b/packages/pyright-internal/src/languageService/definitionProvider.ts
@@ -23,7 +23,7 @@ import * as ParseTreeUtils from '../analyzer/parseTreeUtils';
 import { SourceMapper, isStubFile } from '../analyzer/sourceMapper';
 import { TypeEvaluator } from '../analyzer/typeEvaluatorTypes';
 import { doForEachSubtype } from '../analyzer/typeUtils';
-import { TypeCategory, isOverloadedFunction } from '../analyzer/types';
+import { OverloadedFunctionType, TypeCategory, isOverloadedFunction } from '../analyzer/types';
 import { throwIfCancellationRequested } from '../common/cancellationUtils';
 import { appendArray } from '../common/collectionUtils';
 import { isDefined } from '../common/core';
@@ -89,7 +89,7 @@ export function addDeclarationsToDefinitions(
             // Handle overloaded function case
             const functionType = evaluator.getTypeForDeclaration(resolvedDecl)?.type;
             if (functionType && isOverloadedFunction(functionType)) {
-                for (const overloadDecl of functionType.priv.overloads
+                for (const overloadDecl of OverloadedFunctionType.getOverloads(functionType)
                     .map((o) => o.shared.declaration)
                     .filter(isDefined)) {
                     _addIfUnique(definitions, {

--- a/packages/pyright-internal/src/languageService/tooltipUtils.ts
+++ b/packages/pyright-internal/src/languageService/tooltipUtils.ts
@@ -145,7 +145,7 @@ export function getConstructorTooltip(
     let signature = '';
 
     if (isOverloadedFunction(type)) {
-        const overloads = type.priv.overloads.map((overload) =>
+        const overloads = OverloadedFunctionType.getOverloads(type).map((overload) =>
             getConstructorTooltip(constructorName, overload, evaluator, functionSignatureDisplay)
         );
         overloads.forEach((overload, index) => {
@@ -189,17 +189,18 @@ export function getOverloadedFunctionDocStringsFromType(
     sourceMapper: SourceMapper,
     evaluator: TypeEvaluator
 ) {
-    if (type.priv.overloads.length === 0) {
+    const overloads = OverloadedFunctionType.getOverloads(type);
+    if (overloads.length === 0) {
         return [];
     }
 
-    const decl = type.priv.overloads[0].shared.declaration;
+    const decl = overloads[0].shared.declaration;
     const enclosingClass = decl ? ParseTreeUtils.getEnclosingClass(decl.node) : undefined;
     const classResults = enclosingClass ? evaluator.getTypeOfClass(enclosingClass) : undefined;
 
     return getOverloadedFunctionDocStringsInherited(
         type,
-        type.priv.overloads.map((o) => o.shared.declaration).filter(isDefined),
+        overloads.map((o) => o.shared.declaration).filter(isDefined),
         sourceMapper,
         evaluator,
 


### PR DESCRIPTION
…-on change. Users of OverloadedFunctionType must now use the accessor functions to get the overloads and implementation.