### PR TITLE
Fixed recent regression that results in a false negative when calling…

### DIFF
--- a/packages/pyright-internal/src/analyzer/constructors.ts
+++ b/packages/pyright-internal/src/analyzer/constructors.ts
@@ -595,15 +595,17 @@ function validateMetaclassCall(
         );
     });
 
-    // If the return type is unannotated, don't use the inferred return type.
-    const callType = metaclassCallMethodInfo.type;
-    if (isFunction(callType) && !callType.shared.declaredReturnType) {
-        return undefined;
-    }
+    if (!callResult.argumentErrors) {
+        // If the return type is unannotated, don't use the inferred return type.
+        const callType = metaclassCallMethodInfo.type;
+        if (isFunction(callType) && !callType.shared.declaredReturnType) {
+            return undefined;
+        }
 
-    // If the return type is unknown, ignore it.
-    if (callResult.returnType && isUnknown(callResult.returnType)) {
-        return undefined;
+        // If the return type is unknown, ignore it.
+        if (callResult.returnType && isUnknown(callResult.returnType)) {
+            return undefined;
+        }
     }
 
     return callResult;

--- a/packages/pyright-internal/src/tests/samples/constructor32.py
+++ b/packages/pyright-internal/src/tests/samples/constructor32.py
@@ -2,7 +2,9 @@
 # and supplies a different bidirectional type inference context than
 # the __new__ or __init__ methods.
 
-from typing import TypedDict
+from typing import TypedDict, TypeVar
+
+T = TypeVar("T")
 
 
 class TD1(TypedDict):
@@ -20,3 +22,15 @@ class A(metaclass=AMeta):
 
 
 A({"x": 42})
+
+
+class BMeta(type):
+    def __call__(cls: type[T], x: int, y: str) -> T: ...
+
+
+class B(metaclass=BMeta): ...
+
+
+def func1(cls: type[B]):
+    # This should generate an error.
+    cls()

--- a/packages/pyright-internal/src/tests/typeEvaluator6.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator6.test.ts
@@ -825,7 +825,7 @@ test('Constructor31', () => {
 test('Constructor32', () => {
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['constructor32.py']);
 
-    TestUtils.validateResults(analysisResults, 0);
+    TestUtils.validateResults(analysisResults, 1);
 });
 
 test('ConstructorCallable1', () => {


### PR DESCRIPTION
… a constructor for a class with a custom metaclass with a `__call__` method that has an unannotated return type if the arguments passed to the constructor are incorrect. This addresses #9200.