### PR TITLE
Fixed bug that results in a false negative when assigning a value to …

### DIFF
--- a/packages/pyright-internal/src/analyzer/constraintSolver.ts
+++ b/packages/pyright-internal/src/analyzer/constraintSolver.ts
@@ -807,16 +807,6 @@ function assignUnconstrainedTypeVar(
                 // source type.
                 newLowerBound = adjSrcType;
             } else {
-                // We need to widen the type.
-                if (constraints?.isLocked()) {
-                    diag?.addMessage(
-                        LocAddendum.typeAssignmentMismatch().format(
-                            evaluator.printSrcDestTypes(adjSrcType, curLowerBound)
-                        )
-                    );
-                    return false;
-                }
-
                 if (
                     evaluator.assignType(
                         adjSrcType,
@@ -974,14 +964,12 @@ function assignUnconstrainedTypeVar(
         }
     }
 
-    if (constraints && !constraints.isLocked()) {
-        constraints.setBounds(
-            destType,
-            newLowerBound,
-            newUpperBound,
-            (flags & (AssignTypeFlags.PopulateExpectedType | AssignTypeFlags.RetainLiteralsForTypeVar)) !== 0
-        );
-    }
+    constraints?.setBounds(
+        destType,
+        newLowerBound,
+        newUpperBound,
+        (flags & (AssignTypeFlags.PopulateExpectedType | AssignTypeFlags.RetainLiteralsForTypeVar)) !== 0
+    );
 
     return true;
 }
@@ -1160,9 +1148,7 @@ function assignConstrainedTypeVar(
                     recursionCount
                 )
             ) {
-                if (constraints && !constraints.isLocked()) {
-                    constraints.setBounds(destType, constrainedType, curUpperBound);
-                }
+                constraints?.setBounds(destType, constrainedType, curUpperBound);
             } else {
                 diag?.addMessage(
                     LocAddendum.typeConstrainedTypeVar().format({
@@ -1175,9 +1161,7 @@ function assignConstrainedTypeVar(
         }
     } else {
         // Assign the type to the type var.
-        if (constraints && !constraints.isLocked()) {
-            constraints.setBounds(destType, constrainedType, curUpperBound, retainLiterals);
-        }
+        constraints?.setBounds(destType, constrainedType, curUpperBound, retainLiterals);
     }
 
     return true;
@@ -1219,9 +1203,7 @@ function assignParamSpec(
                     }
                 }
             } else {
-                if (!constraints.isLocked()) {
-                    constraintSet.setBounds(destType, adjSrcType);
-                }
+                constraintSet.setBounds(destType, adjSrcType);
                 return;
             }
         } else if (isFunction(adjSrcType)) {
@@ -1276,9 +1258,7 @@ function assignParamSpec(
             }
 
             if (updateContextWithNewFunction) {
-                if (!constraints.isLocked()) {
-                    constraintSet.setBounds(destType, newFunction);
-                }
+                constraintSet.setBounds(destType, newFunction);
                 return;
             }
         } else if (isAnyOrUnknown(adjSrcType)) {

--- a/packages/pyright-internal/src/analyzer/constraintTracker.ts
+++ b/packages/pyright-internal/src/analyzer/constraintTracker.ts
@@ -183,7 +183,6 @@ export class ConstraintSet {
 }
 
 export class ConstraintTracker {
-    private _isLocked = false;
     private _constraintSets: ConstraintSet[];
 
     constructor() {
@@ -194,7 +193,6 @@ export class ConstraintTracker {
         const newTypeVarMap = new ConstraintTracker();
 
         newTypeVarMap._constraintSets = this._constraintSets.map((set) => set.clone());
-        newTypeVarMap._isLocked = this._isLocked;
 
         return newTypeVarMap;
     }
@@ -220,7 +218,6 @@ export class ConstraintTracker {
     // Copies a cloned type var context back into this object.
     copyFromClone(clone: ConstraintTracker) {
         this._constraintSets = clone._constraintSets.map((context) => context.clone());
-        this._isLocked = clone._isLocked;
     }
 
     copyBounds(entry: TypeVarConstraints) {
@@ -248,28 +245,11 @@ export class ConstraintTracker {
         return this._constraintSets.every((set, index) => set.isSame(other._constraintSets[index]));
     }
 
-    lock() {
-        // Locks the type var map, preventing any further changes.
-        assert(!this._isLocked);
-        this._isLocked = true;
-    }
-
-    unlock() {
-        // Unlocks the type var map, allowing further changes.
-        this._isLocked = false;
-    }
-
-    isLocked(): boolean {
-        return this._isLocked;
-    }
-
     isEmpty() {
         return this._constraintSets.every((set) => set.isEmpty());
     }
 
     setBounds(typeVar: TypeVarType, lowerBound: Type | undefined, upperBound?: Type, retainLiterals?: boolean) {
-        assert(!this._isLocked);
-
         return this._constraintSets.forEach((set) => {
             set.setBounds(typeVar, lowerBound, upperBound, retainLiterals);
         });
@@ -295,16 +275,9 @@ export class ConstraintTracker {
     }
 
     doForEachConstraintSet(callback: (constraintSet: ConstraintSet, index: number) => void) {
-        const wasLocked = this.isLocked();
-        this.unlock();
-
         this.getConstraintSets().forEach((set, index) => {
             callback(set, index);
         });
-
-        if (wasLocked) {
-            this.lock();
-        }
     }
 
     getConstraintSet(index: number) {

--- a/packages/pyright-internal/src/analyzer/constructors.ts
+++ b/packages/pyright-internal/src/analyzer/constructors.ts
@@ -428,7 +428,6 @@ function validateNewMethod(
         argumentErrors = true;
 
         // Evaluate the arguments in a non-speculative manner to generate any diagnostics.
-        constraints.unlock();
         evaluator.validateCallArgs(
             errorNode,
             argList,

--- a/packages/pyright-internal/src/analyzer/protocols.ts
+++ b/packages/pyright-internal/src/analyzer/protocols.ts
@@ -736,7 +736,7 @@ function assignToProtocolInternal(
             ) {
                 typesAreConsistent = false;
             }
-        } else if (constraints && !constraints.isLocked()) {
+        } else if (constraints) {
             for (const typeParam of destType.shared.typeParams) {
                 const typeArgEntry = protocolConstraints.getMainConstraintSet().getTypeVar(typeParam);
 

--- a/packages/pyright-internal/src/tests/samples/solver42.py
+++ b/packages/pyright-internal/src/tests/samples/solver42.py
@@ -1,0 +1,21 @@
+# This sample tests the case involving assignment to a union that contains
+# multiple instances of the same TypeVar.
+
+from typing import TypeVar
+
+
+T = TypeVar("T")
+
+
+def func1(x: tuple[T, list[T]] | list[T]) -> None: ...
+
+
+def func2(x: tuple[T, list[T]] | None) -> None: ...
+
+
+def test1(list_of_int: list[int]):
+    # This should generate an error.
+    func1((None, list_of_int))
+
+    # This should generate an error.
+    func2((None, list_of_int))

--- a/packages/pyright-internal/src/tests/typeEvaluator2.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator2.test.ts
@@ -819,6 +819,12 @@ test('Solver41', () => {
     TestUtils.validateResults(analysisResults, 0);
 });
 
+test('Solver42', () => {
+    const analysisResults = TestUtils.typeAnalyzeSampleFiles(['solver42.py']);
+
+    TestUtils.validateResults(analysisResults, 2);
+});
+
 test('SolverScoring1', () => {
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['solverScoring1.py']);
 


### PR DESCRIPTION
…a union type that includes the same type variable multiple times in at least one invariant context. This change eliminates the concept of a "locked" constraint tracker, which is no longer needed and was the underlying cause of the bug. This addresses #9047.