### PR TITLE
Handle undefined python versions

### DIFF
--- a/packages/pyright-internal/src/common/pythonVersion.ts
+++ b/packages/pyright-internal/src/common/pythonVersion.ts
@@ -50,7 +50,12 @@ export namespace PythonVersion {
         };
     }
 
-    export function isEqualTo(version: PythonVersion, other: PythonVersion) {
+    export function isEqualTo(version: PythonVersion | undefined, other: PythonVersion | undefined) {
+        if (version === undefined && other === undefined) {
+            return true;
+        } else if (version === undefined || other === undefined) {
+            return false;
+        }
         if (version.major !== other.major || version.minor !== other.minor) {
             return false;
         }
@@ -76,7 +81,14 @@ export namespace PythonVersion {
         return true;
     }
 
-    export function isGreaterThan(version: PythonVersion, other: PythonVersion) {
+    export function isGreaterThan(version: PythonVersion | undefined, other: PythonVersion | undefined) {
+        if (version && !other) {
+            return true;
+        } else if (!version && other) {
+            return false;
+        } else if (!version || !other) {
+            return false;
+        }
         if (version.major > other.major) {
             return true;
         } else if (version.major < other.major) {
@@ -118,38 +130,38 @@ export namespace PythonVersion {
         return false;
     }
 
-    export function isGreaterOrEqualTo(version: PythonVersion, other: PythonVersion) {
+    export function isGreaterOrEqualTo(version: PythonVersion | undefined, other: PythonVersion | undefined) {
         return isEqualTo(version, other) || isGreaterThan(version, other);
     }
 
-    export function isLessThan(version: PythonVersion, other: PythonVersion) {
+    export function isLessThan(version: PythonVersion | undefined, other: PythonVersion | undefined) {
         return !isGreaterOrEqualTo(version, other);
     }
 
-    export function isLessOrEqualTo(version: PythonVersion, other: PythonVersion) {
+    export function isLessOrEqualTo(version: PythonVersion | undefined, other: PythonVersion | undefined) {
         return !isGreaterThan(version, other);
     }
 
-    export function toMajorMinorString(version: PythonVersion): string {
-        return `${version.major}.${version.minor}`;
+    export function toMajorMinorString(version: PythonVersion | undefined): string {
+        return `${version?.major}.${version?.minor}`;
     }
 
-    export function toString(version: PythonVersion): string {
+    export function toString(version: PythonVersion | undefined): string {
         let versString = toMajorMinorString(version);
 
-        if (version.micro === undefined) {
+        if (version?.micro === undefined) {
             return versString;
         }
 
         versString += `.${version.micro}`;
 
-        if (version.releaseLevel === undefined) {
+        if (version?.releaseLevel === undefined) {
             return versString;
         }
 
         versString += `.${version.releaseLevel}`;
 
-        if (version.serial === undefined) {
+        if (version?.serial === undefined) {
             return versString;
         }
 

--- a/packages/pyright-internal/src/common/pythonVersion.ts
+++ b/packages/pyright-internal/src/common/pythonVersion.ts
@@ -84,8 +84,6 @@ export namespace PythonVersion {
     export function isGreaterThan(version: PythonVersion | undefined, other: PythonVersion | undefined) {
         if (version && !other) {
             return true;
-        } else if (!version && other) {
-            return false;
         } else if (!version || !other) {
             return false;
         }
@@ -143,7 +141,7 @@ export namespace PythonVersion {
     }
 
     export function toMajorMinorString(version: PythonVersion | undefined): string {
-        return `${version?.major}.${version?.minor}`;
+        return version ? `${version.major}.${version.minor}` : '';
     }
 
     export function toString(version: PythonVersion | undefined): string {

--- a/packages/pyright-internal/src/tests/pythonVersion.test.ts
+++ b/packages/pyright-internal/src/tests/pythonVersion.test.ts
@@ -1,0 +1,54 @@
+/*
+ * pythonVersion.test.ts
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT license.
+ *
+ * Unit tests for pythonVersion module.
+ */
+
+import assert from 'assert';
+
+import { PythonVersion, pythonVersion3_8 } from '../common/pythonVersion';
+
+test('isEqualTo', () => {
+    const version = PythonVersion.create(3, 8);
+    assert.ok(PythonVersion.isEqualTo(version, version));
+    assert.ok(PythonVersion.isEqualTo(version, { ...version }));
+    assert.ok(PythonVersion.isEqualTo(undefined, undefined));
+    assert.ok(!PythonVersion.isEqualTo(version, undefined));
+    assert.ok(!PythonVersion.isEqualTo(undefined, version));
+    assert.ok(PythonVersion.isEqualTo(version, PythonVersion.create(3, 8)));
+    assert.ok(PythonVersion.isEqualTo(version, pythonVersion3_8));
+    assert.ok(!PythonVersion.isEqualTo(version, PythonVersion.create(3, 9)));
+    assert.ok(!PythonVersion.isEqualTo(version, PythonVersion.create(4, 8)));
+    assert.ok(PythonVersion.isEqualTo(version, PythonVersion.create(3, 8, 1)));
+    assert.ok(PythonVersion.isEqualTo(version, PythonVersion.create(3, 8, 0, 'alpha')));
+    assert.ok(PythonVersion.isEqualTo(version, PythonVersion.create(3, 8, 0, 'alpha', 1)));
+    assert.ok(PythonVersion.isEqualTo(version, PythonVersion.create(3, 8, 0, 'final', 1)));
+    assert.ok(PythonVersion.isEqualTo(version, PythonVersion.create(3, 8, 0, 'final', 0)));
+});
+
+test('isGreaterOrEqualTo', () => {
+    const version = PythonVersion.create(3, 8);
+    assert.ok(PythonVersion.isGreaterOrEqualTo(version, version));
+    assert.ok(PythonVersion.isGreaterOrEqualTo(version, { ...version }));
+    assert.ok(PythonVersion.isGreaterOrEqualTo(version, undefined));
+    assert.ok(!PythonVersion.isGreaterOrEqualTo(undefined, version));
+    assert.ok(PythonVersion.isGreaterOrEqualTo(version, PythonVersion.create(3, 7)));
+    assert.ok(PythonVersion.isGreaterOrEqualTo(version, PythonVersion.create(3, 7, 0, 'alpha')));
+    assert.ok(PythonVersion.isGreaterOrEqualTo(version, PythonVersion.create(3, 7, 0, 'alpha', 1)));
+    assert.ok(PythonVersion.isGreaterOrEqualTo(version, PythonVersion.create(3, 7, 0, 'beta', 1)));
+    assert.ok(PythonVersion.isGreaterOrEqualTo(version, PythonVersion.create(3, 7, 0, 'candidate', 1)));
+    assert.ok(PythonVersion.isGreaterOrEqualTo(version, PythonVersion.create(3, 7, 0, 'final', 1)));
+    assert.ok(PythonVersion.isGreaterOrEqualTo(version, pythonVersion3_8));
+    assert.ok(!PythonVersion.isGreaterOrEqualTo(version, PythonVersion.create(3, 9)));
+    assert.ok(!PythonVersion.isGreaterOrEqualTo(version, PythonVersion.create(4, 8)));
+    assert.ok(PythonVersion.isGreaterOrEqualTo(version, PythonVersion.create(3, 8, 1)));
+    assert.ok(PythonVersion.isGreaterOrEqualTo(version, PythonVersion.create(3, 8, 0, 'alpha')));
+    assert.ok(PythonVersion.isGreaterOrEqualTo(version, PythonVersion.create(3, 8, 0, 'alpha', 1)));
+    assert.ok(PythonVersion.isGreaterOrEqualTo(version, PythonVersion.create(3, 8, 0, 'final', 1)));
+    assert.ok(PythonVersion.isGreaterOrEqualTo(version, PythonVersion.create(3, 8, 0, 'final', 0)));
+    assert.ok(
+        PythonVersion.isGreaterOrEqualTo(PythonVersion.create(3, 8, 0, 'final'), PythonVersion.create(3, 8, 0, 'alpha'))
+    );
+});


### PR DESCRIPTION
While testing our latest release, we had an undefined PythonVersion happen at this point here:
https://github.com/microsoft/pyrx/blob/c1a1f8f062d3391f32b2c1ecc0e25082cf6a794c/packages/pyright/packages/pyright-internal/src/analyzer/importResolver.ts#L2002

Which caused a crash.

This change makes PythonVersion handle undefined.