### PR TITLE
Improved type narrowing for `issubclass` in the negative ("else") cas…

### DIFF
--- a/packages/pyright-internal/src/tests/samples/typeNarrowingIsinstance1.py
+++ b/packages/pyright-internal/src/tests/samples/typeNarrowingIsinstance1.py
@@ -135,6 +135,20 @@ def func6_2(ty: type[int] | int):
         reveal_type(ty, expected_text="int")
 
 
+def func6_3(ty: type):
+    if issubclass(ty, str):
+        reveal_type(ty, expected_text="type[str]")
+    else:
+        reveal_type(ty, expected_text="type[Unknown]")
+
+
+def func6_4(ty: Any):
+    if issubclass(ty, str):
+        reveal_type(ty, expected_text="type[str]")
+    else:
+        reveal_type(ty, expected_text="Any")
+
+
 # Test the handling of protocol classes that support runtime checking.
 def func7(a: Union[list[int], int]):
     if isinstance(a, Sized):


### PR DESCRIPTION
…e when the subject type is `type` or `Any`. This addresses #9656.