### PR TITLE
Fixed a bug that can result in a false positive error when a function…

### DIFF
--- a/packages/pyright-internal/src/tests/samples/kwargsUnpack1.py
+++ b/packages/pyright-internal/src/tests/samples/kwargsUnpack1.py
@@ -77,33 +77,27 @@ def func3():
 
 
 class TDProtocol1(Protocol):
-    def __call__(self, *, v1: int, v3: str) -> None:
-        ...
+    def __call__(self, *, v1: int, v3: str) -> None: ...
 
 
 class TDProtocol2(Protocol):
-    def __call__(self, *, v1: int, v3: str, v2: str = "") -> None:
-        ...
+    def __call__(self, *, v1: int, v3: str, v2: str = "") -> None: ...
 
 
 class TDProtocol3(Protocol):
-    def __call__(self, *, v1: int, v2: int, v3: str) -> None:
-        ...
+    def __call__(self, *, v1: int, v2: int, v3: str) -> None: ...
 
 
 class TDProtocol4(Protocol):
-    def __call__(self, *, v1: int) -> None:
-        ...
+    def __call__(self, *, v1: int) -> None: ...
 
 
 class TDProtocol5(Protocol):
-    def __call__(self, v1: int, v3: str) -> None:
-        ...
+    def __call__(self, v1: int, v3: str) -> None: ...
 
 
 class TDProtocol6(Protocol):
-    def __call__(self, **kwargs: Unpack[TD2]) -> None:
-        ...
+    def __call__(self, **kwargs: Unpack[TD2]) -> None: ...
 
 
 v1: TDProtocol1 = func1
@@ -121,11 +115,20 @@ v5: TDProtocol5 = func1
 v6: TDProtocol6 = func1
 
 
-def func4(v1: int, /, **kwargs: Unpack[TD2]) -> None:
-    ...
+def func4(v1: int, /, **kwargs: Unpack[TD2]) -> None: ...
 
 
 # This should generate an error because parameter v1 overlaps
 # with the TypedDict.
-def func5(v1: int, **kwargs: Unpack[TD2]) -> None:
-    ...
+def func5(v1: int, **kwargs: Unpack[TD2]) -> None: ...
+
+
+class TD3(TypedDict):
+    a: int
+
+
+def func6(a: int, /, **kwargs: Unpack[TD3]):
+    pass
+
+
+func6(1, a=2)

--- a/packages/pyright-internal/src/tests/samples/paramSpec53.py
+++ b/packages/pyright-internal/src/tests/samples/paramSpec53.py
@@ -1,0 +1,22 @@
+# This sample tests the case where a ParamSpec captures a named parameter
+# that is combined with a positional-only parameter of the same name.
+
+from typing import TypeVar, Callable, ParamSpec
+
+P = ParamSpec("P")
+T = TypeVar("T")
+
+
+class Mixin:
+    @classmethod
+    def factory(
+        cls: Callable[P, T], data: str, /, *args: P.args, **kwargs: P.kwargs
+    ) -> T: ...
+
+
+class Next(Mixin):
+    def __init__(self, data: int) -> None:
+        pass
+
+
+Next.factory("", data=2)

--- a/packages/pyright-internal/src/tests/typeEvaluator4.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator4.test.ts
@@ -823,3 +823,8 @@ test('ParamSpec52', () => {
     const results = TestUtils.typeAnalyzeSampleFiles(['paramSpec52.py']);
     TestUtils.validateResults(results, 2);
 });
+
+test('ParamSpec53', () => {
+    const results = TestUtils.typeAnalyzeSampleFiles(['paramSpec53.py']);
+    TestUtils.validateResults(results, 0);
+});


### PR DESCRIPTION
… signature contains a positional-only parameter and a keyword parameter with the same name. This can result from the application of a ParamSpec or through the use of an unpacked TypedDict. This addresses #9043 and #8964.