### PR TITLE
Counting files before error message

### DIFF
--- a/packages/pyright-internal/src/analyzer/service.ts
+++ b/packages/pyright-internal/src/analyzer/service.ts
@@ -1323,7 +1323,10 @@ export class AnalyzerService {
         const results: Uri[] = [];
         const startTime = Date.now();
         const longOperationLimitInSec = 10;
+        const nFilesToSuggestSubfolder = 50;
+        
         let loggedLongOperationError = false;
+        let nFilesVisited = 0;
 
         const visitDirectoryUnchecked = (absolutePath: Uri, includeRegExp: RegExp, hasDirectoryWildcard: boolean) => {
             if (!loggedLongOperationError) {
@@ -1331,7 +1334,7 @@ export class AnalyzerService {
 
                 // If this is taking a long time, log an error to help the user
                 // diagnose and mitigate the problem.
-                if (secondsSinceStart >= longOperationLimitInSec) {
+                if (secondsSinceStart >= longOperationLimitInSec && nFilesVisited >= nFilesToSuggestSubfolder) {
                     this._console.error(
                         `Enumeration of workspace source files is taking longer than ${longOperationLimitInSec} seconds.\n` +
                             'This may be because:\n' +
@@ -1368,6 +1371,7 @@ export class AnalyzerService {
 
             for (const filePath of files) {
                 if (FileSpec.matchIncludeFileSpec(includeRegExp, exclude, filePath)) {
+                    nFilesVisited++;
                     results.push(filePath);
                 }
             }


### PR DESCRIPTION
Adds a counter for number of files seen. Only shows "too many files" error message if bigger than a given number (hardcoded to 50 same as number of seconds is hardcoded to 10).

This ensures the error suggesting opening a subfolder is only thrown when the long operation time for directory reading is actually due to the number of files being read (as opposed to very large, very few files).