### PR TITLE
Specify return type for createHost

### DIFF
--- a/packages/pyright-internal/src/server.ts
+++ b/packages/pyright-internal/src/server.ts
@@ -225,7 +225,7 @@ export class PyrightServer extends LanguageServerBase {
         return new BackgroundAnalysis(this.serverOptions.serviceProvider);
     }
 
-    protected override createHost() {
+    protected override createHost(): Host {
         return new FullAccessHost(this.serverOptions.serviceProvider);
     }
 


### PR DESCRIPTION
Currently the return type of PyrightServer.createHost is left blank, inferred by typescript to be FullAccessHost. Therefore anyone who inherits from PyrightServer must also return FullAccessHost.

We should specify the return type explicitly. That way someone can inherit from it and return NoAccessHost, say.