### PR TITLE
Renamed OverloadedFunctionType to OverloadedType for brevity and to r…

### DIFF
--- a/packages/pyright-internal/src/analyzer/codeFlowEngine.ts
+++ b/packages/pyright-internal/src/analyzer/codeFlowEngine.ts
@@ -52,14 +52,14 @@ import {
     isFunction,
     isInstantiableClass,
     isNever,
-    isOverloadedFunction,
+    isOverloaded,
     isParamSpec,
     isTypeSame,
     isTypeVar,
     isTypeVarTuple,
     maxTypeRecursionCount,
     NeverType,
-    OverloadedFunctionType,
+    OverloadedType,
     Type,
     TypeVarType,
     UnboundType,
@@ -1726,7 +1726,7 @@ export function getCodeFlowEngine(
 
                     const newMethodResult = getBoundNewMethod(evaluator, node, callSubtype);
                     if (newMethodResult) {
-                        if (isFunction(newMethodResult.type) || isOverloadedFunction(newMethodResult.type)) {
+                        if (isFunction(newMethodResult.type) || isOverloaded(newMethodResult.type)) {
                             callSubtype = newMethodResult.type;
                         }
                     }
@@ -1743,11 +1743,11 @@ export function getCodeFlowEngine(
                     if (isFunctionNoReturn(callSubtype, isCallAwaited)) {
                         noReturnTypeCount++;
                     }
-                } else if (isOverloadedFunction(callSubtype)) {
+                } else if (isOverloaded(callSubtype)) {
                     let overloadCount = 0;
                     let noReturnOverloadCount = 0;
 
-                    OverloadedFunctionType.getOverloads(callSubtype).forEach((overload) => {
+                    OverloadedType.getOverloads(callSubtype).forEach((overload) => {
                         overloadCount++;
 
                         if (isFunctionNoReturn(overload, isCallAwaited)) {

--- a/packages/pyright-internal/src/analyzer/constructorTransform.ts
+++ b/packages/pyright-internal/src/analyzer/constructorTransform.ts
@@ -29,10 +29,10 @@ import {
     isClassInstance,
     isFunction,
     isInstantiableClass,
-    isOverloadedFunction,
+    isOverloaded,
     isTypeSame,
     isTypeVar,
-    OverloadedFunctionType,
+    OverloadedType,
     Type,
 } from './types';
 import { convertToInstance, lookUpObjectMember, makeInferenceContext, MemberAccessFlags } from './typeUtils';
@@ -137,9 +137,9 @@ function applyPartialTransform(
         };
     }
 
-    if (isOverloadedFunction(origFunctionType)) {
+    if (isOverloaded(origFunctionType)) {
         const applicableOverloads: FunctionType[] = [];
-        const overloads = OverloadedFunctionType.getOverloads(origFunctionType);
+        const overloads = OverloadedType.getOverloads(origFunctionType);
         let sawArgErrors = false;
 
         // Apply the partial transform to each of the functions in the overload.
@@ -183,7 +183,7 @@ function applyPartialTransform(
         if (applicableOverloads.length === 1) {
             synthesizedCallType = applicableOverloads[0];
         } else {
-            synthesizedCallType = OverloadedFunctionType.create(
+            synthesizedCallType = OverloadedType.create(
                 // Set the "overloaded" flag for each of the __call__ overloads.
                 applicableOverloads.map((overload) =>
                     FunctionType.cloneWithNewFlags(overload, overload.shared.flags | FunctionTypeFlags.Overloaded)

--- a/packages/pyright-internal/src/analyzer/decorators.ts
+++ b/packages/pyright-internal/src/analyzer/decorators.ts
@@ -33,7 +33,7 @@ import {
     FunctionParam,
     FunctionType,
     FunctionTypeFlags,
-    OverloadedFunctionType,
+    OverloadedType,
     Type,
     TypeBase,
     UnknownType,
@@ -41,7 +41,7 @@ import {
     isClassInstance,
     isFunction,
     isInstantiableClass,
-    isOverloadedFunction,
+    isOverloaded,
 } from './types';
 
 export interface FunctionDecoratorInfo {
@@ -315,7 +315,7 @@ export function applyClassDecorator(
         }
     }
 
-    if (isOverloadedFunction(decoratorType)) {
+    if (isOverloaded(decoratorType)) {
         const dataclassBehaviors = getDataclassDecoratorBehaviors(decoratorType);
         if (dataclassBehaviors) {
             applyDataClassDecorator(
@@ -468,7 +468,7 @@ function getTypeOfDecorator(evaluator: TypeEvaluator, node: DecoratorNode, funct
 
 // Given a function node and the function type associated with it, this
 // method searches for prior function nodes that are marked as @overload
-// and creates an OverloadedFunctionType that includes this function and
+// and creates an OverloadedType that includes this function and
 // all previous ones.
 export function addOverloadsToFunctionType(evaluator: TypeEvaluator, node: FunctionNode, type: Type): Type {
     let functionDecl: FunctionDeclaration | undefined;
@@ -506,8 +506,8 @@ export function addOverloadsToFunctionType(evaluator: TypeEvaluator, node: Funct
                         if (FunctionType.isOverloaded(prevDeclDeclTypeInfo.decoratedType)) {
                             overloadedTypes.push(prevDeclDeclTypeInfo.decoratedType);
                         }
-                    } else if (isOverloadedFunction(prevDeclDeclTypeInfo.decoratedType)) {
-                        implementation = OverloadedFunctionType.getImplementation(prevDeclDeclTypeInfo.decoratedType);
+                    } else if (isOverloaded(prevDeclDeclTypeInfo.decoratedType)) {
+                        implementation = OverloadedType.getImplementation(prevDeclDeclTypeInfo.decoratedType);
                         // If the previous overloaded function already had an implementation,
                         // this new function completely replaces the previous one.
                         if (implementation) {
@@ -516,10 +516,7 @@ export function addOverloadsToFunctionType(evaluator: TypeEvaluator, node: Funct
 
                         // If the previous declaration was itself an overloaded function,
                         // copy the entries from it.
-                        appendArray(
-                            overloadedTypes,
-                            OverloadedFunctionType.getOverloads(prevDeclDeclTypeInfo.decoratedType)
-                        );
+                        appendArray(overloadedTypes, OverloadedType.getOverloads(prevDeclDeclTypeInfo.decoratedType));
                     }
                 }
             }
@@ -563,7 +560,7 @@ export function addOverloadsToFunctionType(evaluator: TypeEvaluator, node: Funct
                 });
             }
 
-            return OverloadedFunctionType.create(overloadedTypes, implementation);
+            return OverloadedType.create(overloadedTypes, implementation);
         }
     }
 

--- a/packages/pyright-internal/src/analyzer/enums.ts
+++ b/packages/pyright-internal/src/analyzer/enums.ts
@@ -33,7 +33,7 @@ import {
     isClassInstance,
     isFunction,
     isInstantiableClass,
-    isOverloadedFunction,
+    isOverloaded,
     maxTypeRecursionCount,
 } from './types';
 
@@ -444,7 +444,7 @@ export function transformTypeForEnumMember(
 
     // The enum spec doesn't explicitly specify this, but it
     // appears that callables are excluded.
-    if (!findSubtype(valueType, (subtype) => !isFunction(subtype) && !isOverloadedFunction(subtype))) {
+    if (!findSubtype(valueType, (subtype) => !isFunction(subtype) && !isOverloaded(subtype))) {
         return undefined;
     }
 

--- a/packages/pyright-internal/src/analyzer/functionTransform.ts
+++ b/packages/pyright-internal/src/analyzer/functionTransform.ts
@@ -21,7 +21,7 @@ import {
     isClassInstance,
     isFunction,
     isInstantiableClass,
-    OverloadedFunctionType,
+    OverloadedType,
     Type,
 } from './types';
 import { ClassMember, lookUpObjectMember, MemberAccessFlags, synthesizeTypeVarForSelfCls } from './typeUtils';
@@ -30,7 +30,7 @@ export function applyFunctionTransform(
     evaluator: TypeEvaluator,
     errorNode: ExpressionNode,
     argList: Arg[],
-    functionType: FunctionType | OverloadedFunctionType,
+    functionType: FunctionType | OverloadedType,
     result: FunctionResult
 ): FunctionResult {
     if (isFunction(functionType)) {

--- a/packages/pyright-internal/src/analyzer/operations.ts
+++ b/packages/pyright-internal/src/analyzer/operations.ts
@@ -59,7 +59,7 @@ import {
     isFunction,
     isInstantiableClass,
     isNever,
-    isOverloadedFunction,
+    isOverloaded,
     isUnion,
 } from './types';
 
@@ -1241,7 +1241,7 @@ function customMetaclassSupportsMethod(type: Type, methodName: string): boolean 
 // of the capabilities of an object. This function converts a function
 // to an object instance.
 function convertFunctionToObject(evaluator: TypeEvaluator, type: Type) {
-    if (isFunction(type) || isOverloadedFunction(type)) {
+    if (isFunction(type) || isOverloaded(type)) {
         return evaluator.getObjectType();
     }
 

--- a/packages/pyright-internal/src/analyzer/packageTypeVerifier.ts
+++ b/packages/pyright-internal/src/analyzer/packageTypeVerifier.ts
@@ -49,7 +49,7 @@ import {
     isTypeSame,
     isUnknown,
     ModuleType,
-    OverloadedFunctionType,
+    OverloadedType,
     Type,
     TypeBase,
     TypeCategory,
@@ -832,8 +832,8 @@ export class PackageTypeVerifier {
                 break;
             }
 
-            case TypeCategory.OverloadedFunction: {
-                for (const overload of OverloadedFunctionType.getOverloads(type)) {
+            case TypeCategory.Overloaded: {
+                for (const overload of OverloadedType.getOverloads(type)) {
                     knownStatus = this._updateKnownStatusIfWorse(
                         knownStatus,
                         this._getSymbolTypeKnownStatus(
@@ -1346,8 +1346,8 @@ export class PackageTypeVerifier {
                 break;
             }
 
-            case TypeCategory.OverloadedFunction: {
-                for (const overload of OverloadedFunctionType.getOverloads(type)) {
+            case TypeCategory.Overloaded: {
+                for (const overload of OverloadedType.getOverloads(type)) {
                     knownStatus = this._updateKnownStatusIfWorse(
                         knownStatus,
                         this._getTypeKnownStatus(report, overload, publicSymbols, diag.createAddendum())
@@ -1425,7 +1425,7 @@ export class PackageTypeVerifier {
 
         switch (type.category) {
             case TypeCategory.Function:
-            case TypeCategory.OverloadedFunction: {
+            case TypeCategory.Overloaded: {
                 const funcDecl = symbol
                     .getDeclarations()
                     .find((decl) => decl.type === DeclarationType.Function) as FunctionDeclaration;

--- a/packages/pyright-internal/src/analyzer/properties.ts
+++ b/packages/pyright-internal/src/analyzer/properties.ts
@@ -33,7 +33,7 @@ import {
     isTypeSame,
     isTypeVar,
     ModuleType,
-    OverloadedFunctionType,
+    OverloadedType,
     Type,
     TypeVarType,
     UnknownType,
@@ -344,7 +344,7 @@ function addGetMethodToPropertySymbolTable(evaluator: TypeEvaluator, propertyObj
     // problems specifically for the `NoneType` class because None.__class__
     // is a property, and both overloads match in this case because None
     // is passed for the "obj" parameter.
-    const getFunctionOverload = OverloadedFunctionType.create([getFunction2, getFunction1]);
+    const getFunctionOverload = OverloadedType.create([getFunction2, getFunction1]);
     const getSymbol = Symbol.createWithType(SymbolFlags.ClassMember, getFunctionOverload);
     fields.set('__get__', getSymbol);
 }

--- a/packages/pyright-internal/src/analyzer/protocols.ts
+++ b/packages/pyright-internal/src/analyzer/protocols.ts
@@ -26,10 +26,10 @@ import {
     isClassInstance,
     isFunction,
     isInstantiableClass,
-    isOverloadedFunction,
+    isOverloaded,
     isTypeSame,
     ModuleType,
-    OverloadedFunctionType,
+    OverloadedType,
     Type,
     TypeBase,
     TypeVarType,
@@ -448,7 +448,7 @@ function assignClassToProtocolInternal(
                 }
 
                 // If the source is a method, bind it.
-                if (isFunction(srcMemberType) || isOverloadedFunction(srcMemberType)) {
+                if (isFunction(srcMemberType) || isOverloaded(srcMemberType)) {
                     if (isMemberFromMetaclass || isInstantiableClass(srcMemberInfo.classType)) {
                         let isInstanceMember = !srcMemberInfo.symbol.isClassMember();
 
@@ -508,8 +508,8 @@ function assignClassToProtocolInternal(
             destMemberType = applySolvedTypeVars(destMemberType, selfSolution);
 
             // If the dest is a method, bind it.
-            if (isFunction(destMemberType) || isOverloadedFunction(destMemberType)) {
-                let boundDeclaredType: FunctionType | OverloadedFunctionType | undefined;
+            if (isFunction(destMemberType) || isOverloaded(destMemberType)) {
+                let boundDeclaredType: FunctionType | OverloadedType | undefined;
 
                 if (isClass(srcType)) {
                     assert(srcMemberInfo);

--- a/packages/pyright-internal/src/analyzer/sourceMapper.ts
+++ b/packages/pyright-internal/src/analyzer/sourceMapper.ts
@@ -38,7 +38,7 @@ import { isUserCode } from './sourceFileInfoUtils';
 import { buildImportTree } from './sourceMapperUtils';
 import { TypeEvaluator } from './typeEvaluatorTypes';
 import { lookUpClassMember } from './typeUtils';
-import { ClassType, isFunction, isInstantiableClass, isOverloadedFunction, OverloadedFunctionType } from './types';
+import { ClassType, isFunction, isInstantiableClass, isOverloaded, OverloadedType } from './types';
 
 type ClassOrFunctionOrVariableDeclaration =
     | ClassDeclaration
@@ -520,8 +520,8 @@ export class SourceMapper {
 
             if (isFunction(type) && type.shared.declaration) {
                 this._addClassOrFunctionDeclarations(type.shared.declaration, result, recursiveDeclCache);
-            } else if (isOverloadedFunction(type)) {
-                const overloads = OverloadedFunctionType.getOverloads(type);
+            } else if (isOverloaded(type)) {
+                const overloads = OverloadedType.getOverloads(type);
                 for (const overloadDecl of overloads.map((o) => o.shared.declaration).filter(isDefined)) {
                     this._addClassOrFunctionDeclarations(overloadDecl, result, recursiveDeclCache);
                 }

--- a/packages/pyright-internal/src/analyzer/tracePrinter.ts
+++ b/packages/pyright-internal/src/analyzer/tracePrinter.ts
@@ -17,7 +17,7 @@ import * as AnalyzerNodeInfo from './analyzerNodeInfo';
 import { Declaration, DeclarationType } from './declaration';
 import * as ParseTreeUtils from './parseTreeUtils';
 import { Symbol } from './symbol';
-import { OverloadedFunctionType, Type, TypeBase, TypeCategory } from './types';
+import { OverloadedType, Type, TypeBase, TypeCategory } from './types';
 
 export type PrintableType = ParseNode | Declaration | Symbol | Type | undefined;
 
@@ -77,8 +77,8 @@ export function createTracePrinter(roots: Uri[]): TracePrinter {
                 case TypeCategory.Never:
                     return `Never ${wrap(type.props?.typeAliasInfo?.fullName)}`;
 
-                case TypeCategory.OverloadedFunction:
-                    return `OverloadedFunction [${OverloadedFunctionType.getOverloads(type)
+                case TypeCategory.Overloaded:
+                    return `Overloaded [${OverloadedType.getOverloads(type)
                         .map((o) => wrap(printType(o), '"'))
                         .join(',')}]`;
 

--- a/packages/pyright-internal/src/analyzer/typeComplexity.ts
+++ b/packages/pyright-internal/src/analyzer/typeComplexity.ts
@@ -33,7 +33,7 @@ export function getComplexityScoreForType(type: Type, recursionCount = 0): numbe
         }
 
         case TypeCategory.Function:
-        case TypeCategory.OverloadedFunction: {
+        case TypeCategory.Overloaded: {
             // Classes and unions should be preferred over functions,
             // so make this relatively high (more than 0.75).
             return TypeBase.isInstantiable(type) ? 0.85 : 0.8;

--- a/packages/pyright-internal/src/analyzer/typeEvaluatorTypes.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluatorTypes.ts
@@ -43,7 +43,7 @@ import {
     ClassType,
     FunctionParam,
     FunctionType,
-    OverloadedFunctionType,
+    OverloadedType,
     Type,
     TypeCondition,
     TypeVarScopeId,
@@ -547,7 +547,7 @@ export interface TypeEvaluator {
     validateOverloadedArgTypes: (
         errorNode: ExpressionNode,
         argList: Arg[],
-        typeResult: TypeResult<OverloadedFunctionType>,
+        typeResult: TypeResult<OverloadedType>,
         constraints: ConstraintTracker | undefined,
         skipUnknownArgCheck: boolean,
         inferenceContext: InferenceContext | undefined
@@ -613,7 +613,7 @@ export interface TypeEvaluator {
     getFunctionInferredReturnType: (type: FunctionType, callSiteInfo?: CallSiteEvaluationInfo) => Type;
     getBestOverloadForArgs: (
         errorNode: ExpressionNode,
-        typeResult: TypeResult<OverloadedFunctionType>,
+        typeResult: TypeResult<OverloadedType>,
         argList: Arg[]
     ) => FunctionType | undefined;
     getBuiltInType: (node: ParseNode, name: string) => Type;
@@ -633,7 +633,7 @@ export interface TypeEvaluator {
         selfType?: ClassType | TypeVarType | undefined,
         diag?: DiagnosticAddendum,
         recursionCount?: number
-    ) => FunctionType | OverloadedFunctionType | undefined;
+    ) => FunctionType | OverloadedType | undefined;
     getTypeOfMagicMethodCall: (
         objType: Type,
         methodName: string,
@@ -643,13 +643,13 @@ export interface TypeEvaluator {
     ) => TypeResult | undefined;
     bindFunctionToClassOrObject: (
         baseType: ClassType | undefined,
-        memberType: FunctionType | OverloadedFunctionType,
+        memberType: FunctionType | OverloadedType,
         memberClass?: ClassType,
         treatConstructorAsClassMethod?: boolean,
         selfType?: ClassType | TypeVarType,
         diag?: DiagnosticAddendum,
         recursionCount?: number
-    ) => FunctionType | OverloadedFunctionType | undefined;
+    ) => FunctionType | OverloadedType | undefined;
     getCallSignatureInfo: (node: CallNode, activeIndex: number, activeOrFake: boolean) => CallSignatureInfo | undefined;
     getAbstractSymbols: (classType: ClassType) => AbstractSymbol[];
     narrowConstrainedTypeVar: (node: ParseNode, typeVar: TypeVarType) => Type | undefined;
@@ -664,7 +664,7 @@ export interface TypeEvaluator {
     ) => boolean;
     validateOverrideMethod: (
         baseMethod: Type,
-        overrideMethod: FunctionType | OverloadedFunctionType,
+        overrideMethod: FunctionType | OverloadedType,
         baseClass: ClassType | undefined,
         diag: DiagnosticAddendum,
         enforceParamNames?: boolean

--- a/packages/pyright-internal/src/analyzer/typeGuards.ts
+++ b/packages/pyright-internal/src/analyzer/typeGuards.ts
@@ -47,14 +47,14 @@ import {
     isInstantiableClass,
     isModule,
     isNever,
-    isOverloadedFunction,
+    isOverloaded,
     isParamSpec,
     isSameWithoutLiteralValue,
     isTypeSame,
     isTypeVar,
     isUnpackedTypeVarTuple,
     maxTypeRecursionCount,
-    OverloadedFunctionType,
+    OverloadedType,
     TupleTypeArg,
     Type,
     TypeBase,
@@ -741,8 +741,8 @@ export function getTypeNarrowingCallback(
                 if (isFunction(callType) && isFunctionReturnTypeGuard(callType)) {
                     isPossiblyTypeGuard = true;
                 } else if (
-                    isOverloadedFunction(callType) &&
-                    OverloadedFunctionType.getOverloads(callType).some((o) => isFunctionReturnTypeGuard(o))
+                    isOverloaded(callType) &&
+                    OverloadedType.getOverloads(callType).some((o) => isFunctionReturnTypeGuard(o))
                 ) {
                     isPossiblyTypeGuard = true;
                 } else if (isClassInstance(callType)) {
@@ -1714,7 +1714,7 @@ function narrowTypeForIsInstanceInternal(
         return filteredTypes.map((t) => (isInstantiableClass(t) ? convertToInstantiable(convertToInstance(t)) : t));
     };
 
-    const filterFunctionType = (varType: FunctionType | OverloadedFunctionType, unexpandedType: Type): Type[] => {
+    const filterFunctionType = (varType: FunctionType | OverloadedType, unexpandedType: Type): Type[] => {
         const filteredTypes: Type[] = [];
 
         if (isPositiveTest) {
@@ -1832,7 +1832,7 @@ function narrowTypeForIsInstanceInternal(
                     );
                 }
 
-                if ((isFunction(subtype) || isOverloadedFunction(subtype)) && isInstanceCheck) {
+                if ((isFunction(subtype) || isOverloaded(subtype)) && isInstanceCheck) {
                     return combineTypes(filterFunctionType(subtype, convertToInstance(unexpandedSubtype)));
                 }
 
@@ -2681,7 +2681,7 @@ function narrowTypeForCallable(
     return evaluator.mapSubtypesExpandTypeVars(type, /* options */ undefined, (subtype) => {
         switch (subtype.category) {
             case TypeCategory.Function:
-            case TypeCategory.OverloadedFunction: {
+            case TypeCategory.Overloaded: {
                 return isPositiveTest ? subtype : undefined;
             }
 

--- a/packages/pyright-internal/src/analyzer/typePrinter.ts
+++ b/packages/pyright-internal/src/analyzer/typePrinter.ts
@@ -29,7 +29,7 @@ import {
     isUnknown,
     isUnpacked,
     maxTypeRecursionCount,
-    OverloadedFunctionType,
+    OverloadedType,
     TupleTypeArg,
     Type,
     TypeBase,
@@ -497,8 +497,8 @@ function printTypeInternal(
                 );
             }
 
-            case TypeCategory.OverloadedFunction: {
-                const overloads = OverloadedFunctionType.getOverloads(type).map((overload) =>
+            case TypeCategory.Overloaded: {
+                const overloads = OverloadedType.getOverloads(type).map((overload) =>
                     printTypeInternal(
                         overload,
                         printTypeFlags,
@@ -1393,8 +1393,8 @@ class UniqueNameMap {
                     break;
                 }
 
-                case TypeCategory.OverloadedFunction: {
-                    OverloadedFunctionType.getOverloads(type).forEach((overload) => {
+                case TypeCategory.Overloaded: {
+                    OverloadedType.getOverloads(type).forEach((overload) => {
                         this.build(overload, recursionTypes, recursionCount);
                     });
                     break;

--- a/packages/pyright-internal/src/analyzer/typeWalker.ts
+++ b/packages/pyright-internal/src/analyzer/typeWalker.ts
@@ -15,7 +15,7 @@ import {
     FunctionType,
     ModuleType,
     NeverType,
-    OverloadedFunctionType,
+    OverloadedType,
     Type,
     TypeCategory,
     TypeVarType,
@@ -75,8 +75,8 @@ export class TypeWalker {
                 this.visitFunction(type);
                 break;
 
-            case TypeCategory.OverloadedFunction:
-                this.visitOverloadedFunction(type);
+            case TypeCategory.Overloaded:
+                this.visitOverloaded(type);
                 break;
 
             case TypeCategory.Class:
@@ -156,8 +156,8 @@ export class TypeWalker {
         }
     }
 
-    visitOverloadedFunction(type: OverloadedFunctionType): void {
-        const overloads = OverloadedFunctionType.getOverloads(type);
+    visitOverloaded(type: OverloadedType): void {
+        const overloads = OverloadedType.getOverloads(type);
         for (const overload of overloads) {
             this.walk(overload);
             if (this._isWalkCanceled) {
@@ -165,7 +165,7 @@ export class TypeWalker {
             }
         }
 
-        const impl = OverloadedFunctionType.getImplementation(type);
+        const impl = OverloadedType.getImplementation(type);
         if (impl) {
             this.walk(impl);
         }

--- a/packages/pyright-internal/src/analyzer/typedDicts.ts
+++ b/packages/pyright-internal/src/analyzer/typedDicts.ts
@@ -48,7 +48,7 @@ import {
     isNever,
     maxTypeRecursionCount,
     NeverType,
-    OverloadedFunctionType,
+    OverloadedType,
     Type,
     TypedDictEntries,
     TypedDictEntry,
@@ -353,7 +353,7 @@ export function synthesizeTypedDictClassMethods(
     }
 
     const symbolTable = ClassType.getSymbolTable(classType);
-    const initType = OverloadedFunctionType.create([initOverride1, initOverride2]);
+    const initType = OverloadedType.create([initOverride1, initOverride2]);
     symbolTable.set('__init__', Symbol.createWithType(SymbolFlags.ClassMember, initType));
     symbolTable.set('__new__', Symbol.createWithType(SymbolFlags.ClassMember, newType));
 
@@ -587,7 +587,7 @@ export function synthesizeTypedDictClassMethods(
             // Note that the order of method1 and method2 is swapped. This is done so
             // the method1 signature is used in the error message when neither method2
             // or method1 match.
-            return OverloadedFunctionType.create([updateMethod2, updateMethod1, updateMethod3]);
+            return OverloadedType.create([updateMethod2, updateMethod1, updateMethod3]);
         }
 
         const getOverloads: FunctionType[] = [];
@@ -643,22 +643,16 @@ export function synthesizeTypedDictClassMethods(
             getOverloads.push(createGetMethod(strType, AnyType.create(), /* includeDefault */ true));
         }
 
-        symbolTable.set(
-            'get',
-            Symbol.createWithType(SymbolFlags.ClassMember, OverloadedFunctionType.create(getOverloads))
-        );
+        symbolTable.set('get', Symbol.createWithType(SymbolFlags.ClassMember, OverloadedType.create(getOverloads)));
 
         if (popOverloads.length > 0) {
-            symbolTable.set(
-                'pop',
-                Symbol.createWithType(SymbolFlags.ClassMember, OverloadedFunctionType.create(popOverloads))
-            );
+            symbolTable.set('pop', Symbol.createWithType(SymbolFlags.ClassMember, OverloadedType.create(popOverloads)));
         }
 
         if (setDefaultOverloads.length > 0) {
             symbolTable.set(
                 'setdefault',
-                Symbol.createWithType(SymbolFlags.ClassMember, OverloadedFunctionType.create(setDefaultOverloads))
+                Symbol.createWithType(SymbolFlags.ClassMember, OverloadedType.create(setDefaultOverloads))
             );
         }
 

--- a/packages/pyright-internal/src/analyzer/types.ts
+++ b/packages/pyright-internal/src/analyzer/types.ts
@@ -36,7 +36,7 @@ export const enum TypeCategory {
 
     // Functions defined with @overload decorator in stub files that
     // have multiple function declarations for a common implementation.
-    OverloadedFunction,
+    Overloaded,
 
     // Class definition, including associated instance methods,
     // class methods, static methods, properties, and variables.
@@ -75,7 +75,7 @@ export type UnionableType =
     | UnknownType
     | AnyType
     | FunctionType
-    | OverloadedFunctionType
+    | OverloadedType
     | ClassType
     | ModuleType
     | TypeVarType;
@@ -1598,7 +1598,7 @@ export interface CallSiteInferenceTypeCacheEntry {
 }
 
 export interface SignatureWithOffsets {
-    type: FunctionType | OverloadedFunctionType;
+    type: FunctionType | OverloadedType;
     expressionOffsets: number[];
 }
 
@@ -1632,7 +1632,7 @@ export interface FunctionDetailsPriv {
 
     // If this function is part of an overloaded function, this
     // refers back to the overloaded function type.
-    overloaded?: OverloadedFunctionType;
+    overloaded?: OverloadedType;
 
     // If this function is created with a "Callable" annotation with
     // type arguments? This allows us to detect and report an error
@@ -2251,7 +2251,7 @@ export namespace FunctionType {
     }
 }
 
-export interface OverloadedFunctionDetailsPriv {
+export interface OverloadedDetailsPriv {
     // eslint-disable-next-line @typescript-eslint/naming-convention
     _overloads: FunctionType[];
 
@@ -2259,14 +2259,14 @@ export interface OverloadedFunctionDetailsPriv {
     _implementation: Type | undefined;
 }
 
-export interface OverloadedFunctionType extends TypeBase<TypeCategory.OverloadedFunction> {
-    priv: OverloadedFunctionDetailsPriv;
+export interface OverloadedType extends TypeBase<TypeCategory.Overloaded> {
+    priv: OverloadedDetailsPriv;
 }
 
-export namespace OverloadedFunctionType {
-    export function create(overloads: FunctionType[], implementation?: Type): OverloadedFunctionType {
-        const newType: OverloadedFunctionType = {
-            category: TypeCategory.OverloadedFunction,
+export namespace OverloadedType {
+    export function create(overloads: FunctionType[], implementation?: Type): OverloadedType {
+        const newType: OverloadedType = {
+            category: TypeCategory.Overloaded,
             flags: TypeFlags.Instance,
             props: undefined,
             cached: undefined,
@@ -2278,23 +2278,23 @@ export namespace OverloadedFunctionType {
         };
 
         overloads.forEach((overload) => {
-            OverloadedFunctionType.addOverload(newType, overload);
+            OverloadedType.addOverload(newType, overload);
         });
 
         return newType;
     }
 
     // Adds a new overload or an implementation.
-    export function addOverload(type: OverloadedFunctionType, functionType: FunctionType) {
+    export function addOverload(type: OverloadedType, functionType: FunctionType) {
         functionType.priv.overloaded = type;
         type.priv._overloads.push(functionType);
     }
 
-    export function getOverloads(type: OverloadedFunctionType): FunctionType[] {
+    export function getOverloads(type: OverloadedType): FunctionType[] {
         return type.priv._overloads;
     }
 
-    export function getImplementation(type: OverloadedFunctionType): Type | undefined {
+    export function getImplementation(type: OverloadedType): Type | undefined {
         return type.priv._implementation;
     }
 }
@@ -3140,8 +3140,8 @@ export function isFunction(type: Type): type is FunctionType {
     return type.category === TypeCategory.Function;
 }
 
-export function isOverloadedFunction(type: Type): type is OverloadedFunctionType {
-    return type.category === TypeCategory.OverloadedFunction;
+export function isOverloaded(type: Type): type is OverloadedType {
+    return type.category === TypeCategory.Overloaded;
 }
 
 export function getTypeAliasInfo(type: Type) {
@@ -3344,9 +3344,9 @@ export function isTypeSame(type1: Type, type2: Type, options: TypeSameOptions = 
             return true;
         }
 
-        case TypeCategory.OverloadedFunction: {
+        case TypeCategory.Overloaded: {
             // Make sure the overload counts match.
-            const functionType2 = type2 as OverloadedFunctionType;
+            const functionType2 = type2 as OverloadedType;
             if (type1.priv._overloads.length !== functionType2.priv._overloads.length) {
                 return false;
             }

--- a/packages/pyright-internal/src/commands/dumpFileDebugInfoCommand.ts
+++ b/packages/pyright-internal/src/commands/dumpFileDebugInfoCommand.ts
@@ -532,8 +532,8 @@ function getTypeCategoryString(typeCategory: TypeCategory, type: any) {
             return 'Never';
         case TypeCategory.Function:
             return 'Function';
-        case TypeCategory.OverloadedFunction:
-            return 'OverloadedFunction';
+        case TypeCategory.Overloaded:
+            return 'Overloaded';
         case TypeCategory.Class:
             if (TypeBase.isInstantiable(type)) {
                 return 'Class';

--- a/packages/pyright-internal/src/languageService/completionProvider.ts
+++ b/packages/pyright-internal/src/languageService/completionProvider.ts
@@ -54,7 +54,7 @@ import {
     isFunction,
     isInstantiableClass,
     isModule,
-    isOverloadedFunction,
+    isOverloaded,
     isUnknown,
     Type,
     TypeBase,
@@ -770,7 +770,7 @@ export class CompletionProvider {
                 }
             } else if (isModule(subtype)) {
                 getMembersForModule(subtype, symbolTable);
-            } else if (isFunction(subtype) || isOverloadedFunction(subtype)) {
+            } else if (isFunction(subtype) || isOverloaded(subtype)) {
                 const functionClass = this.evaluator.getBuiltInType(leftExprNode, 'function');
                 if (functionClass && isInstantiableClass(functionClass)) {
                     getMembersForClass(functionClass, symbolTable, /* includeInstanceVars */ true);
@@ -3093,7 +3093,7 @@ export class CompletionProvider {
             case TypeCategory.Class:
                 return CompletionItemKind.Class;
             case TypeCategory.Function:
-            case TypeCategory.OverloadedFunction:
+            case TypeCategory.Overloaded:
                 if (isMaybeDescriptorInstance(type, /* requireSetter */ false)) {
                     return CompletionItemKind.Property;
                 }

--- a/packages/pyright-internal/src/languageService/completionProviderUtils.ts
+++ b/packages/pyright-internal/src/languageService/completionProviderUtils.ts
@@ -22,7 +22,7 @@ import {
     isClassInstance,
     isFunction,
     isModule,
-    isOverloadedFunction,
+    isOverloaded,
 } from '../analyzer/types';
 import { SignatureDisplayType } from '../common/configOptions';
 import { TextEditAction } from '../common/editAction';
@@ -97,7 +97,7 @@ export function getTypeDetail(
                 }
             }
             // Handle the case where type is a function and was assigned to a variable.
-            if (type.category === TypeCategory.OverloadedFunction || type.category === TypeCategory.Function) {
+            if (type.category === TypeCategory.Overloaded || type.category === TypeCategory.Function) {
                 return getToolTipForType(
                     type,
                     /* label */ '',
@@ -113,7 +113,7 @@ export function getTypeDetail(
 
         case DeclarationType.Function: {
             const functionType =
-                detail?.boundObjectOrClass && (isFunction(type) || isOverloadedFunction(type))
+                detail?.boundObjectOrClass && (isFunction(type) || isOverloaded(type))
                     ? evaluator.bindFunctionToClassOrObject(detail.boundObjectOrClass, type)
                     : type;
             if (!functionType) {

--- a/packages/pyright-internal/src/languageService/definitionProvider.ts
+++ b/packages/pyright-internal/src/languageService/definitionProvider.ts
@@ -23,7 +23,7 @@ import * as ParseTreeUtils from '../analyzer/parseTreeUtils';
 import { SourceMapper, isStubFile } from '../analyzer/sourceMapper';
 import { TypeEvaluator } from '../analyzer/typeEvaluatorTypes';
 import { doForEachSubtype } from '../analyzer/typeUtils';
-import { OverloadedFunctionType, TypeCategory, isOverloadedFunction } from '../analyzer/types';
+import { OverloadedType, TypeCategory, isOverloaded } from '../analyzer/types';
 import { throwIfCancellationRequested } from '../common/cancellationUtils';
 import { appendArray } from '../common/collectionUtils';
 import { isDefined } from '../common/core';
@@ -88,8 +88,8 @@ export function addDeclarationsToDefinitions(
         if (isFunctionDeclaration(resolvedDecl)) {
             // Handle overloaded function case
             const functionType = evaluator.getTypeForDeclaration(resolvedDecl)?.type;
-            if (functionType && isOverloadedFunction(functionType)) {
-                for (const overloadDecl of OverloadedFunctionType.getOverloads(functionType)
+            if (functionType && isOverloaded(functionType)) {
+                for (const overloadDecl of OverloadedType.getOverloads(functionType)
                     .map((o) => o.shared.declaration)
                     .filter(isDefined)) {
                     _addIfUnique(definitions, {

--- a/packages/pyright-internal/src/languageService/hoverProvider.ts
+++ b/packages/pyright-internal/src/languageService/hoverProvider.ts
@@ -31,7 +31,7 @@ import {
     isClassInstance,
     isFunction,
     isModule,
-    isOverloadedFunction,
+    isOverloaded,
     isParamSpec,
     isTypeVar,
 } from '../analyzer/types';
@@ -156,7 +156,7 @@ export function getVariableTypeText(
     }
 
     // Handle the case where type is a function and was assigned to a variable.
-    if (type.category === TypeCategory.Function || type.category === TypeCategory.OverloadedFunction) {
+    if (type.category === TypeCategory.Function || type.category === TypeCategory.Overloaded) {
         return getToolTipForType(type, label, name, evaluator, /* isProperty */ false, functionSignatureDisplay);
     }
 
@@ -480,7 +480,7 @@ export class HoverProvider {
             return false;
         }
 
-        if (result.methodType && (isFunction(result.methodType) || isOverloadedFunction(result.methodType))) {
+        if (result.methodType && (isFunction(result.methodType) || isOverloaded(result.methodType))) {
             this._addResultsPart(
                 parts,
                 getConstructorTooltip(node.d.value, result.methodType, this._evaluator, this._functionSignatureDisplay),


### PR DESCRIPTION
…eflect the fact that non-function types are now supported for overloads. No functional change, just a rename.