### PR TITLE
Fixed a bug that results in incorrect narrowing of types for `TypeIs`…

### DIFF
--- a/packages/pyright-internal/src/analyzer/typeGuards.ts
+++ b/packages/pyright-internal/src/analyzer/typeGuards.ts
@@ -1497,16 +1497,22 @@ function narrowTypeForInstance(
 
                         filteredTypes.push(addConditionToType(specializedFilterType, conditions));
                     } else if (ClassType.isSameGenericClass(concreteVarType, concreteFilterType)) {
-                        // Don't attempt to narrow in this case.
-                        if (
-                            concreteVarType.priv?.literalValue === undefined &&
-                            concreteFilterType.priv?.literalValue === undefined
-                        ) {
-                            const intersection = intersectSameClassType(evaluator, concreteVarType, concreteFilterType);
-                            filteredTypes.push(intersection ?? varType);
+                        if (!isTypeIsCheck) {
+                            // Don't attempt to narrow in this case.
+                            if (
+                                concreteVarType.priv?.literalValue === undefined &&
+                                concreteFilterType.priv?.literalValue === undefined
+                            ) {
+                                const intersection = intersectSameClassType(
+                                    evaluator,
+                                    concreteVarType,
+                                    concreteFilterType
+                                );
+                                filteredTypes.push(intersection ?? varType);
 
-                            // Don't attempt to narrow in the negative direction.
-                            isClassRelationshipIndeterminate = true;
+                                // Don't attempt to narrow in the negative direction.
+                                isClassRelationshipIndeterminate = true;
+                            }
                         }
                     } else if (
                         allowIntersections &&

--- a/packages/pyright-internal/src/tests/samples/typeIs1.py
+++ b/packages/pyright-internal/src/tests/samples/typeIs1.py
@@ -28,8 +28,7 @@ def func1(val: Union[str, int]):
         reveal_type(val, expected_text="int")
 
 
-def is_true(o: object) -> TypeIs[Literal[True]]:
-    ...
+def is_true(o: object) -> TypeIs[Literal[True]]: ...
 
 
 def func2(val: bool):
@@ -85,16 +84,13 @@ def func6(direction: Literal["NW", "E"]):
         reveal_type(direction, expected_text="Literal['NW']")
 
 
-class Animal:
-    ...
+class Animal: ...
 
 
-class Kangaroo(Animal):
-    ...
+class Kangaroo(Animal): ...
 
 
-class Koala(Animal):
-    ...
+class Koala(Animal): ...
 
 
 T = TypeVar("T")
@@ -138,8 +134,7 @@ def func7(names: tuple[str, ...]):
         reveal_type(names, expected_text="tuple[str, ...]")
 
 
-def is_int(obj: type) -> TypeIs[type[int]]:
-    ...
+def is_int(obj: type) -> TypeIs[type[int]]: ...
 
 
 def func8(x: type) -> None:
@@ -159,22 +154,37 @@ def func9(val: Collection[object]) -> None:
 
 
 @overload
-def func10(v: tuple[int | str, ...], b: Literal[False]) -> TypeIs[tuple[str, ...]]:
-    ...
+def func10(v: tuple[int | str, ...], b: Literal[False]) -> TypeIs[tuple[str, ...]]: ...
 
 
 @overload
 def func10(
     v: tuple[int | str, ...], b: Literal[True] = True
-) -> TypeIs[tuple[int, ...]]:
-    ...
+) -> TypeIs[tuple[int, ...]]: ...
 
 
-def func10(v: tuple[int | str, ...], b: bool = True) -> bool:
-    ...
+def func10(v: tuple[int | str, ...], b: bool = True) -> bool: ...
 
 
 v0 = is_int(int)
 v1: bool = v0
 v2: int = v0
 v3 = v0 & v0
+
+
+def is_sequence_of_int(sequence: Sequence) -> TypeIs[Sequence[int]]:
+    return all(isinstance(x, int) for x in sequence)
+
+
+def func11(v: Sequence[int] | Sequence[str]):
+    if is_sequence_of_int(v):
+        reveal_type(v, expected_text="Sequence[int]")
+    else:
+        reveal_type(v, expected_text="Sequence[str]")
+
+
+def func12(v: Sequence[int | str] | Sequence[list[Any]]):
+    if is_sequence_of_int(v):
+        reveal_type(v, expected_text="Sequence[int]")
+    else:
+        reveal_type(v, expected_text="Sequence[int | str] | Sequence[list[Any]]")

--- a/packages/pyright-internal/src/tests/samples/typeIs3.py
+++ b/packages/pyright-internal/src/tests/samples/typeIs3.py
@@ -11,8 +11,6 @@ def is_tuple_of_strings(v: tuple[int | str, ...]) -> TypeIs[tuple[str, ...]]:
 
 def test1(t: tuple[int]) -> None:
     if is_tuple_of_strings(t):
-        # This will fail currently because pyright lacks
-        # the logic to narrow tuples in this manner.
         reveal_type(t, expected_text="Never")
     else:
         reveal_type(t, expected_text="tuple[int]")
@@ -20,8 +18,6 @@ def test1(t: tuple[int]) -> None:
 
 def test2(t: tuple[str, int]) -> None:
     if is_tuple_of_strings(t):
-        # This will fail currently because pyright lacks
-        # the logic to narrow tuples in this manner.
         reveal_type(t, expected_text="Never")
     else:
         reveal_type(t, expected_text="tuple[str, int]")
@@ -29,8 +25,6 @@ def test2(t: tuple[str, int]) -> None:
 
 def test3(t: tuple[int | str]) -> None:
     if is_tuple_of_strings(t):
-        # This will fail currently because pyright lacks
-        # the logic to narrow tuples in this manner.
         reveal_type(t, expected_text="tuple[str]")
     else:
         reveal_type(t, expected_text="tuple[int | str]")
@@ -38,8 +32,6 @@ def test3(t: tuple[int | str]) -> None:
 
 def test4(t: tuple[int | str, int | str]) -> None:
     if is_tuple_of_strings(t):
-        # This will fail currently because pyright lacks
-        # the logic to narrow tuples in this manner.
         reveal_type(t, expected_text="tuple[str, str]")
     else:
         reveal_type(t, expected_text="tuple[int | str, int | str]")
@@ -54,8 +46,6 @@ def test5(t: tuple[int | str, ...]) -> None:
 
 def test6(t: tuple[str, *tuple[int | str, ...], str]) -> None:
     if is_tuple_of_strings(t):
-        # This will fail currently because pyright lacks
-        # the logic to narrow tuples in this manner.
         reveal_type(t, expected_text="tuple[str, *tuple[str, ...], str]")
     else:
         reveal_type(t, expected_text="tuple[str, *tuple[int | str, ...], str]")

--- a/packages/pyright-internal/src/tests/typeEvaluator6.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator6.test.ts
@@ -140,7 +140,7 @@ test('TypeIs2', () => {
 
 test('TypeIs3', () => {
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['typeIs3.py']);
-    TestUtils.validateResults(analysisResults, 5);
+    TestUtils.validateResults(analysisResults, 0);
 });
 
 test('TypeIs4', () => {


### PR DESCRIPTION
… user-defined type guard in certain cases when variable type is a union. This addresses #8966.