### PR TITLE
Fixed a bug that resulted in incorrect evaluation when converting a c…

### DIFF
--- a/packages/pyright-internal/src/analyzer/constructors.ts
+++ b/packages/pyright-internal/src/analyzer/constructors.ts
@@ -761,7 +761,7 @@ function createFunctionFromMetaclassCall(
         callType,
         callInfo && isInstantiableClass(callInfo.classType) ? callInfo.classType : undefined,
         /* treatConstructorAsClassMethod */ false,
-        ClassType.cloneAsInstantiable(classType),
+        classType,
         /* diag */ undefined,
         recursionCount
     );

--- a/packages/pyright-internal/src/tests/samples/constructorCallable2.py
+++ b/packages/pyright-internal/src/tests/samples/constructorCallable2.py
@@ -43,11 +43,9 @@ reveal_type(r2(), expected_text="Class2")
 
 
 class Class3:
-    def __new__(cls, *args, **kwargs) -> Self:
-        ...
+    def __new__(cls, *args, **kwargs) -> Self: ...
 
-    def __init__(self, x: int) -> None:
-        ...
+    def __init__(self, x: int) -> None: ...
 
 
 r3 = accepts_callable(Class3)
@@ -56,8 +54,7 @@ reveal_type(r3(3), expected_text="Class3")
 
 
 class Class4:
-    def __new__(cls, x: int) -> int:
-        ...
+    def __new__(cls, x: int) -> int: ...
 
 
 r4 = accepts_callable(Class4)
@@ -79,8 +76,7 @@ r5 = accepts_callable(Class5)
 reveal_type(r5, expected_text="(...) -> NoReturn")
 
 
-class Class6Proxy:
-    ...
+class Class6Proxy: ...
 
 
 class Class6:
@@ -112,12 +108,10 @@ reveal_type(r6_2(), expected_text="Any")
 
 class Class7(Generic[T]):
     @overload
-    def __init__(self: "Class7[int]", x: int) -> None:
-        ...
+    def __init__(self: "Class7[int]", x: int) -> None: ...
 
     @overload
-    def __init__(self: "Class7[str]", x: str) -> None:
-        ...
+    def __init__(self: "Class7[str]", x: str) -> None: ...
 
     def __init__(self, x: int | str) -> None:
         pass
@@ -150,3 +144,20 @@ class Class9:
 r9 = accepts_callable(Class9)
 reveal_type(r9, expected_text="(x: list[T@__init__], y: list[T@__init__]) -> Class9")
 reveal_type(r9([""], [""]), expected_text="Class9")
+
+
+M = TypeVar("M")
+
+
+class Meta2(type):
+    def __call__(cls: type[M], *args: Any, **kwargs: Any) -> M: ...
+
+
+class Class10(metaclass=Meta2):
+    def __new__(cls, x: int, y: str) -> Self:
+        return super().__new__(cls)
+
+
+r10 = accepts_callable(Class10)
+reveal_type(r10, expected_text="(x: int, y: str) -> Class10")
+reveal_type(r10(1, ""), expected_text="Class10")


### PR DESCRIPTION
…onstructor to a callable and the constructed class has a metaclass with a `__call__` method whose `cls` parameter is annotated with `type[T]`. This addresses https://github.com/microsoft/pylance-release/issues/6297.