### PR TITLE
Fixed bug that results in a false negative `reportIncompatibleMethodO…

### DIFF
--- a/packages/pyright-internal/src/analyzer/checker.ts
+++ b/packages/pyright-internal/src/analyzer/checker.ts
@@ -6770,7 +6770,7 @@ export class Checker extends ParseTreeWalker {
         const baseClass = baseClassAndSymbol.classType;
         const childClassSelf = ClassType.cloneAsInstance(selfSpecializeClass(childClassType));
 
-        const baseType = partiallySpecializeType(
+        let baseType = partiallySpecializeType(
             this._evaluator.getEffectiveTypeOfSymbol(baseClassAndSymbol.symbol),
             baseClass,
             this._evaluator.getTypeClassType(),
@@ -6783,6 +6783,11 @@ export class Checker extends ParseTreeWalker {
             this._evaluator.getTypeClassType(),
             childClassSelf
         );
+
+        if (childClassType.shared.typeVarScopeId) {
+            baseType = makeTypeVarsBound(baseType, [childClassType.shared.typeVarScopeId]);
+            overrideType = makeTypeVarsBound(overrideType, [childClassType.shared.typeVarScopeId]);
+        }
 
         if (isFunction(baseType) || isOverloaded(baseType)) {
             const diagAddendum = new DiagnosticAddendum();

--- a/packages/pyright-internal/src/tests/samples/methodOverride1.py
+++ b/packages/pyright-internal/src/tests/samples/methodOverride1.py
@@ -13,10 +13,11 @@ from typing import (
     overload,
 )
 
-
 T_ParentClass = TypeVar("T_ParentClass", bound="ParentClass")
 
 P = ParamSpec("P")
+T = TypeVar("T")
+S = TypeVar("S")
 
 
 def decorator(func: Callable[P, None]) -> Callable[P, int]:
@@ -558,3 +559,40 @@ class C(Base4, Base5):
 
 class MyObject(TypedDict):
     values: list[str]
+
+
+class Base6(Generic["T"]):
+    def method1(self, v: int) -> None:
+        ...
+
+    def method2(self, v: T) -> None:
+        ...
+
+    def method3(self, v: T) -> None:
+        ...
+
+    def method4(self, v: S) -> S:
+        ...
+
+    def method5(self, v: S) -> S:
+        ...
+
+
+class Derived6(Base6[int], Generic["T"]):
+    # This should generate an error.
+    def method1(self, v: T):
+        ...
+
+    # This should generate an error.
+    def method2(self, v: T) -> None:
+        ...
+
+    def method3(self, v: int) -> None:
+        ...
+
+    # This should generate an error.
+    def method4(self, v: T) -> T:
+        ...
+
+    def method5(self, v: S) -> S:
+        ...

--- a/packages/pyright-internal/src/tests/typeEvaluator3.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator3.test.ts
@@ -892,7 +892,7 @@ test('MethodOverride1', () => {
 
     configOptions.diagnosticRuleSet.reportIncompatibleMethodOverride = 'error';
     analysisResults = TestUtils.typeAnalyzeSampleFiles(['methodOverride1.py'], configOptions);
-    TestUtils.validateResults(analysisResults, 38);
+    TestUtils.validateResults(analysisResults, 41);
 });
 
 test('MethodOverride2', () => {


### PR DESCRIPTION
…verride` when the child class method uses a type parameter that is scoped to the child class. This addresses #8622.