### PR TITLE
Fixed bug that results in incorrect inferred type for an instance or …

### DIFF
--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -4434,17 +4434,17 @@ export function createTypeEvaluator(
             }
 
             case ParseNodeType.Unpack: {
-                if (target.d.expr.nodeType === ParseNodeType.Name) {
-                    assignTypeToNameNode(
-                        target.d.expr,
-                        {
-                            type: getBuiltInObject(target.d.expr, 'list', [typeResult.type]),
-                            isIncomplete: typeResult.isIncomplete,
-                        },
-                        ignoreEmptyContainers,
-                        srcExpr
-                    );
-                }
+                assignTypeToExpression(
+                    target.d.expr,
+                    {
+                        type: getBuiltInObject(target.d.expr, 'list', [typeResult.type]),
+                        isIncomplete: typeResult.isIncomplete,
+                    },
+                    srcExpr,
+                    ignoreEmptyContainers,
+                    allowAssignmentToFinalVar,
+                    expectedTypeDiagAddendum
+                );
                 break;
             }
 


### PR DESCRIPTION
…class variable assigned a value as part of a tuple expression target with an unpack operator (e.g. `a, *self.b = (1, 2, 3)`). This addresses #9842.