### PR TITLE
Mutate sourceFile imports list whenever it changes

### DIFF
--- a/packages/pyright-internal/src/analyzer/program.ts
+++ b/packages/pyright-internal/src/analyzer/program.ts
@@ -1492,7 +1492,7 @@ export class Program {
         // Only mutate if absolutely necessary otherwise we
         // can end up rebinding a lot of files we don't need to.
         if (
-            newImports.length > sourceFileInfo.imports.length ||
+            newImports.length !== sourceFileInfo.imports.length ||
             !newImports.every((i) => sourceFileInfo.imports.includes(i))
         ) {
             sourceFileInfo.mutate((s) => (s.imports = newImports));


### PR DESCRIPTION
This change fixes a bug in which module imports stop resolving after file edits that change the set of modules a file imports.

Previously, in _updateSourceFileImports, we would mutate the import list of the source file we were updating only if the new imports list was longer than the old list or any element mismatched between the old and new lists. This behavior led to a situation in which, potentially due to buffer editing, if the new import list was a prefix of the old list, we would fail to call sourceFileInfo.mutate(). Consequently, when those imports came back (perhaps due to further buffer editing) we would skip adding them to the sourceFileInfo import list (because, as we didn't call sourceFileInfo.mutate(), we falsely believe we still had the imports). Because we skipped the addition logic, we would not add the importing buffer to the importedBy lists of the imported SourceFileInfo. If our not updating the importedBy list ended up leaving it empty, we regarded the imported source files as "not needed", didn't parse them, and consequently failed to resolve symbols imported from these modules.

Now, we call sourceFileInfo.mutate() when the old and new import lists differ in any way, restoring correct behavior under buffer edits that remove imports.