### PR TITLE
Changed inference logic for exception groups to more closely match th…

### DIFF
--- a/packages/pyright-internal/src/tests/samples/exceptionGroup1.py
+++ b/packages/pyright-internal/src/tests/samples/exceptionGroup1.py
@@ -9,7 +9,7 @@ def func1():
 
     # This should generate an error if using Python 3.10 or earlier.
     except* ValueError as e:
-        reveal_type(e, expected_text="BaseExceptionGroup[ValueError]")
+        reveal_type(e, expected_text="ExceptionGroup[ValueError]")
         pass
 
     # This should generate an error if using Python 3.10 or earlier.
@@ -105,3 +105,19 @@ def func7():
             # return is not allowed in an except* block.
             return
 
+
+
+def func8():
+
+    try:
+        pass
+
+    # This should generate an error if using Python 3.10 or earlier.
+    except* (ValueError, FloatingPointError) as e:
+        reveal_type(e, expected_text="ExceptionGroup[ValueError | FloatingPointError]")
+        pass
+
+    # This should generate an error if using Python 3.10 or earlier.
+    except* BaseException as e:
+        reveal_type(e, expected_text="BaseExceptionGroup[BaseException]")
+        pass

--- a/packages/pyright-internal/src/tests/typeEvaluator7.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator7.test.ts
@@ -971,7 +971,7 @@ test('exceptionGroup1', () => {
 
     configOptions.defaultPythonVersion = pythonVersion3_10;
     const analysisResults1 = TestUtils.typeAnalyzeSampleFiles(['exceptionGroup1.py'], configOptions);
-    TestUtils.validateResults(analysisResults1, 28);
+    TestUtils.validateResults(analysisResults1, 34);
 
     configOptions.defaultPythonVersion = pythonVersion3_11;
     const analysisResults2 = TestUtils.typeAnalyzeSampleFiles(['exceptionGroup1.py'], configOptions);


### PR DESCRIPTION
…e runtime. If a non-base exception is targeted, the inferred type is now `ExceptionGroup` rather than `BaseExceptionGroup`. This addresses #9466.