### PR TITLE
Enhanced the special-case logic for functools.partial so it handles t…

### DIFF
--- a/packages/pyright-internal/src/analyzer/parameterUtils.ts
+++ b/packages/pyright-internal/src/analyzer/parameterUtils.ts
@@ -242,6 +242,8 @@ export function getParamListDetails(type: FunctionType): ParamListDetails {
 
                 const typedDictType = paramType;
                 paramType.shared.typedDictEntries.knownItems.forEach((entry, name) => {
+                    entry = paramType.priv.typedDictNarrowedEntries?.get(name) ?? entry;
+
                     const specializedParamType = partiallySpecializeType(
                         entry.valueType,
                         typedDictType,

--- a/packages/pyright-internal/src/tests/samples/partial7.py
+++ b/packages/pyright-internal/src/tests/samples/partial7.py
@@ -1,0 +1,28 @@
+# This sample tests the case where functools.partial is applied to
+# a function that has a **kwargs parameter that is typed as an
+# unpacked TypedDict.
+
+from functools import partial
+from typing import TypedDict, NotRequired, Unpack
+
+
+class TD1(TypedDict):
+    c: list[str]
+    a: int
+    b: NotRequired[str]
+
+
+def func1(**kwargs: Unpack[TD1]) -> None:
+    print(f"a: {kwargs['a']}, b: {kwargs.get( 'b' )}, c: {kwargs['c']}")
+
+
+func1_1 = partial(func1, c=["a", "b"], a=2)
+func1_1(b="2")
+
+func1_2 = partial(func1, a=2, b="", c=["a", "b"])
+func1_2(a=2, b="2")
+
+func1_3 = partial(func1, c=["a", "b"])
+
+# This should generate an error.
+func1_3(b="2")

--- a/packages/pyright-internal/src/tests/typeEvaluator8.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator8.test.ts
@@ -761,6 +761,12 @@ test('Partial6', () => {
     TestUtils.validateResults(analysisResults, 2);
 });
 
+test('Partial7', () => {
+    const analysisResults = TestUtils.typeAnalyzeSampleFiles(['partial7.py']);
+
+    TestUtils.validateResults(analysisResults, 1);
+});
+
 test('TotalOrdering1', () => {
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['totalOrdering1.py']);
 


### PR DESCRIPTION
…he case where the function has a `**kwargs` parameter typed with an unpacked TypedDict. This addresses #9181.