### PR TITLE
Extended type narrowing for the `X is L` and `X is not L` type guard …

### DIFF
--- a/docs/type-concepts-advanced.md
+++ b/docs/type-concepts-advanced.md
@@ -61,7 +61,7 @@ In addition to assignment-based type narrowing, Pyright supports the following t
 * `x == ...` and `x != ...` (where `...` is an ellipsis token)
 * `type(x) is T` and `type(x) is not T`
 * `type(x) == T` and `type(x) != T`
-* `x is E` and `x is not E` (where E is a literal enum or bool)
+* `x is E` and `x is not L` (where L is an expression that evaluates to a literal type)
 * `x is C` and `x is not C` (where C is a class)
 * `x == L` and `x != L` (where L is an expression that evaluates to a literal type)
 * `x.y is None` and `x.y is not None` (where x is a type that is distinguished by a field with a None)

--- a/packages/pyright-internal/src/tests/samples/typeNarrowingLiteral2.py
+++ b/packages/pyright-internal/src/tests/samples/typeNarrowingLiteral2.py
@@ -2,7 +2,7 @@
 # types that have enumerated literals (bool and enums).
 
 from enum import Enum
-from typing import Any, Literal, Union
+from typing import Any, Literal, Union, reveal_type
 
 
 class SomeEnum(Enum):
@@ -27,12 +27,10 @@ def func2(a: SomeEnum) -> Literal[3]:
         return a.value
 
 
-def must_be_true(a: Literal[True]):
-    ...
+def must_be_true(a: Literal[True]): ...
 
 
-def must_be_false(a: Literal[False]):
-    ...
+def must_be_false(a: Literal[False]): ...
 
 
 def func3(a: bool):
@@ -75,3 +73,10 @@ def func7(x: Any):
         reveal_type(x, expected_text="Literal[MyEnum.ZERO]")
     else:
         reveal_type(x, expected_text="Any")
+
+
+def func8(x: Literal[0, 1] | None):
+    if x is 1:
+        reveal_type(x, expected_text="Literal[1]")
+    else:
+        reveal_type(x, expected_text="Literal[0, 1] | None")


### PR DESCRIPTION
…pattern. Previously, narrowing was performed only when `L` was an enum or bool literal. Narrowing is also now applied for other literal types but only in the positive (`if`) direction. This addresses #9758.