### PR TITLE
Fixed a bug that leads to a false positive "default value is specifie…

### DIFF
--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -26073,9 +26073,7 @@ export function createTypeEvaluator(
                                 FunctionType.getParamType(effectiveSrcType, index),
                                 p.flags,
                                 p.name,
-                                FunctionType.getParamDefaultType(effectiveSrcType, index)
-                                    ? AnyType.create(/* isEllipsis */ true)
-                                    : undefined,
+                                FunctionType.getParamDefaultType(effectiveSrcType, index),
                                 p.defaultExpr
                             )
                         );


### PR DESCRIPTION
…d as ..." when using `--verifytypes` and the function has a decorator applied that uses a ParamSpec. This addresses #8905.