### PR TITLE
Fixed a bug that leads to incorrect type evaluation when `__getitem__…

### DIFF
--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -2443,7 +2443,7 @@ export function createTypeEvaluator(
             return getBoundMagicMethod(
                 boundMethodResult.type,
                 '__call__',
-                selfType ?? ClassType.cloneAsInstance(classType),
+                /* selfType */ undefined,
                 diag,
                 recursionCount
             );

--- a/packages/pyright-internal/src/tests/samples/index1.py
+++ b/packages/pyright-internal/src/tests/samples/index1.py
@@ -54,13 +54,11 @@ ClassA["1"]
 
 
 class ClassB:
-    def __setitem__(self, index: int, value: "ClassB"):
-        ...
+    def __setitem__(self, index: int, value: "ClassB"): ...
 
 
 class ClassC:
-    def __setitem__(self, index: int, value: "ClassC"):
-        ...
+    def __setitem__(self, index: int, value: "ClassC"): ...
 
 
 B_or_C = TypeVar("B_or_C", ClassB, ClassC)
@@ -75,8 +73,7 @@ TD = TypeVar("TD", bound="ClassD[Any]")
 
 
 class ClassD(Generic[TD]):
-    def __setitem__(self, index: int, value: TD):
-        ...
+    def __setitem__(self, index: int, value: TD): ...
 
 
 def func2(container: ClassD[TD], value: TD):
@@ -98,8 +95,7 @@ e["test"] = 3
 
 
 class ClassF(Generic[T]):
-    def __getitem__(self, args: int) -> Self:
-        ...
+    def __getitem__(self, args: int) -> Self: ...
 
     def get(self, index: int) -> Self:
         reveal_type(self[index], expected_text="Self@ClassF[T@ClassF]")
@@ -113,3 +109,15 @@ class ClassG:
 def func3(g: ClassG):
     reveal_type(g.x, expected_text="Unbound")
     reveal_type(g.x[0], expected_text="Unknown")
+
+
+class ClassH:
+    def __call__(self, *args, **kwargs) -> Self:
+        return self
+
+
+class ClassI:
+    __getitem__ = ClassH()
+
+
+reveal_type(ClassI()[0], expected_text="ClassH")


### PR DESCRIPTION
…` is set to a callable object. This addresses #9470.