### PR TITLE
Changed type checking logic to retain a reference to default expressi…

### DIFF
--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -14362,7 +14362,8 @@ export function createTypeEvaluator(
                     paramType ?? UnknownType.create(),
                     FunctionParamFlags.TypeDeclared,
                     param.d.name ? param.d.name.d.value : undefined,
-                    param.d.defaultValue ? AnyType.create(/* isEllipsis */ true) : undefined
+                    param.d.defaultValue ? AnyType.create(/* isEllipsis */ true) : undefined,
+                    param.d.defaultValue
                 );
 
                 FunctionType.addParam(functionType, functionParam);
@@ -18148,7 +18149,8 @@ export function createTypeEvaluator(
                     (isTypeInferred ? FunctionParamFlags.TypeInferred : FunctionParamFlags.None) |
                         (paramTypeNode ? FunctionParamFlags.TypeDeclared : FunctionParamFlags.None),
                     param.d.name ? param.d.name.d.value : undefined,
-                    defaultValueType
+                    defaultValueType,
+                    param.d.defaultValue
                 );
 
                 FunctionType.addParam(functionType, functionParam);
@@ -25506,7 +25508,8 @@ export function createTypeEvaluator(
                                 p.name,
                                 FunctionType.getParamDefaultType(effectiveSrcType, index)
                                     ? AnyType.create(/* isEllipsis */ true)
-                                    : undefined
+                                    : undefined,
+                                p.defaultExpr
                             )
                         );
                     }

--- a/packages/pyright-internal/src/analyzer/typePrinter.ts
+++ b/packages/pyright-internal/src/analyzer/typePrinter.ts
@@ -1086,7 +1086,6 @@ function printFunctionPartsInternal(
 ): [string[], string] {
     const paramTypeStrings: string[] = [];
     let sawDefinedName = false;
-    const functionNode = type.shared.declaration?.node;
 
     // Remove the (*args: P.args, **kwargs: P.kwargs) from the end of the parameter list.
     const paramSpec = FunctionType.getParamSpecFromArgsKwargs(type);
@@ -1231,9 +1230,8 @@ function printFunctionPartsInternal(
         }
 
         if (defaultType) {
-            const paramNode = functionNode?.d.params.find((p) => p.d.name?.d.value === param.name);
-            if (paramNode?.d.defaultValue) {
-                paramString += defaultValueAssignment + ParseTreeUtils.printExpression(paramNode.d.defaultValue);
+            if (param.defaultExpr) {
+                paramString += defaultValueAssignment + ParseTreeUtils.printExpression(param.defaultExpr);
             } else {
                 // If the function doesn't originate from a function declaration (e.g. it is
                 // synthesized), we can't get to the default declaration, but we can still indicate

--- a/packages/pyright-internal/src/analyzer/typeUtils.ts
+++ b/packages/pyright-internal/src/analyzer/typeUtils.ts
@@ -3205,7 +3205,8 @@ export function convertTypeToParamSpecValue(type: Type): FunctionType {
                     FunctionType.getParamType(type, index),
                     param.flags,
                     param.name,
-                    FunctionType.getParamDefaultType(type, index)
+                    FunctionType.getParamDefaultType(type, index),
+                    param.defaultExpr
                 )
             );
         });
@@ -3766,7 +3767,8 @@ export class TypeVarTransformer {
                                 param.name && FunctionParam.isNameSynthesized(param)
                                     ? `__p${newFunctionType.shared.parameters.length}`
                                     : param.name,
-                                FunctionType.getParamDefaultType(functionType, index)
+                                FunctionType.getParamDefaultType(functionType, index),
+                                param.defaultExpr
                             )
                         );
                     }

--- a/packages/pyright-internal/src/analyzer/types.ts
+++ b/packages/pyright-internal/src/analyzer/types.ts
@@ -9,7 +9,7 @@
 
 import { assert } from '../common/debug';
 import { Uri } from '../common/uri/uri';
-import { ArgumentNode, NameNode, ParamCategory } from '../parser/parseNodes';
+import { ArgumentNode, ExpressionNode, NameNode, ParamCategory } from '../parser/parseNodes';
 import { ClassDeclaration, FunctionDeclaration, SpecialBuiltInClassDeclaration } from './declaration';
 import { Symbol, SymbolTable } from './symbol';
 
@@ -505,6 +505,7 @@ export interface DataClassEntry {
     alias?: string | undefined;
     hasDefault?: boolean | undefined;
     nameNode: NameNode | undefined;
+    defaultExpr?: ExpressionNode | undefined;
     includeInInit: boolean;
     type: Type;
     converter?: ArgumentNode | undefined;
@@ -1442,6 +1443,8 @@ export interface FunctionParam {
     // Use getEffectiveParamDefaultArgType to access this field.
     // eslint-disable-next-line @typescript-eslint/naming-convention
     _defaultType: Type | undefined;
+
+    defaultExpr: ExpressionNode | undefined;
 }
 
 export namespace FunctionParam {
@@ -1450,9 +1453,10 @@ export namespace FunctionParam {
         type: Type,
         flags = FunctionParamFlags.None,
         name?: string,
-        defaultType?: Type
+        defaultType?: Type,
+        defaultExpr?: ExpressionNode
     ): FunctionParam {
-        return { category, flags, name, _type: type, _defaultType: defaultType };
+        return { category, flags, name, _type: type, _defaultType: defaultType, defaultExpr };
     }
 
     export function isNameSynthesized(param: FunctionParam) {
@@ -1815,7 +1819,8 @@ export namespace FunctionType {
                     FunctionType.getParamType(paramSpecValue, index),
                     (param.flags & FunctionParamFlags.NameSynthesized) | FunctionParamFlags.TypeDeclared,
                     param.name,
-                    FunctionType.getParamDefaultType(paramSpecValue, index)
+                    FunctionType.getParamDefaultType(paramSpecValue, index),
+                    param.defaultExpr
                 );
             }),
         ];

--- a/packages/pyright-internal/src/tests/samples/lambda14.py
+++ b/packages/pyright-internal/src/tests/samples/lambda14.py
@@ -2,7 +2,7 @@
 # context but has a default argument value.
 
 lambda1 = lambda x="": x
-reveal_type(lambda1, expected_text="(x: str = ...) -> str")
+reveal_type(lambda1, expected_text='(x: str = "") -> str')
 
 lambda2 = lambda x=None: x
-reveal_type(lambda2, expected_text="(x: Unknown | None = ...) -> (Unknown | None)")
+reveal_type(lambda2, expected_text="(x: Unknown | None = None) -> (Unknown | None)")

--- a/packages/pyright-internal/src/tests/samples/paramSpec3.py
+++ b/packages/pyright-internal/src/tests/samples/paramSpec3.py
@@ -113,7 +113,7 @@ def func8(cb1: Callback1, cb2: Callback2, cb3: Callback3):
     reveal_type(v1, expected_text="(x: int, /) -> None")
 
     v2 = func7(cb1, cb3)
-    reveal_type(v2, expected_text="(x: int | str, y: int = ...) -> None")
+    reveal_type(v2, expected_text="(x: int | str, y: int = 3) -> None")
 
 
 def func9(f: Callable[P, object], *args: P.args, **kwargs: P.kwargs) -> object:


### PR DESCRIPTION
…ons in function signatures, including synthesized signatures (such as `__init__` methods in dataclasses). This allows the original default value expression to be printed in error messages and language server strings. This addresses #8781.