### PR TITLE
Changed the evaluated type of an `in` or `not in` operator to be `boo…

### DIFF
--- a/packages/pyright-internal/src/analyzer/operations.ts
+++ b/packages/pyright-internal/src/analyzer/operations.ts
@@ -1198,7 +1198,7 @@ function validateContainmentOperation(
                         deprecatedInfo = returnTypeResult.magicMethodDeprecationInfo;
                     }
 
-                    return returnTypeResult?.type;
+                    return returnTypeResult?.type ?? evaluator.getBuiltInObject(errorNode, 'bool');
                 }
             );
         }


### PR DESCRIPTION
…l` if the LHS doesn't support containment. Previously, the expression evaluated to `Never`. This addresses #9327.