### PR TITLE
Fixed a bug in the `callable(x)` type narrowing logic. It was not pro…

### DIFF
--- a/packages/pyright-internal/src/analyzer/typeGuards.ts
+++ b/packages/pyright-internal/src/analyzer/typeGuards.ts
@@ -2533,6 +2533,12 @@ function narrowTypeForCallable(
                     return isPositiveTest ? subtype : undefined;
                 }
 
+                if (ClassType.isBuiltIn(subtype, 'object')) {
+                    return isPositiveTest
+                        ? addConditionToType(getUnknownTypeForCallable(), getTypeCondition(subtype))
+                        : subtype;
+                }
+
                 // See if the object is callable.
                 const callMemberType = lookUpClassMember(subtype, '__call__', MemberAccessFlags.SkipInstanceMembers);
 

--- a/packages/pyright-internal/src/tests/samples/typeNarrowingCallable1.py
+++ b/packages/pyright-internal/src/tests/samples/typeNarrowingCallable1.py
@@ -76,3 +76,10 @@ def test3(v: _T2) -> Union[_T2, int, str]:
     else:
         reveal_type(v, expected_text="int* | str*")
         return v
+
+
+def test4(v: type[int] | object):
+    if callable(v):
+        reveal_type(v, expected_text="type[int] | ((...) -> Unknown)")
+    else:
+        reveal_type(v, expected_text="object")


### PR DESCRIPTION
…perly handling supertypes of a callable (namely, `object`). This addresses #8944.