### PR TITLE
Fixed bug that results in a false positive when using a traditional (…

### DIFF
--- a/packages/pyright-internal/src/tests/samples/literals6.py
+++ b/packages/pyright-internal/src/tests/samples/literals6.py
@@ -28,8 +28,7 @@ Wrong10 = Literal[Any]
 Wrong11 = Literal[...]
 
 
-def func():
-    ...
+def func(): ...
 
 
 Wrong12 = Literal[func]
@@ -59,7 +58,7 @@ var6: Literal[{"a": "b", "c": "d"}]
 # This should generate two errors.
 var7: Literal[Path("abcd")]
 
-# This should generate two errors.
+# This should generate an error.
 var8: Literal[T]
 
 # This should generate an error.

--- a/packages/pyright-internal/src/tests/samples/paramSpec12.py
+++ b/packages/pyright-internal/src/tests/samples/paramSpec12.py
@@ -67,7 +67,7 @@ def puts_p_into_scope(f: Callable[P, int]) -> None:
     ) -> None:
         pass
 
-    # This should generate an error because P.args cannot be used in
+    # This should generate two errors because P.args cannot be used in
     # a union.
     def union_args2(
         *args: P.args | Sequence[Any], **kwargs: Union[P.kwargs, Mapping[str, Any]]

--- a/packages/pyright-internal/src/tests/samples/typeForm2.py
+++ b/packages/pyright-internal/src/tests/samples/typeForm2.py
@@ -19,11 +19,14 @@ from typing import (
     Type,
     TypeAlias,
     TypeGuard,
+    TypeVar,
     Union,
     Unpack,
 )
 import typing as tp
 from typing_extensions import TypeForm, TypeIs, ReadOnly
+
+T = TypeVar("T")
 
 type TA1 = int | str
 type TA2[T] = list[T] | T
@@ -187,7 +190,26 @@ def func5():
     reveal_type(t2, expected_text="TypeForm[TypeForm[TypeForm[int | str]]]")
 
 
-def func6():
+def func6(x: T) -> T:
+    v1: TypeForm[T] = T
+    v2 = tf(T)
+    reveal_type(v2, expected_text="TypeForm[T@func6]")
+
+    v3: TypeForm[T | int] = T
+    v3 = T | int
+
+    v4 = tf(T | int)
+    reveal_type(v4, expected_text="TypeForm[T@func6 | int]")
+
+    v5: TypeForm[list[T]] = list[T]
+
+    v6 = tf(list[T])
+    reveal_type(v6, expected_text="TypeForm[list[T@func6]]")
+
+    return x
+
+
+def func7():
     # This should generate an error.
     t1 = tf(Generic)
 

--- a/packages/pyright-internal/src/tests/typeEvaluator3.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator3.test.ts
@@ -596,7 +596,7 @@ test('Literals5', () => {
 test('Literals6', () => {
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['literals6.py']);
 
-    TestUtils.validateResults(analysisResults, 26);
+    TestUtils.validateResults(analysisResults, 25);
 });
 
 test('Literals7', () => {

--- a/packages/pyright-internal/src/tests/typeEvaluator4.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator4.test.ts
@@ -621,7 +621,7 @@ test('ParamSpec11', () => {
 
 test('ParamSpec12', () => {
     const results = TestUtils.typeAnalyzeSampleFiles(['paramSpec12.py']);
-    TestUtils.validateResults(results, 15);
+    TestUtils.validateResults(results, 14);
 });
 
 test('ParamSpec13', () => {


### PR DESCRIPTION
…non-PEP 695) TypeVar in a type expression and assigning to a `TypeForm`. This addresses #9159.