### PR TITLE
Fixed a bug that leads to incorrect type narrowing with `isinstance` …

### DIFF
--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -23816,6 +23816,21 @@ export function createTypeEvaluator(
             }
         }
 
+        // If one or both of the types has an instantiable depth greater than
+        // zero, convert both to instances first.
+        if (TypeBase.isInstantiable(destType) && TypeBase.isInstantiable(srcType)) {
+            if (TypeBase.getInstantiableDepth(destType) > 0 || TypeBase.getInstantiableDepth(srcType) > 0) {
+                return assignType(
+                    convertToInstance(destType),
+                    convertToInstance(srcType),
+                    diag,
+                    constraints,
+                    flags,
+                    recursionCount
+                );
+            }
+        }
+
         // Transform recursive type aliases if necessary.
         const transformedDestType = transformPossibleRecursiveTypeAlias(destType);
         const transformedSrcType = transformPossibleRecursiveTypeAlias(srcType);

--- a/packages/pyright-internal/src/analyzer/typeGuards.ts
+++ b/packages/pyright-internal/src/analyzer/typeGuards.ts
@@ -1290,17 +1290,7 @@ function narrowTypeForInstanceOrSubclassInternal(
 
             if (isMetaclassInstance(subtype) && !isTypeInstance) {
                 // Handle metaclass instances specially.
-                adjFilterTypes = filterTypes.map((filterType) => {
-                    // if (
-                    //     isInstantiableClass(filterType) &&
-                    //     filterType.props?.instantiableDepth === undefined &&
-                    //     filterType.shared.effectiveMetaclass
-                    // ) {
-                    //     return filterType.shared.effectiveMetaclass;
-                    // }
-
-                    return convertToInstantiable(filterType);
-                });
+                adjFilterTypes = filterTypes.map((filterType) => convertToInstantiable(filterType));
             } else {
                 const convSubtype = convertToInstance(subtype);
 
@@ -1718,7 +1708,6 @@ function narrowTypeForInstance(
             // on a constrained TypeVar that they want to filter based on its constrained
             // parts.
             const negativeFallback = getTypeCondition(subtype) ? subtype : unexpandedSubtype;
-            const isSubtypeMetaclass = isMetaclassInstance(subtype);
 
             if (isPositiveTest && isAnyOrUnknown(subtype)) {
                 // If this is a positive test and the effective type is Any or
@@ -1751,7 +1740,7 @@ function narrowTypeForInstance(
                 }
             }
 
-            if (isClassInstance(subtype)) {
+            if (isClass(subtype)) {
                 return combineTypes(
                     filterClassType(
                         unexpandedSubtype,
@@ -1764,20 +1753,6 @@ function narrowTypeForInstance(
 
             if (isFunction(subtype) || isOverloaded(subtype)) {
                 return combineTypes(filterFunctionType(subtype, convertToInstance(unexpandedSubtype)));
-            }
-
-            if (isInstantiableClass(subtype) || isSubtypeMetaclass) {
-                // Handle the special case of isinstance(x, metaclass).
-                const includesMetaclassType = filterTypes.some((classType) => isInstantiableMetaclass(classType));
-                const includesObject = filterTypes.some(
-                    (classType) => isInstantiableClass(classType) && ClassType.isBuiltIn(classType, 'object')
-                );
-
-                if (isPositiveTest) {
-                    return includesMetaclassType || includesObject ? negativeFallback : undefined;
-                } else {
-                    return includesMetaclassType ? undefined : negativeFallback;
-                }
             }
 
             return isPositiveTest ? undefined : negativeFallback;

--- a/packages/pyright-internal/src/tests/samples/typeNarrowingIsinstance19.py
+++ b/packages/pyright-internal/src/tests/samples/typeNarrowingIsinstance19.py
@@ -41,7 +41,7 @@ def func3(m: ABCMeta) -> None:
 
 def func4(m: ABCMeta) -> None:
     if issubclass(m, (Parent1, Child1, int)):
-        reveal_type(m, expected_text="type[Parent1] | type[Child1]")
+        reveal_type(m, expected_text="type[Parent1] | type[Child1] | ABCMeta")
     else:
         reveal_type(m, expected_text="ABCMeta")
 

--- a/packages/pyright-internal/src/tests/samples/typeNarrowingIsinstance21.py
+++ b/packages/pyright-internal/src/tests/samples/typeNarrowingIsinstance21.py
@@ -1,0 +1,35 @@
+# This sample tests the case where the filter type is a class object.
+
+# pyright: reportMissingModuleSource=false
+
+from typing_extensions import TypeIs
+
+
+class Sentinel:
+    pass
+
+
+def is_sentinel(value: object) -> TypeIs[type[Sentinel]]: ...
+
+
+def _(a: dict[str, int] | type[Sentinel]):
+    if is_sentinel(a):
+        reveal_type(a, expected_text="type[Sentinel]")
+    else:
+        reveal_type(a, expected_text="dict[str, int]")
+
+
+def is_str_type(typ: object) -> TypeIs[type[str]]:
+    return typ is str
+
+
+def test_typevar[T](typ: type[T], val: T) -> None:
+    if is_str_type(typ):
+        reveal_type(typ, expected_text="type[str]*")
+
+
+def func1(v: Sentinel | type[Sentinel]):
+    if isinstance(v, Sentinel):
+        reveal_type(v, expected_text="Sentinel")
+    else:
+        reveal_type(v, expected_text="type[Sentinel]")

--- a/packages/pyright-internal/src/tests/typeEvaluator1.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator1.test.ts
@@ -480,6 +480,12 @@ test('TypeNarrowingIsinstance20', () => {
     TestUtils.validateResults(analysisResults, 0);
 });
 
+test('TypeNarrowingIsinstance21', () => {
+    const analysisResults = TestUtils.typeAnalyzeSampleFiles(['typeNarrowingIsinstance21.py']);
+
+    TestUtils.validateResults(analysisResults, 0);
+});
+
 test('TypeNarrowingTupleLength1', () => {
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['typeNarrowingTupleLength1.py']);
 


### PR DESCRIPTION
…or `TypeIs` when the filter type (the second argument to `isinstance`) is a subclass of `type`. This addresses #8691 and #8686.