### PR TITLE
Fixed bug that results in spurious type evaluation error when an oper…

### DIFF
--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -2412,11 +2412,12 @@ export function createTypeEvaluator(
         classType: ClassType,
         memberName: string,
         selfType?: ClassType | TypeVarType | undefined,
+        errorNode?: ExpressionNode | undefined,
         diag?: DiagnosticAddendum,
         recursionCount = 0
     ): FunctionType | OverloadedType | undefined {
         const boundMethodResult = getTypeOfBoundMember(
-            /* errorNode */ undefined,
+            errorNode,
             classType,
             memberName,
             /* usage */ undefined,
@@ -2444,6 +2445,7 @@ export function createTypeEvaluator(
                 boundMethodResult.type,
                 '__call__',
                 /* selfType */ undefined,
+                errorNode,
                 diag,
                 recursionCount
             );
@@ -13469,7 +13471,7 @@ export function createTypeEvaluator(
             const concreteSubtype = makeTopLevelTypeVarsConcrete(subtype);
 
             if (isClass(concreteSubtype)) {
-                magicMethodType = getBoundMagicMethod(concreteSubtype, methodName, subtype, diag);
+                magicMethodType = getBoundMagicMethod(concreteSubtype, methodName, subtype, errorNode, diag);
             }
 
             if (magicMethodType) {
@@ -24738,6 +24740,7 @@ export function createTypeEvaluator(
                     concreteSrcType,
                     '__call__',
                     /* selfType */ undefined,
+                    /* errorNode */ undefined,
                     /* diag */ undefined,
                     recursionCount
                 );
@@ -25667,6 +25670,7 @@ export function createTypeEvaluator(
             objType,
             '__call__',
             /* selfType */ undefined,
+            /* errorNode */ undefined,
             /* diag */ undefined,
             recursionCount
         );

--- a/packages/pyright-internal/src/analyzer/typeEvaluatorTypes.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluatorTypes.ts
@@ -742,6 +742,7 @@ export interface TypeEvaluator {
         classType: ClassType,
         memberName: string,
         selfType?: ClassType | TypeVarType | undefined,
+        errorNode?: ExpressionNode | undefined,
         diag?: DiagnosticAddendum,
         recursionCount?: number
     ) => FunctionType | OverloadedType | undefined;


### PR DESCRIPTION
…ator overload method like `__add__` is implemented with a descriptor object. This addresses #9574.