### PR TITLE
Expanded `reportUnnecessaryIsinstance` check to report cases where an…

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -195,7 +195,7 @@ The following settings allow more fine grained control over the **typeCheckingMo
 
 - <a name="reportCallInDefaultInitializer"></a> **reportCallInDefaultInitializer** [boolean or string, optional]: Generate or suppress diagnostics for function calls, list expressions, set expressions, or dictionary expressions within a default value initialization expression. Such calls can mask expensive operations that are performed at module initialization time. The default value for this setting is `"none"`.
 
-- <a name="reportUnnecessaryIsInstance"></a> **reportUnnecessaryIsInstance** [boolean or string, optional]: Generate or suppress diagnostics for `isinstance` or `issubclass` calls where the result is statically determined to be always true. Such calls are often indicative of a programming error. The default value for this setting is `"none"`.
+- <a name="reportUnnecessaryIsInstance"></a> **reportUnnecessaryIsInstance** [boolean or string, optional]: Generate or suppress diagnostics for `isinstance` or `issubclass` calls where the result is statically determined to be always true or always false. Such calls are often indicative of a programming error. The default value for this setting is `"none"`.
 
 - <a name="reportUnnecessaryCast"></a> **reportUnnecessaryCast** [boolean or string, optional]: Generate or suppress diagnostics for `cast` calls that are statically determined to be unnecessary. Such calls are sometimes indicative of a programming error. The default value for this setting is `"none"`.
 

--- a/packages/pyright-internal/src/localization/localize.ts
+++ b/packages/pyright-internal/src/localization/localize.ts
@@ -1134,6 +1134,14 @@ export namespace Localizer {
             new ParameterizedString<{ testType: string; classType: string }>(
                 getRawString('Diagnostic.unnecessaryIsSubclassAlways')
             );
+        export const unnecessaryIsInstanceNever = () =>
+            new ParameterizedString<{ testType: string; classType: string }>(
+                getRawString('Diagnostic.unnecessaryIsInstanceNever')
+            );
+        export const unnecessaryIsSubclassNever = () =>
+            new ParameterizedString<{ testType: string; classType: string }>(
+                getRawString('Diagnostic.unnecessaryIsSubclassNever')
+            );
         export const unnecessaryPyrightIgnore = () => getRawString('Diagnostic.unnecessaryPyrightIgnore');
         export const unnecessaryPyrightIgnoreRule = () =>
             new ParameterizedString<{ name: string }>(getRawString('Diagnostic.unnecessaryPyrightIgnoreRule'));

--- a/packages/pyright-internal/src/localization/package.nls.en-us.json
+++ b/packages/pyright-internal/src/localization/package.nls.en-us.json
@@ -1544,6 +1544,14 @@
             "message": "Unnecessary issubclass call; \"{testType}\" is always a subclass of \"{classType}\"",
             "comment": "{Locked='issubclass'}"
         },
+        "unnecessaryIsInstanceNever": {
+            "message": "Unnecessary isinstance call; \"{testType}\" is never an instance of \"{classType}\"",
+            "comment": "{Locked='isinstance'}"
+        },
+        "unnecessaryIsSubclassNever": {
+            "message": "Unnecessary issubclass call; \"{testType}\" is never a subclass of \"{classType}\"",
+            "comment": "{Locked='issubclass'}"
+        },
         "unnecessaryPyrightIgnore": {
             "message": "Unnecessary \"# pyright: ignore\" comment",
             "comment": "{Locked='# pyright: ignore'}"

--- a/packages/pyright-internal/src/tests/checker.test.ts
+++ b/packages/pyright-internal/src/tests/checker.test.ts
@@ -247,6 +247,18 @@ test('UnnecessaryIsInstance1', () => {
     TestUtils.validateResults(analysisResults, 5);
 });
 
+test('UnnecessaryIsInstance2', () => {
+    const configOptions = new ConfigOptions(Uri.empty());
+
+    let analysisResults = TestUtils.typeAnalyzeSampleFiles(['unnecessaryIsInstance2.py'], configOptions);
+    TestUtils.validateResults(analysisResults, 0);
+
+    // Turn on errors.
+    configOptions.diagnosticRuleSet.reportUnnecessaryIsInstance = 'error';
+    analysisResults = TestUtils.typeAnalyzeSampleFiles(['unnecessaryIsInstance2.py'], configOptions);
+    TestUtils.validateResults(analysisResults, 2);
+});
+
 test('UnnecessaryIsSubclass1', () => {
     const configOptions = new ConfigOptions(Uri.empty());
 

--- a/packages/pyright-internal/src/tests/samples/unnecessaryIsInstance1.py
+++ b/packages/pyright-internal/src/tests/samples/unnecessaryIsInstance1.py
@@ -1,4 +1,4 @@
-# This sample tests unnecessary isinstance error reporting.
+# This sample tests for isinstance calls that always evaluate to true.
 
 from typing import ClassVar, Protocol, TypedDict, runtime_checkable
 from unknown_import import CustomClass1

--- a/packages/pyright-internal/src/tests/samples/unnecessaryIsInstance2.py
+++ b/packages/pyright-internal/src/tests/samples/unnecessaryIsInstance2.py
@@ -1,0 +1,35 @@
+# This sample tests for isinstance calls that never evaluate to true.
+
+from typing import final
+
+
+class ABase: ...
+
+
+@final
+class AFinal(ABase): ...
+
+
+class BBase: ...
+
+
+@final
+class BFinal(BBase): ...
+
+
+def func1(a: AFinal, b: BFinal):
+    # This should generate an error if reportUnnecessaryIsinstance is true.
+    if isinstance(a, BBase):
+        reveal_type(a)
+
+    # This should generate an error if reportUnnecessaryIsinstance is true.
+    if isinstance(a, BBase):
+        reveal_type(a)
+
+
+def func2(a: ABase, b: BBase):
+    if isinstance(a, BBase):
+        reveal_type(a)
+
+    if isinstance(b, ABase):
+        reveal_type(b)

--- a/packages/pyright-internal/src/tests/samples/unnecessaryIsSubclass1.py
+++ b/packages/pyright-internal/src/tests/samples/unnecessaryIsSubclass1.py
@@ -1,4 +1,4 @@
-# This sample tests unnecessary issubclass error reporting.
+# This sample tests issubclass calls that always evaluate to true.
 
 
 def func1(p1: type[int], p2: type[int] | type[str]):

--- a/packages/vscode-pyright/package.json
+++ b/packages/vscode-pyright/package.json
@@ -1156,7 +1156,7 @@
                                 "string",
                                 "boolean"
                             ],
-                            "description": "Diagnostics for 'isinstance' or 'issubclass' calls where the result is statically determined to be always true. Such calls are often indicative of a programming error.",
+                            "description": "Diagnostics for 'isinstance' or 'issubclass' calls where the result is statically determined to be always (or never) true. Such calls are often indicative of a programming error.",
                             "default": "none",
                             "enum": [
                                 "none",

--- a/packages/vscode-pyright/schemas/pyrightconfig.schema.json
+++ b/packages/vscode-pyright/schemas/pyrightconfig.schema.json
@@ -401,7 +401,7 @@
     },
     "reportUnnecessaryIsInstance": {
       "$ref": "#/definitions/diagnostic",
-      "title": "Controls reporting calls to 'isinstance' or 'issubclass' where the result is statically determined to be always true",
+      "title": "Controls reporting calls to 'isinstance' or 'issubclass' where the result is statically determined to be always (or never) true",
       "default": "none"
     },
     "reportUnnecessaryCast": {


### PR DESCRIPTION
… `isinstance` or `issubclass` call always evaluates to `False`. This addresses #8961.