### PR TITLE
Added support for `*args: Unpack[T]` when `T` is a type variable with…

### DIFF
--- a/packages/pyright-internal/src/analyzer/constraintSolver.ts
+++ b/packages/pyright-internal/src/analyzer/constraintSolver.ts
@@ -60,6 +60,7 @@ import {
     isEffectivelyInstantiable,
     isLiteralTypeOrUnion,
     isPartlyUnknown,
+    makeUnpacked,
     mapSubtypes,
     simplifyFunctionToParamSpec,
     sortTypes,
@@ -138,17 +139,22 @@ export function assignTypeVar(
         isAssignable = assignParamSpec(evaluator, destType, srcType, diag, constraints, recursionCount);
     } else {
         if (isTypeVarTuple(destType) && !destType.priv.isInUnion) {
-            const tupleClassType = evaluator.getTupleClassType();
-            if (!isUnpacked(srcType) && tupleClassType) {
-                // Package up the type into a tuple.
-                srcType = convertToInstance(
-                    specializeTupleClass(
-                        tupleClassType,
-                        [{ type: srcType, isUnbounded: false }],
-                        /* isTypeArgExplicit */ true,
-                        /* isUnpacked */ true
-                    )
-                );
+            if (destType.priv.isUnpacked) {
+                const tupleClassType = evaluator.getTupleClassType();
+
+                if (!isUnpacked(srcType) && tupleClassType) {
+                    // Package up the type into a tuple.
+                    srcType = convertToInstance(
+                        specializeTupleClass(
+                            tupleClassType,
+                            [{ type: srcType, isUnbounded: false }],
+                            /* isTypeArgExplicit */ true,
+                            /* isUnpacked */ true
+                        )
+                    );
+                }
+            } else {
+                srcType = makeUnpacked(srcType);
             }
         }
 

--- a/packages/pyright-internal/src/analyzer/patternMatching.ts
+++ b/packages/pyright-internal/src/analyzer/patternMatching.ts
@@ -60,6 +60,7 @@ import {
     isTypeSame,
     isTypeVarTuple,
     isUnknown,
+    isUnpackedTypeVar,
     isUnpackedTypeVarTuple,
 } from './types';
 import {
@@ -1387,7 +1388,7 @@ function getSequencePatternInfo(
                     ];
 
                     const tupleIndeterminateIndex = typeArgs.findIndex(
-                        (t) => t.isUnbounded || isUnpackedTypeVarTuple(t.type)
+                        (t) => t.isUnbounded || isUnpackedTypeVarTuple(t.type) || isUnpackedTypeVar(t.type)
                     );
 
                     let tupleDeterminateEntryCount = typeArgs.length;
@@ -1417,7 +1418,9 @@ function getSequencePatternInfo(
                         const removedEntries = typeArgs.splice(patternStarEntryIndex, entriesToCombine);
                         typeArgs.splice(patternStarEntryIndex, 0, {
                             type: combineTypes(removedEntries.map((t) => t.type)),
-                            isUnbounded: removedEntries.every((t) => t.isUnbounded || isUnpackedTypeVarTuple(t.type)),
+                            isUnbounded: removedEntries.every(
+                                (t) => t.isUnbounded || isUnpackedTypeVarTuple(t.type) || isUnpackedTypeVar(t.type)
+                            ),
                         });
                     }
 

--- a/packages/pyright-internal/src/analyzer/tuples.ts
+++ b/packages/pyright-internal/src/analyzer/tuples.ts
@@ -26,6 +26,7 @@ import {
     isTypeVar,
     isTypeVarTuple,
     isUnion,
+    isUnpackedTypeVar,
     isUnpackedTypeVarTuple,
     TupleTypeArg,
     Type,
@@ -366,9 +367,11 @@ export function adjustTupleTypeArgs(
     srcTypeArgs: TupleTypeArg[],
     flags: AssignTypeFlags
 ): boolean {
-    const destUnboundedOrVariadicIndex = destTypeArgs.findIndex((t) => t.isUnbounded || isTypeVarTuple(t.type));
+    const destUnboundedOrVariadicIndex = destTypeArgs.findIndex(
+        (t) => t.isUnbounded || isUnpackedTypeVarTuple(t.type) || isUnpackedTypeVar(t.type)
+    );
     const srcUnboundedIndex = srcTypeArgs.findIndex((t) => t.isUnbounded);
-    const srcVariadicIndex = srcTypeArgs.findIndex((t) => isTypeVarTuple(t.type));
+    const srcVariadicIndex = srcTypeArgs.findIndex((t) => isUnpackedTypeVarTuple(t.type) || isUnpackedTypeVar(t.type));
 
     if (srcUnboundedIndex >= 0) {
         if (isAnyOrUnknown(srcTypeArgs[srcUnboundedIndex].type)) {

--- a/packages/pyright-internal/src/analyzer/typePrinter.ts
+++ b/packages/pyright-internal/src/analyzer/typePrinter.ts
@@ -615,14 +615,12 @@ function printTypeInternal(
                         (printTypeFlags & PrintTypeFlags.OmitTypeVarScopes) === 0
                 );
 
-                if (isTypeVarTuple(type)) {
-                    if (type.priv.isUnpacked) {
-                        typeVarName = _printUnpack(typeVarName, printTypeFlags);
-                    }
+                if (type.priv.isUnpacked) {
+                    typeVarName = _printUnpack(typeVarName, printTypeFlags);
+                }
 
-                    if (type.priv.isInUnion) {
-                        typeVarName = `Union[${typeVarName}]`;
-                    }
+                if (isTypeVarTuple(type) && type.priv.isInUnion) {
+                    typeVarName = `Union[${typeVarName}]`;
                 }
 
                 if (TypeBase.isInstantiable(type)) {

--- a/packages/pyright-internal/src/analyzer/typeUtils.ts
+++ b/packages/pyright-internal/src/analyzer/typeUtils.ts
@@ -42,6 +42,7 @@ import {
     isUnion,
     isUnknown,
     isUnpackedClass,
+    isUnpackedTypeVar,
     isUnpackedTypeVarTuple,
     maxTypeRecursionCount,
     ModuleType,
@@ -1385,7 +1386,9 @@ export function isTupleClass(type: ClassType) {
 // the form tuple[x, ...] where the number of elements
 // in the tuple is unknown.
 export function isUnboundedTupleClass(type: ClassType) {
-    return type.priv.tupleTypeArgs?.some((t) => t.isUnbounded || isUnpackedTypeVarTuple(t.type));
+    return type.priv.tupleTypeArgs?.some(
+        (t) => t.isUnbounded || isUnpackedTypeVarTuple(t.type) || isUnpackedTypeVar(t.type)
+    );
 }
 
 // Indicates whether the specified index is within range and its type is unambiguous
@@ -1395,7 +1398,9 @@ export function isTupleIndexUnambiguous(type: ClassType, index: number) {
         return false;
     }
 
-    const unboundedIndex = type.priv.tupleTypeArgs.findIndex((t) => t.isUnbounded || isUnpackedTypeVarTuple(t.type));
+    const unboundedIndex = type.priv.tupleTypeArgs.findIndex(
+        (t) => t.isUnbounded || isUnpackedTypeVarTuple(t.type) || isUnpackedTypeVar(t.type)
+    );
 
     if (index < 0) {
         const lowerIndexLimit = unboundedIndex < 0 ? 0 : unboundedIndex;
@@ -2680,16 +2685,33 @@ export function combineSameSizedTuples(type: Type, tupleType: Type | undefined):
 }
 
 export function combineTupleTypeArgs(typeArgs: TupleTypeArg[]): Type {
-    return combineTypes(
-        typeArgs.map((t) => {
-            if (isTypeVar(t.type) && isUnpackedTypeVarTuple(t.type)) {
+    const typesToCombine: Type[] = [];
+
+    typeArgs.forEach((t) => {
+        if (isTypeVar(t.type)) {
+            if (isUnpackedTypeVarTuple(t.type)) {
                 // Treat the unpacked TypeVarTuple as a union.
-                return TypeVarType.cloneForUnpacked(t.type, /* isInUnion */ true);
+                typesToCombine.push(TypeVarType.cloneForUnpacked(t.type, /* isInUnion */ true));
+                return;
             }
 
-            return t.type;
-        })
-    );
+            if (isUnpackedTypeVar(t.type)) {
+                if (
+                    t.type.shared.boundType &&
+                    isClassInstance(t.type.shared.boundType) &&
+                    isTupleClass(t.type.shared.boundType) &&
+                    t.type.shared.boundType.priv.tupleTypeArgs
+                ) {
+                    typesToCombine.push(combineTupleTypeArgs(t.type.shared.boundType.priv.tupleTypeArgs));
+                }
+                return;
+            }
+        }
+
+        typesToCombine.push(t.type);
+    });
+
+    return combineTypes(typesToCombine);
 }
 
 // Tuples require special handling for specialization. This method computes
@@ -2719,6 +2741,39 @@ export function specializeTupleClass(
 function _expandUnpackedTypeVarTupleUnion(type: Type) {
     if (isClassInstance(type) && isTupleClass(type) && type.priv.tupleTypeArgs && type.priv.isUnpacked) {
         return combineTypes(type.priv.tupleTypeArgs.map((t) => t.type));
+    }
+
+    return type;
+}
+
+// If this is an unpacked type, returns the type as no longer unpacked.
+export function makePacked(type: Type): Type {
+    if (isUnpackedClass(type)) {
+        return ClassType.cloneForPacked(type);
+    }
+
+    if (isUnpackedTypeVarTuple(type) && !type.priv.isInUnion) {
+        return TypeVarType.cloneForPacked(type);
+    }
+
+    if (isUnpackedTypeVar(type)) {
+        return TypeVarType.cloneForPacked(type);
+    }
+
+    return type;
+}
+
+export function makeUnpacked(type: Type): Type {
+    if (isClass(type)) {
+        return ClassType.cloneForUnpacked(type);
+    }
+
+    if (isTypeVarTuple(type) && !type.priv.isInUnion) {
+        return TypeVarType.cloneForUnpacked(type);
+    }
+
+    if (isTypeVar(type)) {
+        return TypeVarType.cloneForUnpacked(type);
     }
 
     return type;
@@ -2826,6 +2881,16 @@ function _requiresSpecialization(type: Type, options?: RequiresSpecializationOpt
 
             if (!type.priv.isTypeArgExplicit && options?.ignoreImplicitTypeArgs) {
                 return false;
+            }
+
+            if (type.priv.tupleTypeArgs) {
+                if (
+                    type.priv.tupleTypeArgs.some((typeArg) =>
+                        requiresSpecialization(typeArg.type, options, recursionCount)
+                    )
+                ) {
+                    return true;
+                }
             }
 
             if (type.priv.typeArgs) {
@@ -3544,6 +3609,7 @@ export class TypeVarTransformer {
         if (ClassType.isTupleClass(classType)) {
             if (classType.priv.tupleTypeArgs) {
                 newTupleTypeArgs = [];
+
                 classType.priv.tupleTypeArgs.forEach((oldTypeArgType) => {
                     const newTypeArgType = this.apply(oldTypeArgType.type, recursionCount);
 
@@ -3557,6 +3623,8 @@ export class TypeVarTransformer {
                         isTupleClass(newTypeArgType) &&
                         newTypeArgType.priv.tupleTypeArgs
                     ) {
+                        appendArray(newTupleTypeArgs!, newTypeArgType.priv.tupleTypeArgs);
+                    } else if (isUnpackedClass(newTypeArgType) && newTypeArgType.priv.tupleTypeArgs) {
                         appendArray(newTupleTypeArgs!, newTypeArgType.priv.tupleTypeArgs);
                     } else {
                         // Handle the special case where tuple[T, ...] is being specialized
@@ -4038,6 +4106,15 @@ class ApplySolvedTypeVarsTransformer extends TypeVarTransformer {
                 return TypeVarType.cloneForUnpacked(replacement, typeVar.priv.isInUnion);
             }
 
+            if (
+                !isTypeVarTuple(replacement) &&
+                isTypeVar(replacement) &&
+                isTypeVar(typeVar) &&
+                typeVar.priv.isUnpacked
+            ) {
+                return TypeVarType.cloneForUnpacked(replacement);
+            }
+
             // If this isn't a TypeVarTuple, combine all of the tuple
             // type args into a common type.
             if (
@@ -4047,6 +4124,10 @@ class ApplySolvedTypeVarsTransformer extends TypeVarTransformer {
                 replacement.priv.isUnpacked
             ) {
                 replacement = combineTupleTypeArgs(replacement.priv.tupleTypeArgs);
+            }
+
+            if (isUnpackedTypeVar(typeVar) && isClass(replacement)) {
+                replacement = ClassType.cloneForUnpacked(replacement);
             }
 
             if (!isTypeVar(replacement) || !TypeVarType.isUnification(replacement) || !this._options.replaceUnsolved) {

--- a/packages/pyright-internal/src/tests/samples/tupleUnpack4.py
+++ b/packages/pyright-internal/src/tests/samples/tupleUnpack4.py
@@ -1,0 +1,30 @@
+# This sample tests the handling of a TypeVar whose upper bound is
+# a tuple when used for an *args parameter.
+
+from typing import TypeVar, Unpack
+
+
+T = TypeVar("T", bound="tuple[int, ...]")
+
+
+def func1(*args: Unpack[T]) -> tuple[int, ...]:
+    a, *v = args
+
+    reveal_type(a, expected_text="*T@func1")
+
+    b: int = a
+
+    # This should generate an error.
+    c: str = a
+
+    reveal_type(v, expected_text="list[*T@func1]")
+
+    return args
+
+
+S = TypeVar("S", bound=list[int])
+
+
+# This should generate an error.
+def func2(*args: Unpack[S]) -> int:
+    return 0

--- a/packages/pyright-internal/src/tests/samples/typeVarTuple8.py
+++ b/packages/pyright-internal/src/tests/samples/typeVarTuple8.py
@@ -15,32 +15,25 @@ _Xs = TypeVarTuple("_Xs")
 _Ys = TypeVarTuple("_Ys")
 
 
-def func1(x: Union[Unpack[_Xs]]) -> Union[Unpack[_Xs]]:
-    ...
+def func1(x: Union[Unpack[_Xs]]) -> Union[Unpack[_Xs]]: ...
 
 
-def func2(x: Union[Unpack[_Xs], Unpack[_Ys]]) -> Union[Unpack[_Xs], Unpack[_Ys]]:
-    ...
+def func2(x: Union[Unpack[_Xs], Unpack[_Ys]]) -> Union[Unpack[_Xs], Unpack[_Ys]]: ...
 
 
-def func3(x: Union[int, Unpack[_Xs]]) -> Union[Unpack[_Xs]]:
-    ...
+def func3(x: Union[int, Unpack[_Xs]]) -> Union[Unpack[_Xs]]: ...
 
 
-def func4(x: Union[_T, Unpack[_Xs]]) -> Union[_T, Unpack[_Xs]]:
-    ...
+def func4(x: Union[_T, Unpack[_Xs]]) -> Union[_T, Unpack[_Xs]]: ...
 
 
-def func5(x: Union[Unpack[_Xs]], *args: Unpack[_Xs]) -> Union[Unpack[_Xs]]:
-    ...
+def func5(x: Union[Unpack[_Xs]], *args: Unpack[_Xs]) -> Union[Unpack[_Xs]]: ...
 
 
-def func6(*args: Unpack[_Xs]) -> Union[Unpack[_Xs]]:
-    ...
+def func6(*args: Unpack[_Xs]) -> Union[Unpack[_Xs]]: ...
 
 
-def func7(a: list[Union[Unpack[_Xs]]]) -> Union[Unpack[_Xs]]:
-    ...
+def func7(a: list[Union[Unpack[_Xs]]]) -> Union[Unpack[_Xs]]: ...
 
 
 def test1(a: int, b: str, c: list[int], d: Union[complex, str]):
@@ -84,11 +77,11 @@ def test1(a: int, b: str, c: list[int], d: Union[complex, str]):
 
     # ---------
 
-    # This should generate an error
     v5_1 = func5(a)
+    reveal_type(v5_1, expected_text="int")
 
-    # This should generate an error
     v5_2 = func5(a, a)
+    reveal_type(v5_2, expected_text="int")
 
     # This should generate an error
     v5_3 = func5(a, b)

--- a/packages/pyright-internal/src/tests/typeEvaluator6.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator6.test.ts
@@ -248,7 +248,7 @@ test('TypeVarTuple8', () => {
 
     configOptions.defaultPythonVersion = pythonVersion3_11;
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['typeVarTuple8.py'], configOptions);
-    TestUtils.validateResults(analysisResults, 5);
+    TestUtils.validateResults(analysisResults, 3);
 });
 
 test('TypeVarTuple9', () => {

--- a/packages/pyright-internal/src/tests/typeEvaluator8.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator8.test.ts
@@ -787,6 +787,11 @@ test('TupleUnpack3', () => {
     TestUtils.validateResults(analysisResults1, 1);
 });
 
+test('TupleUnpack4', () => {
+    const analysisResults1 = TestUtils.typeAnalyzeSampleFiles(['tupleUnpack4.py']);
+    TestUtils.validateResults(analysisResults1, 2);
+});
+
 test('PseudoGeneric1', () => {
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['pseudoGeneric1.py']);
 


### PR DESCRIPTION
… an upper bound of a tuple.