### PR TITLE
Fix hover on `.get()` of `TypedDict` instance

### DIFF
--- a/packages/pyright-internal/src/languageService/hoverProvider.ts
+++ b/packages/pyright-internal/src/languageService/hoverProvider.ts
@@ -263,9 +263,9 @@ export class HoverProvider {
                 const primaryDeclaration = HoverProvider.getPrimaryDeclaration(declarations);
                 this._addResultsForDeclaration(results.parts, primaryDeclaration, node);
             } else if (declInfo && declInfo.synthesizedTypes.length > 0) {
-                const name = node.d.value;
+                const nameNode = node;
                 declInfo?.synthesizedTypes.forEach((type) => {
-                    this._addResultsForSynthesizedType(results.parts, type, name);
+                    this._addResultsForSynthesizedType(results.parts, type, nameNode);
                 });
                 this._addDocumentationPart(results.parts, node, /* resolvedDecl */ undefined);
             } else if (!node.parent || node.parent.nodeType !== ParseNodeType.ModuleName) {
@@ -458,19 +458,21 @@ export class HoverProvider {
         }
     }
 
-    private _addResultsForSynthesizedType(parts: HoverTextPart[], typeInfo: SynthesizedTypeInfo, name: string) {
+    private _addResultsForSynthesizedType(parts: HoverTextPart[], typeInfo: SynthesizedTypeInfo, hoverNode: NameNode) {
         let typeText: string | undefined;
 
         if (isModule(typeInfo.type)) {
-            typeText = '(module) ' + name;
-        } else if (typeInfo.node) {
-            const type = this._getType(typeInfo.node);
+            typeText = '(module) ' + hoverNode.d.value;
+        } else {
+            const node = typeInfo.node ?? hoverNode;
+
+            const type = this._getType(node);
             typeText = getVariableTypeText(
                 this._evaluator,
                 /* declaration */ undefined,
-                typeInfo.node.d.value,
+                node.d.value,
                 type,
-                typeInfo.node,
+                node,
                 this._functionSignatureDisplay
             );
         }

--- a/packages/pyright-internal/src/tests/fourslash/hover.typedDict.get.fourslash.ts
+++ b/packages/pyright-internal/src/tests/fourslash/hover.typedDict.get.fourslash.ts
@@ -1,0 +1,15 @@
+/// <reference path="typings/fourslash.d.ts" />
+
+// @filename: test.py
+//// from typing_extensions import TypedDict
+////
+//// class Cls(TypedDict):
+////     a: int
+////     b: str
+////
+//// dct: Cls = {"a": 1, "b": "2"}
+//// dct.[|/*marker1*/get|]("a")
+
+helper.verifyHover('markdown', {
+    marker1: "```python\n(variable) def get(k: Literal['a']) -> int\n```",
+});


### PR DESCRIPTION
Fix https://github.com/microsoft/pyright/issues/9289

Prior to [the fix for #9252](https://github.com/microsoft/pyright/commit/8ddffa4b49ff41444acf3a8044e324109393d17b#diff-e8178cbc8c6f5764a3b368c69c7aad9132af94c62d25559c433c80d58e9cf51dL21542), in this scenario the `SynthesizedTypeInfo.node` value was the `NameNode` passed into `getDeclInfoForNameNode`. 

Fixed by falling back to that node in the hover provider if `SynthesizedTypeInfo.node` is `undefined`.