### PR TITLE
Improved consistency of parameter name restrictions for the `reportSe…

### DIFF
--- a/packages/pyright-internal/src/tests/checker.test.ts
+++ b/packages/pyright-internal/src/tests/checker.test.ts
@@ -377,7 +377,7 @@ test('ParamNames1', () => {
     const configOptions = new ConfigOptions(Uri.empty());
 
     let analysisResults = TestUtils.typeAnalyzeSampleFiles(['paramNames1.py'], configOptions);
-    TestUtils.validateResults(analysisResults, 0, 7);
+    TestUtils.validateResults(analysisResults, 0, 11);
 
     configOptions.diagnosticRuleSet.reportSelfClsParameterName = 'none';
     analysisResults = TestUtils.typeAnalyzeSampleFiles(['paramNames1.py'], configOptions);
@@ -385,7 +385,7 @@ test('ParamNames1', () => {
 
     configOptions.diagnosticRuleSet.reportSelfClsParameterName = 'error';
     analysisResults = TestUtils.typeAnalyzeSampleFiles(['paramNames1.py'], configOptions);
-    TestUtils.validateResults(analysisResults, 7, 0);
+    TestUtils.validateResults(analysisResults, 11, 0);
 });
 
 test('ParamType1', () => {

--- a/packages/pyright-internal/src/tests/samples/paramNames1.py
+++ b/packages/pyright-internal/src/tests/samples/paramNames1.py
@@ -10,6 +10,11 @@ def foo():
 
 class Class1:
     # This should generate an error or warning if the setting
+    # is enabled because __new__ is expected to take cls.
+    def __new__(blah):
+        return super().__new__(blah)
+
+    # This should generate an error or warning if the setting
     # is enabled because it's missing a "self" parameter.
     def foo1():
         return 3
@@ -51,9 +56,38 @@ class Class1:
     def foo6(x) -> int | str:
         ...
 
+    @classmethod
+    # This should generate an error or warning if the setting
+    # is enabled because this isn't a metaclass.
+    def foo7(mcls):
+        return 4
+
 
 class Metaclass(type):
+    def __new__(mcls):
+        ...
+
     # This should not generate a error because the class derives
     # from type and is assumed to be a metaclass.
     def foo1(cls):
+        return 3
+
+    # This should generate an error.
+    def foo2(mcls):
+        return 3
+
+    def foo3(self):
+        return 3
+
+    @classmethod
+    def foo4(cls):
+        return 3
+
+    @classmethod
+    def foo5(metacls):
+        return 3
+
+    # This should generate an error.
+    @classmethod
+    def foo6(bar):
         return 3


### PR DESCRIPTION
…lfClsParameterName` check. Previously, different rules were applied to `__new__` and class methods within metaclasses. This addresses #8717.