### PR TITLE
Fixed bug that results in a false positive error when type argument f…

### DIFF
--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -14993,7 +14993,7 @@ export function createTypeEvaluator(
             if (!type) {
                 const exprType = getTypeOfExpression(
                     itemExpr,
-                    (flags & EvalFlags.ForwardRefs) | EvalFlags.NoConvertSpecialForm | EvalFlags.TypeExpression
+                    (flags & (EvalFlags.ForwardRefs | EvalFlags.TypeExpression)) | EvalFlags.NoConvertSpecialForm
                 );
 
                 // Is this an enum type?
@@ -15022,8 +15022,12 @@ export function createTypeEvaluator(
             }
 
             if (!type) {
-                addDiagnostic(DiagnosticRule.reportInvalidTypeForm, LocMessage.literalUnsupportedType(), item);
-                type = UnknownType.create();
+                if ((flags & EvalFlags.TypeExpression) !== 0) {
+                    addDiagnostic(DiagnosticRule.reportInvalidTypeForm, LocMessage.literalUnsupportedType(), item);
+                    type = UnknownType.create();
+                } else {
+                    return ClassType.cloneAsInstance(classType);
+                }
             }
 
             literalTypes.push(type);

--- a/packages/pyright-internal/src/tests/samples/literals1.py
+++ b/packages/pyright-internal/src/tests/samples/literals1.py
@@ -60,3 +60,8 @@ reveal_type(bytes4, expected_text='Literal[b"\'"]')
 
 x = [Literal[1], Literal[2]]
 reveal_type(x, expected_text="list[type[Literal]]")
+
+
+values = ("a", "b", "c")
+t1 = Literal[values]
+reveal_type(t1, expected_text="Literal")

--- a/packages/pyright-internal/src/tests/samples/literals6.py
+++ b/packages/pyright-internal/src/tests/samples/literals6.py
@@ -4,38 +4,27 @@ from enum import Enum
 from pathlib import Path
 from typing import Any, Literal, TypeVar
 
-# This should generate two errors.
 Wrong1 = Literal[3 + 4]
 
-# This should generate two errors.
 Wrong2 = Literal["foo".replace("o", "b")]
 
-# This should generate two errors.
 Wrong3 = Literal[4 + 3j]
 
-# This should generate three errors.
 Wrong4 = Literal[-4 + 2j]
 
-# This should generate an error.
 Wrong5 = Literal[(1, "foo", "bar")]
 
-# This should generate an error.
 Wrong6 = Literal[{"a": "b", "c": "d"}]
 
-# This should generate two errors.
 Wrong7 = Literal[Path("abcd")]
 T = TypeVar("T")
 
-# This should generate an error.
 Wrong8 = Literal[T]
 
-# This should generate an error.
 Wrong9 = Literal[3.14]
 
-# This should generate an error.
 Wrong10 = Literal[Any]
 
-# This should generate an error.
 Wrong11 = Literal[...]
 
 
@@ -43,11 +32,9 @@ def func():
     ...
 
 
-# This should generate an error.
 Wrong12 = Literal[func]
 some_variable = "foo"
 
-# This should generate two errors.
 Wrong13 = Literal[some_variable]
 
 

--- a/packages/pyright-internal/src/tests/typeEvaluator3.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator3.test.ts
@@ -578,7 +578,7 @@ test('Literals5', () => {
 test('Literals6', () => {
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['literals6.py']);
 
-    TestUtils.validateResults(analysisResults, 45);
+    TestUtils.validateResults(analysisResults, 25);
 });
 
 test('Literals7', () => {


### PR DESCRIPTION
…or `Literal` doesn't follow type expression rules within a value expression context. This addresses 8696.