### PR TITLE
Added check for `alias` keyword argument in a `dataclass_transform` f…

### DIFF
--- a/packages/pyright-internal/src/analyzer/dataClasses.ts
+++ b/packages/pyright-internal/src/analyzer/dataClasses.ts
@@ -27,6 +27,7 @@ import {
     ParseNodeType,
     TypeAnnotationNode,
 } from '../parser/parseNodes';
+import { Tokenizer } from '../parser/tokenizer';
 import * as AnalyzerNodeInfo from './analyzerNodeInfo';
 import { getFileInfo } from './analyzerNodeInfo';
 import { ConstraintSolution } from './constraintSolution';
@@ -326,6 +327,14 @@ export function synthesizeDataClassMethods(
                                 isLiteralType(valueType)
                             ) {
                                 aliasName = valueType.priv.literalValue as string;
+
+                                if (!Tokenizer.isPythonIdentifier(aliasName)) {
+                                    evaluator.addDiagnostic(
+                                        DiagnosticRule.reportGeneralTypeIssues,
+                                        LocMessage.dataClassFieldInvalidAlias().format({ aliasName }),
+                                        aliasArg.d.valueExpr
+                                    );
+                                }
                             }
                         }
 

--- a/packages/pyright-internal/src/analyzer/importResolver.ts
+++ b/packages/pyright-internal/src/analyzer/importResolver.ts
@@ -22,7 +22,7 @@ import * as StringUtils from '../common/stringUtils';
 import { equateStringsCaseInsensitive } from '../common/stringUtils';
 import { Uri } from '../common/uri/uri';
 import { getFileSystemEntriesFromDirEntries, isDirectory, isFile, tryRealpath, tryStat } from '../common/uri/uriUtils';
-import { isIdentifierChar, isIdentifierStartChar } from '../parser/characters';
+import { Tokenizer } from '../parser/tokenizer';
 import { ImplicitImport, ImportResult, ImportType } from './importResult';
 import { getDirectoryLeadingDotsPointsTo } from './importStatementUtils';
 import { ImportPath, ParentDirectoryCache } from './parentDirectoryCache';
@@ -2818,7 +2818,7 @@ function _getModuleNameInfoFromPath(
     }
 
     // Check whether parts contains invalid characters.
-    const containsInvalidCharacters = parts.some((p) => !_isIdentifier(p));
+    const containsInvalidCharacters = parts.some((p) => !Tokenizer.isPythonIdentifier(p));
 
     return {
         moduleName: parts.join('.'),
@@ -2832,14 +2832,4 @@ function _isNativeModuleFileExtension(fileExtension: string): boolean {
 
 function _isDefaultWorkspace(uri: Uri | undefined) {
     return !uri || uri.isEmpty() || Uri.isDefaultWorkspace(uri);
-}
-
-function _isIdentifier(value: string) {
-    for (let i = 0; i < value.length; i++) {
-        if (i === 0 ? !isIdentifierStartChar(value.charCodeAt(i)) : !isIdentifierChar(value.charCodeAt(i))) {
-            return false;
-        }
-    }
-
-    return true;
 }

--- a/packages/pyright-internal/src/localization/localize.ts
+++ b/packages/pyright-internal/src/localization/localize.ts
@@ -360,6 +360,8 @@ export namespace Localizer {
             );
         export const dataClassFieldInheritedDefault = () =>
             new ParameterizedString<{ fieldName: string }>(getRawString('Diagnostic.dataClassFieldInheritedDefault'));
+        export const dataClassFieldInvalidAlias = () =>
+            new ParameterizedString<{ aliasName: string }>(getRawString('Diagnostic.dataClassFieldInvalidAlias'));
         export const dataClassFieldWithDefault = () => getRawString('Diagnostic.dataClassFieldWithDefault');
         export const dataClassFieldWithoutAnnotation = () => getRawString('Diagnostic.dataClassFieldWithoutAnnotation');
         export const dataClassFieldWithPrivateName = () => getRawString('Diagnostic.dataClassFieldWithPrivateName');

--- a/packages/pyright-internal/src/localization/package.nls.en-us.json
+++ b/packages/pyright-internal/src/localization/package.nls.en-us.json
@@ -218,6 +218,7 @@
         "dataClassConverterFunction": "Argument of type \"{argType}\" is not a valid converter for field \"{fieldName}\" of type \"{fieldType}\"",
         "dataClassConverterOverloads": "No overloads of \"{funcName}\" are valid converters for field \"{fieldName}\" of type \"{fieldType}\"",
         "dataClassFieldInheritedDefault": "\"{fieldName}\" overrides a field of the same name but is missing a default value",
+        "dataClassFieldInvalidAlias": "Alias name \"{aliasName}\" is not a valid identifier",
         "dataClassFieldWithDefault": "Fields without default values cannot appear after fields with default values",
         "dataClassFieldWithPrivateName": "Dataclass field cannot use private name",
         "dataClassFieldWithoutAnnotation": "Dataclass field without type annotation will cause runtime exception",

--- a/packages/pyright-internal/src/parser/tokenizer.ts
+++ b/packages/pyright-internal/src/parser/tokenizer.ts
@@ -387,6 +387,16 @@ export class Tokenizer {
         return !_softKeywords.has(name);
     }
 
+    static isPythonIdentifier(value: string) {
+        for (let i = 0; i < value.length; i++) {
+            if (i === 0 ? !isIdentifierStartChar(value.charCodeAt(i)) : !isIdentifierChar(value.charCodeAt(i))) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
     static isOperatorAssignment(operatorType?: OperatorType): boolean {
         if (operatorType === undefined || _operatorInfo[operatorType] === undefined) {
             return false;

--- a/packages/pyright-internal/src/tests/samples/dataclassTransform3.py
+++ b/packages/pyright-internal/src/tests/samples/dataclassTransform3.py
@@ -18,14 +18,12 @@ def __dataclass_transform__(
 
 
 class ModelField:
-    def __init__(self, *, init: bool = True, default: Any | None = None) -> None:
-        ...
+    def __init__(self, *, init: bool = True, default: Any | None = None) -> None: ...
 
 
 def model_field(
     *, init: bool = True, default: Any | None = None, alias: str | None = None
-) -> Any:
-    ...
+) -> Any: ...
 
 
 @__dataclass_transform__(
@@ -41,8 +39,7 @@ class ModelBase:
         frozen: bool = False,
         kw_only: bool = True,
         order: bool = True,
-    ) -> None:
-        ...
+    ) -> None: ...
 
 
 class Customer1(ModelBase, frozen=True):
@@ -102,8 +99,7 @@ class GenericModelBase(Generic[_T]):
         frozen: bool = False,
         kw_only: bool = True,
         order: bool = True,
-    ) -> None:
-        ...
+    ) -> None: ...
 
 
 class GenericCustomer(GenericModelBase[int]):
@@ -127,3 +123,11 @@ c3_1 = Customer3(id=2, name="hi")
 
 # This should generate an error because Customer3 is frozen.
 c3_1.id = 4
+
+
+class Customer4(ModelBase):
+    # This should generate an error because alias must be a valid identifier.
+    name1: str = model_field(alias="other name")
+
+    # This should generate an error because alias must be a valid identifier.
+    name2: str = model_field(alias="+test")

--- a/packages/pyright-internal/src/tests/typeEvaluator5.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator5.test.ts
@@ -423,7 +423,7 @@ test('DataclassTransform2', () => {
 test('DataclassTransform3', () => {
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['dataclassTransform3.py']);
 
-    TestUtils.validateResults(analysisResults, 6);
+    TestUtils.validateResults(analysisResults, 8);
 });
 
 test('DataclassTransform4', () => {


### PR DESCRIPTION
…ield definition call to ensure that it's a valid Python identifier. This addresses #9220.