### PR TITLE
Fixed a bug that causes incorrect type narrowing of expressions used …

### DIFF
--- a/packages/pyright-internal/src/analyzer/binder.ts
+++ b/packages/pyright-internal/src/analyzer/binder.ts
@@ -2224,7 +2224,18 @@ export class Binder extends ParseTreeWalker {
         this.walk(node.d.expr);
 
         const expressionList: CodeFlowReferenceExpressionNode[] = [];
-        const isSubjectNarrowable = this._isNarrowingExpression(node.d.expr, expressionList);
+        let isSubjectNarrowable = this._isNarrowingExpression(node.d.expr, expressionList);
+
+        // We also support narrowing of individual tuple entries found within a
+        // match subject expression, so add those here as well.
+        if (node.d.expr.nodeType === ParseNodeType.Tuple) {
+            node.d.expr.d.items.forEach((itemExpr) => {
+                if (this._isNarrowingExpression(itemExpr, expressionList)) {
+                    isSubjectNarrowable = true;
+                }
+            });
+        }
+
         if (isSubjectNarrowable) {
             expressionList.forEach((expr) => {
                 const referenceKey = createKeyForReference(expr);

--- a/packages/pyright-internal/src/tests/samples/matchSequence1.py
+++ b/packages/pyright-internal/src/tests/samples/matchSequence1.py
@@ -75,8 +75,7 @@ _T_co = TypeVar("_T_co", covariant=True)
 
 
 class SeqProto(Protocol[_T_co]):
-    def __reversed__(self) -> Iterator[_T_co]:
-        ...
+    def __reversed__(self) -> Iterator[_T_co]: ...
 
 
 def test_protocol(value_to_match: SeqProto[str]):
@@ -281,11 +280,9 @@ def test_union(
 
 
 class SupportsLessThan(Protocol):
-    def __lt__(self, __other: Any) -> bool:
-        ...
+    def __lt__(self, __other: Any) -> bool: ...
 
-    def __le__(self, __other: Any) -> bool:
-        ...
+    def __le__(self, __other: Any) -> bool: ...
 
 
 SupportsLessThanT = TypeVar("SupportsLessThanT", bound=SupportsLessThan)
@@ -404,12 +401,10 @@ class A(Generic[_T]):
     a: _T
 
 
-class B:
-    ...
+class B: ...
 
 
-class C:
-    ...
+class C: ...
 
 
 AAlias = A
@@ -618,3 +613,15 @@ def test_variadic_tuple(subj: tuple[int, Unpack[Ts]]) -> tuple[Unpack[Ts]]:
         case _, *rest:
             reveal_type(rest, expected_text="list[Unknown]")
             return (*rest,)
+
+
+class D:
+    x: float
+    y: float
+
+
+def test_tuple_subexpressions(d: D):
+    match (d.x, d.y):
+        case (int(), int()):
+            reveal_type(d.x, expected_text="int")
+            reveal_type(d.y, expected_text="int")


### PR DESCRIPTION
…within a tuple expression in the subject expression of a `match` statement. This addresses #8897.