### PR TITLE
Fixed bug that results in incorrect variance inference for some gener…

### DIFF
--- a/packages/pyright-internal/src/analyzer/typeUtils.ts
+++ b/packages/pyright-internal/src/analyzer/typeUtils.ts
@@ -2874,6 +2874,20 @@ function _requiresSpecialization(type: Type, options?: RequiresSpecializationOpt
     return false;
 }
 
+// Converts contravariant to a covariant or vice versa. Leaves
+// other variances unchanged.
+export function invertVariance(variance: Variance) {
+    if (variance === Variance.Contravariant) {
+        return Variance.Covariant;
+    }
+
+    if (variance === Variance.Covariant) {
+        return Variance.Contravariant;
+    }
+
+    return variance;
+}
+
 // Combines two variances to produce a resulting variance.
 export function combineVariances(variance1: Variance, variance2: Variance) {
     if (variance1 === Variance.Unknown) {

--- a/packages/pyright-internal/src/analyzer/types.ts
+++ b/packages/pyright-internal/src/analyzer/types.ts
@@ -2975,6 +2975,12 @@ export namespace TypeVarType {
         return newInstance;
     }
 
+    export function cloneWithComputedVariance(type: TypeVarType, computedVariance: Variance): TypeVarType {
+        const newInstance = TypeBase.cloneType(type);
+        newInstance.priv.computedVariance = computedVariance;
+        return newInstance;
+    }
+
     export function makeNameWithScope(name: string, scopeId: string, scopeName: string) {
         // We include the scopeName here even though it's normally already part
         // of the scopeId. There are cases where it can diverge, specifically

--- a/packages/pyright-internal/src/languageService/hoverProvider.ts
+++ b/packages/pyright-internal/src/languageService/hoverProvider.ts
@@ -389,7 +389,8 @@ export class HoverProvider {
                 // If the user is hovering over a type parameter name in a class type parameter
                 // list, display the computed variance of the type param.
                 const typeParamListNode = ParseTreeUtils.getParentNodeOfType(node, ParseNodeType.TypeParameterList);
-                const printTypeVarVariance = typeParamListNode?.parent?.nodeType === ParseNodeType.Class;
+                const nodeType = typeParamListNode?.parent?.nodeType;
+                const printTypeVarVariance = nodeType === ParseNodeType.Class || nodeType === ParseNodeType.TypeAlias;
 
                 this._addResultsPart(
                     parts,


### PR DESCRIPTION
…ic type aliases that use auto variance and nested callable types.

Added the ability to view inferred variance for type aliases created with a `type` statement by hovering over the type parameter declaration.

This partly addresses #9081.