### PR TITLE
Changed synthesized comparison methods (`__lt__`, etc.) for dataclass…

### DIFF
--- a/packages/pyright-internal/src/analyzer/dataClasses.ts
+++ b/packages/pyright-internal/src/analyzer/dataClasses.ts
@@ -624,9 +624,8 @@ export function synthesizeDataClassMethods(
     }
 
     if (ClassType.isDataClassGenerateOrder(classType)) {
-        const objType = ClassType.cloneAsInstance(classType);
         ['__lt__', '__le__', '__gt__', '__ge__'].forEach((operator) => {
-            synthesizeComparisonMethod(operator, objType);
+            synthesizeComparisonMethod(operator, selfType);
         });
     }
 


### PR DESCRIPTION
…es when `order=True` to use `Self` rather than an instance of the class. This is not only more consistent with other synthesized methods, but it also preserves covariance of type variables if the dataclass is frozen.