### PR TITLE
Changed behavior for protocols that have methods with method-scoped t…

### DIFF
--- a/packages/pyright-internal/src/analyzer/protocols.ts
+++ b/packages/pyright-internal/src/analyzer/protocols.ts
@@ -43,6 +43,7 @@ import {
     ClassMember,
     containsLiteralType,
     lookUpClassMember,
+    makeFunctionTypeVarsBound,
     MemberAccessFlags,
     partiallySpecializeType,
     requiresSpecialization,
@@ -545,6 +546,7 @@ function assignClassToProtocolInternal(
                 }
 
                 if (boundDeclaredType) {
+                    boundDeclaredType = makeFunctionTypeVarsBound(boundDeclaredType);
                     destMemberType = boundDeclaredType;
                 } else {
                     typesAreConsistent = false;

--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -329,6 +329,7 @@ import {
     isVarianceOfTypeArgCompatible,
     lookUpClassMember,
     lookUpObjectMember,
+    makeFunctionTypeVarsBound,
     makeInferenceContext,
     makeTypeVarsBound,
     makeTypeVarsFree,
@@ -24662,7 +24663,19 @@ export function createTypeEvaluator(
             }
         }
 
-        return getBoundMagicMethod(objType, '__call__', /* selfType */ undefined, /* diag */ undefined, recursionCount);
+        const callType = getBoundMagicMethod(
+            objType,
+            '__call__',
+            /* selfType */ undefined,
+            /* diag */ undefined,
+            recursionCount
+        );
+
+        if (!callType) {
+            return undefined;
+        }
+
+        return makeFunctionTypeVarsBound(callType);
     }
 
     function assignParam(

--- a/packages/pyright-internal/src/analyzer/typeUtils.ts
+++ b/packages/pyright-internal/src/analyzer/typeUtils.ts
@@ -1505,6 +1505,18 @@ export function ensureSignaturesAreUnique<T extends Type>(
     return transformer.apply(type, 0) as T;
 }
 
+export function makeFunctionTypeVarsBound(type: FunctionType | OverloadedType): FunctionType | OverloadedType {
+    const scopeIds: TypeVarScopeId[] = [];
+    doForEachSignature(type, (signature) => {
+        const localScopeId = getTypeVarScopeId(signature);
+        if (localScopeId) {
+            scopeIds.push(localScopeId);
+        }
+    });
+
+    return makeTypeVarsBound(type, scopeIds);
+}
+
 export function makeTypeVarsBound<T extends TypeBase<any>>(type: T, scopeIds: TypeVarScopeId[] | undefined): T;
 export function makeTypeVarsBound(type: Type, scopeIds: TypeVarScopeId[] | undefined): Type {
     const transformer = new BoundTypeVarTransform(scopeIds);

--- a/packages/pyright-internal/src/tests/samples/callbackProtocol11.py
+++ b/packages/pyright-internal/src/tests/samples/callbackProtocol11.py
@@ -13,12 +13,12 @@ class A(Generic[T_co, U_co]):
 
 
 class BProto(Protocol):
-    def __call__(self) -> A[list[T], T]:
+    def __call__(self, x: T) -> A[list[T], T]:
         ...
 
 
 def func1() -> BProto:
-    def make_a() -> A[list[T], T]:
+    def make_a(x: T) -> A[list[T], T]:
         ...
 
     return make_a

--- a/packages/pyright-internal/src/tests/samples/protocol47.py
+++ b/packages/pyright-internal/src/tests/samples/protocol47.py
@@ -1,8 +1,7 @@
 # This sample tests protocol matching for a protocol and an implementation
 # that use a mixture of class-scoped and function-scoped TypeVars.
 
-from typing import TypeVar, Protocol, Generic
-
+from typing import Generic, Protocol, TypeVar
 
 T1 = TypeVar("T1", covariant=True)
 T2 = TypeVar("T2")
@@ -25,9 +24,20 @@ class A(Generic[T3]):
 a1: A[str] = A()
 
 
-def func1(storage: ProtoA[int]):
+def func1(storage: ProtoA[str]):
     ...
 
 
-v1: ProtoA[int] = a1
+v1: ProtoA[str] = a1
 func1(a1)
+
+
+def func2(storage: ProtoA[int]):
+    ...
+
+
+# This should generate an error.
+v2: ProtoA[int] = a1
+
+# This should generate an error.
+func2(a1)

--- a/packages/pyright-internal/src/tests/typeEvaluator7.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator7.test.ts
@@ -572,7 +572,7 @@ test('Protocol46', () => {
 test('Protocol47', () => {
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['protocol47.py']);
 
-    TestUtils.validateResults(analysisResults, 0);
+    TestUtils.validateResults(analysisResults, 2);
 });
 
 test('Protocol48', () => {


### PR DESCRIPTION
…ype variables. These are no longer treated as free type variables during protocol matching, so they can be used to support rank-2 polymorphism. This behavior is not currently dictated by the typing spec, but it is more consistent with mypy. This addresses #8685.