### PR TITLE
Fixed a bug that results in incorrect type narrowing for `TypeIs` whe…

### DIFF
--- a/packages/pyright-internal/src/analyzer/typeGuards.ts
+++ b/packages/pyright-internal/src/analyzer/typeGuards.ts
@@ -1618,7 +1618,7 @@ function narrowTypeForInstance(
 
                 if (isCallable) {
                     if (isPositiveTest) {
-                        filteredTypes.push(varType);
+                        filteredTypes.push(convertToInstantiable(varType));
                     } else {
                         foundSuperclass = true;
                     }
@@ -1632,7 +1632,7 @@ function narrowTypeForInstance(
                     )
                 ) {
                     if (isPositiveTest) {
-                        filteredTypes.push(filterType);
+                        filteredTypes.push(addConditionToType(filterType, concreteVarType.props?.condition));
                     }
                 }
             }

--- a/packages/pyright-internal/src/tests/samples/typeIs4.py
+++ b/packages/pyright-internal/src/tests/samples/typeIs4.py
@@ -1,0 +1,38 @@
+# This sample tests TypeIs when used with a Callable type.
+
+# pyright: reportMissingModuleSource=false
+
+from typing import Callable
+from typing_extensions import TypeIs
+
+
+def is_callable(obj: object, /) -> TypeIs[Callable[..., object]]: ...
+
+
+def func1(x: type[int]):
+    if is_callable(x):
+        reveal_type(x, expected_text="type[int]")
+    else:
+        reveal_type(x, expected_text="Never")
+
+
+def func2[T](x: type[T]):
+    if is_callable(x):
+        reveal_type(x, expected_text="type[T@func2]")
+    else:
+        reveal_type(x, expected_text="Never")
+
+
+def func3[T](x: type[T] | T):
+    if is_callable(x):
+        reveal_type(x, expected_text="type[T@func3] | ((...) -> object)")
+    else:
+        reveal_type(x, expected_text="object*")
+
+
+def func4[T](x: T) -> T:
+    if not is_callable(x):
+        reveal_type(x, expected_text="object*")
+        raise ValueError()
+    reveal_type(x, expected_text="(...) -> object")
+    return x

--- a/packages/pyright-internal/src/tests/typeEvaluator6.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator6.test.ts
@@ -143,6 +143,11 @@ test('TypeIs3', () => {
     TestUtils.validateResults(analysisResults, 5);
 });
 
+test('TypeIs4', () => {
+    const analysisResults = TestUtils.typeAnalyzeSampleFiles(['typeIs4.py']);
+    TestUtils.validateResults(analysisResults, 0);
+});
+
 test('Never1', () => {
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['never1.py']);
 


### PR DESCRIPTION
…n it is used with a `Callable` type form. This addresses #8951.