### PR TITLE
Fixed a bug that results in incorrect handling (and spurious errors) …

### DIFF
--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -2293,7 +2293,7 @@ export function createTypeEvaluator(
                 memberName,
                 usage,
                 /* diag */ undefined,
-                flags | MemberAccessFlags.SkipAttributeAccessOverride,
+                flags | MemberAccessFlags.SkipAttributeAccessOverride | MemberAccessFlags.SkipTypedDictEntries,
                 objectType,
                 recursionCount
             );
@@ -2310,7 +2310,7 @@ export function createTypeEvaluator(
         let subDiag: DiagnosticAddendum | undefined;
 
         if (!skipObjectTypeLookup) {
-            let effectiveFlags = flags;
+            let effectiveFlags = flags | MemberAccessFlags.SkipTypedDictEntries;
 
             if (objectTypeIsInstantiable) {
                 effectiveFlags |=

--- a/packages/pyright-internal/src/tests/samples/typedDict25.py
+++ b/packages/pyright-internal/src/tests/samples/typedDict25.py
@@ -1,0 +1,13 @@
+# This sample tests that member accesses to a TypedDict are properly
+# handled even if one of the items in the TypedDict shadows the name
+# of a TypedDict attribute.
+
+from typing import TypedDict
+
+
+class TD1(TypedDict):
+    items: int
+
+
+td1 = TD1(items=0)
+td1.items()

--- a/packages/pyright-internal/src/tests/typeEvaluator7.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator7.test.ts
@@ -767,6 +767,12 @@ test('TypedDict24', () => {
     TestUtils.validateResults(analysisResults, 1);
 });
 
+test('TypedDict25', () => {
+    const analysisResults = TestUtils.typeAnalyzeSampleFiles(['typedDict25.py']);
+
+    TestUtils.validateResults(analysisResults, 0);
+});
+
 test('TypedDictInline1', () => {
     const configOptions = new ConfigOptions(Uri.empty());
     configOptions.diagnosticRuleSet.enableExperimentalFeatures = true;


### PR DESCRIPTION
…when accessing an attribute on a TypedDict that is shadowed by a TypedDict item. This addresses #9814.