### PR TITLE
Removed support for custom `callable` type guard pattern. Now that ty…

### DIFF
--- a/docs/type-concepts-advanced.md
+++ b/docs/type-concepts-advanced.md
@@ -76,7 +76,6 @@ In addition to assignment-based type narrowing, Pyright supports the following t
 * `S in D` and `S not in D` (where S is a string literal and D is a TypedDict)
 * `isinstance(x, T)` (where T is a type or a tuple of types)
 * `issubclass(x, T)` (where T is a type or a tuple of types)
-* `callable(x)`
 * `f(x)` (where f is a user-defined type guard as defined in [PEP 647](https://www.python.org/dev/peps/pep-0647/) or [PEP 742](https://www.python.org/dev/peps/pep-0742))
 * `bool(x)` (where x is any expression that is statically verifiable to be truthy or falsey in all cases)
 * `x` (where x is any expression that is statically verifiable to be truthy or falsey in all cases)

--- a/packages/pyright-internal/src/tests/samples/typeNarrowingCallable1.py
+++ b/packages/pyright-internal/src/tests/samples/typeNarrowingCallable1.py
@@ -76,3 +76,10 @@ def test3(v: _T2) -> Union[_T2, int, str]:
     else:
         reveal_type(v, expected_text="int* | str*")
         return v
+
+
+def test4(v: type[int] | object):
+    if callable(v):
+        reveal_type(v, expected_text="type[int] | ((...) -> object)")
+    else:
+        reveal_type(v, expected_text="object")


### PR DESCRIPTION
…peshed defines this with a `TypeIs`, we no longer require custom logic here. This addresses #8944.