### PR TITLE
Fixed issue that results in a false positive "type could not be deter…

### DIFF
--- a/packages/pyright-internal/src/tests/samples/loop51.py
+++ b/packages/pyright-internal/src/tests/samples/loop51.py
@@ -1,0 +1,21 @@
+# This sample tests a case where type evaluation for a type guard
+# within a loop may trigger a false positive "type depends on itself"
+# error message.
+
+# For details, see https://github.com/microsoft/pyright/issues/9139.
+
+from enum import StrEnum
+
+
+class MyEnum(StrEnum):
+    A = "A"
+
+
+for _ in range(2):
+    x: dict[MyEnum, int] = {}
+
+    if MyEnum.A in x:
+        ...
+
+    for _ in x.values():
+        ...

--- a/packages/pyright-internal/src/tests/typeEvaluator3.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator3.test.ts
@@ -485,6 +485,12 @@ test('Loop50', () => {
     TestUtils.validateResults(analysisResults, 0);
 });
 
+test('Loop51', () => {
+    const analysisResults = TestUtils.typeAnalyzeSampleFiles(['loop51.py']);
+
+    TestUtils.validateResults(analysisResults, 0);
+});
+
 test('ForLoop1', () => {
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['forLoop1.py']);
 


### PR DESCRIPTION
…mined because it refers to itself" error caused by a false dependency due to narrowing logic. This may also improve type analysis performance in some code. This addresses #9139.