### PR TITLE
Fixed a recent regression that results in a false positive in cases w…

### DIFF
--- a/packages/pyright-internal/src/analyzer/dataClasses.ts
+++ b/packages/pyright-internal/src/analyzer/dataClasses.ts
@@ -73,6 +73,7 @@ import {
     getTypeVarScopeIds,
     isLiteralType,
     isMetaclassInstance,
+    makeInferenceContext,
     requiresSpecialization,
     specializeTupleClass,
     synthesizeTypeVarForSelfCls,
@@ -571,7 +572,11 @@ export function synthesizeDataClassMethods(
                             if (entry.isDefaultFactory || !entry.defaultExpr) {
                                 defaultType = entry.type;
                             } else {
-                                defaultType = evaluator.getTypeOfExpression(entry.defaultExpr).type;
+                                defaultType = evaluator.getTypeOfExpression(
+                                    entry.defaultExpr,
+                                    /* flags */ undefined,
+                                    makeInferenceContext(entry.type)
+                                ).type;
                             }
                         }
                     }

--- a/packages/pyright-internal/src/tests/samples/dataclass1.py
+++ b/packages/pyright-internal/src/tests/samples/dataclass1.py
@@ -1,7 +1,7 @@
 # This sample tests the handling of the @dataclass decorator.
 
 from dataclasses import dataclass, InitVar, field
-from typing import Generic, TypeVar
+from typing import Generic, Literal, Sequence, TypeVar
 
 
 @dataclass
@@ -112,3 +112,8 @@ reveal_type(v8_1, expected_text="DC8[int]")
 
 # This should generate an error.
 v8_2 = DC8[str]()
+
+
+@dataclass
+class DC9(Generic[T1]):
+    x: Sequence[Literal["a", "b"]] = ["a"]


### PR DESCRIPTION
…here a dataclass field has a default value where the expression requires bidirectional type inference for proper type evaluation. This addresses #9205.