### PR TITLE
Fixed a recent regression that results in a false positive type error…

### DIFF
--- a/packages/pyright-internal/src/analyzer/checker.ts
+++ b/packages/pyright-internal/src/analyzer/checker.ts
@@ -707,7 +707,11 @@ export class Checker extends ParseTreeWalker {
 
         this._scopedNodes.push(node);
 
-        if (functionTypeResult && isOverloaded(functionTypeResult.decoratedType)) {
+        if (
+            functionTypeResult &&
+            isOverloaded(functionTypeResult.decoratedType) &&
+            functionTypeResult.functionType.priv.overloaded
+        ) {
             // If this is the implementation for the overloaded function, skip
             // overload consistency checks.
             if (

--- a/packages/pyright-internal/src/analyzer/constructors.ts
+++ b/packages/pyright-internal/src/analyzer/constructors.ts
@@ -697,7 +697,7 @@ export function createFunctionFromConstructor(
         return fromMetaclassCall;
     }
 
-    const fromNew = createFunctionFromNewMethod(evaluator, classType, selfType, recursionCount);
+    let fromNew = createFunctionFromNewMethod(evaluator, classType, selfType, recursionCount);
 
     if (fromNew) {
         let skipInitMethod = false;
@@ -715,6 +715,13 @@ export function createFunctionFromConstructor(
     }
 
     const fromInit = createFunctionFromInitMethod(evaluator, classType, selfType, recursionCount);
+
+    // If there is a valid __init__ method and the __new__ method
+    // is the default __new__ method provided by the object class,
+    // discard the __new__ method.
+    if (fromInit && fromNew && isDefaultNewMethod(fromNew)) {
+        fromNew = undefined;
+    }
 
     // If there is both a __new__ and __init__ method, return a union
     // comprised of both resulting function types.

--- a/packages/pyright-internal/src/analyzer/types.ts
+++ b/packages/pyright-internal/src/analyzer/types.ts
@@ -2312,6 +2312,10 @@ export namespace OverloadedType {
             OverloadedType.addOverload(newType, overload);
         });
 
+        if (implementation && isFunction(implementation)) {
+            implementation.priv.overloaded = newType;
+        }
+
         return newType;
     }
 

--- a/packages/pyright-internal/src/tests/samples/constructorCallable1.py
+++ b/packages/pyright-internal/src/tests/samples/constructorCallable1.py
@@ -20,13 +20,11 @@ P = ParamSpec("P")
 R = TypeVar("R")
 
 
-def func1(callback: Callable[[T1], T2], val: T1) -> T2:
-    ...
+def func1(callback: Callable[[T1], T2], val: T1) -> T2: ...
 
 
 class A(Generic[T1]):
-    def __new__(cls, x: T1) -> "A[T1]":
-        ...
+    def __new__(cls, x: T1) -> "A[T1]": ...
 
 
 a1 = func1(A[float], 3.4)
@@ -41,15 +39,12 @@ reveal_type(a3, expected_text="A[int]")
 
 class B(Generic[T1]):
     @overload
-    def __new__(cls, x: int, y: Literal[True]) -> "B[None]":
-        ...
+    def __new__(cls, x: int, y: Literal[True]) -> "B[None]": ...
 
     @overload
-    def __new__(cls, x: T1, y: bool = ...) -> "B[T1]":
-        ...
+    def __new__(cls, x: T1, y: bool = ...) -> "B[T1]": ...
 
-    def __new__(cls, x: Union[T1, int], y: bool = False) -> "B[Any]":
-        ...
+    def __new__(cls, x: Union[T1, int], y: bool = False) -> "B[Any]": ...
 
 
 b1 = func1(B[int], 3)
@@ -69,8 +64,7 @@ reveal_type(b5, expected_text="B[int | str]")
 
 
 class C(Generic[T1]):
-    def __init__(self, x: T1) -> None:
-        ...
+    def __init__(self, x: T1) -> None: ...
 
 
 c1 = func1(C[float], 3.4)
@@ -85,15 +79,12 @@ reveal_type(c3, expected_text="C[int]")
 
 class D(Generic[T1]):
     @overload
-    def __init__(self: "D[None]", x: int, y: Literal[True]) -> None:
-        ...
+    def __init__(self: "D[None]", x: int, y: Literal[True]) -> None: ...
 
     @overload
-    def __init__(self, x: T1, y: bool = ...) -> None:
-        ...
+    def __init__(self, x: T1, y: bool = ...) -> None: ...
 
-    def __init__(self, x: Any, y: bool = False) -> None:
-        ...
+    def __init__(self, x: Any, y: bool = False) -> None: ...
 
 
 d1 = func1(D[int], 3)
@@ -120,8 +111,7 @@ class E(Generic[T1]):
 e1: Callable[[int], E[int]] = E
 
 
-def func2(x: T1) -> E[T1]:
-    ...
+def func2(x: T1) -> E[T1]: ...
 
 
 e2: Callable[[int], E[int]] = func2
@@ -157,3 +147,28 @@ def func4(c: Callable[[T1], T2]) -> Callable[[T1], T2]:
 
 
 reveal_type(func4(G), expected_text="(int) -> G")
+
+
+# Test the conversion of a complex constructor that involves
+# a bunch of type variables, a default __new__ (that comes
+# from object), and an __init__ that involves custom self
+# types. This is meant to test a class like defaultdict.
+KT = TypeVar("KT")
+VT = TypeVar("VT")
+
+
+class DDict(dict[KT, VT]):
+    @overload
+    def __init__(self) -> None: ...
+    @overload
+    def __init__(self: "DDict[str, T1]", **kwargs: T1) -> None: ...
+    @overload
+    def __init__(self, default_factory: Callable[[], VT] | None, /) -> None: ...
+    def __init__(self, *args: Any, **kwargs: Any) -> None: ...
+
+
+dd1 = cast_to_callable(DDict)
+reveal_type(
+    dd1,
+    expected_text="Overload[() -> DDict[Unknown, Unknown], (**kwargs: T1@__init__) -> DDict[str, T1@__init__], (default_factory: (() -> VT@DDict) | None, /) -> DDict[Unknown, VT@DDict]]",
+)

--- a/packages/pyright-internal/src/tests/samples/overload2.py
+++ b/packages/pyright-internal/src/tests/samples/overload2.py
@@ -9,18 +9,15 @@ P = ParamSpec("P")
 
 # This should generate an error because there is only one overload.
 @overload
-def func1() -> None:
-    ...
+def func1() -> None: ...
 
 
-def func1() -> None:
-    ...
+def func1() -> None: ...
 
 
 # This should generate an error because there is only one overload.
 @overload
-def func2(a: int) -> None:
-    ...
+def func2(a: int) -> None: ...
 
 
 def func2(a: int) -> None:
@@ -30,66 +27,54 @@ def func2(a: int) -> None:
 class ClassA:
     # This should generate an error because there is no implementation.
     @overload
-    def func3(self) -> None:
-        ...
+    def func3(self) -> None: ...
 
     @overload
-    def func3(self, a: int) -> None:
-        ...
+    def func3(self, a: int) -> None: ...
 
 
 class ClassB(Protocol):
     # An implementation should not be required in a protocol class.
     @overload
-    def func4(self) -> None:
-        ...
+    def func4(self) -> None: ...
 
     @overload
-    def func4(self, name: str) -> str:
-        ...
+    def func4(self, name: str) -> str: ...
 
 
 def deco1(
     _origin: Callable[P, T],
-) -> Callable[[Callable[..., Any]], Callable[P, T]]:
-    ...
+) -> Callable[[Callable[..., Any]], Callable[P, T]]: ...
 
 
 @overload
-def func5(v: int) -> int:
-    ...
+def func5(v: int) -> int: ...
 
 
 @overload
-def func5(v: str) -> str:
-    ...
+def func5(v: str) -> str: ...
 
 
-def func5(v: int | str) -> int | str:
-    ...
+def func5(v: int | str) -> int | str: ...
 
 
 @deco1(func5)
-def func6(*args: Any, **kwargs: Any) -> Any:
-    ...
+def func6(*args: Any, **kwargs: Any) -> Any: ...
 
 
 @overload
-def deco2() -> Callable[[Callable[P, T]], Callable[P, T | None]]:
-    ...
+def deco2() -> Callable[[Callable[P, T]], Callable[P, T | None]]: ...
 
 
 @overload
 def deco2(
     x: Callable[[], T],
-) -> Callable[[Callable[P, T]], Callable[P, T]]:
-    ...
+) -> Callable[[Callable[P, T]], Callable[P, T]]: ...
 
 
 def deco2(
     x: Callable[[], T | None] = lambda: None,
-) -> Callable[[Callable[P, T]], Callable[P, T | None]]:
-    ...
+) -> Callable[[Callable[P, T]], Callable[P, T | None]]: ...
 
 
 @deco2(x=dict)

--- a/packages/pyright-internal/src/tests/samples/overload3.py
+++ b/packages/pyright-internal/src/tests/samples/overload3.py
@@ -7,13 +7,11 @@ from typing import Any, overload
 class A:
     @overload
     # This should emit an error because @staticmethod is used inconsistently.
-    def method1(self, x: int) -> int:
-        ...
+    def method1(self, x: int) -> int: ...
 
     @overload
     @staticmethod
-    def method1(x: str) -> str:
-        ...
+    def method1(x: str) -> str: ...
 
     def method1(*args: Any, **kwargs: Any) -> Any:
         return
@@ -21,24 +19,20 @@ class A:
     @overload
     @classmethod
     # This should emit an error because @classmethod is used inconsistently.
-    def method2(cls, x: str) -> str:
-        ...
+    def method2(cls, x: str) -> str: ...
 
     @overload
-    def method2(self, x: int) -> int:
-        ...
+    def method2(self, x: int) -> int: ...
 
     def method2(*args: Any, **kwargs: Any) -> Any:
         return
 
     @overload
     # This should emit an error because @staticmethod is used inconsistently.
-    def method3(self, x: str) -> str:
-        ...
+    def method3(self, x: str) -> str: ...
 
     @overload
-    def method3(self, x: int) -> int:
-        ...
+    def method3(self, x: int) -> int: ...
 
     @staticmethod
     def method3(*args: Any, **kwargs: Any) -> Any:


### PR DESCRIPTION
… when converting certain constructors (such as for the class `defaultdict`) to a callable type. This addresses #8840.