### PR TITLE
Added check for a frozen dataclass entry that is overridden by a non-…

### DIFF
--- a/packages/pyright-internal/src/analyzer/checker.ts
+++ b/packages/pyright-internal/src/analyzer/checker.ts
@@ -5899,7 +5899,7 @@ export class Checker extends ParseTreeWalker {
                     const dataclassEntry = overriddenClassAndSymbol.classType.shared.dataClassEntries.find(
                         (entry) => entry.name === memberName
                     );
-                    if (dataclassEntry) {
+                    if (dataclassEntry && ClassType.isDataClass(overrideClassAndSymbol.classType)) {
                         isInvariant = false;
                     }
                 }
@@ -6735,7 +6735,7 @@ export class Checker extends ParseTreeWalker {
                         const dataclassEntry = baseClass.shared.dataClassEntries.find(
                             (entry) => entry.name === memberName
                         );
-                        if (dataclassEntry) {
+                        if (dataclassEntry && ClassType.isDataClass(childClassType)) {
                             isInvariant = false;
                         }
                     }

--- a/packages/pyright-internal/src/tests/samples/dataclassReplace1.py
+++ b/packages/pyright-internal/src/tests/samples/dataclassReplace1.py
@@ -43,3 +43,24 @@ nt1.__replace__(b=2)
 
 # This should generate an error.
 nt1.__replace__(d="")
+
+
+
+
+@dataclass(frozen=True)
+class DC2:
+    x: int | str
+
+
+@dataclass(frozen=True)
+class DC3(DC2):
+    x: str
+    y: str
+
+
+class DC4(DC2):
+    # This should generate an error because DC4 is not
+    # a dataclass, and it inherits the __replace__ method
+    # from DC2, which means that x can be mutated.
+    x: str
+    y: str

--- a/packages/pyright-internal/src/tests/typeEvaluator4.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator4.test.ts
@@ -376,11 +376,11 @@ test('DataClassReplace1', () => {
 
     configOptions.defaultPythonVersion = pythonVersion3_12;
     const analysisResults1 = TestUtils.typeAnalyzeSampleFiles(['dataclassReplace1.py'], configOptions);
-    TestUtils.validateResults(analysisResults1, 10);
+    TestUtils.validateResults(analysisResults1, 11);
 
     configOptions.defaultPythonVersion = pythonVersion3_13;
     const analysisResults2 = TestUtils.typeAnalyzeSampleFiles(['dataclassReplace1.py'], configOptions);
-    TestUtils.validateResults(analysisResults2, 4);
+    TestUtils.validateResults(analysisResults2, 5);
 });
 
 test('DataClassFrozen1', () => {


### PR DESCRIPTION
…dataclass subclass. Such an entry must be invariant because it can be mutated via a call to `__replace__`. This addresses #9351.