### PR TITLE
Fixed bug that results in incorrect type evaluation when performing p…

### DIFF
--- a/packages/pyright-internal/src/analyzer/protocols.ts
+++ b/packages/pyright-internal/src/analyzer/protocols.ts
@@ -569,7 +569,7 @@ function assignToProtocolInternal(
             destMemberType = applySolvedTypeVars(destMemberType, selfSolution);
 
             // If the dest is a method, bind it.
-            if (isFunction(destMemberType) || isOverloaded(destMemberType)) {
+            if (!destSymbol.isInstanceMember() && (isFunction(destMemberType) || isOverloaded(destMemberType))) {
                 let boundDeclaredType: FunctionType | OverloadedType | undefined;
 
                 // Functions are considered read-only.

--- a/packages/pyright-internal/src/tests/samples/protocol52.py
+++ b/packages/pyright-internal/src/tests/samples/protocol52.py
@@ -1,0 +1,24 @@
+# This sample tests the case where a protocol includes a callable
+# attribute that is an instance variable. It shouldn't be bound
+# to the concrete class in this case.
+
+from typing import Callable, Protocol
+
+
+class A:
+    def __init__(self, *, p1: int, p2: str) -> None: ...
+
+
+class ProtoB[**P, T](Protocol):
+    x: Callable[P, T]
+
+
+class B:
+    x: type[A]
+
+
+def func1[**P, T](v: ProtoB[P, T]) -> Callable[P, T]: ...
+
+
+x1 = func1(B())
+reveal_type(x1, expected_text="(*, p1: int, p2: str) -> A")

--- a/packages/pyright-internal/src/tests/typeEvaluator7.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator7.test.ts
@@ -605,6 +605,12 @@ test('Protocol51', () => {
     TestUtils.validateResults(analysisResults, 0);
 });
 
+test('Protocol52', () => {
+    const analysisResults = TestUtils.typeAnalyzeSampleFiles(['protocol52.py']);
+
+    TestUtils.validateResults(analysisResults, 0);
+});
+
 test('ProtocolExplicit1', () => {
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['protocolExplicit1.py']);
 


### PR DESCRIPTION
…rotocol matching that involves an attribute with a callable type parameterized by a ParamSpec. This addresses #9330.