### PR TITLE
Fixed bug that results in false negative when a format string with a …

### DIFF
--- a/packages/pyright-internal/src/parser/parser.ts
+++ b/packages/pyright-internal/src/parser/parser.ts
@@ -4945,9 +4945,12 @@ export class Parser {
                 continue;
             }
 
-            // We've hit an error. Consume tokens until we find the end.
-            if (this._consumeTokensUntilType([TokenType.FStringEnd])) {
-                this._getNextToken();
+            // We've hit an error. Try to recover as gracefully as possible.
+            if (nextToken.type !== TokenType.NewLine) {
+                // Consume tokens until we find the end.
+                if (this._consumeTokensUntilType([TokenType.FStringEnd])) {
+                    this._getNextToken();
+                }
             }
 
             this._addSyntaxError(

--- a/packages/pyright-internal/src/parser/tokenizer.ts
+++ b/packages/pyright-internal/src/parser/tokenizer.ts
@@ -1649,13 +1649,15 @@ export class Tokenizer {
                     }
                 }
             } else if (this._cs.currentChar === Char.LineFeed || this._cs.currentChar === Char.CarriageReturn) {
-                if (!isTriplicate && !isFString) {
-                    // Unterminated single-line string
-                    flags |= StringTokenFlags.Unterminated;
-                    return {
-                        escapedValue: getEscapedValue(),
-                        flags,
-                    };
+                if (!isTriplicate) {
+                    if (!isFString || !this._activeFString?.activeReplacementField) {
+                        // Unterminated single-line string
+                        flags |= StringTokenFlags.Unterminated;
+                        return {
+                            escapedValue: getEscapedValue(),
+                            flags,
+                        };
+                    }
                 }
 
                 // Skip over the new line (either one or two characters).

--- a/packages/pyright-internal/src/tests/samples/fstring1.py
+++ b/packages/pyright-internal/src/tests/samples/fstring1.py
@@ -152,3 +152,8 @@ w1 = 1
 w2 = f"__{
     w1:d
 }__"
+
+
+# This should generate an error because it's unterminated.
+w3 = f"test
+

--- a/packages/pyright-internal/src/tests/typeEvaluator4.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator4.test.ts
@@ -86,11 +86,11 @@ test('FString1', () => {
 
     configOptions.defaultPythonVersion = pythonVersion3_11;
     const analysisResults1 = TestUtils.typeAnalyzeSampleFiles(['fstring1.py'], configOptions);
-    TestUtils.validateResults(analysisResults1, 14, 1);
+    TestUtils.validateResults(analysisResults1, 15, 1);
 
     configOptions.defaultPythonVersion = pythonVersion3_12;
     const analysisResults2 = TestUtils.typeAnalyzeSampleFiles(['fstring1.py'], configOptions);
-    TestUtils.validateResults(analysisResults2, 10, 1);
+    TestUtils.validateResults(analysisResults2, 11, 1);
 });
 
 test('FString2', () => {


### PR DESCRIPTION
…single quote has a newline character within it. This results in a syntax error at runtime. This addresses #9789.