### PR TITLE
Fixed bug that leads to incorrect type narrowing in the negative ("el…

### DIFF
--- a/packages/pyright-internal/src/analyzer/typeGuards.ts
+++ b/packages/pyright-internal/src/analyzer/typeGuards.ts
@@ -1426,7 +1426,7 @@ function narrowTypeForInstance(
                 // class whose type is unknown (e.g. an import failed). We'll
                 // note this case specially so we don't do any narrowing, which
                 // will generate false positives.
-                if (filterIsSubclass && filterIsSuperclass) {
+                if (filterIsSuperclass) {
                     if (!isTypeIsCheck && concreteFilterType.priv.includeSubclasses) {
                         // If the filter type includes subclasses, we can't eliminate
                         // this type in the negative direction. We'll relax this for
@@ -1434,7 +1434,7 @@ function narrowTypeForInstance(
                         isClassRelationshipIndeterminate = true;
                     }
 
-                    if (!ClassType.isSameGenericClass(runtimeVarType, concreteFilterType)) {
+                    if (filterIsSubclass && !ClassType.isSameGenericClass(runtimeVarType, concreteFilterType)) {
                         isClassRelationshipIndeterminate = true;
                     }
                 }
@@ -1521,9 +1521,6 @@ function narrowTypeForInstance(
                                     concreteFilterType
                                 );
                                 filteredTypes.push(intersection ?? varType);
-
-                                // Don't attempt to narrow in the negative direction.
-                                isClassRelationshipIndeterminate = true;
                             }
                         }
                     } else if (

--- a/packages/pyright-internal/src/tests/samples/typeNarrowingIsinstance21.py
+++ b/packages/pyright-internal/src/tests/samples/typeNarrowingIsinstance21.py
@@ -64,3 +64,14 @@ def func4(t: B):
         reveal_type(t, expected_text="<subclass of B and type[A]>")
     else:
         reveal_type(t, expected_text="B")
+
+
+class CParent: ...
+
+
+class CChild(CParent): ...
+
+
+def func5(val: CChild, t: type[CParent]):
+    if not isinstance(val, t):
+        reveal_type(val, expected_text="CChild")


### PR DESCRIPTION
…se") case when using `isinstance` with a filter type that is typed as `type[X]`. This addresses #9272.