### PR TITLE
Fixed bug that results in a false negative if a `|` union operator cr…

### DIFF
--- a/packages/pyright-internal/src/analyzer/operations.ts
+++ b/packages/pyright-internal/src/analyzer/operations.ts
@@ -44,6 +44,7 @@ import {
     removeNoneFromUnion,
     someSubtypes,
     specializeTupleClass,
+    specializeWithDefaultTypeArgs,
     transformPossibleRecursiveTypeAlias,
 } from './typeUtils';
 import {
@@ -366,6 +367,14 @@ export function getTypeOfBinaryOperation(
         }
 
         if (isUnionableType([adjustedLeftType, adjustedRightType])) {
+            if (isInstantiableClass(adjustedLeftType)) {
+                adjustedLeftType = specializeWithDefaultTypeArgs(adjustedLeftType);
+            }
+
+            if (isInstantiableClass(adjustedRightType)) {
+                adjustedRightType = specializeWithDefaultTypeArgs(adjustedRightType);
+            }
+
             return createUnionType(
                 evaluator,
                 node,

--- a/packages/pyright-internal/src/tests/samples/unions4.py
+++ b/packages/pyright-internal/src/tests/samples/unions4.py
@@ -18,3 +18,13 @@ def func1() -> Union: ...
 
 # This should generate an error.
 var1: Union
+
+
+# This should generate two errors.
+def func2(x: (list | set)[int]):
+    reveal_type(x)
+
+
+# This should generate two errors.
+def func3(x: Union[list, set][int]):
+    reveal_type(x)

--- a/packages/pyright-internal/src/tests/typeEvaluator4.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator4.test.ts
@@ -548,7 +548,7 @@ test('Unions3', () => {
 test('Unions4', () => {
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['unions4.py']);
 
-    TestUtils.validateResults(analysisResults, 3);
+    TestUtils.validateResults(analysisResults, 7);
 });
 
 test('Unions5', () => {


### PR DESCRIPTION
…eates a union of generic types. These types should be specialized with default type arguments. This addresses #9415.