### PR TITLE
Fixed bug that results in a crash (due to infinite recursion) if an e…

### DIFF
--- a/packages/pyright-internal/src/tests/samples/enum14.py
+++ b/packages/pyright-internal/src/tests/samples/enum14.py
@@ -1,0 +1,16 @@
+# This sample tests certain error conditions that previously caused
+# an infinite recursion condition in the type evaluator.
+
+from __future__ import annotations
+from enum import Enum
+from typing import Literal
+
+
+class A(Enum):
+    # This should generate two errors.
+    x: Literal[A.x]
+
+
+class B(Enum):
+    # This should generate an error.
+    x: B.x

--- a/packages/pyright-internal/src/tests/typeEvaluator3.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator3.test.ts
@@ -1082,6 +1082,12 @@ test('Enum13', () => {
     TestUtils.validateResults(analysisResults, 3);
 });
 
+test('Enum14', () => {
+    const analysisResults = TestUtils.typeAnalyzeSampleFiles(['enum14.py']);
+
+    TestUtils.validateResults(analysisResults, 3);
+});
+
 test('EnumAuto1', () => {
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['enumAuto1.py']);
 


### PR DESCRIPTION
…num class uses a reference to an enum member in an annotation for that same enum member. This addresses #9740.