### PR TITLE
Fixed bug that results in the `extraPaths` configuration option withi…

### DIFF
--- a/packages/pyright-internal/src/common/configOptions.ts
+++ b/packages/pyright-internal/src/common/configOptions.ts
@@ -1648,6 +1648,10 @@ export class ConfigOptions {
                         `Config executionEnvironments index ${index}: extraPaths field must contain an array.`
                     );
                 } else {
+                    // If specified, this overrides the default extra paths inherited
+                    // from the top-level config.
+                    newExecEnv.extraPaths = [];
+
                     const pathList = envObj.extraPaths as string[];
                     pathList.forEach((path, pathIndex) => {
                         if (typeof path !== 'string') {

--- a/packages/pyright-internal/src/tests/config.test.ts
+++ b/packages/pyright-internal/src/tests/config.test.ts
@@ -473,7 +473,6 @@ test('Command line options can override config but only when not using extension
     commandLineOptions.configSettings.useLibraryCodeForTypes = true;
     commandLineOptions.configSettings.includeFileSpecs = ['test2'];
     commandLineOptions.configSettings.excludeFileSpecs = ['test2'];
-    commandLineOptions.configSettings.extraPaths = ['test2'];
     commandLineOptions.configSettings.diagnosticSeverityOverrides = {
         reportMissingImports: DiagnosticSeverityOverrides.Error,
     };
@@ -485,10 +484,6 @@ test('Command line options can override config but only when not using extension
     assert.notDeepStrictEqual(defaultOptions.exclude, overriddenOptions.exclude);
     assert.notDeepStrictEqual(defaultOptions.ignore, overriddenOptions.ignore);
     assert.notDeepStrictEqual(defaultOptions.diagnosticRuleSet, overriddenOptions.diagnosticRuleSet);
-    assert.notDeepStrictEqual(
-        defaultOptions.executionEnvironments[0].extraPaths,
-        overriddenOptions.executionEnvironments[0].extraPaths
-    );
     assert.notDeepStrictEqual(defaultOptions.venvPath, overriddenOptions.venvPath);
     // Typeshed and stub path are an exception, it should just be reported as a dupe.
     assert.deepStrictEqual(defaultOptions.typeshedPath, overriddenOptions.typeshedPath);


### PR DESCRIPTION
…n an execution extending rather than overriding the `extraPaths` provided in the top-level config. This addresses #9636.