### PR TITLE
Fixed bug that results in incorrect code flow involving a call to a `…

### DIFF
--- a/packages/pyright-internal/src/analyzer/codeFlowEngine.ts
+++ b/packages/pyright-internal/src/analyzer/codeFlowEngine.ts
@@ -1821,7 +1821,7 @@ export function getCodeFlowEngine(
     }
 
     function isFunctionNoReturn(functionType: FunctionType, isCallAwaited: boolean) {
-        const returnType = functionType.shared.declaredReturnType;
+        const returnType = FunctionType.getEffectiveReturnType(functionType, /* includeInferred */ false);
         if (returnType) {
             if (
                 isClassInstance(returnType) &&


### PR DESCRIPTION
…NoReturn` callable with a function decorator applied. This addresses https://github.com/microsoft/pylance-release/issues/6391.