### PR TITLE
Added missing check for a PEP 695 type parameter being the target of …

### DIFF
--- a/packages/pyright-internal/src/localization/localize.ts
+++ b/packages/pyright-internal/src/localization/localize.ts
@@ -703,15 +703,17 @@ export namespace Localizer {
             new ParameterizedString<{ operator: string }>(getRawString('Diagnostic.noneOperator'));
         export const noneUnknownMember = () =>
             new ParameterizedString<{ name: string }>(getRawString('Diagnostic.noneUnknownMember'));
+        export const nonLocalInModule = () => getRawString('Diagnostic.nonLocalInModule');
         export const nonLocalNoBinding = () =>
             new ParameterizedString<{ name: string }>(getRawString('Diagnostic.nonLocalNoBinding'));
         export const nonLocalReassignment = () =>
             new ParameterizedString<{ name: string }>(getRawString('Diagnostic.nonLocalReassignment'));
         export const nonLocalRedefinition = () =>
             new ParameterizedString<{ name: string }>(getRawString('Diagnostic.nonLocalRedefinition'));
-        export const nonLocalInModule = () => getRawString('Diagnostic.nonLocalInModule');
         export const noOverload = () =>
             new ParameterizedString<{ name: string }>(getRawString('Diagnostic.noOverload'));
+        export const nonlocalTypeParam = () =>
+            new ParameterizedString<{ name: string }>(getRawString('Diagnostic.nonlocalTypeParam'));
         export const noReturnContainsReturn = () => getRawString('Diagnostic.noReturnContainsReturn');
         export const noReturnContainsYield = () => getRawString('Diagnostic.noReturnContainsYield');
         export const noReturnReturnsNone = () => getRawString('Diagnostic.noReturnReturnsNone');

--- a/packages/pyright-internal/src/localization/package.nls.en-us.json
+++ b/packages/pyright-internal/src/localization/package.nls.en-us.json
@@ -844,6 +844,10 @@
             "message": "\"{name}\" was already declared nonlocal",
             "comment": "{Locked='nonlocal'}"
         },
+        "nonlocalTypeParam": {
+            "message": "Nonlocal binding is not allowed for type parameter \"{name}\"",
+            "comment": ["{StrContains=i'nonlocal'}", "'nonlocal' is a keyword and should not be localized. It is only capitalized here because it is the first word in the sentence"]
+        },
         "noneNotCallable": {
             "message": "Object of type \"None\" cannot be called",
             "comment": "{Locked='None'}"

--- a/packages/pyright-internal/src/tests/samples/typeParams1.py
+++ b/packages/pyright-internal/src/tests/samples/typeParams1.py
@@ -101,3 +101,15 @@ class ClassI2:
 
 
 class ClassI3: ...
+
+
+def func9[T, **P, S](x: T) -> T:
+    S = 1
+
+    def inner():
+        # This should generate two errors.
+        nonlocal T, P
+
+        nonlocal S
+
+    return x

--- a/packages/pyright-internal/src/tests/typeEvaluator5.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator5.test.ts
@@ -18,7 +18,7 @@ test('TypeParams1', () => {
     configOptions.defaultPythonVersion = pythonVersion3_12;
 
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['typeParams1.py'], configOptions);
-    TestUtils.validateResults(analysisResults, 6);
+    TestUtils.validateResults(analysisResults, 8);
 });
 
 test('TypeParams2', () => {


### PR DESCRIPTION
…a `nonlocal` statement. This results in a runtime exception, so it should be reported as an error. This addresses #9817.