### PR TITLE
Add new vscode signing (#8977)

### DIFF
--- a/build/azuredevops/azure-pipelines-release.yml
+++ b/build/azuredevops/azure-pipelines-release.yml
@@ -108,7 +108,6 @@ extends:
 
               - task: PowerShell@2
                 displayName: 'Compare extension.manifest and extension.signature.p7s'
-                condition: eq('${{ parameters.signType }}', 'real')
                 inputs:
                   targetType: 'inline'
                   script: |

--- a/build/azuredevops/azure-pipelines-release.yml
+++ b/build/azuredevops/azure-pipelines-release.yml
@@ -22,8 +22,7 @@ extends:
     sdl:
       codeql:
         compiled:
-          enabled: false
-          justificationForDisabling: 'Running a scan on the Pyright-Build'
+          enabled: true
       sourceAnalysisPool: VSEngSS-MicroBuild2022-1ES
     pool:
       pool:

--- a/build/azuredevops/azure-pipelines-release.yml
+++ b/build/azuredevops/azure-pipelines-release.yml
@@ -22,7 +22,8 @@ extends:
     sdl:
       codeql:
         compiled:
-          enabled: true
+          enabled: false
+          justificationForDisabling: 'Running a scan on the Pyright-Build azure-pipelines.yml'
       sourceAnalysisPool: VSEngSS-MicroBuild2022-1ES
     pool:
       pool:

--- a/build/azuredevops/azure-pipelines-release.yml
+++ b/build/azuredevops/azure-pipelines-release.yml
@@ -186,7 +186,7 @@ extends:
                 displayName: 'Download Artifacts from Validation Job'
                 inputs:
                   buildType: 'current'
-                  artifactName: 'artifactName' # Replace with the name of your artifact
+                  artifactName: '$(ARTIFACT_NAME_VSIX)'
                   targetPath: '$(System.ArtifactsDirectory)'
               # https://code.visualstudio.com/api/working-with-extensions/publishing-extension
               # Install dependencies and VS Code Extension Manager (vsce >= v2.26.1 needed)

--- a/build/azuredevops/azure-pipelines-release.yml
+++ b/build/azuredevops/azure-pipelines-release.yml
@@ -82,6 +82,60 @@ extends:
                   SourceFolder: packages/vscode-pyright
                   Contents: '*.vsix'
                   TargetFolder: build_output
+
+              - script: |
+                  npm install -g @vscode/vsce
+                displayName: 'Install vsce and dependencies'
+
+              - script: npx vsce generate-manifest -i $(VSIX_NAME) -o extension.manifest
+                displayName: 'Generate extension manifest'
+                workingDirectory: packages/vscode-pyright
+
+              - task: NuGetToolInstaller@1
+                displayName: 'Install NuGet'
+
+              - task: NuGetCommand@2
+                inputs:
+                  command: 'restore'
+                  restoreSolution: '$(Build.SourcesDirectory)/packages/vscode-pyright/packages.config'
+                  restoreDirectory: '$(Build.SourcesDirectory)/packages/vscode-pyright/packages'
+
+              - task: MSBuild@1
+                displayName: 'Sign binaries'
+                inputs:
+                  solution: 'packages/vscode-pyright/sign.proj'
+                  msbuildArguments: '/verbosity:diagnostic /p:SignType=real'
+
+              - task: PowerShell@2
+                displayName: 'Compare extension.manifest and extension.signature.p7s'
+                condition: eq('${{ parameters.signType }}', 'real')
+                inputs:
+                  targetType: 'inline'
+                  script: |
+                    $manifestPath = "$(Build.SourcesDirectory)\packages\vscode-pyright\extension.manifest"
+                    $signaturePath = "$(Build.SourcesDirectory)\packages\vscode-pyright\extension.signature.p7s"
+                    $compareResult = Compare-Object (Get-Content $manifestPath) (Get-Content $signaturePath)
+                    if ($compareResult -eq $null) {
+                      Write-Error "Files are identical. Failing the build."
+                      exit 1
+                    } else {
+                      Write-Output "Files are different."
+                    }
+
+              - task: CopyFiles@2
+                displayName: 'Copy extension.manifest'
+                inputs:
+                  SourceFolder: 'packages/vscode-pyright'
+                  Contents: 'extension.manifest'
+                  TargetFolder: build_output
+
+              - task: CopyFiles@2
+                displayName: 'Copy extension.signature.p7s'
+                inputs:
+                  SourceFolder: 'packages/vscode-pyright'
+                  Contents: 'extension.signature.p7s'
+                  TargetFolder: build_output
+
       - stage: CreateRelease
         dependsOn:
           - BuildVsix
@@ -129,14 +183,12 @@ extends:
               - task: NodeTool@0
                 inputs:
                   versionSpec: 18.x
-              - task: DownloadGitHubRelease@0
-                displayName: 'Download VSIX'
+              - task: DownloadPipelineArtifact@2
+                displayName: 'Download Artifacts from Validation Job'
                 inputs:
-                  connection: 'Github-Pylance'
-                  userRepository: 'microsoft/pyright'
-                  defaultVersionType: 'specificTag'
-                  version: $(Build.SourceBranchName)
-                  downloadPath: '$(System.ArtifactsDirectory)'
+                  buildType: 'current'
+                  artifactName: 'artifactName' # Replace with the name of your artifact
+                  targetPath: '$(System.ArtifactsDirectory)'
               # https://code.visualstudio.com/api/working-with-extensions/publishing-extension
               # Install dependencies and VS Code Extension Manager (vsce >= v2.26.1 needed)
               - script: |
@@ -145,13 +197,13 @@ extends:
               # https://code.visualstudio.com/api/working-with-extensions/publishing-extension#get-a-personal-access-token
               # Publish to Marketplace
               # see. stackoverflow.com/collectives/ci-cd/articles/76873787/publish-azure-devops-extensions-using-azure-workload-identity
-              - task: AzureCLI@2
-                displayName: 'Publishing with Managed Identity'
-                inputs:
-                  azureSubscription: PyrightPublishPipelineSecureConnectionWithManagedIdentity
-                  scriptType: 'pscore'
-                  scriptLocation: 'inlineScript'
-                  inlineScript: |
-                    az rest -u https://app.vssps.visualstudio.com/_apis/profile/profiles/me --resource 499b84ac-1321-427f-aa17-267ca6975798
-                    $aadToken = az account get-access-token --query accessToken --resource 499b84ac-1321-427f-aa17-267ca6975798 -o tsv
-                    vsce publish --pat $aadToken --packagePath $(System.ArtifactsDirectory)/$(VSIX_NAME) --noVerify
+              # - task: AzureCLI@2
+              #   displayName: 'Publishing with Managed Identity'
+              #   inputs:
+              #     azureSubscription: PyrightPublishPipelineSecureConnectionWithManagedIdentity
+              #     scriptType: 'pscore'
+              #     scriptLocation: 'inlineScript'
+              #     inlineScript: |
+              #       az rest -u https://app.vssps.visualstudio.com/_apis/profile/profiles/me --resource 499b84ac-1321-427f-aa17-267ca6975798
+              #       $aadToken = az account get-access-token --query accessToken --resource 499b84ac-1321-427f-aa17-267ca6975798 -o tsv
+              #       vsce publish --pat $aadToken --packagePath $(System.ArtifactsDirectory)/$(VSIX_NAME) --noVerify --manifestPath $(System.ArtifactsDirectory)/extension.manifest --signaturePath $(System.ArtifactsDirectory)/extension.signature.p7s

--- a/build/azuredevops/azure-pipelines-release.yml
+++ b/build/azuredevops/azure-pipelines-release.yml
@@ -195,13 +195,13 @@ extends:
               # https://code.visualstudio.com/api/working-with-extensions/publishing-extension#get-a-personal-access-token
               # Publish to Marketplace
               # see. stackoverflow.com/collectives/ci-cd/articles/76873787/publish-azure-devops-extensions-using-azure-workload-identity
-              # - task: AzureCLI@2
-              #   displayName: 'Publishing with Managed Identity'
-              #   inputs:
-              #     azureSubscription: PyrightPublishPipelineSecureConnectionWithManagedIdentity
-              #     scriptType: 'pscore'
-              #     scriptLocation: 'inlineScript'
-              #     inlineScript: |
-              #       az rest -u https://app.vssps.visualstudio.com/_apis/profile/profiles/me --resource 499b84ac-1321-427f-aa17-267ca6975798
-              #       $aadToken = az account get-access-token --query accessToken --resource 499b84ac-1321-427f-aa17-267ca6975798 -o tsv
-              #       vsce publish --pat $aadToken --packagePath $(System.ArtifactsDirectory)/$(VSIX_NAME) --noVerify --manifestPath $(System.ArtifactsDirectory)/extension.manifest --signaturePath $(System.ArtifactsDirectory)/extension.signature.p7s
+              # az rest -u https://app.vssps.visualstudio.com/_apis/profile/profiles/me --resource 499b84ac-1321-427f-aa17-267ca6975798
+              - task: AzureCLI@2
+                displayName: 'Publishing with Managed Identity'
+                inputs:
+                  azureSubscription: PyrightPublishPipelineSecureConnectionWithManagedIdentity
+                  scriptType: 'pscore'
+                  scriptLocation: 'inlineScript'
+                  inlineScript: |
+                    $aadToken = az account get-access-token --query accessToken --resource 499b84ac-1321-427f-aa17-267ca6975798 -o tsv
+                    vsce publish --pat $aadToken --packagePath $(System.ArtifactsDirectory)/$(VSIX_NAME) --noVerify --manifestPath $(System.ArtifactsDirectory)/extension.manifest --signaturePath $(System.ArtifactsDirectory)/extension.signature.p7s

--- a/packages/vscode-pyright/packages.config
+++ b/packages/vscode-pyright/packages.config
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Microsoft.VisualStudioEng.MicroBuild.Core" version="1.0.0" />
+</packages>

--- a/packages/vscode-pyright/sign.proj
+++ b/packages/vscode-pyright/sign.proj
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project InitialTargets="SetSigningProperties" DefaultTargets="SignFiles" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="packages\Microsoft.VisualStudioEng.MicroBuild.Core.1.0.0\build\Microsoft.VisualStudioEng.MicroBuild.Core.props" Condition="Exists('packages\Microsoft.VisualStudioEng.MicroBuild.Core.1.0.0\build\Microsoft.VisualStudioEng.MicroBuild.Core.props')" />
+
+
+  <Target Name="SetSigningProperties">
+    <PropertyGroup>
+      <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+      <BaseOutputDirectory>dist\</BaseOutputDirectory>
+      <!-- These properties are required by MicroBuild, which only signs files that are under these paths -->
+      <IntermediateOutputPath Condition="'$(IntermediateOutputPath)' == ''">$(BaseOutputDirectory)/intermediate</IntermediateOutputPath>
+      <OutDir Condition="'$(OutDir)' == ''">$(BaseOutputDirectory)</OutDir>
+    </PropertyGroup>
+  </Target>
+
+   <Target Name="CopySignatureFile" BeforeTargets="GetFilesToSign">
+    <Copy SourceFiles="$(ProjectDir)extension.manifest" DestinationFiles="$(OutDir)\extension.signature.p7s" />
+  </Target>
+
+  <Target Name="CopyBackSignatureFile" AfterTargets="SignFiles">
+    <Copy SourceFiles="$(OutDir)extension.signature.p7s" DestinationFiles="$(ProjectDir)extension.signature.p7s" />
+  </Target>
+
+
+  <!-- This will be overridden if we're building with MicroBuild -->
+  <Target Name="SignFiles">
+    <Message Text="Fake sign target" Importance="high" />
+  </Target>
+
+
+  <Target Name="GetFilesToSign" BeforeTargets="SignFiles">
+    <ItemGroup>
+     <FilesToSign Include="$(OutDir)extension.signature.p7s"> 
+        <!-- Add the certificate friendly name below -->
+        <Authenticode>VSCodePublisher</Authenticode> 
+     </FilesToSign> 
+    </ItemGroup>
+  </Target>
+
+  <Target Name="Build" BeforeTargets="CopySignatureFile">
+    <MakeDir Directories="$(OutDir)"/>
+  </Target>
+
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="Build">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('packages\Microsoft.VisualStudioEng.MicroBuild.Core.1.0.0\build\Microsoft.VisualStudioEng.MicroBuild.Core.props')" Text="$([System.String]::Format('$(ErrorText)', 'packages\Microsoft.VisualStudioEng.MicroBuild.Core.1.0.0\build\Microsoft.VisualStudioEng.MicroBuild.Core.props'))" />
+    <Error Condition="!Exists('packages\Microsoft.VisualStudioEng.MicroBuild.Core.1.0.0\build\Microsoft.VisualStudioEng.MicroBuild.Core.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\Microsoft.VisualStudioEng.MicroBuild.Core.1.0.0\build\Microsoft.VisualStudioEng.MicroBuild.Core.targets'))" />
+  </Target>
+
+  <Import Project="packages\Microsoft.VisualStudioEng.MicroBuild.Core.1.0.0\build\Microsoft.VisualStudioEng.MicroBuild.Core.targets" Condition="Exists('packages\Microsoft.VisualStudioEng.MicroBuild.Core.1.0.0\build\Microsoft.VisualStudioEng.MicroBuild.Core.targets')" />
+</Project>


### PR DESCRIPTION
* Add new vscode signing, make sure signature file is different from the source manifest file.
* When publishing to marketplace reuse artifacts for VSIX, instead of downloading from github
* Include new manifest and signature files when publishing to marketplace

