### PR TITLE
Fixed bug that results in a crash under certain circumstances when a …

### DIFF
--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -10287,7 +10287,7 @@ export function createTypeEvaluator(
                     paramSpecTarget = TypeVarType.cloneForParamSpecAccess(varArgListParamType, /* access */ undefined);
                 } else {
                     positionalOnlyLimitIndex = varArgListParamIndex;
-                    positionalArgCount = varArgListParamIndex;
+                    positionalArgCount = Math.min(varArgListParamIndex, positionalArgCount);
                     positionParamLimitIndex = varArgListParamIndex;
                 }
             }

--- a/packages/pyright-internal/src/tests/samples/paramSpec52.py
+++ b/packages/pyright-internal/src/tests/samples/paramSpec52.py
@@ -1,0 +1,20 @@
+# This sample tests an illegal use of a ParamSpec that resulted in
+# a crash.
+
+from typing import Callable, Generic, ParamSpec
+
+P = ParamSpec("P")
+
+
+class A(Generic[P]):
+    def __call__(self, a: int, b: int, *args: P.args, **kwargs: P.kwargs) -> None:
+        ...
+
+
+class B:
+    # This should generate an error.
+    x: A[P]
+
+
+# This should generate an error, not crash.
+B().x(1)

--- a/packages/pyright-internal/src/tests/typeEvaluator4.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator4.test.ts
@@ -818,3 +818,8 @@ test('ParamSpec51', () => {
     const results = TestUtils.typeAnalyzeSampleFiles(['paramSpec51.py']);
     TestUtils.validateResults(results, 0);
 });
+
+test('ParamSpec52', () => {
+    const results = TestUtils.typeAnalyzeSampleFiles(['paramSpec52.py']);
+    TestUtils.validateResults(results, 2);
+});


### PR DESCRIPTION
…ParamSpec without a scope is used illegally to specialize a class. This addresses #8757.