### PR TITLE
Removed duplicated code and use same method to create default workspace key.

### DIFF
--- a/packages/pyright-internal/src/workspaceFactory.ts
+++ b/packages/pyright-internal/src/workspaceFactory.ts
@@ -354,20 +354,20 @@ export class WorkspaceFactory implements IWorkspaceFactory {
         }
     }
 
-    private _getDefaultWorkspaceKey(pythonPath: Uri | undefined) {
-        return `${this._defaultWorkspacePath}:${!Uri.isEmpty(pythonPath) ? pythonPath : '$Empty$'}`;
+    private _getDefaultWorkspaceKey() {
+        return `${this._defaultWorkspacePath}`;
     }
 
     private _getWorkspaceKey(value: Workspace) {
         // Special the root path for the default workspace. It will be created
         // without a root path
-        const rootPath = value.kinds.includes(WellKnownWorkspaceKinds.Default)
-            ? this._defaultWorkspacePath
-            : value.rootUri;
+        if (value.kinds.includes(WellKnownWorkspaceKinds.Default)) {
+            return this._getDefaultWorkspaceKey();
+        }
 
         // Key is defined by the rootPath and the pythonPath. We might include platform in this, but for now
         // platform is only used by the import resolver.
-        return `${rootPath}`;
+        return `${value.rootUri}`;
     }
 
     private async _getOrCreateBestWorkspaceForFile(uri: Uri, pythonPath: Uri | undefined): Promise<Workspace> {
@@ -437,7 +437,7 @@ export class WorkspaceFactory implements IWorkspaceFactory {
 
     private _getOrCreateDefaultWorkspace(pythonPath: Uri | undefined): DefaultWorkspace {
         // Default key depends upon the pythonPath
-        let defaultWorkspace = this._map.get(this._getDefaultWorkspaceKey(pythonPath)) as DefaultWorkspace;
+        let defaultWorkspace = this._map.get(this._getDefaultWorkspaceKey()) as DefaultWorkspace;
         if (!defaultWorkspace) {
             // Create a default workspace for files that are outside
             // of all workspaces.


### PR DESCRIPTION
Recently, Pylance added its own workspace factory to support other types of workspaces, such as Copilot or Code Block workspaces, which require their own behaviors.

While doing that, we moved all notebook-related code from the existing workspace factory. It seems this introduced a bug where the default workspace still uses notebook-related bits when generating the default workspace key.

Now, we use the same code to generate the default workspace key, rather than having two separate places generating it differently that caused us to miss this one spot.

fixes https://github.com/microsoft/pylance-release/issues/6348