### PR TITLE
Fixed a bug that results in false negatives for errors in argument ex…

### DIFF
--- a/packages/pyright-internal/src/analyzer/constructors.ts
+++ b/packages/pyright-internal/src/analyzer/constructors.ts
@@ -196,17 +196,19 @@ export function validateConstructorArgs(
                 isTypeIncomplete: !!returnResult.isTypeIncomplete,
             });
 
-            returnResult.returnType = transformed.returnType;
+            if (transformed) {
+                returnResult.returnType = transformed.returnType;
 
-            if (transformed.isTypeIncomplete) {
-                returnResult.isTypeIncomplete = true;
+                if (transformed.isTypeIncomplete) {
+                    returnResult.isTypeIncomplete = true;
+                }
+
+                if (transformed.argumentErrors) {
+                    returnResult.argumentErrors = true;
+                }
+
+                validatedArgExpressions = true;
             }
-
-            if (transformed.argumentErrors) {
-                returnResult.argumentErrors = true;
-            }
-
-            validatedArgExpressions = true;
         }
     }
 


### PR DESCRIPTION
…pressions used in a call to `functools.partial` in some cases. This same issue also causes symbols accessed in these arg expressions to not be marked as referenced. This addresses #8807.