### PR TITLE
Fixed a bug that results in incorrect type narrowing for the `x is ..…

### DIFF
--- a/packages/pyright-internal/src/tests/samples/typeNarrowingIsEllipsis1.py
+++ b/packages/pyright-internal/src/tests/samples/typeNarrowingIsEllipsis1.py
@@ -34,3 +34,10 @@ def func4(val: int | ellipsis):
         reveal_type(val, expected_text="int")
     else:
         reveal_type(val, expected_text="EllipsisType")
+
+
+def func5(val: object):
+    if val is ...:
+        reveal_type(val, expected_text="EllipsisType")
+    else:
+        reveal_type(val, expected_text="object")


### PR DESCRIPTION
….` (ellipsis) type guard pattern. This addresses #8939.