### PR TITLE
Fixed bug that results in an "incompatible method override" false neg…

### DIFF
--- a/packages/pyright-internal/src/analyzer/checker.ts
+++ b/packages/pyright-internal/src/analyzer/checker.ts
@@ -6619,7 +6619,7 @@ export class Checker extends ParseTreeWalker {
             selfSpecializeClass(childClassType, { useBoundTypeVars: true })
         );
 
-        const baseType = partiallySpecializeType(
+        let baseType = partiallySpecializeType(
             this._evaluator.getEffectiveTypeOfSymbol(baseClassAndSymbol.symbol),
             baseClass,
             this._evaluator.getTypeClassType(),
@@ -6635,6 +6635,7 @@ export class Checker extends ParseTreeWalker {
 
         if (childClassType.shared.typeVarScopeId) {
             overrideType = makeTypeVarsBound(overrideType, [childClassType.shared.typeVarScopeId]);
+            baseType = makeTypeVarsBound(baseType, [childClassType.shared.typeVarScopeId]);
         }
 
         if (isFunction(baseType) || isOverloaded(baseType)) {

--- a/packages/pyright-internal/src/tests/samples/methodOverride1.py
+++ b/packages/pyright-internal/src/tests/samples/methodOverride1.py
@@ -521,6 +521,7 @@ class Base7(Generic[T]):
 
 
 class Derived7_1(Base7[T]):
+    # This should generate an error.
     def method1(self, x: S) -> S:
         return x
 
@@ -528,3 +529,12 @@ class Derived7_1(Base7[T]):
 class Derived7_2(Base7[int]):
     def method1(self, x: U) -> U:
         return x
+
+
+class Base8[T]:
+    def method1(self, x: T) -> T: ...
+
+
+class Derived8[T](Base8[T]):
+    # This should generate an error.
+    def method1[U: str](self, x: U) -> U: ...

--- a/packages/pyright-internal/src/tests/typeEvaluator3.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator3.test.ts
@@ -946,7 +946,7 @@ test('MethodOverride1', () => {
 
     configOptions.diagnosticRuleSet.reportIncompatibleMethodOverride = 'error';
     analysisResults = TestUtils.typeAnalyzeSampleFiles(['methodOverride1.py'], configOptions);
-    TestUtils.validateResults(analysisResults, 40);
+    TestUtils.validateResults(analysisResults, 42);
 });
 
 test('MethodOverride2', () => {


### PR DESCRIPTION
…ative when overriding a method that uses class-scoped type parameters with a method that uses method-scoped type parameters. This addresses #9405.