### PR TITLE
Added missing check for illegal use of `Final` within a TypedDict or …

### DIFF
--- a/packages/pyright-internal/src/analyzer/dataClasses.ts
+++ b/packages/pyright-internal/src/analyzer/dataClasses.ts
@@ -259,8 +259,8 @@ export function synthesizeDataClassMethods(
                             (assignmentStatement.d.leftExpr as TypeAnnotationNode).d.annotation,
                             {
                                 varTypeAnnotation: true,
-                                allowFinal: true,
-                                allowClassVar: true,
+                                allowFinal: !isNamedTuple,
+                                allowClassVar: !isNamedTuple,
                             }
                         );
                     };
@@ -370,8 +370,8 @@ export function synthesizeDataClassMethods(
                     variableTypeEvaluator = () =>
                         evaluator.getTypeOfAnnotation(annotationStatement.d.annotation, {
                             varTypeAnnotation: true,
-                            allowFinal: true,
-                            allowClassVar: true,
+                            allowFinal: !isNamedTuple,
+                            allowClassVar: !isNamedTuple,
                         });
 
                     // Is this a KW_ONLY separator introduced in Python 3.10?

--- a/packages/pyright-internal/src/tests/samples/dataclassNamedTuple1.py
+++ b/packages/pyright-internal/src/tests/samples/dataclassNamedTuple1.py
@@ -23,8 +23,7 @@ class DataTuple(NamedTuple):
     not_annotated = 5
 
     name: str | None = None
-
-    name2: Final[str | None] = None
+    name2: str | None = None
 
     not_a_method = standalone
 
@@ -47,3 +46,18 @@ d5 = DataTuple(id=1, aid=Other(), name=3)
 # This should generate an error because aid is a required
 # parameter and is missing an argument here.
 d6 = DataTuple(id=1, name=None)
+
+
+class DataTuple2(NamedTuple):
+    # This should generate an error because Final cannot
+    # be used in a NamedTuple. A second downstream error
+    # is also generated.
+    x: Final[int]
+
+    # This should generate an error because Final cannot
+    # be used in a NamedTuple.
+    y: Final = 1
+
+    # This should generate an error because ClassVar cannot
+    # be used in a NamedTuple.
+    z: ClassVar[int] = 1

--- a/packages/pyright-internal/src/tests/typeEvaluator4.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator4.test.ts
@@ -265,7 +265,7 @@ test('MemberAccess28', () => {
 test('DataClassNamedTuple1', () => {
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['dataclassNamedTuple1.py']);
 
-    TestUtils.validateResults(analysisResults, 2);
+    TestUtils.validateResults(analysisResults, 6);
 });
 
 test('DataClassNamedTuple2', () => {


### PR DESCRIPTION
…NamedTuple definition. This addresses #9767.