### PR TITLE
Improved the "x is y" and "type(x) is y" type guards to better handle…

### DIFF
--- a/packages/pyright-internal/src/analyzer/typeGuards.ts
+++ b/packages/pyright-internal/src/analyzer/typeGuards.ts
@@ -2332,7 +2332,7 @@ function narrowTypeForTypeIs(evaluator: TypeEvaluator, type: Type, classType: Cl
                 if (isPositiveTest) {
                     if (matches) {
                         if (ClassType.isSameGenericClass(ClassType.cloneAsInstantiable(subtype), classType)) {
-                            return addConditionToType(subtype, classType.props?.condition);
+                            return addConditionToType(subtype, getTypeCondition(classType));
                         }
 
                         return addConditionToType(ClassType.cloneAsInstance(classType), subtype.props?.condition);
@@ -2354,7 +2354,9 @@ function narrowTypeForTypeIs(evaluator: TypeEvaluator, type: Type, classType: Cl
                     return subtype;
                 }
             } else if (isAnyOrUnknown(subtype)) {
-                return isPositiveTest ? ClassType.cloneAsInstance(classType) : subtype;
+                return isPositiveTest
+                    ? ClassType.cloneAsInstance(addConditionToType(classType, getTypeCondition(subtype)))
+                    : subtype;
             }
 
             return unexpandedSubtype;
@@ -2386,7 +2388,7 @@ function narrowTypeForClassComparison(
             }
 
             if (isAnyOrUnknown(concreteSubtype)) {
-                return classType;
+                return addConditionToType(classType, getTypeCondition(concreteSubtype));
             }
 
             if (isClass(concreteSubtype)) {
@@ -2405,7 +2407,7 @@ function narrowTypeForClassComparison(
                     }
 
                     if (isSuperType) {
-                        return classType;
+                        return addConditionToType(classType, getTypeCondition(concreteSubtype));
                     }
 
                     const isSubType = ClassType.isDerivedFrom(classType, concreteSubtype);


### PR DESCRIPTION
… the case where `x` is a TypeVar.