### PR TITLE
Fixed a bug that leads to incorrect (unsound) type narrowing when usi…

### DIFF
--- a/packages/pyright-internal/src/analyzer/typeEvaluatorTypes.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluatorTypes.ts
@@ -768,6 +768,7 @@ export interface TypeEvaluator {
     getCallSignatureInfo: (node: CallNode, activeIndex: number, activeOrFake: boolean) => CallSignatureInfo | undefined;
     getAbstractSymbols: (classType: ClassType) => AbstractSymbol[];
     narrowConstrainedTypeVar: (node: ParseNode, typeVar: TypeVarType) => Type | undefined;
+    isTypeComparable: (leftType: Type, rightType: Type) => boolean;
 
     assignType: (
         destType: Type,

--- a/packages/pyright-internal/src/tests/samples/typeNarrowingIn1.py
+++ b/packages/pyright-internal/src/tests/samples/typeNarrowingIn1.py
@@ -85,10 +85,10 @@ def func6(x: type):
 
 def func7(x: object | bytes, y: str, z: int):
     if x in (y, z):
-        reveal_type(x, expected_text="str | int")
+        reveal_type(x, expected_text="object")
     else:
         reveal_type(x, expected_text="object | bytes")
-    reveal_type(x, expected_text="str | int | object | bytes")
+    reveal_type(x, expected_text="object | bytes")
 
 
 def func8(x: object):
@@ -125,13 +125,6 @@ class TD1(TypedDict):
 
 class TD2(TypedDict):
     y: str
-
-
-def func11(x: dict[str, str]):
-    if x in (TD1(x="a"), TD2(y="b")):
-        reveal_type(x, expected_text="TD1 | TD2")
-    else:
-        reveal_type(x, expected_text="dict[str, str]")
 
 
 T1 = TypeVar("T1", TD1, TD2)
@@ -175,4 +168,39 @@ def func14(x: str, y: dict[Any, Any]):
 
 def func15(x: Any, y: dict[str, str]):
     if x in y:
-        reveal_type(x, expected_text="str")
+        reveal_type(x, expected_text="Any")
+
+
+def func16(x: int, y: list[Literal[0, 1]]):
+    if x in y:
+        reveal_type(x, expected_text="Literal[0, 1]")
+
+
+def func17(x: Literal[-1, 0], y: list[Literal[0, 1]]):
+    if x in y:
+        reveal_type(x, expected_text="Literal[0]")
+
+
+def func18(x: Literal[0, 1, 2], y: list[Literal[0, 1]]):
+    if x in y:
+        reveal_type(x, expected_text="Literal[0, 1]")
+
+
+def func19(x: float, y: list[int]):
+    if x in y:
+        reveal_type(x, expected_text="float")
+
+
+def func20(x: float, y: list[Literal[0, 1]]):
+    if x in y:
+        reveal_type(x, expected_text="Literal[0, 1]")
+
+
+def func21(x: int, y: list[Literal[0, True]]):
+    if x in y:
+        reveal_type(x, expected_text="Literal[0, True]")
+
+
+def func22(x: bool, y: list[Literal[0, 1]]):
+    if x in y:
+        reveal_type(x, expected_text="bool")

--- a/packages/pyright-internal/src/tests/samples/unnecessaryContains1.py
+++ b/packages/pyright-internal/src/tests/samples/unnecessaryContains1.py
@@ -34,7 +34,7 @@ def func3(x: list[str]):
         return
 
     # This should generate an error if "reportUnnecessaryContains" is enabled.
-    if x not in ([1, 2], [3]):
+    if x not in ((1, 2), (3,)):
         pass
 
 


### PR DESCRIPTION
…ng the `x in y` type guard pattern. The `in` operator uses equality checks, and `__eq__` can succeed for objects of disjoint types, which means disjointedness cannot be used as the basis for narrowing here. This change also affects the `reportUnnecessaryContains` check, which leverages the same logic. This addresses #9338.