### PR TITLE
Fixed a bug that results in a false positive type error and confusing…

### DIFF
--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -2641,6 +2641,7 @@ export function createTypeEvaluator(
     // Determines whether the specified expression is a symbol with a declared type.
     function getDeclaredTypeForExpression(expression: ExpressionNode, usage?: EvaluatorUsage): Type | undefined {
         let symbol: Symbol | undefined;
+        let selfType: ClassType | TypeVarType | undefined;
         let classOrObjectBase: ClassType | undefined;
         let memberAccessClass: Type | undefined;
         let bindFunction = true;
@@ -2683,18 +2684,18 @@ export function createTypeEvaluator(
             }
 
             case ParseNodeType.MemberAccess: {
-                const baseType = makeTopLevelTypeVarsConcrete(
-                    getTypeOfExpression(expression.d.leftExpr, EvalFlags.MemberAccessBaseDefaults).type
-                );
+                const baseType = getTypeOfExpression(expression.d.leftExpr, EvalFlags.MemberAccessBaseDefaults).type;
+                const baseTypeConcrete = makeTopLevelTypeVarsConcrete(baseType);
                 let classMemberInfo: ClassMember | undefined;
 
-                if (isClassInstance(baseType)) {
+                if (isClassInstance(baseTypeConcrete)) {
                     classMemberInfo = lookUpObjectMember(
-                        baseType,
+                        baseTypeConcrete,
                         expression.d.member.d.value,
                         MemberAccessFlags.DeclaredTypesOnly
                     );
-                    classOrObjectBase = baseType;
+                    classOrObjectBase = baseTypeConcrete;
+                    selfType = isTypeVar(baseType) ? baseType : undefined;
                     memberAccessClass = classMemberInfo?.classType;
 
                     // If this is an instance member (e.g. a dataclass field), don't
@@ -2704,13 +2705,14 @@ export function createTypeEvaluator(
                     }
 
                     useDescriptorSetterType = true;
-                } else if (isInstantiableClass(baseType)) {
+                } else if (isInstantiableClass(baseTypeConcrete)) {
                     classMemberInfo = lookUpClassMember(
-                        baseType,
+                        baseTypeConcrete,
                         expression.d.member.d.value,
                         MemberAccessFlags.SkipInstanceMembers | MemberAccessFlags.DeclaredTypesOnly
                     );
-                    classOrObjectBase = baseType;
+                    classOrObjectBase = baseTypeConcrete;
+                    selfType = isTypeVar(baseType) ? TypeVarType.cloneAsInstance(baseType) : undefined;
                     memberAccessClass = classMemberInfo?.classType;
                 }
 
@@ -2765,12 +2767,23 @@ export function createTypeEvaluator(
 
                 if (classOrObjectBase) {
                     if (memberAccessClass && isInstantiableClass(memberAccessClass)) {
-                        declaredType = partiallySpecializeType(declaredType, memberAccessClass, getTypeClassType());
+                        declaredType = partiallySpecializeType(
+                            declaredType,
+                            memberAccessClass,
+                            getTypeClassType(),
+                            selfType
+                        );
                     }
 
                     if (isFunction(declaredType) || isOverloaded(declaredType)) {
                         if (bindFunction) {
-                            declaredType = bindFunctionToClassOrObject(classOrObjectBase, declaredType);
+                            declaredType = bindFunctionToClassOrObject(
+                                classOrObjectBase,
+                                declaredType,
+                                /* memberClass */ undefined,
+                                /* treatConstructorAsClassMethod */ undefined,
+                                selfType
+                            );
                         }
                     }
                 }

--- a/packages/pyright-internal/src/tests/samples/classVar5.py
+++ b/packages/pyright-internal/src/tests/samples/classVar5.py
@@ -1,0 +1,16 @@
+# This sample tests the access of a ClassVar that uses Self in its
+# declaration.
+
+# It's not clear whether this should be permitted. Arguably, it's not
+# type safe, but mypy admits it. This should be clarified in the typing
+# spec.
+
+from typing import ClassVar, Self
+
+
+class Parent:
+    x: ClassVar[dict[str, Self]] = {}
+
+    @classmethod
+    def __init_subclass__(cls):
+        cls.x = {}

--- a/packages/pyright-internal/src/tests/typeEvaluator7.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator7.test.ts
@@ -773,6 +773,12 @@ test('ClassVar4', () => {
     TestUtils.validateResults(analysisResults, 0);
 });
 
+test('ClassVar5', () => {
+    const analysisResults = TestUtils.typeAnalyzeSampleFiles(['classVar5.py']);
+
+    TestUtils.validateResults(analysisResults, 0);
+});
+
 test('TypeVar1', () => {
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['typeVar1.py']);
 


### PR DESCRIPTION
… error message when assigning to a class variable that uses `Self` in its type definition. This addresses #9011.