### PR TITLE
Allow venvPath to be set in settings.json

### DIFF
--- a/packages/pyright-internal/src/common/commandLineOptions.ts
+++ b/packages/pyright-internal/src/common/commandLineOptions.ts
@@ -146,6 +146,9 @@ export class CommandLineLanguageServerOptions {
     // Path to python interpreter. This is used when the language server
     // gets the python path from the client.
     pythonPath?: string | undefined;
+
+    // Virtual environments directory.
+    venvPath?: string | undefined;
 }
 
 // Some options can be specified from a source other than the pyright config file.

--- a/packages/pyright-internal/src/languageService/analyzerServiceExecutor.ts
+++ b/packages/pyright-internal/src/languageService/analyzerServiceExecutor.ts
@@ -116,7 +116,7 @@ function getEffectiveCommandLineOptions(
     }
 
     if (serverSettings.venvPath) {
-        commandLineOptions.configSettings.venvPath = serverSettings.venvPath.getFilePath();
+        commandLineOptions.languageServerSettings.venvPath = serverSettings.venvPath.getFilePath();
     }
 
     if (serverSettings.pythonPath) {


### PR DESCRIPTION
The original submission for the pyrightconfig.json isolation assumed venvPath was only used in config situations. venvPath is supposed to be per user, so this assumption was incorrect.

This change allows the venvPath to be set in this order of priority:

- Command line
- Config file
- Settings.json (if empty in the config file)

The third option was what was broken.

Addresses https://github.com/microsoft/pyright/issues/9001