### PR TITLE
Use "Central Feed Services" rather than public npm registry

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+registry=https://pkgs.dev.azure.com/azure-public/vside/_packaging/Pyright_PublicPackages/npm/registry/

--- a/packages/pyright-internal/.npmrc
+++ b/packages/pyright-internal/.npmrc
@@ -1,0 +1,1 @@
+registry=https://pkgs.dev.azure.com/azure-public/vside/_packaging/Pyright_PublicPackages/npm/registry/

--- a/packages/pyright/.npmrc
+++ b/packages/pyright/.npmrc
@@ -1,0 +1,1 @@
+registry=https://pkgs.dev.azure.com/azure-public/vside/_packaging/Pyright_PublicPackages/npm/registry/

--- a/packages/vscode-pyright/.npmrc
+++ b/packages/vscode-pyright/.npmrc
@@ -1,0 +1,1 @@
+registry=https://pkgs.dev.azure.com/azure-public/vside/_packaging/Pyright_PublicPackages/npm/registry/


### PR DESCRIPTION
Microsoft security policy now requires products with npm dependencies to pull those dependencies from a Microsoft-controlled Azure Artifacts feed (with the public npmjs registry as an upstream) rather than directly from the public npmjs registry. This allows the Central Feed Services (CFS) feature to override dependencies as needed for security reasons (ex. disallow use of certain packages or package versions). I have yet to see this happen for what it's worth, so I'm not sure what the user experience will be when this feature kicks in.

The CFS feed for Pyright is https://dev.azure.com/azure-public/vside/_artifacts/feed/Pyright_PublicPackages

@erictraut, I believe the only change you should notice is that you won't be able to introduce new npm dependencies. External users are able to read from the Pyright_PublicPackages feed, but they cannot add additional packages to it, even if those packages are available on the public upstream feed. Apparently, the Azure Artifacts team is working on improving this experience. but I don't have a timeline for that.

In the meantime, if you need to add a new npm dependency, you can test your changes on your dev machine by deleting Pyright's four `.npmrc` files. That will cause `npm install` to use the public npmjs registry. But GitHub builds and AzDO builds (i.e. PR, CI, and release builds) with the new dependency will fail until an internal user (someone on the Pylance team) adds the needed package(s) to the Pyright_PublicPackages feed.

FYI, the AzDO builds check that these .npmrc files exist. Currently we only get warnings if they are missing, but in the future they will be required and removing them will cause the builds to fail.

I'm hoping this won't be too inconvenient for you, since, looking at the repo history, it seems that you rarely change the npm dependencies.