### PR TITLE
Don't honor dataclass field aliases if they aren't valid identifiers

### DIFF
--- a/packages/pyright-internal/src/analyzer/dataClasses.ts
+++ b/packages/pyright-internal/src/analyzer/dataClasses.ts
@@ -25,6 +25,7 @@ import {
     ParseNodeType,
     TypeAnnotationNode,
 } from '../parser/parseNodes';
+import { Tokenizer } from '../parser/tokenizer';
 import * as AnalyzerNodeInfo from './analyzerNodeInfo';
 import { getFileInfo } from './analyzerNodeInfo';
 import { ConstraintSolution } from './constraintSolution';
@@ -329,7 +330,8 @@ export function synthesizeDataClassMethods(
                             if (
                                 isClassInstance(valueType) &&
                                 ClassType.isBuiltIn(valueType, 'str') &&
-                                isLiteralType(valueType)
+                                isLiteralType(valueType) &&
+                                Tokenizer.isPythonIdentifier(valueType.priv.literalValue as string)
                             ) {
                                 aliasName = valueType.priv.literalValue as string;
                             }

--- a/packages/pyright-internal/src/analyzer/typedDicts.ts
+++ b/packages/pyright-internal/src/analyzer/typedDicts.ts
@@ -24,6 +24,7 @@ import {
     ParamCategory,
     ParseNodeType,
 } from '../parser/parseNodes';
+import { Tokenizer } from '../parser/tokenizer';
 import { KeywordType } from '../parser/tokenizerTypes';
 import * as AnalyzerNodeInfo from './analyzerNodeInfo';
 import { ConstraintTracker } from './constraintTracker';
@@ -359,27 +360,29 @@ export function synthesizeTypedDictClassMethods(
     }
 
     entries.knownItems.forEach((entry, name) => {
-        FunctionType.addParam(
-            initOverride1,
-            FunctionParam.create(
-                ParamCategory.Simple,
-                entry.valueType,
-                FunctionParamFlags.TypeDeclared,
-                name,
-                entry.valueType
-            )
-        );
+        if (Tokenizer.isPythonIdentifier(name)) {
+            FunctionType.addParam(
+                initOverride1,
+                FunctionParam.create(
+                    ParamCategory.Simple,
+                    entry.valueType,
+                    FunctionParamFlags.TypeDeclared,
+                    name,
+                    entry.valueType
+                )
+            );
 
-        FunctionType.addParam(
-            initOverride2,
-            FunctionParam.create(
-                ParamCategory.Simple,
-                entry.valueType,
-                FunctionParamFlags.TypeDeclared,
-                name,
-                entry.isRequired ? undefined : entry.valueType
-            )
-        );
+            FunctionType.addParam(
+                initOverride2,
+                FunctionParam.create(
+                    ParamCategory.Simple,
+                    entry.valueType,
+                    FunctionParamFlags.TypeDeclared,
+                    name,
+                    entry.isRequired ? undefined : entry.valueType
+                )
+            );
+        }
 
         if (!entry.isReadOnly) {
             allEntriesAreReadOnly = false;

--- a/packages/pyright-internal/src/tests/samples/dataclassTransform2.py
+++ b/packages/pyright-internal/src/tests/samples/dataclassTransform2.py
@@ -2,7 +2,6 @@
 # when applied to a metaclass.
 
 from typing import Any, TypeVar
-
 from typing_extensions import (  # pyright: ignore[reportMissingModuleSource]
     dataclass_transform,
 )

--- a/packages/pyright-internal/src/tests/samples/dataclassTransform2.py
+++ b/packages/pyright-internal/src/tests/samples/dataclassTransform2.py
@@ -2,6 +2,7 @@
 # when applied to a metaclass.
 
 from typing import Any, TypeVar
+
 from typing_extensions import (  # pyright: ignore[reportMissingModuleSource]
     dataclass_transform,
 )
@@ -100,3 +101,10 @@ c3_1 = Customer3(id=2, name="hi")
 
 # This should generate an error because Customer3 is frozen.
 c3_1.id = 4
+
+
+class Customer4(ModelBase):
+    name1: str = model_field(alias="valid_alias")
+    name2: str = model_field(alias="invalid alias")
+
+c4_1 = Customer4(valid_alias="hi", name2="hi")

--- a/packages/pyright-internal/src/tests/samples/typedDict6.py
+++ b/packages/pyright-internal/src/tests/samples/typedDict6.py
@@ -1,7 +1,7 @@
 # This sample tests the type analyzer's handling of TypedDict
 # "alternate syntax" defined in PEP 589.
 
-from typing import NotRequired, Required, TypedDict
+from typing import NotRequired, Required, TypedDict, reveal_type
 
 Movie = TypedDict("Movie", {"name": str, "year": int})
 
@@ -81,3 +81,7 @@ movie12: Movie12 = {"title": "Two Towers", "predecessor": {"title": "Fellowship"
 # This should generate an error because the name doesn't match.
 # the arguments are missing.
 Movie13 = TypedDict("NotMovie13", {"name": str, "year": int})
+
+
+Movie14 = TypedDict("Movie14", {"@illegal identifier": int, "legal_identifier": int})
+reveal_type(Movie14.__init__, expected_text="Overload[(self: Movie14, __map: Movie14, /, *, legal_identifier: int = ...) -> None, (self: Movie14, *, legal_identifier: int) -> None]")


### PR DESCRIPTION
What do you think of this approach? In https://github.com/microsoft/pyright/issues/9386#issuecomment-2457620152 you seemed to be suggesting fixing this in the completion provider, but it's also an issue for signature help and hover. So it seemed cleaner to handle this in the type synthesis code for dataclasses and TypedDicts. Unless this is going to cause problems elsewhere?