### PR TITLE
Fixed bug in dictionary expression type inference that results in the…

### DIFF
--- a/packages/pyright-internal/src/tests/samples/dictionary1.py
+++ b/packages/pyright-internal/src/tests/samples/dictionary1.py
@@ -4,20 +4,20 @@
 from typing import Any, Callable, Literal, Sequence
 
 
-def wantsIntDict(a: dict[int, int]):
+def wants_int_dict(a: dict[int, int]):
     pass
 
 
-wantsIntDict({3: 3, 5: 5})
-wantsIntDict({x: x for x in [2, 3, 4]})
+wants_int_dict({3: 3, 5: 5})
+wants_int_dict({x: x for x in [2, 3, 4]})
 
 # This should generate an error because
 # the type is wrong.
-wantsIntDict({"hello": 3, "bye": 5})
+wants_int_dict({"hello": 3, "bye": 5})
 
 # This should generate an error because
 # the type is wrong.
-wantsIntDict({"sdf": x for x in [2, 3, 4]})
+wants_int_dict({"sdf": x for x in [2, 3, 4]})
 
 t1 = ()
 
@@ -47,3 +47,11 @@ d6: LiteralDict = {"ab": "x"}
 d7: LiteralDict = {"bcd": "y"}
 d6 = {**d6, **d7}
 d6 = d6 | d7
+
+
+def func1(args):
+    d1 = {**args, "x": 123}
+    reveal_type(d1, expected_text="dict[Unknown, Unknown]")
+
+
+#


### PR DESCRIPTION
… incorrect type when a dictionary expansion is used and the resulting expansion type is unknown. This addresses #9650.