### PR TITLE
Fixed a bug that results in incorrect type evaluation behaviors when …

### DIFF
--- a/packages/pyright-internal/src/tests/samples/constructor32.py
+++ b/packages/pyright-internal/src/tests/samples/constructor32.py
@@ -1,0 +1,22 @@
+# This sample tests the case where a metaclass __call__ method is present
+# and supplies a different bidirectional type inference context than
+# the __new__ or __init__ methods.
+
+from typing import TypedDict
+
+
+class TD1(TypedDict):
+    x: int
+
+
+class AMeta(type):
+    def __call__(cls, *args, **kwargs):
+        super().__call__(*args, **kwargs)
+
+
+class A(metaclass=AMeta):
+    def __init__(self, params: TD1):
+        pass
+
+
+A({"x": 42})

--- a/packages/pyright-internal/src/tests/typeEvaluator6.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator6.test.ts
@@ -814,6 +814,12 @@ test('Constructor31', () => {
     TestUtils.validateResults(analysisResults, 0);
 });
 
+test('Constructor32', () => {
+    const analysisResults = TestUtils.typeAnalyzeSampleFiles(['constructor32.py']);
+
+    TestUtils.validateResults(analysisResults, 0);
+});
+
 test('ConstructorCallable1', () => {
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['constructorCallable1.py']);
 


### PR DESCRIPTION
…a class has a custom metaclass with a `__call__` method and a `__new__` or `__init__` method that provides a different bidirectional type inference context for parameters. This addresses #9067.