### PR TITLE
Fixed a bug that results in a false positive when defining a metaclas…

### DIFF
--- a/packages/pyright-internal/src/analyzer/typeUtils.ts
+++ b/packages/pyright-internal/src/analyzer/typeUtils.ts
@@ -2128,7 +2128,9 @@ export function derivesFromStdlibClass(classType: ClassType, className: string) 
 // checking for derivation. If ignoreUnknown is false, a return value
 // of true is assumed.
 export function derivesFromClassRecursive(classType: ClassType, baseClassToFind: ClassType, ignoreUnknown: boolean) {
-    if (ClassType.isSameGenericClass(classType, baseClassToFind)) {
+    if (
+        ClassType.isSameGenericClass(ClassType.cloneAsInstance(classType), ClassType.cloneAsInstance(baseClassToFind))
+    ) {
         return true;
     }
 

--- a/packages/pyright-internal/src/tests/samples/classes1.py
+++ b/packages/pyright-internal/src/tests/samples/classes1.py
@@ -2,7 +2,7 @@
 # handle various class definition cases.
 
 
-from typing import Any, TypeVar
+from typing import Any, Protocol, TypeVar
 
 
 T = TypeVar("T")
@@ -85,3 +85,7 @@ def func3(cls: T2) -> T2:
         pass
     
     return M
+
+
+class N(type(Protocol)):
+    pass


### PR DESCRIPTION
…s that derives from `type(Protocol)`. This addresses #9217.