### PR TITLE
Fixed bug that results in an incorrect "overlapping overload" error m…

### DIFF
--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -25709,18 +25709,6 @@ export function createTypeEvaluator(
         flags: AssignTypeFlags,
         recursionCount: number
     ) {
-        // Handle the special case where the dest type is a synthesized
-        // "self" for a protocol class.
-        if (
-            isTypeVar(destType) &&
-            destType.shared.isSynthesized &&
-            destType.shared.boundType &&
-            isClassInstance(destType.shared.boundType) &&
-            ClassType.isProtocolClass(destType.shared.boundType)
-        ) {
-            return true;
-        }
-
         if (isTypeVarTuple(destType) && !isUnpacked(srcType)) {
             return false;
         }


### PR DESCRIPTION
…essage in certain cases involving parameters annotated with `Self`. This addresses #9662.