### PR TITLE
Added some code improvements from a working branch:

### DIFF
--- a/packages/pyright-internal/src/analyzer/analyzerFileInfo.ts
+++ b/packages/pyright-internal/src/analyzer/analyzerFileInfo.ts
@@ -52,6 +52,7 @@ export interface AnalyzerFileInfo {
     lines: TextRangeCollection<TextRange>;
     typingSymbolAliases: Map<string, string>;
     definedConstants: Map<string, boolean | string>;
+    fileId: string;
     fileUri: Uri;
     moduleName: string;
     isStubFile: boolean;

--- a/packages/pyright-internal/src/analyzer/constraintSolution.ts
+++ b/packages/pyright-internal/src/analyzer/constraintSolution.ts
@@ -16,16 +16,9 @@ export class ConstraintSolutionSet {
     // Indexed by TypeVar ID.
     private _typeVarMap: Map<string, Type | undefined>;
 
-    // See the comment in constraintTracker for details about identifying
-    // solution sets by scope ID.
-    private _scopeIds: Set<string> | undefined;
 
-    constructor(scopeIds?: Set<string>) {
+    constructor() {
         this._typeVarMap = new Map<string, Type>();
-
-        if (scopeIds) {
-            this._scopeIds = new Set<string>(scopeIds);
-        }
     }
 
     isEmpty() {

--- a/packages/pyright-internal/src/analyzer/constraintSolution.ts
+++ b/packages/pyright-internal/src/analyzer/constraintSolution.ts
@@ -16,7 +16,6 @@ export class ConstraintSolutionSet {
     // Indexed by TypeVar ID.
     private _typeVarMap: Map<string, Type | undefined>;
 
-
     constructor() {
         this._typeVarMap = new Map<string, Type>();
     }

--- a/packages/pyright-internal/src/analyzer/constraintSolver.ts
+++ b/packages/pyright-internal/src/analyzer/constraintSolver.ts
@@ -236,7 +236,7 @@ export function solveConstraintSet(
     constraintSet: ConstraintSet,
     options?: SolveConstraintsOptions
 ): ConstraintSolutionSet {
-    const solutionSet = new ConstraintSolutionSet(constraintSet.getScopeIds());
+    const solutionSet = new ConstraintSolutionSet();
 
     constraintSet.doForEachTypeVar((entry) => {
         solveTypeVarRecursive(evaluator, constraintSet, options, solutionSet, entry);

--- a/packages/pyright-internal/src/analyzer/constraintTracker.ts
+++ b/packages/pyright-internal/src/analyzer/constraintTracker.ts
@@ -38,6 +38,7 @@ export interface TypeVarConstraints {
 // Records the constraints information for a set of type variables
 // associated with a callee's signature.
 export class ConstraintSet {
+    // Maps type variable IDs to their current constraints.
     private _typeVarMap: Map<string, TypeVarConstraints>;
 
     // A set of one or more TypeVar scope IDs that identify this constraint set.

--- a/packages/pyright-internal/src/analyzer/declarationUtils.ts
+++ b/packages/pyright-internal/src/analyzer/declarationUtils.ts
@@ -7,6 +7,7 @@
  * Collection of static methods that operate on declarations.
  */
 
+import { assertNever } from '../common/debug';
 import { getEmptyRange } from '../common/textRange';
 import { Uri } from '../common/uri/uri';
 import { NameNode, ParseNodeType } from '../parser/parseNodes';
@@ -138,6 +139,10 @@ export function getNameFromDeclaration(declaration: Declaration) {
                 declaration.node.d.valueExpr.nodeType === ParseNodeType.Name
                 ? declaration.node.d.valueExpr.d.value
                 : undefined;
+
+        default: {
+            assertNever(declaration);
+        }
     }
 
     throw new Error(`Shouldn't reach here`);
@@ -167,6 +172,10 @@ export function getNameNodeForDeclaration(declaration: Declaration): NameNode | 
         case DeclarationType.Intrinsic:
         case DeclarationType.SpecialBuiltInClass:
             return undefined;
+
+        default: {
+            assertNever(declaration);
+        }
     }
 
     throw new Error(`Shouldn't reach here`);
@@ -197,7 +206,7 @@ export function getDeclarationsWithUsesLocalNameRemoved(decls: Declaration[]) {
     });
 }
 
-export function createSynthesizedAliasDeclaration(uri: Uri): AliasDeclaration {
+export function synthesizeAliasDeclaration(uri: Uri): AliasDeclaration {
     // The only time this decl is used is for IDE services such as
     // the find all references, hover provider and etc.
     return {

--- a/packages/pyright-internal/src/analyzer/parseTreeUtils.ts
+++ b/packages/pyright-internal/src/analyzer/parseTreeUtils.ts
@@ -2876,7 +2876,7 @@ export function getScopeIdForNode(node: ParseNode): string {
     }
 
     const fileInfo = AnalyzerNodeInfo.getFileInfo(node);
-    return `${fileInfo.fileUri.key}.${node.start.toString()}-${name}`;
+    return `${fileInfo.fileId}.${node.start.toString()}-${name}`;
 }
 
 // Walks up the parse tree and finds all scopes that can provide

--- a/packages/pyright-internal/src/analyzer/parseTreeWalker.ts
+++ b/packages/pyright-internal/src/analyzer/parseTreeWalker.ts
@@ -795,7 +795,15 @@ export class ParseTreeVisitor<T> {
         return this._default;
     }
 
+    visitPatternMapping(node: PatternMappingNode) {
+        return this._default;
+    }
+
     visitPatternMappingExpandEntry(node: PatternMappingExpandEntryNode) {
+        return this._default;
+    }
+
+    visitPatternMappingKeyEntry(node: PatternMappingKeyEntryNode) {
         return this._default;
     }
 
@@ -804,14 +812,6 @@ export class ParseTreeVisitor<T> {
     }
 
     visitPatternValue(node: PatternValueNode) {
-        return this._default;
-    }
-
-    visitPatternMappingKeyEntry(node: PatternMappingKeyEntryNode) {
-        return this._default;
-    }
-
-    visitPatternMapping(node: PatternMappingNode) {
         return this._default;
     }
 

--- a/packages/pyright-internal/src/analyzer/sourceFile.ts
+++ b/packages/pyright-internal/src/analyzer/sourceFile.ts
@@ -71,6 +71,9 @@ export enum IPythonMode {
     CellDocs,
 }
 
+// A monotonically increasing number used to create unique file IDs.
+let nextUniqueFileId = 1;
+
 class WriteableData {
     // Number that is incremented every time the diagnostics
     // are updated.
@@ -193,6 +196,10 @@ export class SourceFile {
     // a real file on disk.
     private readonly _uri: Uri;
 
+    // A short string that is guaranteed to uniquely
+    // identify this file.
+    private readonly _fileId: string;
+
     // Period-delimited import path for the module.
     private _moduleName: string;
 
@@ -258,6 +265,7 @@ export class SourceFile {
 
         this._editMode = editMode;
         this._uri = uri;
+        this._fileId = this._makeFileId(uri);
         this._moduleName = moduleName;
         this._isStubFile = uri.hasExtension('.pyi');
         this._isThirdPartyImport = isThirdPartyImport;
@@ -954,6 +962,27 @@ export class SourceFile {
         return new TextRangeDiagnosticSink(lines);
     }
 
+    // Creates a short string that can be used to uniquely identify
+    // this file from all other files. It is used in the type evaluator
+    // to distinguish between types that are defined in different files
+    // or scopes.
+    private _makeFileId(uri: Uri) {
+        const maxNameLength = 8;
+
+        // Use a small portion of the file name to help with debugging.
+        let fileName = uri.fileNameWithoutExtensions;
+        if (fileName.length > maxNameLength) {
+            fileName = fileName.substring(fileName.length - maxNameLength);
+        }
+
+        // Append a number to guarantee uniqueness.
+        const uniqueNumber = nextUniqueFileId++;
+
+        // Use a "/" to separate the two components, since this
+        // character will never appear in a file name.
+        return `${fileName}/${uniqueNumber.toString()}`;
+    }
+
     // Computes an updated set of accumulated diagnostics for the file
     // based on the partial diagnostics from various analysis stages.
     private _recomputeDiagnostics(configOptions: ConfigOptions) {
@@ -1302,6 +1331,7 @@ export class SourceFile {
             lines: this._writableData.tokenizerLines!,
             typingSymbolAliases: this._writableData.parserOutput!.typingSymbolAliases,
             definedConstants: configOptions.defineConstant,
+            fileId: this._fileId,
             fileUri: this._uri,
             moduleName: this.getModuleName(),
             isStubFile: this._isStubFile,

--- a/packages/pyright-internal/src/analyzer/typePrinterUtils.ts
+++ b/packages/pyright-internal/src/analyzer/typePrinterUtils.ts
@@ -1,0 +1,49 @@
+/*
+ * typePrinterUtils.ts
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT license.
+ * Author: Eric Traut
+ *
+ * Simple utility functions used by the type printer.
+ */
+
+export function printStringLiteral(value: string, quotation = '"'): string {
+    const singleTickRegEx = /'/g;
+    const escapedDoubleQuoteRegEx = /\\"/g;
+
+    // JSON.stringify will perform proper escaping for " case.
+    // So, we only need to do our own escaping for ' case.
+    let literalStr = JSON.stringify(value).toString();
+    if (quotation !== '"') {
+        literalStr = `'${literalStr
+            .substring(1, literalStr.length - 1)
+            .replace(escapedDoubleQuoteRegEx, '"')
+            .replace(singleTickRegEx, "\\'")}'`; // CodeQL [SM02383] Code ql is just wrong here. We don't need to replace backslashes.
+    }
+
+    return literalStr;
+}
+
+export function printBytesLiteral(value: string) {
+    let bytesString = '';
+
+    // There's no good built-in conversion routine in javascript to convert
+    // bytes strings. Determine on a character-by-character basis whether
+    // it can be rendered into an ASCII character. If not, use an escape.
+    for (let i = 0; i < value.length; i++) {
+        const char = value.substring(i, i + 1);
+        const charCode = char.charCodeAt(0);
+
+        if (charCode >= 20 && charCode <= 126) {
+            if (charCode === 34) {
+                bytesString += '\\' + char;
+            } else {
+                bytesString += char;
+            }
+        } else {
+            bytesString += `\\x${((charCode >> 4) & 0xf).toString(16)}${(charCode & 0xf).toString(16)}`;
+        }
+    }
+
+    return `b"${bytesString}"`;
+}

--- a/packages/pyright-internal/src/languageService/documentSymbolCollector.ts
+++ b/packages/pyright-internal/src/languageService/documentSymbolCollector.ts
@@ -14,8 +14,8 @@ import * as AnalyzerNodeInfo from '../analyzer/analyzerNodeInfo';
 import { AliasDeclaration, Declaration, DeclarationType, isAliasDeclaration } from '../analyzer/declaration';
 import {
     areDeclarationsSame,
-    createSynthesizedAliasDeclaration,
     getDeclarationsWithUsesLocalNameRemoved,
+    synthesizeAliasDeclaration,
 } from '../analyzer/declarationUtils';
 import { getModuleNode, getStringNodeValueRange } from '../analyzer/parseTreeUtils';
 import { ParseTreeWalker } from '../analyzer/parseTreeWalker';
@@ -450,7 +450,7 @@ function _getDeclarationsForNonModuleNameNode(
         const type = evaluator.getType(node);
         if (type?.category === TypeCategory.Module) {
             // Synthesize decl for the module.
-            return [createSynthesizedAliasDeclaration(type.priv.fileUri)];
+            return [synthesizeAliasDeclaration(type.priv.fileUri)];
         }
     }
 


### PR DESCRIPTION
* Created a shortened "fileId" for each source file. This reduces memory used for tracking symbols and TypeVars that are scoped to files.
* Removed some unused or redundant code.
* Added assertNever calls to catch potential bugs.
* Renamed a few symbols for consistency and readability.
* Improved handling of literal type expressions that are lazily parsed.
* Refactored literal type printing into a utility module.