### PR TITLE
Fixed bug that results in false positive error when a dataclass field…

### DIFF
--- a/packages/pyright-internal/src/tests/samples/dataclass1.py
+++ b/packages/pyright-internal/src/tests/samples/dataclass1.py
@@ -1,7 +1,7 @@
 # This sample tests the handling of the @dataclass decorator.
 
 from dataclasses import dataclass, InitVar, field
-from typing import Generic, Literal, Sequence, TypeVar
+from typing import Callable, Generic, Literal, Sequence, TypeVar
 
 
 @dataclass
@@ -117,3 +117,12 @@ v8_2 = DC8[str]()
 @dataclass
 class DC9(Generic[T1]):
     x: Sequence[Literal["a", "b"]] = ["a"]
+
+
+@dataclass
+class DC10[T]:
+    a: type[T]
+    b: Callable[[T], bool] = lambda _: True
+
+
+DC10(a=int)


### PR DESCRIPTION
… is annotated with a class-scoped type variable and includes a default value whose type require bidirectional type inference. This addresses #9222.