### PR TITLE
Added check for `\u` and `\N` escapes within bytes literals, which ar…

### DIFF
--- a/packages/pyright-internal/src/analyzer/checker.ts
+++ b/packages/pyright-internal/src/analyzer/checker.ts
@@ -1351,7 +1351,9 @@ export class Checker extends ParseTreeWalker {
                         this._evaluator.addDiagnosticForTextRange(
                             this._fileInfo,
                             DiagnosticRule.reportInvalidStringEscapeSequence,
-                            LocMessage.stringUnsupportedEscape(),
+                            node.d.strings.some((string) => (string.d.token.flags & StringTokenFlags.Bytes) !== 0)
+                                ? LocMessage.bytesUnsupportedEscape()
+                                : LocMessage.stringUnsupportedEscape(),
                             { start: start + error.offset, length: error.length }
                         );
                     }

--- a/packages/pyright-internal/src/localization/localize.ts
+++ b/packages/pyright-internal/src/localization/localize.ts
@@ -286,6 +286,7 @@ export namespace Localizer {
             );
         export const breakInExceptionGroup = () => getRawString('Diagnostic.breakInExceptionGroup');
         export const breakOutsideLoop = () => getRawString('Diagnostic.breakOutsideLoop');
+        export const bytesUnsupportedEscape = () => getRawString('Diagnostic.bytesUnsupportedEscape');
         export const callableExtraArgs = () => getRawString('Diagnostic.callableExtraArgs');
         export const callableFirstArg = () => getRawString('Diagnostic.callableFirstArg');
         export const callableNotInstantiable = () =>

--- a/packages/pyright-internal/src/localization/package.nls.en-us.json
+++ b/packages/pyright-internal/src/localization/package.nls.en-us.json
@@ -115,6 +115,10 @@
             "message": "\"break\" can be used only within a loop",
             "comment": "{Locked='break'}"
         },
+        "bytesUnsupportedEscape": {
+            "message": "Unsupported escape sequence in bytes literal",
+            "comment": "{Locked='bytes'}"
+        },
         "callableExtraArgs": {
             "message": "Expected only two type arguments to \"Callable\"",
             "comment": "{Locked='Callable'}"

--- a/packages/pyright-internal/src/tests/samples/strings2.py
+++ b/packages/pyright-internal/src/tests/samples/strings2.py
@@ -12,3 +12,5 @@ v3 = "a" b"b"
 # This should generate an error.
 v4 = b"a" f""
 
+# This should generate a warning.
+v5 = b"\u00FF"

--- a/packages/pyright-internal/src/tests/typeEvaluator8.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator8.test.ts
@@ -830,7 +830,7 @@ test('PseudoGeneric3', () => {
 test('Strings2', () => {
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['strings2.py']);
 
-    TestUtils.validateResults(analysisResults, 2);
+    TestUtils.validateResults(analysisResults, 2, 1);
 });
 
 test('LiteralString1', () => {


### PR DESCRIPTION
…e illegal.