### PR TITLE
Fixed bug that results in a `reportIncompatibleMethodOverride` diagno…

### DIFF
--- a/packages/pyright-internal/src/analyzer/checker.ts
+++ b/packages/pyright-internal/src/analyzer/checker.ts
@@ -6865,10 +6865,7 @@ export class Checker extends ParseTreeWalker {
                             enforceParamNameMatch
                         )
                     ) {
-                        const decl =
-                            isFunction(overrideType) && overrideType.shared.declaration
-                                ? overrideType.shared.declaration
-                                : getLastTypedDeclarationForSymbol(overrideSymbol);
+                        const decl = getLastTypedDeclarationForSymbol(overrideSymbol);
                         if (decl) {
                             const diag = this._evaluator.addDiagnostic(
                                 DiagnosticRule.reportIncompatibleMethodOverride,


### PR DESCRIPTION
…stic being reported in the wrong location in some cases involving decorators. This addresses #8842.