### PR TITLE
Fixed bug that leads to a false positive when a callable object uses …

### DIFF
--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -2407,11 +2407,6 @@ export function createTypeEvaluator(
         diag?: DiagnosticAddendum,
         recursionCount = 0
     ): FunctionType | OverloadedType | undefined {
-        if (recursionCount > maxTypeRecursionCount) {
-            return undefined;
-        }
-        recursionCount++;
-
         const boundMethodResult = getTypeOfBoundMember(
             /* errorNode */ undefined,
             classType,
@@ -2432,6 +2427,11 @@ export function createTypeEvaluator(
         }
 
         if (isClassInstance(boundMethodResult.type)) {
+            if (recursionCount > maxTypeRecursionCount) {
+                return undefined;
+            }
+            recursionCount++;
+
             return getBoundMagicMethod(
                 boundMethodResult.type,
                 '__call__',

--- a/packages/pyright-internal/src/tests/samples/callbackProtocol1.py
+++ b/packages/pyright-internal/src/tests/samples/callbackProtocol1.py
@@ -1,6 +1,6 @@
 # This sample tests support for callback protocols (defined in PEP 544).
 
-from typing import Protocol
+from typing import Callable, Protocol
 
 
 class TestClass1(Protocol):
@@ -114,8 +114,7 @@ var4: TestClass4 = test_func4
 
 
 class TestClass5(Protocol):
-    def __call__(self, *, a: int, b: str) -> int:
-        ...
+    def __call__(self, *, a: int, b: str) -> int: ...
 
 
 def test_func5(a: int, b: str) -> int:
@@ -126,8 +125,7 @@ f5: TestClass5 = test_func5
 
 
 class TestClass6(Protocol):
-    def __call__(self, a: int, /, *, b: str) -> int:
-        ...
+    def __call__(self, a: int, /, *, b: str) -> int: ...
 
 
 def test_func6(a: int, b: str) -> int:
@@ -148,3 +146,14 @@ def test_func7(*args: *tuple[int, *tuple[int, ...]]) -> int:
 
 # This should generate an error.
 f7: TestClass7 = test_func7
+
+
+class TestClass8:
+    def __call__(self: Callable[[int], int], v: int) -> int:
+        return v
+
+
+def func8(f: Callable[[int], int]): ...
+
+
+func8(TestClass8())


### PR DESCRIPTION
…a `Callable` type annotation for the `self` parameter in its own `__call__` method. This addresses #9166.