### PR TITLE
Improved error message for TypedDict base classes that are not closed…

### DIFF
--- a/packages/pyright-internal/src/localization/package.nls.en-us.json
+++ b/packages/pyright-internal/src/localization/package.nls.en-us.json
@@ -1476,7 +1476,7 @@
             "comment": "{Locked='True','False'}"
         },
         "typedDictClosedExtras": {
-            "message": "Base class \"{name}\" is a closed TypedDict; extra items must be type \"{type}\"",
+            "message": "Base class \"{name}\" is a TypedDict that limits the type of extra items to type \"{type}\"",
             "comment": "{Locked='closed','TypedDict'}"
         },
         "typedDictClosedNoExtras": {
@@ -1498,8 +1498,8 @@
             "comment": "{Locked='TypedDict'}"
         },
         "typedDictExtraItemsClosed": {
-            "message": "A TypedDict cannot be closed if it supports extra items",
-            "comment": "{Locked='TypedDict','closed'}"
+            "message": "TypedDict can use either \"closed\" or \"extra_items\" but not both",
+            "comment": "{Locked='TypedDict','closed','extra_items'}"
         },
         "typedDictFieldNotRequiredRedefinition": {
             "message": "TypedDict item \"{name}\" cannot be redefined as NotRequired",

--- a/packages/pyright-internal/src/tests/samples/typedDictClosed1.py
+++ b/packages/pyright-internal/src/tests/samples/typedDictClosed1.py
@@ -5,7 +5,7 @@ from typing import NotRequired, Required, TypedDict
 from typing_extensions import ReadOnly  # pyright: ignore[reportMissingModuleSource]
 
 
-class Movie(TypedDict, closed=False, extra_items=bool):
+class Movie(TypedDict, extra_items=bool):
     name: str
 
 
@@ -52,3 +52,9 @@ class BadTD2(TypedDict, extra_items=NotRequired[str]):
 # This should generate an error.
 class BadTD3(TypedDict, closed=True, extra_items=str):
     pass
+
+
+# This should generate an error because "closed" and
+# "extra_items" cannot both be specified.
+class BadTD4(TypedDict, closed=False, extra_items=bool):
+    name: str

--- a/packages/pyright-internal/src/tests/typeEvaluator5.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator5.test.ts
@@ -357,7 +357,7 @@ test('TypedDictClosed1', () => {
     configOptions.diagnosticRuleSet.enableExperimentalFeatures = true;
 
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['typedDictClosed1.py'], configOptions);
-    TestUtils.validateResults(analysisResults, 6);
+    TestUtils.validateResults(analysisResults, 7);
 });
 
 test('TypedDictClosed2', () => {


### PR DESCRIPTION
… but specify an `extra_items`. Also added check for cases where `closed` and `extra_items` are both specified. This addresses #9804.