### PR TITLE
Extended `reportUnnecessaryComparison` to cover more cases involving …

### DIFF
--- a/packages/pyright-internal/src/tests/samples/comparison2.py
+++ b/packages/pyright-internal/src/tests/samples/comparison2.py
@@ -6,8 +6,7 @@ from typing import Any, Coroutine
 from dataclasses import dataclass
 
 
-def cond() -> bool:
-    ...
+def cond() -> bool: ...
 
 
 # This should generate a diagnostic when reportUnnecessaryComparison is enabled.
@@ -79,11 +78,31 @@ async def func5() -> None:
         pass
 
 
-def func6() -> Coroutine[Any, Any, int] | None:
-    ...
+def func6() -> Coroutine[Any, Any, int] | None: ...
 
 
 def func7():
     coro = func6()
     if coro:
+        pass
+
+
+class A: ...
+
+
+def func8(x: A):
+    # This should generate an error if reportUnnecessaryComparison is enabled.
+    if x is True:
+        pass
+
+    # This should generate an error if reportUnnecessaryComparison is enabled.
+    if x is False:
+        pass
+
+    # This should generate an error if reportUnnecessaryComparison is enabled.
+    if x is not True:
+        pass
+
+    # This should generate an error if reportUnnecessaryComparison is enabled.
+    if x is not False:
         pass

--- a/packages/pyright-internal/src/tests/typeEvaluator6.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator6.test.ts
@@ -590,7 +590,7 @@ test('Comparison2', () => {
 
     configOptions.diagnosticRuleSet.reportUnnecessaryComparison = 'error';
     const analysisResults2 = TestUtils.typeAnalyzeSampleFiles(['comparison2.py'], configOptions);
-    TestUtils.validateResults(analysisResults2, 11);
+    TestUtils.validateResults(analysisResults2, 15);
 });
 
 test('EmptyContainers1', () => {


### PR DESCRIPTION
…`is` and `is not` operators. This addresses #9068.