### PR TITLE
Fixed a bug that results in a false positive when a class is defined …

### DIFF
--- a/packages/pyright-internal/src/analyzer/typeUtils.ts
+++ b/packages/pyright-internal/src/analyzer/typeUtils.ts
@@ -2037,6 +2037,11 @@ export function getTypeVarArgsRecursive(type: Type, recursionCount = 0): TypeVar
             return [];
         }
 
+        // Don't return any bound type variables.
+        if (TypeVarType.isBound(type)) {
+            return [];
+        }
+
         // Don't return any P.args or P.kwargs types.
         if (isParamSpec(type) && type.priv.paramSpecAccess) {
             return [TypeVarType.cloneForParamSpecAccess(type, /* access */ undefined)];

--- a/packages/pyright-internal/src/tests/samples/typeParams8.py
+++ b/packages/pyright-internal/src/tests/samples/typeParams8.py
@@ -1,0 +1,13 @@
+# This sample tests the case where a class defined in an inner scope
+# uses type variables from an outer scope.
+
+
+class Parent[S, T]:
+    def task(self, input: S) -> T: ...
+
+
+def outer_func1[S, T]():
+    class Child(Parent[S, T]):
+        def task(self, input: S) -> T: ...
+
+    return Child

--- a/packages/pyright-internal/src/tests/typeEvaluator5.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator5.test.ts
@@ -73,6 +73,14 @@ test('TypeParams7', () => {
     TestUtils.validateResults(analysisResults, 4);
 });
 
+test('TypeParams8', () => {
+    const configOptions = new ConfigOptions(Uri.empty());
+    configOptions.defaultPythonVersion = pythonVersion3_12;
+
+    const analysisResults = TestUtils.typeAnalyzeSampleFiles(['typeParams8.py'], configOptions);
+    TestUtils.validateResults(analysisResults, 0);
+});
+
 test('AutoVariance1', () => {
     const configOptions = new ConfigOptions(Uri.empty());
     configOptions.defaultPythonVersion = pythonVersion3_12;


### PR DESCRIPTION
…within a generic function and uses type parameters from that function. This addresses #9359.