### PR TITLE
Fixed a bug that leads to a false positive when a function is decorat…

### DIFF
--- a/packages/pyright-internal/src/analyzer/decorators.ts
+++ b/packages/pyright-internal/src/analyzer/decorators.ts
@@ -176,7 +176,17 @@ export function applyFunctionDecorator(
         }
     }
 
-    let returnType = getTypeOfDecorator(evaluator, decoratorNode, inputFunctionType);
+    // Clear the PartiallyEvaluated flag in the input if it's set so
+    // it doesn't propagate to the decorated type.
+    const decoratorArg =
+        isFunction(inputFunctionType) && FunctionType.isPartiallyEvaluated(inputFunctionType)
+            ? FunctionType.cloneWithNewFlags(
+                  inputFunctionType,
+                  inputFunctionType.shared.flags & ~FunctionTypeFlags.PartiallyEvaluated
+              )
+            : inputFunctionType;
+
+    let returnType = getTypeOfDecorator(evaluator, decoratorNode, decoratorArg);
 
     // Check for some built-in decorator types with known semantics.
     if (isFunction(decoratorType)) {

--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -18354,7 +18354,6 @@ export function createTypeEvaluator(
         // Set the "partially evaluated" flag around this logic to detect recursion.
         functionType.shared.flags |= FunctionTypeFlags.PartiallyEvaluated;
         const preDecoratedType = node.d.isAsync ? createAsyncFunction(node, functionType) : functionType;
-        functionType.shared.flags &= ~FunctionTypeFlags.PartiallyEvaluated;
 
         // Apply all of the decorators in reverse order.
         decoratedType = preDecoratedType;
@@ -18401,6 +18400,10 @@ export function createTypeEvaluator(
         decoratedType = addOverloadsToFunctionType(evaluatorInterface, node, decoratedType);
 
         writeTypeCache(node, { type: decoratedType }, EvalFlags.None);
+
+        // Now that the decorator has been applied, we can clear the
+        // "partially evaluated" flag.
+        functionType.shared.flags &= ~FunctionTypeFlags.PartiallyEvaluated;
 
         return { functionType, decoratedType };
     }

--- a/packages/pyright-internal/src/tests/samples/loop52.py
+++ b/packages/pyright-internal/src/tests/samples/loop52.py
@@ -1,0 +1,13 @@
+# This sample tests the case where a function accesses its own decorated
+# form within a loop.
+
+from contextlib import contextmanager
+
+
+@contextmanager
+def func1():
+    yield
+
+    for _ in ():
+        with func1():
+            return

--- a/packages/pyright-internal/src/tests/typeEvaluator3.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator3.test.ts
@@ -497,6 +497,12 @@ test('Loop51', () => {
     TestUtils.validateResults(analysisResults, 0);
 });
 
+test('Loop52', () => {
+    const analysisResults = TestUtils.typeAnalyzeSampleFiles(['loop52.py']);
+
+    TestUtils.validateResults(analysisResults, 0);
+});
+
 test('ForLoop1', () => {
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['forLoop1.py']);
 


### PR DESCRIPTION
…ed and has no explicit return type annotation and the body references the decorated function in a loop. This addresses #9492.