### PR TITLE
Fixed bug that results in incorrect type narrowing on assignment if t…

### DIFF
--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -26365,7 +26365,11 @@ export function createTypeEvaluator(
                         return assignedSubtype;
                     }
 
-                    if (!isTypeVar(declaredSubtype) && isTypeVar(assignedSubtype)) {
+                    if (
+                        !isTypeVar(declaredSubtype) &&
+                        isTypeVar(assignedSubtype) &&
+                        !TypeVarType.isBound(assignedSubtype)
+                    ) {
                         // If the source is an unsolved TypeVar but the declared type is concrete,
                         // use the concrete type.
                         return declaredSubtype;

--- a/packages/pyright-internal/src/tests/samples/super1.py
+++ b/packages/pyright-internal/src/tests/samples/super1.py
@@ -1,7 +1,7 @@
 # This sample tests the type analyzer's handling of the super() call.
 
 
-from typing import Generic, TypeVar
+from typing import Generic, NamedTuple, TypeVar
 
 T = TypeVar("T")
 
@@ -88,3 +88,10 @@ class ClassF(Generic[T]):
 class ClassG(ClassF[T]):
     def __init__(self, val: T) -> None:
         super().__init__(val)
+
+
+class ClassH(NamedTuple("NT1", [("y", int), ("x", int)])):
+    def method(self, v: tuple[int, int]):
+        cls = type(self)
+        v = super().__new__(cls, *v)
+        return type(self)(self.y + v.y, self.x + v.x)


### PR DESCRIPTION
…he narrowed type is `Self` or another bound type variable. This addresses #9147.