### PR TITLE
Removed support for python-2 raise statements with comma-delimited op…

### DIFF
--- a/packages/pyright-internal/src/analyzer/binder.ts
+++ b/packages/pyright-internal/src/analyzer/binder.ts
@@ -1456,14 +1456,11 @@ export class Binder extends ParseTreeWalker {
             this._targetFunctionDeclaration.raiseStatements.push(node);
         }
 
-        if (node.d.typeExpression) {
-            this.walk(node.d.typeExpression);
+        if (node.d.expr) {
+            this.walk(node.d.expr);
         }
-        if (node.d.valueExpression) {
-            this.walk(node.d.valueExpression);
-        }
-        if (node.d.tracebackExpression) {
-            this.walk(node.d.tracebackExpression);
+        if (node.d.fromExpr) {
+            this.walk(node.d.fromExpr);
         }
 
         this._finallyTargets.forEach((target) => {

--- a/packages/pyright-internal/src/analyzer/codeFlowEngine.ts
+++ b/packages/pyright-internal/src/analyzer/codeFlowEngine.ts
@@ -1862,9 +1862,9 @@ export function getCodeFlowEngine(
                         continue;
                     }
 
-                    if (simpleStatement.nodeType === ParseNodeType.Raise && simpleStatement.d.typeExpression) {
+                    if (simpleStatement.nodeType === ParseNodeType.Raise && simpleStatement.d.expr) {
                         // Check for a raising about 'NotImplementedError' or a subtype thereof.
-                        const exceptionType = evaluator.getType(simpleStatement.d.typeExpression);
+                        const exceptionType = evaluator.getType(simpleStatement.d.expr);
 
                         if (
                             exceptionType &&

--- a/packages/pyright-internal/src/analyzer/parseTreeWalker.ts
+++ b/packages/pyright-internal/src/analyzer/parseTreeWalker.ts
@@ -272,7 +272,7 @@ export function getChildNodes(node: ParseNode): (ParseNode | undefined)[] {
             return [node.d.expr];
 
         case ParseNodeType.Raise:
-            return [node.d.typeExpression, node.d.valueExpression, node.d.tracebackExpression];
+            return [node.d.expr, node.d.fromExpr];
 
         case ParseNodeType.Return:
             return [node.d.expr];

--- a/packages/pyright-internal/src/analyzer/typeEvaluatorTypes.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluatorTypes.ts
@@ -27,7 +27,6 @@ import {
     ParamCategory,
     ParameterNode,
     ParseNode,
-    RaiseNode,
     StringNode,
 } from '../parser/parseNodes';
 import { AnalyzerFileInfo } from './analyzerFileInfo';
@@ -551,7 +550,7 @@ export interface TypeEvaluator {
     ) => Type;
 
     getExpectedType: (node: ExpressionNode) => ExpectedTypeResult | undefined;
-    verifyRaiseExceptionType: (node: RaiseNode) => void;
+    verifyRaiseExceptionType: (node: ExpressionNode, allowNone: boolean) => void;
     verifyDeleteExpression: (node: ExpressionNode) => void;
     validateOverloadedArgTypes: (
         errorNode: ExpressionNode,

--- a/packages/pyright-internal/src/parser/parseNodes.ts
+++ b/packages/pyright-internal/src/parser/parseNodes.ts
@@ -2314,9 +2314,8 @@ export namespace ReturnNode {
 
 export interface RaiseNode extends ParseNodeBase<ParseNodeType.Raise> {
     d: {
-        typeExpression?: ExpressionNode | undefined;
-        valueExpression?: ExpressionNode | undefined;
-        tracebackExpression?: ExpressionNode | undefined;
+        expr?: ExpressionNode | undefined;
+        fromExpr?: ExpressionNode | undefined;
     };
 }
 

--- a/packages/pyright-internal/src/parser/parser.ts
+++ b/packages/pyright-internal/src/parser/parser.ts
@@ -2821,29 +2821,14 @@ export class Parser {
 
         const raiseNode = RaiseNode.create(raiseToken);
         if (!this._isNextTokenNeverExpression()) {
-            raiseNode.d.typeExpression = this._parseTestExpression(/* allowAssignmentExpression */ true);
-            raiseNode.d.typeExpression.parent = raiseNode;
-            extendRange(raiseNode, raiseNode.d.typeExpression);
+            raiseNode.d.expr = this._parseTestExpression(/* allowAssignmentExpression */ true);
+            raiseNode.d.expr.parent = raiseNode;
+            extendRange(raiseNode, raiseNode.d.expr);
 
             if (this._consumeTokenIfKeyword(KeywordType.From)) {
-                raiseNode.d.valueExpression = this._parseTestExpression(/* allowAssignmentExpression */ true);
-                raiseNode.d.valueExpression.parent = raiseNode;
-                extendRange(raiseNode, raiseNode.d.valueExpression);
-            } else {
-                if (this._consumeTokenIfType(TokenType.Comma)) {
-                    // Handle the Python 2.x variant
-                    raiseNode.d.valueExpression = this._parseTestExpression(/* allowAssignmentExpression */ true);
-                    raiseNode.d.valueExpression.parent = raiseNode;
-                    extendRange(raiseNode, raiseNode.d.valueExpression);
-
-                    if (this._consumeTokenIfType(TokenType.Comma)) {
-                        raiseNode.d.tracebackExpression = this._parseTestExpression(
-                            /* allowAssignmentExpression */ true
-                        );
-                        raiseNode.d.tracebackExpression.parent = raiseNode;
-                        extendRange(raiseNode, raiseNode.d.tracebackExpression);
-                    }
-                }
+                raiseNode.d.fromExpr = this._parseTestExpression(/* allowAssignmentExpression */ true);
+                raiseNode.d.fromExpr.parent = raiseNode;
+                extendRange(raiseNode, raiseNode.d.fromExpr);
             }
         }
 

--- a/packages/pyright-internal/src/tests/checker.test.ts
+++ b/packages/pyright-internal/src/tests/checker.test.ts
@@ -396,7 +396,7 @@ test('ParamType1', () => {
 test('Python2', () => {
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['python2.py']);
 
-    TestUtils.validateResults(analysisResults, 6);
+    TestUtils.validateResults(analysisResults, 7);
 });
 
 test('InconsistentSpaceTab1', () => {

--- a/packages/pyright-internal/src/tests/samples/python2.py
+++ b/packages/pyright-internal/src/tests/samples/python2.py
@@ -26,6 +26,6 @@ a = `b`
 def foo(a, (b, c), d):
     pass
 
-# This should generate an error.
+# This should generate two errors.
 raise NameError, a > 4, a < 4
 


### PR DESCRIPTION
…erands.

Removed redundant logic for checking exception type in `raise x from y` statements. Changed behavior of raise evaluation logic to allow type of exception to be `Never`. This addresses #8911.