### PR TITLE
Fixed bug that leads to a false positive error when using `Literal[]`…

### DIFF
--- a/packages/pyright-internal/src/tests/samples/literals1.py
+++ b/packages/pyright-internal/src/tests/samples/literals1.py
@@ -58,10 +58,12 @@ bytes4 = b"'"
 reveal_type(bytes4, expected_text='Literal[b"\'"]')
 
 
-x = [Literal[1], Literal[2]]
-reveal_type(x, expected_text="list[type[Literal]]")
+t1 = [Literal[1], Literal[2]]
+reveal_type(t1, expected_text="list[type[Literal]]")
 
+t2 = Literal[*(1, 2)]
+reveal_type(t2, expected_text="Literal")
 
 values = ("a", "b", "c")
-t1 = Literal[values]
-reveal_type(t1, expected_text="Literal")
+t3 = Literal[values]
+reveal_type(t3, expected_text="Literal")


### PR DESCRIPTION
… in a value expression (not a type expression) with an unpack operator. This addresses #9194.