### PR TITLE
Fixed bug that results in a false positive when `Union` and `Unpack` …

### DIFF
--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -8009,22 +8009,32 @@ export function createTypeEvaluator(
                         if (unpackedType) {
                             typeResult.type = unpackedType;
                         } else {
-                            addDiagnostic(
-                                DiagnosticRule.reportInvalidTypeForm,
-                                LocMessage.unpackNotAllowed(),
-                                arg.d.valueExpr
-                            );
+                            if ((flags & EvalFlags.TypeExpression) !== 0) {
+                                addDiagnostic(
+                                    DiagnosticRule.reportInvalidTypeForm,
+                                    LocMessage.unpackNotAllowed(),
+                                    arg.d.valueExpr
+                                );
+                                typeResult.typeErrors = true;
+                            } else {
+                                typeResult.type = UnknownType.create();
+                            }
                         }
                     }
                 }
             }
 
             if (arg.d.name) {
-                addDiagnostic(
-                    DiagnosticRule.reportInvalidTypeForm,
-                    LocMessage.keywordArgInTypeArgument(),
-                    arg.d.valueExpr
-                );
+                if ((flags & EvalFlags.TypeExpression) !== 0) {
+                    addDiagnostic(
+                        DiagnosticRule.reportInvalidTypeForm,
+                        LocMessage.keywordArgInTypeArgument(),
+                        arg.d.valueExpr
+                    );
+                    typeResult.typeErrors = true;
+                } else {
+                    typeResult.type = UnknownType.create();
+                }
             }
 
             if (
@@ -16032,7 +16042,9 @@ export function createTypeEvaluator(
         // is allowed if it's an unpacked TypeVarTuple or tuple. None is also allowed
         // since it is used to define NoReturn in typeshed stubs).
         if (types.length === 1 && !allowSingleTypeArg && !isNoneInstance(types[0])) {
-            addDiagnostic(DiagnosticRule.reportInvalidTypeArguments, LocMessage.unionTypeArgCount(), errorNode);
+            if ((flags & EvalFlags.TypeExpression) !== 0) {
+                addDiagnostic(DiagnosticRule.reportInvalidTypeArguments, LocMessage.unionTypeArgCount(), errorNode);
+            }
             isValidTypeForm = false;
         }
 

--- a/packages/pyright-internal/src/tests/samples/unions4.py
+++ b/packages/pyright-internal/src/tests/samples/unions4.py
@@ -4,16 +4,16 @@ from typing import Union
 
 x = Union[int, str]
 
-
-# This should generate an error.
 y = Union[int]
 
 z = Union
 
+# This should generate an error.
+v1: Union[int]
+
 
 # This should generate an error.
-def func1() -> Union:
-    ...
+def func1() -> Union: ...
 
 
 # This should generate an error.


### PR DESCRIPTION
…are used outside of a type expression. Normal type expression rules should not be applied in this case. This addresses #7416.