### PR TITLE
Put back logic of recreating the background analysis token on every schedule analysis

### DIFF
--- a/packages/pyright-internal/src/analyzer/service.ts
+++ b/packages/pyright-internal/src/analyzer/service.ts
@@ -486,8 +486,13 @@ export class AnalyzerService {
     }
 
     protected runAnalysis() {
+        // Recreate the cancellation token every time we start analysis.
+        this._backgroundAnalysisCancellationSource = this.cancellationProvider.createCancellationTokenSource();
+
         // This creates a cancellation source only if it actually gets used.
-        const moreToAnalyze = this._backgroundAnalysisProgram.startAnalysis(this.getCancellationToken());
+        const moreToAnalyze = this._backgroundAnalysisProgram.startAnalysis(
+            this._backgroundAnalysisCancellationSource.token
+        );
         if (moreToAnalyze) {
             this._scheduleReanalysis(/* requireTrackedFileUpdate */ false);
         }

--- a/packages/pyright-internal/src/analyzer/service.ts
+++ b/packages/pyright-internal/src/analyzer/service.ts
@@ -478,21 +478,9 @@ export class AnalyzerService {
         this._backgroundAnalysisProgram.restart();
     }
 
-    protected getCancellationToken() {
-        if (!this._backgroundAnalysisCancellationSource) {
-            this._backgroundAnalysisCancellationSource = this.cancellationProvider.createCancellationTokenSource();
-        }
-        return this._backgroundAnalysisCancellationSource.token;
-    }
-
-    protected runAnalysis() {
-        // Recreate the cancellation token every time we start analysis.
-        this._backgroundAnalysisCancellationSource = this.cancellationProvider.createCancellationTokenSource();
-
+    protected runAnalysis(token: CancellationToken) {
         // This creates a cancellation source only if it actually gets used.
-        const moreToAnalyze = this._backgroundAnalysisProgram.startAnalysis(
-            this._backgroundAnalysisCancellationSource.token
-        );
+        const moreToAnalyze = this._backgroundAnalysisProgram.startAnalysis(token);
         if (moreToAnalyze) {
             this._scheduleReanalysis(/* requireTrackedFileUpdate */ false);
         }
@@ -1895,9 +1883,12 @@ export class AnalyzerService {
                 this._updateTrackedFileList(/* markFilesDirtyUnconditionally */ false);
             }
 
+            // Recreate the cancellation token every time we start analysis.
+            this._backgroundAnalysisCancellationSource = this.cancellationProvider.createCancellationTokenSource();
+
             // Now that the timer has fired, actually send the message to the BG thread to
             // start the analysis.
-            this.runAnalysis();
+            this.runAnalysis(this._backgroundAnalysisCancellationSource.token);
         }, timeUntilNextAnalysisInMs);
     }
 


### PR DESCRIPTION
Change from Pylance caused the background token to be disposed but then never recreated. 

This puts back the original logic.

We'll need to handle this change when we pull Wednesday for Pylance.

Addresses https://github.com/microsoft/pyright/issues/9015