### PR TITLE
Fixed bug with the provisional `TypeForm` support that breaks aliases…

### DIFF
--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -1679,7 +1679,7 @@ export function createTypeEvaluator(
 
         updatedFlags &= ~EvalFlags.TypeFormArg;
 
-        if (node.d.annotation) {
+        if (node.d.annotation && (flags & EvalFlags.TypeExpression) !== 0) {
             return getTypeOfExpression(node.d.annotation, updatedFlags);
         }
 


### PR DESCRIPTION
… of `Annotated`. This addresses #9092.