### PR TITLE
Fixed bug that results in incorrect type narrowing when `TypeIs` inte…

### DIFF
--- a/packages/pyright-internal/src/analyzer/typeGuards.ts
+++ b/packages/pyright-internal/src/analyzer/typeGuards.ts
@@ -1534,9 +1534,7 @@ function narrowTypeForInstance(
                             newClassType = addConditionToType(newClassType, [{ typeVar: varType, constraintIndex: 0 }]);
                         }
 
-                        let newClassObjType = ClassType.cloneAsInstance(newClassType);
-                        newClassObjType = addConditionToType(newClassObjType, concreteVarType.props?.condition);
-                        filteredTypes.push(newClassObjType);
+                        filteredTypes.push(addConditionToType(newClassType, concreteVarType.props?.condition));
                     }
                 } else {
                     if (isAnyOrUnknown(varType)) {

--- a/packages/pyright-internal/src/tests/samples/typeNarrowingIsinstance21.py
+++ b/packages/pyright-internal/src/tests/samples/typeNarrowingIsinstance21.py
@@ -2,6 +2,7 @@
 
 # pyright: reportMissingModuleSource=false
 
+from typing import Any
 from typing_extensions import TypeIs
 
 
@@ -33,3 +34,33 @@ def func1(v: Sentinel | type[Sentinel]):
         reveal_type(v, expected_text="Sentinel")
     else:
         reveal_type(v, expected_text="type[Sentinel]")
+
+
+class A:
+    pass
+
+
+class B:
+    pass
+
+
+def guard3(t: type[Any]) -> TypeIs[type[A]]:
+    return True
+
+
+def func3(t: type[B]):
+    if guard3(t):
+        reveal_type(t, expected_text="type[<subclass of B and A>]")
+    else:
+        reveal_type(t, expected_text="type[B]")
+
+
+def guard4(t: Any) -> TypeIs[type[A]]:
+    return True
+
+
+def func4(t: B):
+    if guard4(t):
+        reveal_type(t, expected_text="<subclass of B and type[A]>")
+    else:
+        reveal_type(t, expected_text="B")


### PR DESCRIPTION
…rsects `type[A]` with `type[B]`. Previously, pyright was producing `<subclass of type[A] and type[B]>` but now produces `type[<subclass of A and B>]`. This addresses #9002 and #9003.