### PR TITLE
Special case pythonPath to also come from the languageServer

### DIFF
--- a/packages/pyright-internal/src/analyzer/service.ts
+++ b/packages/pyright-internal/src/analyzer/service.ts
@@ -817,6 +817,16 @@ export class AnalyzerService {
             configOptions.logTypeEvaluationTime = languageServerOptions.logTypeEvaluationTime;
         }
         configOptions.typeEvaluationTimeThreshold = languageServerOptions.typeEvaluationTimeThreshold;
+
+        // Special case, the language service can also set a pythonPath. It should override any other setting.
+        if (languageServerOptions.pythonPath) {
+            this._console.info(
+                `Setting pythonPath for service "${this._instanceName}": ` + `"${languageServerOptions.pythonPath}"`
+            );
+            configOptions.pythonPath = this.fs.realCasePath(
+                Uri.file(languageServerOptions.pythonPath, this.serviceProvider, /* checkRelative */ true)
+            );
+        }
     }
 
     private _applyCommandLineOverrides(

--- a/packages/pyright-internal/src/common/commandLineOptions.ts
+++ b/packages/pyright-internal/src/common/commandLineOptions.ts
@@ -138,6 +138,10 @@ export class CommandLineLanguageServerOptions {
 
     // Disable reporting of hint diagnostics with tags?
     disableTaggedHints?: boolean;
+
+    // Path to python interpreter. This is used when the language server
+    // gets the python path from the client.
+    pythonPath?: string | undefined;
 }
 
 // Some options can be specified from a source other than the pyright config file.

--- a/packages/pyright-internal/src/languageService/analyzerServiceExecutor.ts
+++ b/packages/pyright-internal/src/languageService/analyzerServiceExecutor.ts
@@ -127,7 +127,7 @@ function getEffectiveCommandLineOptions(
         // the local python interpreter should be used rather than interpreting the
         // setting value as a path to the interpreter. We'll simply ignore it in this case.
         if (!isPythonBinary(serverSettings.pythonPath.getFilePath())) {
-            commandLineOptions.configSettings.pythonPath = serverSettings.pythonPath.getFilePath();
+            commandLineOptions.languageServerSettings.pythonPath = serverSettings.pythonPath.getFilePath();
         }
     }
 

--- a/packages/pyright-internal/src/tests/config.test.ts
+++ b/packages/pyright-internal/src/tests/config.test.ts
@@ -528,6 +528,7 @@ test('Language server specific settings are set whether or not there is a pyproj
     commandLineOptions.languageServerSettings.typeStubTargetImportName = 'test';
     commandLineOptions.languageServerSettings.checkOnlyOpenFiles = true;
     commandLineOptions.languageServerSettings.disableTaggedHints = true;
+    commandLineOptions.languageServerSettings.pythonPath = 'test';
 
     service.setOptions(commandLineOptions);
     let options = service.test_getConfigOptions(commandLineOptions);
@@ -537,6 +538,7 @@ test('Language server specific settings are set whether or not there is a pyproj
     assert.strictEqual(options.logTypeEvaluationTime, true);
     assert.strictEqual(options.typeEvaluationTimeThreshold, 1);
     assert.strictEqual(options.disableTaggedHints, true);
+    assert.strictEqual(options.pythonPath, 'test');
 
     // Test with language server set to true to make sure they are still set.
     commandLineOptions.fromLanguageServer = true;
@@ -548,4 +550,5 @@ test('Language server specific settings are set whether or not there is a pyproj
     assert.strictEqual(options.logTypeEvaluationTime, true);
     assert.strictEqual(options.typeEvaluationTimeThreshold, 1);
     assert.strictEqual(options.disableTaggedHints, true);
+    assert.strictEqual(options.pythonPath, 'test');
 });

--- a/packages/pyright-internal/src/tests/config.test.ts
+++ b/packages/pyright-internal/src/tests/config.test.ts
@@ -528,7 +528,7 @@ test('Language server specific settings are set whether or not there is a pyproj
     commandLineOptions.languageServerSettings.typeStubTargetImportName = 'test';
     commandLineOptions.languageServerSettings.checkOnlyOpenFiles = true;
     commandLineOptions.languageServerSettings.disableTaggedHints = true;
-    commandLineOptions.languageServerSettings.pythonPath = 'test';
+    commandLineOptions.languageServerSettings.pythonPath = 'test_python_path';
 
     service.setOptions(commandLineOptions);
     let options = service.test_getConfigOptions(commandLineOptions);
@@ -538,7 +538,7 @@ test('Language server specific settings are set whether or not there is a pyproj
     assert.strictEqual(options.logTypeEvaluationTime, true);
     assert.strictEqual(options.typeEvaluationTimeThreshold, 1);
     assert.strictEqual(options.disableTaggedHints, true);
-    assert.strictEqual(options.pythonPath, 'test');
+    assert.ok(options.pythonPath?.pathIncludes('test_python_path'));
 
     // Test with language server set to true to make sure they are still set.
     commandLineOptions.fromLanguageServer = true;
@@ -550,5 +550,5 @@ test('Language server specific settings are set whether or not there is a pyproj
     assert.strictEqual(options.logTypeEvaluationTime, true);
     assert.strictEqual(options.typeEvaluationTimeThreshold, 1);
     assert.strictEqual(options.disableTaggedHints, true);
-    assert.strictEqual(options.pythonPath, 'test');
+    assert.ok(options.pythonPath?.pathIncludes('test_python_path'));
 });


### PR DESCRIPTION
In https://github.com/microsoft/pyright/pull/8726 a pyrightconfig.json being present means all settings settable from a pyrightConfig.json would not be applied. There is a special case however where they need to be - the `pythonPath`. This is how a language server specifies which python it's using.

Addresses https://github.com/microsoft/pyright/issues/8727