### PR TITLE
Improved error reporting for "async with" statement. Added check that…

### DIFF
--- a/packages/pyright-internal/src/localization/localize.ts
+++ b/packages/pyright-internal/src/localization/localize.ts
@@ -698,6 +698,7 @@ export namespace Localizer {
         export const noneNotIterable = () => getRawString('Diagnostic.noneNotIterable');
         export const noneNotSubscriptable = () => getRawString('Diagnostic.noneNotSubscriptable');
         export const noneNotUsableWith = () => getRawString('Diagnostic.noneNotUsableWith');
+        export const noneNotUsableWithAsync = () => getRawString('Diagnostic.noneNotUsableWithAsync');
         export const noneOperator = () =>
             new ParameterizedString<{ operator: string }>(getRawString('Diagnostic.noneOperator'));
         export const noneUnknownMember = () =>
@@ -1038,6 +1039,10 @@ export namespace Localizer {
             new ParameterizedString<{ type: string }>(getRawString('Diagnostic.typeNotSubscriptable'));
         export const typeNotUsableWith = () =>
             new ParameterizedString<{ type: string; method: string }>(getRawString('Diagnostic.typeNotUsableWith'));
+        export const typeNotUsableWithAsync = () =>
+            new ParameterizedString<{ type: string; method: string }>(
+                getRawString('Diagnostic.typeNotUsableWithAsync')
+            );
         export const typeNotSupportBinaryOperator = () =>
             new ParameterizedString<{ leftType: string; rightType: string; operator: string }>(
                 getRawString('Diagnostic.typeNotSupportBinaryOperator')

--- a/packages/pyright-internal/src/localization/package.nls.en-us.json
+++ b/packages/pyright-internal/src/localization/package.nls.en-us.json
@@ -860,6 +860,10 @@
             "message": "Object of type \"None\" cannot be used with \"with\"",
             "comment": "{Locked='None','with'}"
         },
+        "noneNotUsableWithAsync": {
+            "message": "Object of type \"None\" cannot be used with \"async with\"",
+            "comment": "{Locked='None','with', 'async}"
+        },
         "noneOperator": {
             "message": "Operator \"{operator}\" not supported for \"None\"",
             "comment": "{Locked='None'}"
@@ -1333,7 +1337,11 @@
         "typeNotSupportBinaryOperatorBidirectional": "Operator \"{operator}\" not supported for types \"{leftType}\" and \"{rightType}\" when expected type is \"{expectedType}\"",
         "typeNotSupportUnaryOperator": "Operator \"{operator}\" not supported for type \"{type}\"",
         "typeNotSupportUnaryOperatorBidirectional": "Operator \"{operator}\" not supported for type \"{type}\" when expected type is \"{expectedType}\"",
-        "typeNotUsableWith": "Object of type \"{type}\" cannot be used with \"with\" because it does not implement {method}",
+        "typeNotUsableWith": "Object of type \"{type}\" cannot be used with \"with\" because it does not correctly implement {method}",
+        "typeNotUsableWithAsync": {
+            "message": "Object of type \"{type}\" cannot be used with \"async with\" because it does not correctly implement {method}",
+            "comment": ["{Locked='async','with}"]
+    },
         "typeParameterBoundNotAllowed": {
             "message": "Bound or constraint cannot be used with a variadic type parameter or ParamSpec",
             "comment": ["{Locked='ParamSpec'}", "'variadic' means that it accepts a variable number of arguments"]

--- a/packages/pyright-internal/src/tests/samples/coroutines1.py
+++ b/packages/pyright-internal/src/tests/samples/coroutines1.py
@@ -48,7 +48,7 @@ class ScopedClass1:
         yield 3
         return 3
 
-    def __aexit__(
+    async def __aexit__(
         self,
         t: Optional[type] = None,
         exc: Optional[BaseException] = None,

--- a/packages/pyright-internal/src/tests/samples/with1.py
+++ b/packages/pyright-internal/src/tests/samples/with1.py
@@ -78,7 +78,7 @@ class Class4:
     async def __aenter__(self: _T1) -> _T1:
         return self
 
-    def __aexit__(
+    async def __aexit__(
         self,
         t: Optional[type] = None,
         exc: Optional[BaseException] = None,
@@ -107,8 +107,7 @@ class Class5(Generic[_T1]):
         return None
 
 
-class Class6(Class5[int]):
-    ...
+class Class6(Class5[int]): ...
 
 
 async def do():


### PR DESCRIPTION
… return result of `__aexit__` is awaitable and improved error messages for the case where `__enter__`, etc. are present but have incorrect signatures. This addresses #9694.