### PR TITLE
Added code to conform with the new checks mandated in the typing spec…

### DIFF
--- a/packages/pyright-internal/src/analyzer/checker.ts
+++ b/packages/pyright-internal/src/analyzer/checker.ts
@@ -6212,7 +6212,7 @@ export class Checker extends ParseTreeWalker {
             const overloads = OverloadedType.getOverloads(typeOfSymbol);
             const implementation = OverloadedType.getImplementation(typeOfSymbol);
 
-            this._validateOverloadFinalConsistency(overloads, implementation);
+            this._validateOverloadFinalOverride(overloads, implementation);
 
             this._validateOverloadAbstractConsistency(overloads, implementation);
         });
@@ -6264,42 +6264,52 @@ export class Checker extends ParseTreeWalker {
         });
     }
 
-    private _validateOverloadFinalConsistency(overloads: FunctionType[], implementation: Type | undefined) {
-        // If there's an implementation, it will determine whether the
-        // function is @final.
-        if (implementation && isFunction(implementation)) {
-            // If one or more of the overloads is marked @final but the
-            // implementation is not, report an error.
-            if (!FunctionType.isFinal(implementation)) {
-                overloads.forEach((overload) => {
-                    if (FunctionType.isFinal(overload) && overload.shared.declaration?.node) {
-                        this._evaluator.addDiagnostic(
-                            DiagnosticRule.reportInconsistentOverload,
-                            LocMessage.overloadFinalInconsistencyImpl().format({
-                                name: overload.shared.name,
-                            }),
-                            getNameNodeForDeclaration(overload.shared.declaration) ?? overload.shared.declaration.node
-                        );
-                    }
-                });
-            }
-            return;
-        }
-
-        if (overloads.length > 0 && !FunctionType.isFinal(overloads[0])) {
-            overloads.slice(1).forEach((overload, index) => {
+    private _validateOverloadFinalOverride(overloads: FunctionType[], implementation: Type | undefined) {
+        // If there's an implementation, the overloads are not allowed to be marked final or override.
+        if (implementation) {
+            overloads.forEach((overload) => {
                 if (FunctionType.isFinal(overload) && overload.shared.declaration?.node) {
                     this._evaluator.addDiagnostic(
                         DiagnosticRule.reportInconsistentOverload,
-                        LocMessage.overloadFinalInconsistencyNoImpl().format({
-                            name: overload.shared.name,
-                            index: index + 2,
-                        }),
+                        LocMessage.overloadFinalImpl(),
+                        getNameNodeForDeclaration(overload.shared.declaration) ?? overload.shared.declaration.node
+                    );
+                }
+
+                if (FunctionType.isOverridden(overload) && overload.shared.declaration?.node) {
+                    this._evaluator.addDiagnostic(
+                        DiagnosticRule.reportInconsistentOverload,
+                        LocMessage.overloadOverrideImpl(),
                         getNameNodeForDeclaration(overload.shared.declaration) ?? overload.shared.declaration.node
                     );
                 }
             });
+
+            return;
         }
+
+        // If there's not an implementation, only the first overload can be marked final.
+        if (overloads.length === 0) {
+            return;
+        }
+
+        overloads.slice(1).forEach((overload, index) => {
+            if (FunctionType.isFinal(overload) && overload.shared.declaration?.node) {
+                this._evaluator.addDiagnostic(
+                    DiagnosticRule.reportInconsistentOverload,
+                    LocMessage.overloadFinalNoImpl(),
+                    getNameNodeForDeclaration(overload.shared.declaration) ?? overload.shared.declaration.node
+                );
+            }
+
+            if (FunctionType.isOverridden(overload) && overload.shared.declaration?.node) {
+                this._evaluator.addDiagnostic(
+                    DiagnosticRule.reportInconsistentOverload,
+                    LocMessage.overloadOverrideNoImpl(),
+                    getNameNodeForDeclaration(overload.shared.declaration) ?? overload.shared.declaration.node
+                );
+            }
+        });
     }
 
     // For a TypedDict class that derives from another TypedDict class

--- a/packages/pyright-internal/src/localization/localize.ts
+++ b/packages/pyright-internal/src/localization/localize.ts
@@ -747,16 +747,14 @@ export namespace Localizer {
             new ParameterizedString<{ name: string }>(getRawString('Diagnostic.overloadAbstractImplMismatch'));
         export const overloadClassMethodInconsistent = () =>
             new ParameterizedString<{ name: string }>(getRawString('Diagnostic.overloadClassMethodInconsistent'));
-        export const overloadFinalInconsistencyImpl = () =>
-            new ParameterizedString<{ name: string }>(getRawString('Diagnostic.overloadFinalInconsistencyImpl'));
-        export const overloadFinalInconsistencyNoImpl = () =>
-            new ParameterizedString<{ name: string; index: number }>(
-                getRawString('Diagnostic.overloadFinalInconsistencyNoImpl')
-            );
+        export const overloadFinalImpl = () => getRawString('Diagnostic.overloadFinalImpl');
+        export const overloadFinalNoImpl = () => getRawString('Diagnostic.overloadFinalNoImpl');
         export const overloadImplementationMismatch = () =>
             new ParameterizedString<{ name: string; index: number }>(
                 getRawString('Diagnostic.overloadImplementationMismatch')
             );
+        export const overloadOverrideImpl = () => getRawString('Diagnostic.overloadOverrideImpl');
+        export const overloadOverrideNoImpl = () => getRawString('Diagnostic.overloadOverrideNoImpl');
         export const overloadReturnTypeMismatch = () =>
             new ParameterizedString<{ name: string; newIndex: number; prevIndex: number }>(
                 getRawString('Diagnostic.overloadReturnTypeMismatch')

--- a/packages/pyright-internal/src/localization/package.nls.cs.json
+++ b/packages/pyright-internal/src/localization/package.nls.cs.json
@@ -365,8 +365,6 @@
         "overloadAbstractImplMismatch": "Přetížení musí odpovídat abstraktnímu stavu implementace.",
         "overloadAbstractMismatch": "Buď musí být všechna přetížení abstraktní, nebo naopak nesmí být žádné z nich abstraktní.",
         "overloadClassMethodInconsistent": "Přetížení pro {name} používají @classmethod nekonzistentně.",
-        "overloadFinalInconsistencyImpl": "Přetížení pro „{name}“ je označené @final ale implementace není",
-        "overloadFinalInconsistencyNoImpl": "Přetížení {index} pro „{name}“ je označené @final ale přetížení 1 není",
         "overloadImplementationMismatch": "Přetížená implementace není konzistentní se signaturou přetížení {index}",
         "overloadReturnTypeMismatch": "Přetížení {prevIndex} pro {name} se překrývá s přetížením {newIndex} a vrací nekompatibilní typ",
         "overloadStaticMethodInconsistent": "Přetížení pro {name} používají @staticmethod nekonzistentně.",

--- a/packages/pyright-internal/src/localization/package.nls.de.json
+++ b/packages/pyright-internal/src/localization/package.nls.de.json
@@ -365,8 +365,6 @@
         "overloadAbstractImplMismatch": "Überladungen müssen dem abstrakten Status der Implementierung entsprechen.",
         "overloadAbstractMismatch": "Überladungen müssen alle abstrakt sein oder nicht.",
         "overloadClassMethodInconsistent": "Überladungen für \"{name}\" verwenden @classmethod inkonsistent",
-        "overloadFinalInconsistencyImpl": "Die Überladung für „{name}“ ist @final markiert, die Implementierung ist es jedoch nicht.",
-        "overloadFinalInconsistencyNoImpl": "Überladung {index} für „{name}“ ist als @final markiert, Überladung 1 ist es jedoch nicht.",
         "overloadImplementationMismatch": "Die überladene Implementierung ist nicht konsistent mit der Signatur der Überladung {index}",
         "overloadReturnTypeMismatch": "Überladung {prevIndex} für \"{name}\" überlappt {newIndex} und gibt einen inkompatiblen Typ zurück.",
         "overloadStaticMethodInconsistent": "Überladungen für \"{name}\" verwenden @staticmethod inkonsistent",

--- a/packages/pyright-internal/src/localization/package.nls.en-us.json
+++ b/packages/pyright-internal/src/localization/package.nls.en-us.json
@@ -908,15 +908,23 @@
             "message": "Overloads for \"{name}\" use @classmethod inconsistently",
             "comment": "{Locked='@classmethod'}"
         },
-        "overloadFinalInconsistencyImpl": {
-            "message": "Overload for \"{name}\" is marked @final but implementation is not",
+        "overloadFinalImpl": {
+            "message": "@final decorator should be applied only to the implementation",
             "comment": "{Locked='@final'}"
         },
-        "overloadFinalInconsistencyNoImpl": {
-            "message": "Overload {index} for \"{name}\" is marked @final but overload 1 is not",
+        "overloadFinalNoImpl": {
+            "message": "Only the first overload should be marked @final",
             "comment": "{Locked='@final'}"
         },
         "overloadImplementationMismatch": "Overloaded implementation is not consistent with signature of overload {index}",
+        "overloadOverrideImpl": {
+            "message": "@override decorator should be applied only to the implementation",
+            "comment": "{Locked='@override'}"
+        },
+        "overloadOverrideNoImpl": {
+            "message": "Only the first overload should be marked @override",
+            "comment": "{Locked='@override'}"
+        },
         "overloadReturnTypeMismatch": "Overload {prevIndex} for \"{name}\" overlaps overload {newIndex} and returns an incompatible type",
         "overloadStaticMethodInconsistent": {
             "message": "Overloads for \"{name}\" use @staticmethod inconsistently",

--- a/packages/pyright-internal/src/localization/package.nls.es.json
+++ b/packages/pyright-internal/src/localization/package.nls.es.json
@@ -365,8 +365,6 @@
         "overloadAbstractImplMismatch": "Las sobrecargas deben coincidir con el estado abstracto de la implementación",
         "overloadAbstractMismatch": "Todos los métodos sobrecargados deben ser abstractos o no",
         "overloadClassMethodInconsistent": "Las sobrecargas de \"{name}\" usan @classmethod de forma incoherente",
-        "overloadFinalInconsistencyImpl": "La sobrecarga de \"{name}\" está marcada @final pero la implementación no",
-        "overloadFinalInconsistencyNoImpl": "La sobrecarga {index} para \"{name}\" está marcada @final pero la sobrecarga 1 no lo está.",
         "overloadImplementationMismatch": "La implementación de la sobrecarga no es consistente con la firma de la sobrecarga {index}",
         "overloadReturnTypeMismatch": "La sobrecarga {prevIndex} para \" {name}\" se superpone con la sobrecarga {newIndex} y devuelve un tipo incompatible",
         "overloadStaticMethodInconsistent": "Las sobrecargas de \"{name}\" usan @staticmethod de forma incoherente",

--- a/packages/pyright-internal/src/localization/package.nls.fr.json
+++ b/packages/pyright-internal/src/localization/package.nls.fr.json
@@ -365,8 +365,6 @@
         "overloadAbstractImplMismatch": "Les surcharges doivent correspondre à l’état abstrait de l’implémentation",
         "overloadAbstractMismatch": "Les surcharges doivent toutes être abstraites ou non",
         "overloadClassMethodInconsistent": "Les surcharges pour « {name} » utilisent @classmethod de manière incohérente",
-        "overloadFinalInconsistencyImpl": "La surcharge pour « {name} » est marquée @final, mais l’implémentation ne l’est pas",
-        "overloadFinalInconsistencyNoImpl": "La surcharge {index} pour « {name} » est marquée @final mais la surcharge 1 n’est pas",
         "overloadImplementationMismatch": "L’implémentation surchargée n’est pas cohérente avec la signature de la surcharge {index}",
         "overloadReturnTypeMismatch": "La surcharge {prevIndex} pour « {name} » chevauche la surcharge {newIndex} et retourne un type incompatible",
         "overloadStaticMethodInconsistent": "Les surcharges pour « {name} » utilisent @staticmethod de manière incohérente",

--- a/packages/pyright-internal/src/localization/package.nls.it.json
+++ b/packages/pyright-internal/src/localization/package.nls.it.json
@@ -365,8 +365,6 @@
         "overloadAbstractImplMismatch": "Gli overload devono corrispondere allo stato astratto dell'implementazione",
         "overloadAbstractMismatch": "Gli overload devono essere tutti astratti o no",
         "overloadClassMethodInconsistent": "Gli overload per \"{name}\" usano @classmethod in modo incoerente",
-        "overloadFinalInconsistencyImpl": "L'overload per “{name}” è contrassegnato @final ma l'implementazione non lo è",
-        "overloadFinalInconsistencyNoImpl": "L'overload {index} per “{name}” è contrassegnato @final ma l'overload 1 non lo è",
         "overloadImplementationMismatch": "L'implementazione di overload non è coerente con la firma dell'overload {index}",
         "overloadReturnTypeMismatch": "L'overload {prevIndex} per \"{name}\" si sovrappone all'overload {newIndex} e restituisce un tipo incompatibile",
         "overloadStaticMethodInconsistent": "Gli overload per \"{name}\" usano @staticmethod in modo incoerente",

--- a/packages/pyright-internal/src/localization/package.nls.ja.json
+++ b/packages/pyright-internal/src/localization/package.nls.ja.json
@@ -365,8 +365,6 @@
         "overloadAbstractImplMismatch": "オーバーロードは実装の抽象状態と一致する必要があります",
         "overloadAbstractMismatch": "オーバーロードはすべて抽象であるか抽象でない必要があります",
         "overloadClassMethodInconsistent": "\"{name}\" のオーバーロードでは、@classmethod を不整合に使用します",
-        "overloadFinalInconsistencyImpl": "\"{name}\" のオーバーロードは @final としてマークされていますが、実装は @final としてマークされていません",
-        "overloadFinalInconsistencyNoImpl": "\"{name}\" のオーバーロード {index} は @final としてマークされていますが、オーバーロード 1 は @final としてマークされていません",
         "overloadImplementationMismatch": "オーバーロードされた実装がオーバーロード {index} のシグネチャと一致しません",
         "overloadReturnTypeMismatch": "\"{name}\" のオーバーロード {prevIndex} はオーバーロード {newIndex} と重複し、互換性のない型を返します",
         "overloadStaticMethodInconsistent": "\"{name}\" のオーバーロードでは、@staticmethod を不整合に使用します",

--- a/packages/pyright-internal/src/localization/package.nls.ko.json
+++ b/packages/pyright-internal/src/localization/package.nls.ko.json
@@ -365,8 +365,6 @@
         "overloadAbstractImplMismatch": "오버로드는 구현의 추상 상태와 일치해야 합니다.",
         "overloadAbstractMismatch": "오버로드는 모두 추상이거나 아니어야 합니다",
         "overloadClassMethodInconsistent": "\"{name}\"의 오버로드가 @classmethod를 일관되지 않게 사용합니다.",
-        "overloadFinalInconsistencyImpl": "\"{name}\"에 대한 오버로드가 @final로 표시되었지만 구현은 아닙니다.",
-        "overloadFinalInconsistencyNoImpl": "\"{name}\"에 대한 오버로드 {index}는 @final로 표시되지만 오버로드 1은 표시되지 않습니다.",
         "overloadImplementationMismatch": "오버로드된 구현이 오버로드 {index}의 시그니처와 일치하지 않습니다.",
         "overloadReturnTypeMismatch": "\"{name}\"에 대한 {prevIndex} 오버로드가 오버로드 {newIndex}과(와) 겹치고 호환되지 않는 형식을 반환합니다.",
         "overloadStaticMethodInconsistent": "\"{name}\"의 오버로드가 @staticmethod를 일관되지 않게 사용합니다.",

--- a/packages/pyright-internal/src/localization/package.nls.pl.json
+++ b/packages/pyright-internal/src/localization/package.nls.pl.json
@@ -365,8 +365,6 @@
         "overloadAbstractImplMismatch": "Przeciążenia muszą być zgodne ze stanem abstrakcyjnym implementacji",
         "overloadAbstractMismatch": "Przeciążenia muszą być abstrakcyjne lub nieabstrakcyjne",
         "overloadClassMethodInconsistent": "Przeciążenia dla nazwy „{name}” używają metody @classmethod niekonsekwentnie",
-        "overloadFinalInconsistencyImpl": "Przeciążenie elementu „{name}” jest oznaczone @final, ale implementacja nie jest",
-        "overloadFinalInconsistencyNoImpl": "Przeciążenie {index} dla elementu „{name}” jest oznaczone @final, ale przeciążenie 1 nie jest",
         "overloadImplementationMismatch": "Przeciążone wdrożenie jest niespójne z sygnaturą przeciążenia {index}",
         "overloadReturnTypeMismatch": "Przeciążenie {prevIndex} dla nazwy „{name}” nakłada się na przeciążenie {newIndex} i zwraca niezgodny typ",
         "overloadStaticMethodInconsistent": "Przeciążenia dla nazwy „{name}” używają metody @staticmethod niekonsekwentnie",

--- a/packages/pyright-internal/src/localization/package.nls.pt-br.json
+++ b/packages/pyright-internal/src/localization/package.nls.pt-br.json
@@ -365,8 +365,6 @@
         "overloadAbstractImplMismatch": "As sobrecargas devem corresponder ao status abstrato da implementação",
         "overloadAbstractMismatch": "As sobrecargas devem ser abstratas ou não",
         "overloadClassMethodInconsistent": "Sobrecargas para \"{name}\" usam @classmethod inconsistentemente",
-        "overloadFinalInconsistencyImpl": "A sobrecarga para \"{name}\" está marcada como @final mas a implementação não está",
-        "overloadFinalInconsistencyNoImpl": "A sobrecarga {index} para \"{name}\" está marcada como @final mas a sobrecarga 1 não está",
         "overloadImplementationMismatch": "A implementação sobrecarregada não é consistente com a assinatura da sobrecarga {index}",
         "overloadReturnTypeMismatch": "A sobrecarga {prevIndex} para \"{name}\" sobrepõe a sobrecarga {newIndex} e retorna um tipo incompatível",
         "overloadStaticMethodInconsistent": "Sobrecargas para \"{name}\" usam @staticmethod inconsistentemente",

--- a/packages/pyright-internal/src/localization/package.nls.qps-ploc.json
+++ b/packages/pyright-internal/src/localization/package.nls.qps-ploc.json
@@ -365,8 +365,6 @@
         "overloadAbstractImplMismatch": "[IgMzu][นั้Øvërløæðs mµst mætçh æþstræçt stætµs øf ïmplëmëñtætïøñẤğ倪İЂҰक्र्तिृまẤğ倪İЂҰक्นั้ढूँ]",
         "overloadAbstractMismatch": "[54DCM][นั้Øvërløæðs mµst æll þë æþstræçt ør ñøtẤğ倪İЂҰक्र्तिृまẤนั้ढूँ]",
         "overloadClassMethodInconsistent": "[8y6vM][นั้Øvërløæðs før \"{ñæmë}\" µsë @classmethod ïñçøñsïstëñtlÿẤğ倪İЂҰक्र्तिृまẤğ倪İЂҰक्นั้ढूँ]",
-        "overloadFinalInconsistencyImpl": "[0hpZY][นั้Øvërløæð før \"{ñæmë}\" ïs mærkëð @final þµt ïmplëmëñtætïøñ ïs ñøtẤğ倪İЂҰक्र्तिृまẤğ倪İЂҰक्र्तिृนั้ढूँ]",
-        "overloadFinalInconsistencyNoImpl": "[Z6TSL][นั้Øvërløæð {ïñðëx} før \"{ñæmë}\" ïs mærkëð @final þµt øvërløæð 1 ïs ñøtẤğ倪İЂҰक्र्तिृまẤğ倪İЂҰक्र्तिृนั้ढूँ]",
         "overloadImplementationMismatch": "[dXlXE][นั้Øvërløæðëð ïmplëmëñtætïøñ ïs ñøt çøñsïstëñt wïth sïgñætµrë øf øvërløæð {ïñðëx}Ấğ倪İЂҰक्र्तिृまẤğ倪İЂҰक्र्तिृまẤğ倪นั้ढूँ]",
         "overloadReturnTypeMismatch": "[6BN74][นั้Øvërløæð {prëvÏñðëx} før \"{ñæmë}\" øvërlæps øvërløæð {ñëwÏñðëx} æñð rëtµrñs æñ ïñçømpætïþlë tÿpëẤğ倪İЂҰक्र्तिृまẤğ倪İЂҰक्र्तिृまẤğ倪İЂҰक्र्นั้ढूँ]",
         "overloadStaticMethodInconsistent": "[PKQvM][นั้Øvërløæðs før \"{ñæmë}\" µsë @staticmethod ïñçøñsïstëñtlÿẤğ倪İЂҰक्र्तिृまẤğ倪İЂҰक्นั้ढूँ]",

--- a/packages/pyright-internal/src/localization/package.nls.ru.json
+++ b/packages/pyright-internal/src/localization/package.nls.ru.json
@@ -365,8 +365,6 @@
         "overloadAbstractImplMismatch": "Перегрузки должны соответствовать абстрактному статусу реализации",
         "overloadAbstractMismatch": "Все перегрузки должны быть абстрактными или не абстрактными",
         "overloadClassMethodInconsistent": "Перегрузки для \"{name}\" используют @classmethod несогласованно",
-        "overloadFinalInconsistencyImpl": "Перегрузка для \"{name}\" помечена как @final, но реализация — нет",
-        "overloadFinalInconsistencyNoImpl": "Перегрузка {index} для \"{name}\" помечена как @final, но перегрузка 1 — нет",
         "overloadImplementationMismatch": "Перегруженная реализация не согласована с сигнатурой перегрузки {index}",
         "overloadReturnTypeMismatch": "Перегрузка {prevIndex} для \"{name}\" перекрывает перегрузку {newIndex} и возвращает несовместимый тип",
         "overloadStaticMethodInconsistent": "Перегрузки для \"{name}\" используют @staticmethod несогласованно",

--- a/packages/pyright-internal/src/localization/package.nls.tr.json
+++ b/packages/pyright-internal/src/localization/package.nls.tr.json
@@ -365,8 +365,6 @@
         "overloadAbstractImplMismatch": "Aşırı yüklemeler uygulamanın özet durumuyla eşleşmelidir",
         "overloadAbstractMismatch": "Aşırı yüklemelerin tümü soyut olmalı veya tümü olmamalıdır",
         "overloadClassMethodInconsistent": "\"{name}\" için aşırı yüklemeler, @classmethod yöntemini tutarlı kullanıyor",
-        "overloadFinalInconsistencyImpl": "\"{name}\" için aşırı yükleme @final olarak işaretlendi ancak uygulama işaretlenmedi",
-        "overloadFinalInconsistencyNoImpl": "\"{name}\" için aşırı yükleme {index} @final olarak işaretlendi ancak aşırı yükleme 1 işaretlenmedi",
         "overloadImplementationMismatch": "Aşırı yüklenmiş uygulama, {index} aşırı yükleme imzası ile tutarlı değil",
         "overloadReturnTypeMismatch": "\"{name}\" için {prevIndex} aşırı yüklemesi {newIndex} aşırı yüklemesi ile çakışıyor ve uyumsuz bir tür döndürüyor",
         "overloadStaticMethodInconsistent": "\"{name}\" için aşırı yüklemeler, @staticmethod yöntemini tutarsız kullanıyor",

--- a/packages/pyright-internal/src/localization/package.nls.zh-cn.json
+++ b/packages/pyright-internal/src/localization/package.nls.zh-cn.json
@@ -365,8 +365,6 @@
         "overloadAbstractImplMismatch": "重载必须与实现的抽象状态匹配",
         "overloadAbstractMismatch": "重载必须全是抽象重载，或者全都不是抽象重载",
         "overloadClassMethodInconsistent": "“{name}”的重载使用 @classmethod 的方式不一致",
-        "overloadFinalInconsistencyImpl": "“{name}”的重载被标记为 @final，但实施未被标记",
-        "overloadFinalInconsistencyNoImpl": "“{name}”的重载 {index} 被标记为 @final，但重载 1 未被标记",
         "overloadImplementationMismatch": "重载实现与重载 {index} 的签名不一致",
         "overloadReturnTypeMismatch": "“{name}”的重载 {prevIndex} 与重载 {newIndex} 重叠，并返回不兼容的类型",
         "overloadStaticMethodInconsistent": "“{name}”的重载使用 @staticmethod 的方式不一致",

--- a/packages/pyright-internal/src/localization/package.nls.zh-tw.json
+++ b/packages/pyright-internal/src/localization/package.nls.zh-tw.json
@@ -365,8 +365,6 @@
         "overloadAbstractImplMismatch": "多載必須符合實作的抽象狀態",
         "overloadAbstractMismatch": "多載必須全為抽象或不抽象",
         "overloadClassMethodInconsistent": "\"{name}\" 的多載不一致地使用 @classmethod",
-        "overloadFinalInconsistencyImpl": "\"{name}\" 的多載已標示為 @final 但未實作",
-        "overloadFinalInconsistencyNoImpl": "\"{name}\" 的多載 {index} 標示為 @final 但多載 1 未標示",
         "overloadImplementationMismatch": "多載的實作與多載 {index} 的簽章不一致",
         "overloadReturnTypeMismatch": "\"{name}\" 的多載 {prevIndex} 與多載 {newIndex} 重疊，並傳回不相容的類型",
         "overloadStaticMethodInconsistent": "\"{name}\" 的多載不一致地使用 @staticmethod",

--- a/packages/pyright-internal/src/tests/samples/overload5.py
+++ b/packages/pyright-internal/src/tests/samples/overload5.py
@@ -1,0 +1,60 @@
+# This sample tests for proper usage of @final and @override within
+# an overload definition.
+
+from typing import Any, Protocol, final, overload, override
+
+
+class ABase:
+    def method2(self, x: int | str) -> int | str: ...
+
+
+class A(ABase):
+    @final
+    @overload
+    # This should generate an error.
+    def method1(self, x: int) -> int: ...
+
+    @final
+    @overload
+    # This should generate an error.
+    def method1(self, x: str) -> str: ...
+
+    @final
+    def method1(self, x: int | str) -> int | str: ...
+
+    @override
+    @overload
+    # This should generate an error.
+    def method2(self, x: int) -> int: ...
+
+    @override
+    @overload
+    # This should generate an error.
+    def method2(self, x: str) -> str: ...
+
+    @override
+    def method2(self, x: int | str) -> int | str: ...
+
+
+class BBase(Protocol):
+    def method2(self, x: Any) -> Any: ...
+
+
+class B(BBase, Protocol):
+    @final
+    @overload
+    def method1(self, x: int) -> int: ...
+
+    @final
+    @overload
+    # This should generate an error.
+    def method1(self, x: str) -> str: ...
+
+    @override
+    @overload
+    def method2(self, x: int) -> int: ...
+
+    @override
+    @overload
+    # This should generate an error.
+    def method2(self, x: str) -> str: ...

--- a/packages/pyright-internal/src/tests/typeEvaluator6.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator6.test.ts
@@ -39,6 +39,11 @@ test('Overload4', () => {
     TestUtils.validateResults(analysisResults, 0);
 });
 
+test('Overload5', () => {
+    const analysisResults = TestUtils.typeAnalyzeSampleFiles(['overload5.py']);
+    TestUtils.validateResults(analysisResults, 6);
+});
+
 test('OverloadCall1', () => {
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['overloadCall1.py']);
     TestUtils.validateResults(analysisResults, 0);


### PR DESCRIPTION
… for `@final` and `@override` applied to an overload. This addresses #9747.