### PR TITLE
Changed behavior of TypedDict to synthesize a fall-back overload for …

### DIFF
--- a/packages/pyright-internal/src/analyzer/typedDicts.ts
+++ b/packages/pyright-internal/src/analyzer/typedDicts.ts
@@ -703,6 +703,17 @@ export function synthesizeTypedDictClassMethods(
             getOverloads.push(createGetMethod(strType, AnyType.create(), /* includeDefault */ true));
         }
 
+        // Add a catch-all pop method.
+        if (ClassType.isTypedDictEffectivelyClosed(classType)) {
+            if (!isNever(extraEntriesInfo.valueType)) {
+                popOverloads.push(
+                    ...createPopMethods(strType, extraEntriesInfo.valueType, /* isEntryRequired */ false)
+                );
+            }
+        } else {
+            popOverloads.push(...createPopMethods(strType, evaluator.getObjectType(), /* isEntryRequired */ false));
+        }
+
         symbolTable.set('get', Symbol.createWithType(SymbolFlags.ClassMember, OverloadedType.create(getOverloads)));
 
         if (popOverloads.length > 0) {

--- a/packages/pyright-internal/src/tests/samples/typedDict12.py
+++ b/packages/pyright-internal/src/tests/samples/typedDict12.py
@@ -40,8 +40,11 @@ v6: str = td1.pop("bar")
 v7: str | int = td1.pop("bar", 1)
 v8: str | int = td1.pop("bar", 3)
 
-# This should generate two errors.
-v9: str = td2.pop("foo")
+v9 = td2.pop("foo")
+reveal_type(v9, expected_text="object")
+
+v10 = td2.pop("foo", None)
+reveal_type(v10, expected_text="object | None")
 
 td1.__delitem__("bar")
 

--- a/packages/pyright-internal/src/tests/typeEvaluator7.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator7.test.ts
@@ -692,7 +692,7 @@ test('TypedDict11', () => {
 test('TypedDict12', () => {
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['typedDict12.py']);
 
-    TestUtils.validateResults(analysisResults, 5);
+    TestUtils.validateResults(analysisResults, 3);
 });
 
 test('TypedDict13', () => {


### PR DESCRIPTION
…the `pop` method to handle the case where the caller passes a key name that is not specified in the TypedDict definition. This addresses #9805.