### PR TITLE
Added support for argument type expansion of bool, enums, and tuples …

### DIFF
--- a/packages/pyright-internal/src/tests/samples/overloadCall4.py
+++ b/packages/pyright-internal/src/tests/samples/overloadCall4.py
@@ -1,36 +1,31 @@
-# This sample tests the expansion of union types during overload matching.
+# This sample tests the expansion of argument types during overload matching.
 
 
+from enum import Enum
 from typing import AnyStr, Literal, TypeVar, overload
 
 
-class A:
-    ...
+class A: ...
 
 
-class B:
-    ...
+class B: ...
 
 
-class C:
-    ...
+class C: ...
 
 
 _T1 = TypeVar("_T1", bound=B)
 
 
 @overload
-def overloaded1(x: A) -> str:
-    ...
+def overloaded1(x: A) -> str: ...
 
 
 @overload
-def overloaded1(x: _T1) -> _T1:
-    ...
+def overloaded1(x: _T1) -> _T1: ...
 
 
-def overloaded1(x: A | B) -> str | B:
-    ...
+def overloaded1(x: A | B) -> str | B: ...
 
 
 def func1(a: A | B, b: A | B | C):
@@ -46,32 +41,26 @@ LargeUnion = Literal["a", "b", "c", "d", "e", "f", "g", 1, 2, 3, 4, 5, 6, 7, 8]
 
 
 @overload
-def overloaded2(a: LargeUnion, b: Literal[2]) -> str:
-    ...
+def overloaded2(a: LargeUnion, b: Literal[2]) -> str: ...
 
 
 @overload
-def overloaded2(a: LargeUnion, b: Literal[3]) -> str:
-    ...
+def overloaded2(a: LargeUnion, b: Literal[3]) -> str: ...
 
 
 @overload
-def overloaded2(a: LargeUnion, b: Literal[4]) -> float:
-    ...
+def overloaded2(a: LargeUnion, b: Literal[4]) -> float: ...
 
 
 @overload
-def overloaded2(a: LargeUnion, b: Literal[9]) -> float:
-    ...
+def overloaded2(a: LargeUnion, b: Literal[9]) -> float: ...
 
 
 @overload
-def overloaded2(a: LargeUnion, b: Literal[10]) -> float:
-    ...
+def overloaded2(a: LargeUnion, b: Literal[10]) -> float: ...
 
 
-def overloaded2(a: LargeUnion, b: LargeUnion | Literal[9, 10]) -> str | float:
-    ...
+def overloaded2(a: LargeUnion, b: LargeUnion | Literal[9, 10]) -> str | float: ...
 
 
 def func2(a: LargeUnion, b: Literal[2, 3, 4], c: Literal[2, 3, 4, 9, 10]):
@@ -91,17 +80,14 @@ _T2 = TypeVar("_T2", str, bytes)
 
 
 @overload
-def overloaded3(x: str) -> str:
-    ...
+def overloaded3(x: str) -> str: ...
 
 
 @overload
-def overloaded3(x: bytes) -> bytes:
-    ...
+def overloaded3(x: bytes) -> bytes: ...
 
 
-def overloaded3(x: str | bytes) -> str | bytes:
-    ...
+def overloaded3(x: str | bytes) -> str | bytes: ...
 
 
 def func3(y: _T2):
@@ -116,17 +102,14 @@ def func5(a: _T3) -> _T3:
 
 
 @overload
-def overloaded4(b: str) -> str:
-    ...
+def overloaded4(b: str) -> str: ...
 
 
 @overload
-def overloaded4(b: int) -> int:
-    ...
+def overloaded4(b: int) -> int: ...
 
 
-def overloaded4(b: str | int) -> str | int:
-    ...
+def overloaded4(b: str | int) -> str | int: ...
 
 
 def func6(x: str | int) -> None:
@@ -134,13 +117,11 @@ def func6(x: str | int) -> None:
 
 
 @overload
-def overloaded5(pattern: AnyStr) -> AnyStr:
-    ...
+def overloaded5(pattern: AnyStr) -> AnyStr: ...
 
 
 @overload
-def overloaded5(pattern: int) -> int:
-    ...
+def overloaded5(pattern: int) -> int: ...
 
 
 def overloaded5(pattern: AnyStr | int) -> AnyStr | int:
@@ -153,3 +134,59 @@ def func7(a: str | bytes) -> str | bytes:
 
 def func8(a: AnyStr | str | bytes) -> str | bytes:
     return overloaded5(a)
+
+
+class E(Enum):
+    A = "A"
+    B = "B"
+
+
+@overload
+def func9(v: Literal[E.A]) -> int: ...
+@overload
+def func9(v: Literal[E.B]) -> str: ...
+@overload
+def func9(v: bool) -> list[str]: ...
+
+
+def func9(v: E | bool) -> int | str | list[str]: ...
+
+
+def test9(a1: E | bool):
+    reveal_type(func9(a1), expected_text="int | str | list[str]")
+
+
+@overload
+def func10(v: Literal[True]) -> int: ...
+@overload
+def func10(v: Literal[False]) -> str: ...
+
+
+def func10(v: bool) -> int | str: ...
+
+
+def test10(a1: bool):
+    reveal_type(func10(a1), expected_text="int | str")
+
+
+@overload
+def func11(v: tuple[int, int]) -> int: ...
+
+
+@overload
+def func11(v: tuple[str, int]) -> str: ...
+
+
+@overload
+def func11(v: tuple[int, str]) -> int: ...
+
+
+@overload
+def func11(v: tuple[str, str]) -> str: ...
+
+
+def func11(v: tuple[int | str, int | str]) -> int | str: ...
+
+
+def test11(a1: tuple[int | str, int | str]):
+    reveal_type(func11(a1), expected_text="int | str")


### PR DESCRIPTION
…of fixed length when evaluating overloads. This behavior is mandated by the new draft typing spec update. This addresses #9706.