### PR TITLE
Fixed a bug that can result in a false positive error when a function…

### DIFF
--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -418,7 +418,6 @@ interface AssignClassToSelfInfo {
 interface ParamAssignmentInfo {
     argsNeeded: number;
     argsReceived: number;
-    isPositionalOnly: boolean;
 }
 
 interface MatchedOverloadInfo {
@@ -10541,11 +10540,11 @@ export function createTypeEvaluator(
         paramDetails.params.forEach((paramInfo) => {
             assert(paramInfo !== undefined, 'paramInfo is undefined for param name map');
             const param = paramInfo.param;
-            if (param.name && param.category === ParamCategory.Simple) {
+
+            if (param.name && param.category === ParamCategory.Simple && paramInfo.kind !== ParamKind.Positional) {
                 paramMap.set(param.name, {
                     argsNeeded: param.category === ParamCategory.Simple && !paramInfo.defaultType ? 1 : 0,
                     argsReceived: 0,
-                    isPositionalOnly: paramInfo.kind === ParamKind.Positional,
                 });
             }
         });
@@ -10929,20 +10928,22 @@ export function createTypeEvaluator(
                     }
                 }
             } else {
-                const paramName = paramDetails.params[paramIndex].param.name;
+                const paramInfo = paramDetails.params[paramIndex];
+                const paramName = paramInfo.param.name;
+
                 validateArgTypeParams.push({
-                    paramCategory: paramDetails.params[paramIndex].param.category,
+                    paramCategory: paramInfo.param.category,
                     paramType,
                     requiresTypeVarMatching: requiresSpecialization(paramType),
                     argument: argList[argIndex],
                     errorNode: argList[argIndex].valueExpression || errorNode,
                     paramName,
-                    isParamNameSynthesized: FunctionParam.isNameSynthesized(paramDetails.params[paramIndex].param),
+                    isParamNameSynthesized: FunctionParam.isNameSynthesized(paramInfo.param),
                 });
-                trySetActive(argList[argIndex], paramDetails.params[paramIndex].param);
+                trySetActive(argList[argIndex], paramInfo.param);
 
                 // Note that the parameter has received an argument.
-                if (paramName && paramMap.has(paramName)) {
+                if (paramName && paramMap.has(paramName) && paramInfo.kind !== ParamKind.Positional) {
                     paramMap.get(paramName)!.argsReceived++;
                 }
 
@@ -11043,7 +11044,7 @@ export function createTypeEvaluator(
 
                         tdEntries.knownItems.forEach((entry, name) => {
                             const paramEntry = paramMap.get(name);
-                            if (paramEntry && !paramEntry.isPositionalOnly) {
+                            if (paramEntry) {
                                 if (paramEntry.argsReceived > 0) {
                                     diag.addMessage(LocMessage.paramAlreadyAssigned().format({ name }));
                                 } else {
@@ -11085,7 +11086,6 @@ export function createTypeEvaluator(
                                 paramMap.set(name, {
                                     argsNeeded: 1,
                                     argsReceived: 1,
-                                    isPositionalOnly: false,
                                 });
                             } else {
                                 // If the function doesn't have a **kwargs parameter, we need to emit an error.
@@ -11227,7 +11227,8 @@ export function createTypeEvaluator(
                     if (paramName) {
                         const paramNameValue = paramName.d.value;
                         const paramEntry = paramMap.get(paramNameValue);
-                        if (paramEntry && !paramEntry.isPositionalOnly) {
+
+                        if (paramEntry) {
                             if (paramEntry.argsReceived > 0) {
                                 if (!canSkipDiagnosticForNode(errorNode) && !isTypeIncomplete) {
                                     addDiagnostic(
@@ -11241,7 +11242,9 @@ export function createTypeEvaluator(
                                 paramEntry.argsReceived++;
 
                                 const paramInfoIndex = paramDetails.params.findIndex(
-                                    (paramInfo) => paramInfo.param.name === paramNameValue
+                                    (paramInfo) =>
+                                        paramInfo.param.name === paramNameValue &&
+                                        paramInfo.kind !== ParamKind.Positional
                                 );
                                 assert(paramInfoIndex >= 0);
                                 const paramType = paramDetails.params[paramInfoIndex].type;
@@ -11283,7 +11286,6 @@ export function createTypeEvaluator(
                                 paramMap.set(paramNameValue, {
                                     argsNeeded: 1,
                                     argsReceived: 1,
-                                    isPositionalOnly: false,
                                 });
                                 assert(
                                     paramDetails.params[paramDetails.kwargsIndex],
@@ -11419,8 +11421,9 @@ export function createTypeEvaluator(
                 paramDetails.params.forEach((paramInfo) => {
                     const param = paramInfo.param;
                     if (param.category === ParamCategory.Simple && param.name) {
-                        const entry = paramMap.get(param.name)!;
-                        if (entry.argsNeeded === 0 && entry.argsReceived === 0) {
+                        const entry = paramMap.get(param.name);
+
+                        if (entry && entry.argsNeeded === 0 && entry.argsReceived === 0) {
                             const defaultArgType = paramInfo.defaultType;
 
                             if (
@@ -18128,7 +18131,11 @@ export function createTypeEvaluator(
                     const paramMap = new Map<string, number>();
                     for (let i = paramListDetails.firstKeywordOnlyIndex; i < paramListDetails.params.length; i++) {
                         const paramInfo = paramListDetails.params[i];
-                        if (paramInfo.param.category === ParamCategory.Simple && paramInfo.param.name) {
+                        if (
+                            paramInfo.param.category === ParamCategory.Simple &&
+                            paramInfo.param.name &&
+                            paramInfo.kind !== ParamKind.Positional
+                        ) {
                             paramMap.set(paramInfo.param.name, i);
                         }
                     }
@@ -25946,7 +25953,11 @@ export function createTypeEvaluator(
             if (destParamDetails.firstKeywordOnlyIndex !== undefined) {
                 destParamDetails.params.forEach((param, index) => {
                     if (index >= destParamDetails.firstKeywordOnlyIndex!) {
-                        if (param.param.name && param.param.category === ParamCategory.Simple) {
+                        if (
+                            param.param.name &&
+                            param.param.category === ParamCategory.Simple &&
+                            param.kind !== ParamKind.Positional
+                        ) {
                             destParamMap.set(param.param.name, param);
                         }
                     }

--- a/packages/pyright-internal/src/tests/samples/kwargsUnpack1.py
+++ b/packages/pyright-internal/src/tests/samples/kwargsUnpack1.py
@@ -77,33 +77,27 @@ def func3():
 
 
 class TDProtocol1(Protocol):
-    def __call__(self, *, v1: int, v3: str) -> None:
-        ...
+    def __call__(self, *, v1: int, v3: str) -> None: ...
 
 
 class TDProtocol2(Protocol):
-    def __call__(self, *, v1: int, v3: str, v2: str = "") -> None:
-        ...
+    def __call__(self, *, v1: int, v3: str, v2: str = "") -> None: ...
 
 
 class TDProtocol3(Protocol):
-    def __call__(self, *, v1: int, v2: int, v3: str) -> None:
-        ...
+    def __call__(self, *, v1: int, v2: int, v3: str) -> None: ...
 
 
 class TDProtocol4(Protocol):
-    def __call__(self, *, v1: int) -> None:
-        ...
+    def __call__(self, *, v1: int) -> None: ...
 
 
 class TDProtocol5(Protocol):
-    def __call__(self, v1: int, v3: str) -> None:
-        ...
+    def __call__(self, v1: int, v3: str) -> None: ...
 
 
 class TDProtocol6(Protocol):
-    def __call__(self, **kwargs: Unpack[TD2]) -> None:
-        ...
+    def __call__(self, **kwargs: Unpack[TD2]) -> None: ...
 
 
 v1: TDProtocol1 = func1
@@ -121,11 +115,20 @@ v5: TDProtocol5 = func1
 v6: TDProtocol6 = func1
 
 
-def func4(v1: int, /, **kwargs: Unpack[TD2]) -> None:
-    ...
+def func4(v1: int, /, **kwargs: Unpack[TD2]) -> None: ...
 
 
 # This should generate an error because parameter v1 overlaps
 # with the TypedDict.
-def func5(v1: int, **kwargs: Unpack[TD2]) -> None:
-    ...
+def func5(v1: int, **kwargs: Unpack[TD2]) -> None: ...
+
+
+class TD3(TypedDict):
+    a: int
+
+
+def func6(a: int, /, **kwargs: Unpack[TD3]):
+    pass
+
+
+func6(1, a=2)

--- a/packages/pyright-internal/src/tests/samples/paramSpec53.py
+++ b/packages/pyright-internal/src/tests/samples/paramSpec53.py
@@ -1,0 +1,22 @@
+# This sample tests the case where a ParamSpec captures a named parameter
+# that is combined with a positional-only parameter of the same name.
+
+from typing import TypeVar, Callable, ParamSpec
+
+P = ParamSpec("P")
+T = TypeVar("T")
+
+
+class Mixin:
+    @classmethod
+    def factory(
+        cls: Callable[P, T], data: str, /, *args: P.args, **kwargs: P.kwargs
+    ) -> T: ...
+
+
+class Next(Mixin):
+    def __init__(self, data: int) -> None:
+        pass
+
+
+Next.factory("", data=2)

--- a/packages/pyright-internal/src/tests/typeEvaluator4.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator4.test.ts
@@ -823,3 +823,8 @@ test('ParamSpec52', () => {
     const results = TestUtils.typeAnalyzeSampleFiles(['paramSpec52.py']);
     TestUtils.validateResults(results, 2);
 });
+
+test('ParamSpec53', () => {
+    const results = TestUtils.typeAnalyzeSampleFiles(['paramSpec53.py']);
+    TestUtils.validateResults(results, 0);
+});


### PR DESCRIPTION
… signature contains a positional-only parameter and a keyword parameter with the same name. This can result from the application of a ParamSpec or through the use of an unpacked TypedDict. This addresses #9043 and #8964.