### PR TITLE
Fixed a bug that results in a false positive error when assigning a `…

### DIFF
--- a/packages/pyright-internal/src/tests/samples/typeGuard1.py
+++ b/packages/pyright-internal/src/tests/samples/typeGuard1.py
@@ -6,6 +6,7 @@
 
 import os
 from typing import Any, Callable, TypeVar
+
 from typing_extensions import TypeGuard  # pyright: ignore[reportMissingModuleSource]
 
 _T = TypeVar("_T")
@@ -124,3 +125,9 @@ takes_int_typeguard(bool_typeguard)
 
 # This should generate an error because TypeGuard is covariant.
 takes_int_typeguard(str_typeguard)
+
+
+v0 = is_int(int)
+v1: bool = v0
+v2: int = v0
+v3 = v0 & v0

--- a/packages/pyright-internal/src/tests/samples/typeIs1.py
+++ b/packages/pyright-internal/src/tests/samples/typeIs1.py
@@ -172,3 +172,9 @@ def func10(
 
 def func10(v: tuple[int | str, ...], b: bool = True) -> bool:
     ...
+
+
+v0 = is_int(int)
+v1: bool = v0
+v2: int = v0
+v3 = v0 & v0


### PR DESCRIPTION
…TypeGuard[T]` or `TypeIs[T]` to a supertype of `bool` (like `int`). This addresses #8769.