### PR TITLE
Fixed several bugs related to the explicit specialization of a generi…

### DIFF
--- a/packages/pyright-internal/src/tests/samples/paramSpec13.py
+++ b/packages/pyright-internal/src/tests/samples/paramSpec13.py
@@ -21,12 +21,10 @@ _T = TypeVar("_T")
 AddIntParam = Callable[Concatenate[int, _P], _T]
 
 
-def func1(func: Callable[_P, _R]) -> AddIntParam[_P, _R]:
-    ...
+def func1(func: Callable[_P, _R]) -> AddIntParam[_P, _R]: ...
 
 
-def func2(a: str, b: list[int]) -> str:
-    ...
+def func2(a: str, b: list[int]) -> str: ...
 
 
 v1 = func1(func2)
@@ -37,19 +35,15 @@ reveal_type(v1, expected_text="(int, a: str, b: list[int]) -> str")
 X = AddIntParam[int, int]
 
 
-class RemoteResponse(Generic[_T]):
-    ...
+class RemoteResponse(Generic[_T]): ...
 
 
 class RemoteFunction(Generic[_P, _R]):
-    def __init__(self, func: Callable[_P, _R]) -> None:
-        ...
+    def __init__(self, func: Callable[_P, _R]) -> None: ...
 
-    def __call__(self, *args: _P.args, **kwargs: _P.kwargs) -> _R:
-        ...
+    def __call__(self, *args: _P.args, **kwargs: _P.kwargs) -> _R: ...
 
-    def remote(self, *args: _P.args, **kwargs: _P.kwargs) -> RemoteResponse[_R]:
-        ...
+    def remote(self, *args: _P.args, **kwargs: _P.kwargs) -> RemoteResponse[_R]: ...
 
 
 r1 = RemoteFunction(func2)
@@ -75,8 +69,7 @@ r1.remote(1, [])
 A = RemoteFunction[int, int]
 
 
-def remote(func: Callable[_P, _R]) -> RemoteFunction[_P, _R]:
-    ...
+def remote(func: Callable[_P, _R]) -> RemoteFunction[_P, _R]: ...
 
 
 v4 = remote(func2)
@@ -87,8 +80,7 @@ Coro = Coroutine[Any, Any, _T]
 CoroFunc = Callable[_P, Coro[_T]]
 
 
-class ClassA:
-    ...
+class ClassA: ...
 
 
 CheckFunc = CoroFunc[Concatenate[ClassA, _P], bool]
@@ -117,3 +109,21 @@ ta1_1: TA1[()] = lambda: 0
 
 # This should generate an error.
 ta1_2: TA1[()] = lambda x: x
+
+
+TA2: TypeAlias = Callable[Concatenate[int, _P], None]
+
+TA3: TypeAlias = TA2[int, int]
+TA4: TypeAlias = TA2[_P]
+
+# This should generate an error.
+TA5: TypeAlias = TA2[[int, _P]]
+
+# This should generate an error.
+TA6: TypeAlias = TA2[[int, ...]]
+
+TA7: TypeAlias = TA2[Concatenate[int, _P]]
+TA8: TypeAlias = TA2[Concatenate[int, ...]]
+
+# This should generate two errors.
+TA9: TypeAlias = TA2[int, Concatenate[int, _P]]

--- a/packages/pyright-internal/src/tests/typeEvaluator4.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator4.test.ts
@@ -626,7 +626,7 @@ test('ParamSpec12', () => {
 
 test('ParamSpec13', () => {
     const results = TestUtils.typeAnalyzeSampleFiles(['paramSpec13.py']);
-    TestUtils.validateResults(results, 7);
+    TestUtils.validateResults(results, 11);
 });
 
 test('ParamSpec14', () => {


### PR DESCRIPTION
…c type alias parameterized by a single ParamSpec. `Concatenate` was being handled incorrectly. This addresses #9088.