### PR TITLE
Fixed a bug that results in incorrect type narrowing with `TypeIs` wh…

### DIFF
--- a/packages/pyright-internal/src/tests/samples/typeIs4.py
+++ b/packages/pyright-internal/src/tests/samples/typeIs4.py
@@ -1,0 +1,34 @@
+# This sample tests the case where IsType uses a type[T].
+
+# pyright: reportMissingModuleSource=false
+
+from inspect import isclass
+from typing import TypeVar
+
+from typing_extensions import TypeIs
+
+T = TypeVar("T")
+
+
+class Foo:
+    ...
+
+
+def is_foo(obj: object) -> TypeIs[type[Foo]]:
+    return isclass(obj) and issubclass(obj, Foo)
+
+
+def test1(obj: type[T]) -> T:
+    if is_foo(obj):
+        reveal_type(obj, expected_text="type[Foo]*")
+    else:
+        reveal_type(obj, expected_text="type[object]*")
+
+    return obj()
+
+
+def test2(obj: dict[str, int] | type[Foo]):
+    if is_foo(obj):
+        reveal_type(obj, expected_text="type[Foo]")
+    else:
+        reveal_type(obj, expected_text="dict[str, int]")

--- a/packages/pyright-internal/src/tests/typeEvaluator6.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator6.test.ts
@@ -148,6 +148,11 @@ test('TypeIs3', () => {
     TestUtils.validateResults(analysisResults, 5);
 });
 
+test('TypeIs4', () => {
+    const analysisResults = TestUtils.typeAnalyzeSampleFiles(['typeIs4.py']);
+    TestUtils.validateResults(analysisResults, 0);
+});
+
 test('Never1', () => {
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['never1.py']);
 


### PR DESCRIPTION
…en result type is `type[T]`. This addresses #8691 and #8686.