### PR TITLE
Enhanced the `type(y) == x` type guard logic to support the case wher…

### DIFF
--- a/packages/pyright-internal/src/analyzer/typeGuards.ts
+++ b/packages/pyright-internal/src/analyzer/typeGuards.ts
@@ -2328,7 +2328,7 @@ function narrowTypeForTypeIs(evaluator: TypeEvaluator, type: Type, classType: Cl
                 if (isPositiveTest) {
                     if (matches) {
                         if (ClassType.isSameGenericClass(subtype, classType)) {
-                            return subtype;
+                            return addConditionToType(subtype, classType.props?.condition);
                         }
 
                         return addConditionToType(ClassType.cloneAsInstance(classType), subtype.props?.condition);

--- a/packages/pyright-internal/src/tests/samples/typeNarrowingTypeIs1.py
+++ b/packages/pyright-internal/src/tests/samples/typeNarrowingTypeIs1.py
@@ -93,12 +93,10 @@ def func7(val: Any):
     reveal_type(val, expected_text="int | Any")
 
 
-class CParent:
-    ...
+class CParent: ...
 
 
-class CChild(CParent):
-    ...
+class CChild(CParent): ...
 
 
 _TC = TypeVar("_TC", bound=CParent)
@@ -127,3 +125,14 @@ class G(str):
             reveal_type(v, expected_text="G*")
         else:
             reveal_type(v, expected_text="str")
+
+
+class H:
+    def __init__(self, x): ...
+
+
+def func9[T: H](x: type[T], y: H) -> T:
+    if type(y) == x:
+        reveal_type(y, expected_text="H*")
+        return y
+    return x(y)


### PR DESCRIPTION
…e `y` is declared as a type variable with an upper bound that overlaps with the type of `x`. This addresses #9227.