### PR TITLE
Fixed bug that results in false negative when raising a value of type…

### DIFF
--- a/packages/pyright-internal/src/analyzer/checker.ts
+++ b/packages/pyright-internal/src/analyzer/checker.ts
@@ -1093,11 +1093,11 @@ export class Checker extends ParseTreeWalker {
 
     override visitRaise(node: RaiseNode): boolean {
         if (node.d.expr) {
-            this._evaluator.verifyRaiseExceptionType(node.d.expr);
+            this._evaluator.verifyRaiseExceptionType(node.d.expr, /* allowNone */ false);
         }
 
         if (node.d.fromExpr) {
-            this._evaluator.verifyRaiseExceptionType(node.d.fromExpr);
+            this._evaluator.verifyRaiseExceptionType(node.d.fromExpr, /* allowNone */ true);
         }
 
         return true;

--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -4418,7 +4418,7 @@ export function createTypeEvaluator(
         }
     }
 
-    function verifyRaiseExceptionType(node: ExpressionNode) {
+    function verifyRaiseExceptionType(node: ExpressionNode, allowNone: boolean) {
         const baseExceptionType = getBuiltInType(node, 'BaseException');
         const exceptionType = getTypeOfExpression(node).type;
 
@@ -4431,7 +4431,11 @@ export function createTypeEvaluator(
             doForEachSubtype(exceptionType, (subtype) => {
                 const concreteSubtype = makeTopLevelTypeVarsConcrete(subtype);
 
-                if (isAnyOrUnknown(concreteSubtype) || isNever(concreteSubtype) || isNoneInstance(concreteSubtype)) {
+                if (isAnyOrUnknown(concreteSubtype) || isNever(concreteSubtype)) {
+                    return;
+                }
+
+                if (allowNone && isNoneInstance(concreteSubtype)) {
                     return;
                 }
 

--- a/packages/pyright-internal/src/analyzer/typeEvaluatorTypes.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluatorTypes.ts
@@ -631,7 +631,7 @@ export interface TypeEvaluator {
     ) => Type;
 
     getExpectedType: (node: ExpressionNode) => ExpectedTypeResult | undefined;
-    verifyRaiseExceptionType: (node: ExpressionNode) => void;
+    verifyRaiseExceptionType: (node: ExpressionNode, allowNone: boolean) => void;
     verifyDeleteExpression: (node: ExpressionNode) => void;
     validateOverloadedArgTypes: (
         errorNode: ExpressionNode,

--- a/packages/pyright-internal/src/tests/samples/tryExcept4.py
+++ b/packages/pyright-internal/src/tests/samples/tryExcept4.py
@@ -29,3 +29,21 @@ class CustomException2:
 # the exception doesn't derive from BaseException.
 if a or 2 > 1:
     raise CustomException2
+
+
+def func1(x1: type[BaseException], x2: type[BaseException]):
+    if 2 > 1:
+        raise x1 from None
+
+    if 2 > 1:
+        raise x1 from x2
+
+    if 2 > 1:
+        # This should generate an error because the exception
+        # type doesn't derive from BaseException.
+        raise 1 from x2
+
+    if 2 > 1:
+        # This should generate an error because the exception
+        # type doesn't derive from BaseException.
+        raise ValueError from 1

--- a/packages/pyright-internal/src/tests/typeEvaluator7.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator7.test.ts
@@ -928,7 +928,7 @@ test('TryExcept3', () => {
 test('TryExcept4', () => {
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['tryExcept4.py']);
 
-    TestUtils.validateResults(analysisResults, 2);
+    TestUtils.validateResults(analysisResults, 4);
 });
 
 test('TryExcept5', () => {


### PR DESCRIPTION
… `None`. This addresses #9423.