### PR TITLE
fixed Uri to use value check rather than reference check.

### DIFF
--- a/packages/pyright-internal/src/analyzer/parentDirectoryCache.ts
+++ b/packages/pyright-internal/src/analyzer/parentDirectoryCache.ts
@@ -56,7 +56,7 @@ export class ParentDirectoryCache {
             this._libPathCache ??
             this._importRootGetter()
                 .map((r) => fs.realCasePath(r))
-                .filter((r) => r !== root)
+                .filter((r) => !r.equals(root))
                 .filter((r) => r.startsWith(root));
 
         if (this._libPathCache.some((p) => sourceFileUri.startsWith(p))) {


### PR DESCRIPTION
fixed https://github.com/microsoft/pyright/issues/9610

https://github.com/microsoft/pyright/blob/0f57009d7df06a6c15105ca5e22c12c24727a9d6/packages/pyright-internal/src/analyzer/parentDirectoryCache.ts#L59

this code wrongly used reference check rather than value check for `uri`. when things were working, this code happens to get the same `Uri` instance so it worked or hid the bug, but now, code changes changed it to get a different instance of `uri` with `the same value` causing it to fail.

fixed the bug by using proper `equals` method instead of `!==`

...

this makes behavior to the same as before. but that said, what user did is a bit weird.

> echo "/home/rgoya/pyright_test" > $CONDA_PREFIX/lib/python3.*/site-packages/pyright_test.pth

this basically makes whole `workspace` folder as `3rd party library folder`. making it ambiguous to `pyright` whether it should think files under the workspace root as user files or 3rd party files. 

right now, behavior is what it is, but not sure whether that's by design or just behavior of what happens to be the current implementation does.

