### PR TITLE
Fixed bug that results in false negative when a parameter is used wit…

### DIFF
--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -4871,7 +4871,9 @@ export function createTypeEvaluator(
         }
 
         if (isTypeVar(type)) {
-            return true;
+            if (type.props?.specialForm || type.props?.typeAliasInfo) {
+                return true;
+            }
         }
 
         // Exempts class types that are created by calling NewType, NamedTuple, etc.

--- a/packages/pyright-internal/src/tests/samples/annotations1.py
+++ b/packages/pyright-internal/src/tests/samples/annotations1.py
@@ -147,3 +147,15 @@ x12: b"int"
 
 # This should generate an error because format strings aren't allowed.
 x13: f"int"
+
+
+class A:
+    def method1(self):
+        # This should result in an error.
+        x: self
+
+    @classmethod
+    def method2(cls):
+        # This should result in an error.
+        x: cls
+

--- a/packages/pyright-internal/src/tests/typeEvaluator1.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator1.test.ts
@@ -978,7 +978,7 @@ test('FunctionMember2', () => {
 test('Annotations1', () => {
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['annotations1.py']);
 
-    TestUtils.validateResults(analysisResults, 19);
+    TestUtils.validateResults(analysisResults, 21);
 });
 
 test('Annotations2', () => {


### PR DESCRIPTION
…hin a type expression and the parameter's type is a TypeVar or Self. This addresses #9750.