### PR TITLE
Fixed bug that results in false positive error regarding a `__bool__`…

### DIFF
--- a/packages/pyright-internal/src/analyzer/checker.ts
+++ b/packages/pyright-internal/src/analyzer/checker.ts
@@ -1264,11 +1264,6 @@ export class Checker extends ParseTreeWalker {
     }
 
     override visitBinaryOperation(node: BinaryOperationNode): boolean {
-        if (node.d.operator === OperatorType.And || node.d.operator === OperatorType.Or) {
-            this._validateConditionalIsBool(node.d.leftExpr);
-            this._validateConditionalIsBool(node.d.rightExpr);
-        }
-
         if (node.d.operator === OperatorType.Equals || node.d.operator === OperatorType.NotEquals) {
             // Don't apply this rule if it's within an assert.
             if (!ParseTreeUtils.isWithinAssertExpression(node)) {

--- a/packages/pyright-internal/src/tests/samples/conditional1.py
+++ b/packages/pyright-internal/src/tests/samples/conditional1.py
@@ -23,11 +23,15 @@ def func1(val: ReturnsNonBool):
     # This should generate an error.
     a = not val
 
-    # This should generate an error.
     b = val or 1
-
     # This should generate an error.
+    if b:
+        pass
+
     c = 1 and val
+    # This should generate an error.
+    if c:
+        pass
 
     # This should generate an error.
     y = 1 if val else 2
@@ -51,11 +55,15 @@ def func2(val: TVal | ReturnsBool) -> TVal | ReturnsBool:
     # This should generate an error.
     a = not val
 
-    # This should generate an error.
     b = val or 1
-
     # This should generate an error.
+    if b:
+        pass
+
     c = 1 and val
+    # This should generate an error.
+    if c:
+        pass
 
     # This should generate an error.
     y = 1 if val else 2


### PR DESCRIPTION
… method for a value used in an operand for an `or` or `and` operator. This addresses #9225.