### PR TITLE
Fixed a bug that causes a false positive "no overload implementation"…

### DIFF
--- a/packages/pyright-internal/src/tests/samples/overload2.py
+++ b/packages/pyright-internal/src/tests/samples/overload2.py
@@ -80,3 +80,12 @@ def deco2(
 @deco2(x=dict)
 def func7() -> dict[str, str]:
     return {}
+
+
+class ClassC[T]:
+    def __init__(self, _: T): ...
+    def __call__(self, a) -> T: ...
+
+
+@ClassC(print)
+def func8(a: int) -> None: ...


### PR DESCRIPTION
… error when a non-overloaded function uses a decorator that changes its type to a an overloaded function. This addresses #9803.