### PR TITLE
Fixed a spec conformance issue relating to callable assignability whe…

### DIFF
--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -10628,7 +10628,7 @@ export function createTypeEvaluator(
         overloadIndex: number
     ): MatchArgsToParamsResult {
         const overload = typeResult.type;
-        const paramDetails = getParamListDetails(overload);
+        const paramDetails = getParamListDetails(overload, { disallowExtraKwargsForTd: true });
         const paramSpec = FunctionType.getParamSpecFromArgsKwargs(overload);
 
         let argIndex = 0;
@@ -11207,8 +11207,8 @@ export function createTypeEvaluator(
 
                                 validateArgTypeParams.push({
                                     paramCategory: ParamCategory.KwargsDict,
-                                    paramType: kwargsParam.declaredType,
-                                    requiresTypeVarMatching: requiresSpecialization(kwargsParam.declaredType),
+                                    paramType: kwargsParam.type,
+                                    requiresTypeVarMatching: requiresSpecialization(kwargsParam.type),
                                     argument: {
                                         argCategory: ArgCategory.UnpackedDictionary,
                                         typeResult: { type: extraItemsType },

--- a/packages/pyright-internal/src/tests/samples/kwargsUnpack1.py
+++ b/packages/pyright-internal/src/tests/samples/kwargsUnpack1.py
@@ -132,3 +132,11 @@ def func6(a: int, /, **kwargs: Unpack[TD3]):
 
 
 func6(1, a=2)
+
+
+def func7(*, v1: int, v3: str, v2: str = "") -> None: ...
+
+
+# This should generate an error because func7 doesn't
+# accept additional keyword arguments.
+v7: TDProtocol6 = func7

--- a/packages/pyright-internal/src/tests/samples/typedDictClosed2.py
+++ b/packages/pyright-internal/src/tests/samples/typedDictClosed2.py
@@ -19,11 +19,18 @@ class Movie2(TypedDict, extra_items=int):
     name: str
 
 
-def func2(**kwargs: Unpack[Movie2]) -> None:
-    ...
+def func2(**kwargs: Unpack[Movie2]) -> None: ...
 
 
 func2(name="")
+
+# It's not clear whether this is allowed from the spec,
+# but based on a reading of PEP 692, extra (non-specified)
+# items should not be allowed as explicit keyword arguments.
+# This is consistent with the original TypedDict PEP
+# that disallows extra items to be present in a literal dict
+# expression that is assigned to a TypedDict type.
+# We'll therefore assume this should generate an error.
 func2(name="", foo=1)
 
 # This should generate an error.

--- a/packages/pyright-internal/src/tests/typeEvaluator1.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator1.test.ts
@@ -954,7 +954,7 @@ test('Function10', () => {
 test('KwargsUnpack1', () => {
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['kwargsUnpack1.py']);
 
-    TestUtils.validateResults(analysisResults, 12);
+    TestUtils.validateResults(analysisResults, 13);
 });
 
 test('FunctionMember1', () => {

--- a/packages/pyright-internal/src/tests/typeEvaluator5.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator5.test.ts
@@ -365,7 +365,7 @@ test('TypedDictClosed2', () => {
     configOptions.diagnosticRuleSet.enableExperimentalFeatures = true;
 
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['typedDictClosed2.py'], configOptions);
-    TestUtils.validateResults(analysisResults, 4);
+    TestUtils.validateResults(analysisResults, 5);
 });
 
 test('TypedDictClosed3', () => {


### PR DESCRIPTION
…n the dest type uses an unpacked TypedDict and the source does not accept `**kwargs`. The typing spec indicates that this should fail because TypedDicts are not closed. This addresses #9807.