### PR TITLE
Fixed a bug that leads to incorrect type evaluation when "literal mat…

### DIFF
--- a/packages/pyright-internal/src/tests/samples/operator8.py
+++ b/packages/pyright-internal/src/tests/samples/operator8.py
@@ -3,7 +3,9 @@
 # class.
 
 from functools import reduce
-from typing import Iterable, Literal
+from typing import Iterable, Literal, TypeVar
+
+TLiteral = TypeVar("TLiteral", bound=Literal[0, 1, 2])
 
 
 def func1(a: Literal[1, 2], b: Literal[0, 4], c: Literal[3, 4]):
@@ -184,3 +186,13 @@ def func9(a: int) -> None:
 
     inner1()
     inner2()
+
+
+def func10(a: TLiteral) -> TLiteral:
+    # This should generate an error.
+    return -a
+
+
+def func11(a: TLiteral, b: TLiteral) -> TLiteral:
+    # This should generate an error.
+    return a + b

--- a/packages/pyright-internal/src/tests/typeEvaluator8.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator8.test.ts
@@ -362,7 +362,7 @@ test('Operator7', () => {
 test('Operator8', () => {
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['operator8.py']);
 
-    TestUtils.validateResults(analysisResults, 0);
+    TestUtils.validateResults(analysisResults, 2);
 });
 
 test('Operator9', () => {


### PR DESCRIPTION
…h" for unary operators are applied to a TypeVar value that has a literal value upper bound. This addresses #9090.