### PR TITLE
Fixed recent regression that results in a spurious type error when ac…

### DIFF
--- a/packages/pyright-internal/src/analyzer/typeUtils.ts
+++ b/packages/pyright-internal/src/analyzer/typeUtils.ts
@@ -1145,7 +1145,9 @@ export function getUnknownTypeForCallable(): FunctionType {
 // "self specializes" the class, filling in its own type parameters
 // as type arguments.
 export function selfSpecializeClass(type: ClassType, options?: SelfSpecializeOptions): ClassType {
-    if (!requiresTypeArgs(type)) {
+    // We can't use requiresTypeArgs(type) here because it returns false
+    // if the type parameters have default values.
+    if (type.shared.typeParams.length === 0) {
         return type;
     }
 

--- a/packages/pyright-internal/src/tests/samples/self11.py
+++ b/packages/pyright-internal/src/tests/samples/self11.py
@@ -1,0 +1,17 @@
+# This sample tests a case where "self" refers to a class with type
+# parameters that have default values. This is a case that regressed.
+
+
+class Base: ...
+
+
+class A(Base): ...
+
+
+class B[T: Base = A]:
+    def __init__(self, x: T) -> None:
+        self._x = x
+
+    @property
+    def x(self) -> T:
+        return self._x

--- a/packages/pyright-internal/src/tests/typeEvaluator8.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator8.test.ts
@@ -689,6 +689,12 @@ test('Self10', () => {
     TestUtils.validateResults(analysisResults, 2);
 });
 
+test('Self11', () => {
+    const analysisResults = TestUtils.typeAnalyzeSampleFiles(['self11.py']);
+
+    TestUtils.validateResults(analysisResults, 0);
+});
+
 test('UnusedVariable1', () => {
     const configOptions = new ConfigOptions(Uri.empty());
 


### PR DESCRIPTION
…cessing an instance variable `self.x` if `x` has the type of a class-scoped type variable with a default value. This addresses #9246.