### PR TITLE
Added special-case handling for the `len(t) == L` type guard pattern …

### DIFF
--- a/packages/pyright-internal/src/analyzer/typeGuards.ts
+++ b/packages/pyright-internal/src/analyzer/typeGuards.ts
@@ -1894,6 +1894,12 @@ function narrowTypeForTupleLength(
             }
 
             if (!isPositiveTest) {
+                // If this is an equality check for the minimum length (e.g.
+                // "len(x) == 0"), we can expand the minimum length by one).
+                const minLen = concreteSubtype.priv.tupleTypeArgs.length - 1;
+                if (lengthValue === minLen) {
+                    return expandUnboundedTupleElement(concreteSubtype, 1, /* keepUnbounded */ true);
+                }
                 return subtype;
             }
 

--- a/packages/pyright-internal/src/tests/samples/typeNarrowingTupleLength1.py
+++ b/packages/pyright-internal/src/tests/samples/typeNarrowingTupleLength1.py
@@ -67,7 +67,7 @@ def func5(
     else:
         reveal_type(
             val,
-            expected_text="tuple[int, ...] | tuple[str] | tuple[str, str, str] | tuple[int, *tuple[str, ...], str] | tuple[int, *tuple[float, ...]]",
+            expected_text="tuple[int, ...] | tuple[str] | tuple[str, str, str] | tuple[int, str, *tuple[str, ...], str] | tuple[int, *tuple[float, ...]]",
         )
 
 
@@ -143,3 +143,19 @@ def func26(fn: Callable[P, None]):
         return fn(*args, **kwargs)
 
     return inner
+
+
+def func27(t: tuple[int, ...]):
+    if len(t) == 0 or len(t) >= 2:
+        reveal_type(t, expected_text="tuple[()] | tuple[int, int, *tuple[int, ...]]")
+    else:
+        reveal_type(t, expected_text="tuple[int]")
+
+
+def func28(t: tuple[int, *tuple[int, ...]]):
+    if len(t) == 1 or len(t) >= 3:
+        reveal_type(
+            t, expected_text="tuple[int] | tuple[int, int, int, *tuple[int, ...]]"
+        )
+    else:
+        reveal_type(t, expected_text="tuple[int, int]")


### PR DESCRIPTION
…to handle the negative narrowing case where tuple `t` has a minimum length of `L`. In this case, the narrowed type can be computed whereas previously it was left unnarrowed. This addresses #9031.