### PR TITLE
Fixed bug that results in a false negative when a type variable is de…

### DIFF
--- a/packages/pyright-internal/src/analyzer/typeEvaluatorTypes.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluatorTypes.ts
@@ -124,6 +124,9 @@ export const enum EvalFlags {
     // Used for PEP 526-style variable type annotations.
     VarTypeAnnotation = 1 << 15,
 
+    // An ellipsis is allowed even if TypeExpression is set.
+    AllowEllipsis = 1 << 16,
+
     // 'ClassVar' is not allowed in this context.
     NoClassVar = 1 << 17,
 
@@ -371,6 +374,7 @@ export interface ExpectedTypeOptions {
     forwardRefs?: boolean;
     typeExpression?: boolean;
     convertEllipsisToAny?: boolean;
+    allowEllipsis?: boolean;
 }
 
 export interface ExpectedTypeResult {

--- a/packages/pyright-internal/src/tests/samples/typeAliasStatement1.py
+++ b/packages/pyright-internal/src/tests/samples/typeAliasStatement1.py
@@ -38,8 +38,7 @@ else:
     type TA7 = int
 
 
-def func1() -> type[int]:
-    ...
+def func1() -> type[int]: ...
 
 
 # This should generate an error because a call expression is not
@@ -87,3 +86,6 @@ def func4():
 
 type TA12[T] = "list[T]"
 ta12: TA12[int] = [1, 2, 3]
+
+# This should generate an error.
+type TA13[T] = ...

--- a/packages/pyright-internal/src/tests/samples/typeAliasType1.py
+++ b/packages/pyright-internal/src/tests/samples/typeAliasType1.py
@@ -53,3 +53,6 @@ print(TA11.__value__)
 
 type TA12 = int | str
 print(TA12.__value__)
+
+# This should generate an error.
+TA13 = TypeAliasType("TA13", ...)

--- a/packages/pyright-internal/src/tests/typeEvaluator3.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator3.test.ts
@@ -596,7 +596,7 @@ test('Literals5', () => {
 test('Literals6', () => {
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['literals6.py']);
 
-    TestUtils.validateResults(analysisResults, 25);
+    TestUtils.validateResults(analysisResults, 26);
 });
 
 test('Literals7', () => {

--- a/packages/pyright-internal/src/tests/typeEvaluator5.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator5.test.ts
@@ -115,7 +115,7 @@ test('TypeAliasStatement1', () => {
     configOptions.defaultPythonVersion = pythonVersion3_12;
 
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['typeAliasStatement1.py'], configOptions);
-    TestUtils.validateResults(analysisResults, 9);
+    TestUtils.validateResults(analysisResults, 10);
 });
 
 test('TypeAliasStatement2', () => {
@@ -187,7 +187,7 @@ test('TypeVarDefault2', () => {
     configOptions.defaultPythonVersion = pythonVersion3_13;
 
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['typeVarDefault2.py'], configOptions);
-    TestUtils.validateResults(analysisResults, 23);
+    TestUtils.validateResults(analysisResults, 24);
 });
 
 test('TypeVarDefault3', () => {
@@ -314,7 +314,7 @@ test('TypeAliasType1', () => {
     configOptions.defaultPythonVersion = pythonVersion3_12;
 
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['typeAliasType1.py'], configOptions);
-    TestUtils.validateResults(analysisResults, 14);
+    TestUtils.validateResults(analysisResults, 15);
 });
 
 test('TypeAliasType2', () => {


### PR DESCRIPTION
…fined with the expression `...`. This should be flagged as an illegal type expression. This addresses #9120.