### PR TITLE
Fixed a bug that results in a false positive when assigning `Never` t…

### DIFF
--- a/packages/pyright-internal/src/analyzer/constraintSolver.ts
+++ b/packages/pyright-internal/src/analyzer/constraintSolver.ts
@@ -587,9 +587,9 @@ function assignBoundTypeVar(
         return true;
     }
 
-    // Never is always assignable in a covariant context.
-    const isCovariant = (flags & (AssignTypeFlags.Invariant | AssignTypeFlags.Contravariant)) === 0;
-    if (isNever(srcType) && isCovariant) {
+    // Never is always assignable except in an invariant context.
+    const isInvariant = (flags & AssignTypeFlags.Invariant) !== 0;
+    if (isNever(srcType) && !isInvariant) {
         return true;
     }
 

--- a/packages/pyright-internal/src/tests/samples/never2.py
+++ b/packages/pyright-internal/src/tests/samples/never2.py
@@ -6,6 +6,8 @@ from typing import Generic, Never, TypeVar
 U = TypeVar("U")
 
 T_co = TypeVar("T_co", covariant=True)
+T_contra = TypeVar("T_contra", contravariant=True)
+T = TypeVar("T")
 
 
 class ClassA(Generic[T_co]):
@@ -16,9 +18,6 @@ def func1(x: U) -> ClassA[U]:
     return ClassA[Never]()
 
 
-T = TypeVar("T")
-
-
 class ClassB(Generic[T]):
     pass
 
@@ -26,3 +25,11 @@ class ClassB(Generic[T]):
 def func2(x: U) -> ClassB[U]:
     # This should generate an error because T is invariant.
     return ClassB[Never]()
+
+
+class ClassC(Generic[T_contra]):
+    def __init__(self, x: T_contra): ...
+
+
+def func3(x: U) -> U | ClassC[Never]:
+    return ClassC(x)


### PR DESCRIPTION
…o a type variable in a contravariant context. This addresses #9056.