### PR TITLE
Fixed a bug that results in incorrect type evaluation when passing a …

### DIFF
--- a/packages/pyright-internal/src/tests/samples/paramSpec55.py
+++ b/packages/pyright-internal/src/tests/samples/paramSpec55.py
@@ -1,0 +1,24 @@
+# This sample tests the case where a function with a ParamSpec
+# is assigned to another function with a Concatenate and a ParamSpec.
+
+from typing import Any, Concatenate, Callable
+
+
+class MyGeneric[**P0]:
+    def __call__(self, *args: P0.args, **kwargs: P0.kwargs) -> Any: ...
+
+
+def deco1[**P1](func: Callable[[Callable[P1, Any]], Any]) -> MyGeneric[P1]: ...
+
+
+@deco1
+def func1[**P2](func: Callable[Concatenate[int, P2], Any]): ...
+
+
+reveal_type(func1, expected_text="MyGeneric[(int, **P2@func1)]")
+
+
+v1: MyGeneric[[int]] = func1
+
+# This should generate an error.
+v2: MyGeneric[[int, int]] = func1

--- a/packages/pyright-internal/src/tests/typeEvaluator4.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator4.test.ts
@@ -857,6 +857,11 @@ test('ParamSpec54', () => {
     TestUtils.validateResults(results, 0);
 });
 
+test('ParamSpec55', () => {
+    const results = TestUtils.typeAnalyzeSampleFiles(['paramSpec55.py']);
+    TestUtils.validateResults(results, 1);
+});
+
 test('Slice1', () => {
     const results = TestUtils.typeAnalyzeSampleFiles(['slice1.py']);
     TestUtils.validateResults(results, 0);


### PR DESCRIPTION
…function with a callable parameter that uses Concatenate plus ParamSpec to a function that accepts a callable with just a ParamSpec. This addresses #9742.