### PR TITLE
Fixed bug that leads to incorrect evaluations when a `ClassVar` and `…

### DIFF
--- a/packages/pyright-internal/src/analyzer/dataClasses.ts
+++ b/packages/pyright-internal/src/analyzer/dataClasses.ts
@@ -396,11 +396,9 @@ export function synthesizeDataClassMethods(
                 const variableSymbol = ClassType.getSymbolTable(classType).get(variableName);
                 namedTupleEntries.add(variableName);
 
-                if (variableSymbol?.isClassVar() && !variableSymbol?.isFinalVarInClassBody()) {
+                if (variableSymbol?.isClassVar()) {
                     // If an ancestor class declared an instance variable but this dataclass
                     // declares a ClassVar, delete the older one from the full data class entries.
-                    // We exclude final variables here because a Final type annotation is implicitly
-                    // considered a ClassVar by the binder, but dataclass rules are different.
                     const index = fullDataClassEntries.findIndex((p) => p.name === variableName);
                     if (index >= 0) {
                         fullDataClassEntries.splice(index, 1);

--- a/packages/pyright-internal/src/tests/samples/dataclass17.py
+++ b/packages/pyright-internal/src/tests/samples/dataclass17.py
@@ -33,3 +33,9 @@ A.d = 0
 
 # This should generate an error.
 A.e = 0
+
+
+@dataclass
+class B:
+    a: ClassVar[Final[int]] = 0
+    b: int = 1


### PR DESCRIPTION
…Final` qualifier are both used on the same dataclass attribute. This addresses #9550.