### PR TITLE
Added support for custom metaclasses that derive from `ABCMeta`. Clas…

### DIFF
--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -17504,7 +17504,7 @@ export function createTypeEvaluator(
                             classType.shared.flags |= ClassTypeFlags.EnumClass;
                         }
 
-                        if (ClassType.isBuiltIn(metaclassType, 'ABCMeta')) {
+                        if (derivesFromStdlibClass(metaclassType, 'ABCMeta')) {
                             classType.shared.flags |= ClassTypeFlags.SupportsAbstractMethods;
                         }
                     }

--- a/packages/pyright-internal/src/tests/checker.test.ts
+++ b/packages/pyright-internal/src/tests/checker.test.ts
@@ -120,6 +120,12 @@ test('AbstractClass10', () => {
     TestUtils.validateResults(analysisResults, 6);
 });
 
+test('AbstractClass11', () => {
+    const analysisResults = TestUtils.typeAnalyzeSampleFiles(['abstractClass11.py']);
+
+    TestUtils.validateResults(analysisResults, 2);
+});
+
 test('Constants1', () => {
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['constants1.py']);
 

--- a/packages/pyright-internal/src/tests/samples/abstractClass11.py
+++ b/packages/pyright-internal/src/tests/samples/abstractClass11.py
@@ -1,0 +1,25 @@
+# This sample tests the handling of a class that is created from a subclass
+# of ABCMeta.
+
+from abc import ABCMeta, abstractmethod
+from typing import final
+
+
+class CustomMeta(ABCMeta):
+    pass
+
+
+class A(metaclass=CustomMeta):
+    @abstractmethod
+    def abstract(self):
+        pass
+
+
+@final
+# This should generate an error.
+class B(A):
+    pass
+
+
+# This should generate an error.
+B()


### PR DESCRIPTION
…ses instantiated from such metaclasses are now treated as abstract. This addresses #8910.