### PR TITLE
Fixed bug that results in incorrect evaluation of class variables ass…

### DIFF
--- a/packages/pyright-internal/src/analyzer/binder.ts
+++ b/packages/pyright-internal/src/analyzer/binder.ts
@@ -4033,9 +4033,10 @@ export class Binder extends ParseTreeWalker {
             // To determine whether the first parameter of the method
             // refers to the class or the instance, we need to apply
             // some heuristics.
-            if (methodNode.d.name.d.value === '__new__') {
-                // The __new__ method is special. It acts as a classmethod even
-                // though it doesn't have a @classmethod decorator.
+            const implicitClassMethods = ['__new__', '__init_subclass__', '__class_getitem__'];
+            if (implicitClassMethods.includes(methodNode.d.name.d.value)) {
+                // Several methods are special. They act as class methods even
+                // though they don't have a @classmethod decorator.
                 isInstanceMember = false;
             } else {
                 // Assume that it's an instance member unless we find

--- a/packages/pyright-internal/src/tests/samples/initsubclass1.py
+++ b/packages/pyright-internal/src/tests/samples/initsubclass1.py
@@ -62,3 +62,14 @@ class ClassH(ClassG):
 # in the object.__init_subclass__ method.
 class ClassI(a=3):
     a: int
+
+
+class ClassJ:
+    def __init_subclass__(cls, **kwargs: Any) -> None:
+        super().__init_subclass__(**kwargs)
+        cls.custom_attribute = 9
+
+
+class ClassJChild(ClassJ):
+    def __init__(self):
+        reveal_type(self.custom_attribute, expected_text="int")


### PR DESCRIPTION
…igned in an `__init_subclass__` or `__class_getitem__` method. These methods are implicitly class methods even though they are not decorated with `@classmethod`. This addresses https://github.com/microsoft/pylance-release/discussions/2781.