### PR TITLE
Fixed bug that results in an incorrect type evaluation when a `match`…

### DIFF
--- a/packages/pyright-internal/src/analyzer/patternMatching.ts
+++ b/packages/pyright-internal/src/analyzer/patternMatching.ts
@@ -859,7 +859,8 @@ function narrowTypeBasedOnClassPattern(
             LocAddendum.typeNotClass().format({ type: evaluator.printType(exprType) }),
             pattern.d.className
         );
-        return NeverType.createNever();
+
+        return isPositiveTest ? UnknownType.create() : type;
     } else if (isInstantiableClass(exprType)) {
         if (ClassType.isProtocolClass(exprType) && !ClassType.isRuntimeCheckable(exprType)) {
             evaluator.addDiagnostic(
@@ -867,12 +868,16 @@ function narrowTypeBasedOnClassPattern(
                 LocAddendum.protocolRequiresRuntimeCheckable(),
                 pattern.d.className
             );
+
+            return isPositiveTest ? UnknownType.create() : type;
         } else if (ClassType.isTypedDictClass(exprType)) {
             evaluator.addDiagnostic(
                 DiagnosticRule.reportGeneralTypeIssues,
                 LocMessage.typedDictInClassPattern(),
                 pattern.d.className
             );
+
+            return isPositiveTest ? UnknownType.create() : type;
         }
     }
 

--- a/packages/pyright-internal/src/tests/samples/matchClass7.py
+++ b/packages/pyright-internal/src/tests/samples/matchClass7.py
@@ -1,0 +1,34 @@
+# This sample tests the case where a class pattern overwrites the subject
+# expression.
+
+from dataclasses import dataclass
+
+
+@dataclass
+class DC1:
+    val: str
+
+
+def func1(val: DC1):
+    result = val
+
+    match result:
+        case DC1(result):
+            reveal_type(result, expected_text="str")
+
+
+@dataclass
+class DC2:
+    val: DC1
+
+
+def func2(val: DC2):
+    result = val
+
+    match result.val:
+        case DC1(result):
+            reveal_type(result, expected_text="str")
+
+            # This should generate an error because result.val
+            # is no longer valid at this point.
+            print(result.val)

--- a/packages/pyright-internal/src/tests/typeEvaluator6.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator6.test.ts
@@ -520,6 +520,14 @@ test('MatchClass6', () => {
     TestUtils.validateResults(analysisResults, 0);
 });
 
+test('MatchClass7', () => {
+    const configOptions = new ConfigOptions(Uri.empty());
+
+    configOptions.defaultPythonVersion = pythonVersion3_10;
+    const analysisResults = TestUtils.typeAnalyzeSampleFiles(['matchClass7.py'], configOptions);
+    TestUtils.validateResults(analysisResults, 1);
+});
+
 test('MatchValue1', () => {
     const configOptions = new ConfigOptions(Uri.empty());
 


### PR DESCRIPTION
… statement uses a pattern with a target expression that overwrites the subject expression. This addresses #9418.