### PR TITLE
Fixed recent regression that results in incorrect type narrowing for …

### DIFF
--- a/packages/pyright-internal/src/analyzer/typeGuards.ts
+++ b/packages/pyright-internal/src/analyzer/typeGuards.ts
@@ -1496,7 +1496,12 @@ function narrowTypeForInstance(
                         }
 
                         filteredTypes.push(addConditionToType(specializedFilterType, conditions));
-                    } else if (ClassType.isSameGenericClass(concreteVarType, concreteFilterType)) {
+                    } else if (
+                        ClassType.isSameGenericClass(
+                            ClassType.cloneAsInstance(concreteVarType),
+                            ClassType.cloneAsInstance(concreteFilterType)
+                        )
+                    ) {
                         if (!isTypeIsCheck) {
                             // Don't attempt to narrow in this case.
                             if (

--- a/packages/pyright-internal/src/analyzer/types.ts
+++ b/packages/pyright-internal/src/analyzer/types.ts
@@ -1301,6 +1301,15 @@ export namespace ClassType {
             return false;
         }
 
+        // Handle type[] specially.
+        if (TypeBase.getInstantiableDepth(classType) > 0) {
+            return TypeBase.isInstantiable(type2) || ClassType.isBuiltIn(type2, 'type');
+        }
+
+        if (TypeBase.getInstantiableDepth(type2) > 0) {
+            return TypeBase.isInstantiable(classType) || ClassType.isBuiltIn(classType, 'type');
+        }
+
         const class1Details = classType.shared;
         const class2Details = type2.shared;
 

--- a/packages/pyright-internal/src/tests/samples/typeNarrowingIsinstance1.py
+++ b/packages/pyright-internal/src/tests/samples/typeNarrowingIsinstance1.py
@@ -128,6 +128,13 @@ def func6(ty: type[T]) -> type[T]:
     return ty
 
 
+def func6_2(ty: type[int] | int):
+    if isinstance(ty, type):
+        reveal_type(ty, expected_text="type[int]")
+    else:
+        reveal_type(ty, expected_text="int")
+
+
 # Test the handling of protocol classes that support runtime checking.
 def func7(a: Union[list[int], int]):
     if isinstance(a, Sized):
@@ -140,8 +147,7 @@ def func7(a: Union[list[int], int]):
 # on isinstance checks.
 
 
-class Base1:
-    ...
+class Base1: ...
 
 
 class Sub1_1(Base1):
@@ -207,14 +213,12 @@ def func10(val: Sub2[str] | Base2[str, float]):
 
 @runtime_checkable
 class Proto1(Protocol):
-    def f0(self, /) -> None:
-        ...
+    def f0(self, /) -> None: ...
 
 
 @runtime_checkable
 class Proto2(Proto1, Protocol):
-    def f1(self, /) -> None:
-        ...
+    def f1(self, /) -> None: ...
 
 
 def func11(x: Proto1):


### PR DESCRIPTION
…`isinstance` in the negative case when using `type` as a filter. This addresses #8963 and #8988.