### PR TITLE
Fixed a bug that leads to a false negative when a class-scoped variab…

### DIFF
--- a/packages/pyright-internal/src/analyzer/typeUtils.ts
+++ b/packages/pyright-internal/src/analyzer/typeUtils.ts
@@ -662,6 +662,21 @@ function compareTypes(a: Type, b: Type, recursionCount = 0): number {
             if (isLiteralType(a)) {
                 if (!isLiteralType(bClass)) {
                     return -1;
+                } else if (ClassType.isSameGenericClass(a, bClass)) {
+                    // Sort by literal value.
+                    const aLiteralValue = a.priv.literalValue;
+                    const bLiteralValue = bClass.priv.literalValue;
+
+                    if (
+                        (typeof aLiteralValue === 'string' && typeof bLiteralValue === 'string') ||
+                        (typeof aLiteralValue === 'number' && typeof bLiteralValue === 'number')
+                    ) {
+                        if (aLiteralValue < bLiteralValue) {
+                            return -1;
+                        } else if (aLiteralValue > bLiteralValue) {
+                            return 1;
+                        }
+                    }
                 }
             } else if (isLiteralType(bClass)) {
                 return 1;

--- a/packages/pyright-internal/src/tests/samples/dataclass1.py
+++ b/packages/pyright-internal/src/tests/samples/dataclass1.py
@@ -1,6 +1,7 @@
 # This sample tests the handling of the @dataclass decorator.
 
-from dataclasses import dataclass, InitVar
+from dataclasses import dataclass, InitVar, field
+from typing import Generic, TypeVar
 
 
 @dataclass
@@ -81,3 +82,18 @@ DC6(int)
 
 # This should generate an error.
 DC6(1)
+
+
+T1 = TypeVar("T1", int, str)
+
+
+@dataclass
+class DC7(Generic[T1]):
+    # This should generate an error.
+    x: T1 = 1
+
+
+@dataclass
+class DC8(Generic[T1]):
+    # This should generate an error.
+    x: T1 = field(default=1)

--- a/packages/pyright-internal/src/tests/typeEvaluator4.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator4.test.ts
@@ -267,7 +267,7 @@ test('DataClassNamedTuple2', () => {
 test('DataClass1', () => {
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['dataclass1.py']);
 
-    TestUtils.validateResults(analysisResults, 7);
+    TestUtils.validateResults(analysisResults, 9);
 });
 
 test('DataClass2', () => {


### PR DESCRIPTION
…le is annotated with a value-constrained type variable and assigned a default value with one of the value constraints. This addresses https://github.com/microsoft/pylance-release/issues/6530.