### PR TITLE
Added check for invalid use of `ClassVar` qualifier within a `NamedTu…

### DIFF
--- a/packages/pyright-internal/src/analyzer/parseTreeUtils.ts
+++ b/packages/pyright-internal/src/analyzer/parseTreeUtils.ts
@@ -1178,15 +1178,6 @@ export function isFinalAllowedForAssignmentTarget(targetNode: ExpressionNode): b
     return false;
 }
 
-export function isClassVarAllowedForAssignmentTarget(targetNode: ExpressionNode): boolean {
-    const classNode = getEnclosingClass(targetNode, /* stopAtFunction */ true);
-    if (!classNode) {
-        return false;
-    }
-
-    return true;
-}
-
 export function isRequiredAllowedForAssignmentTarget(targetNode: ExpressionNode): boolean {
     const classNode = getEnclosingClass(targetNode, /* stopAtFunction */ true);
     if (!classNode) {

--- a/packages/pyright-internal/src/tests/samples/classVar6.py
+++ b/packages/pyright-internal/src/tests/samples/classVar6.py
@@ -1,0 +1,18 @@
+# This sample tests that a ClassVar is disallowed when used in a 
+# NamedTuple or TypedDict class as reflected in the runtime.
+
+from typing import ClassVar, NamedTuple, TypedDict
+
+class NT1(NamedTuple):
+    # This should generate an error.
+    x: ClassVar
+
+    # This should generate an error.
+    y: ClassVar[int]
+
+class TD1(TypedDict):
+    # This should generate an error.
+    x: ClassVar
+
+    # This should generate an error.
+    y: ClassVar[int]

--- a/packages/pyright-internal/src/tests/samples/dataclassNamedTuple1.py
+++ b/packages/pyright-internal/src/tests/samples/dataclassNamedTuple1.py
@@ -15,9 +15,6 @@ class DataTuple(NamedTuple):
     def _m(self):
         pass
 
-    # ClassVar variables should not be included.
-    class_var: ClassVar[int] = 4
-
     id: int
     aid: Other
     value: str = ""

--- a/packages/pyright-internal/src/tests/typeEvaluator7.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator7.test.ts
@@ -805,6 +805,12 @@ test('ClassVar5', () => {
     TestUtils.validateResults(analysisResults, 0);
 });
 
+test('ClassVar6', () => {
+    const analysisResults = TestUtils.typeAnalyzeSampleFiles(['classVar6.py']);
+
+    TestUtils.validateResults(analysisResults, 4);
+});
+
 test('TypeVar1', () => {
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['typeVar1.py']);
 


### PR DESCRIPTION
…ple` or `TypedDict` attribute annotation. This addresses #9526.