### PR TITLE
Pull Pylance with Pyright 1.1.385

### DIFF
--- a/packages/vscode-pyright/package-lock.json
+++ b/packages/vscode-pyright/package-lock.json
@@ -16,7 +16,7 @@
             },
             "devDependencies": {
                 "@types/node": "^22.7.0",
-                "@types/vscode": "^1.82.0",
+                "@types/vscode": "^1.90.0",
                 "@vscode/vsce": "^2.32.0",
                 "copy-webpack-plugin": "^11.0.0",
                 "esbuild-loader": "^3.2.0",
@@ -27,7 +27,7 @@
                 "webpack-cli": "^5.1.4"
             },
             "engines": {
-                "vscode": "^1.89.0"
+                "vscode": "^1.91.0"
             }
         },
         "node_modules/@azure/abort-controller": {
@@ -721,9 +721,9 @@
             "dev": true
         },
         "node_modules/@types/node": {
-            "version": "22.7.0",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-22.7.0.tgz",
-            "integrity": "sha512-MOdOibwBs6KW1vfqz2uKMlxq5xAfAZ98SZjO8e3XnAbFnTJtAspqhWk7hrdSAs9/Y14ZWMiy7/MxMUzAOadYEw==",
+            "version": "22.7.5",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-22.7.5.tgz",
+            "integrity": "sha512-jML7s2NAzMWc//QSJ1a3prpk78cOPchGvXJsC3C6R6PSMoooztvRVQEz89gmBTBY1SPMaqo5teB4uNHPdetShQ==",
             "dev": true,
             "dependencies": {
                 "undici-types": "~6.19.2"

--- a/packages/vscode-pyright/package.json
+++ b/packages/vscode-pyright/package.json
@@ -14,7 +14,7 @@
         "url": "https://github.com/Microsoft/pyright"
     },
     "engines": {
-        "vscode": "^1.89.0"
+        "vscode": "^1.91.0"
     },
     "keywords": [
         "python"
@@ -1583,7 +1583,7 @@
     },
     "devDependencies": {
         "@types/node": "^22.7.0",
-        "@types/vscode": "^1.82.0",
+        "@types/vscode": "^1.90.0",
         "@vscode/vsce": "^2.32.0",
         "copy-webpack-plugin": "^11.0.0",
         "esbuild-loader": "^3.2.0",


### PR DESCRIPTION
Increased minimum VS Code version to 1.91.0 to stay in sync with Pylance