### PR TITLE
Fixed recent regression that affected the evaluation of calls that ta…

### DIFF
--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -10792,7 +10792,7 @@ export function createTypeEvaluator(
                 } else {
                     let tooManyPositionals = false;
 
-                    if (foundUnpackedListArg && argList[argIndex].argCategory === ArgCategory.UnpackedList) {
+                    if (argList[argIndex].argCategory === ArgCategory.UnpackedList) {
                         // If this is an unpacked iterable, we will conservatively assume that it
                         // might have zero iterations unless we can tell from its type that it
                         // definitely has at least one iterable value.
@@ -10806,8 +10806,6 @@ export function createTypeEvaluator(
                             argType.priv.tupleTypeArgs.length > 0
                         ) {
                             tooManyPositionals = true;
-                        } else {
-                            matchedUnpackedListOfUnknownLength = true;
                         }
                     } else {
                         tooManyPositionals = true;
@@ -10919,6 +10917,10 @@ export function createTypeEvaluator(
                         errorNode,
                         /* emitNotIterableError */ false
                     )?.type;
+
+                    if (paramInfo.param.category === ParamCategory.ArgsList) {
+                        matchedUnpackedListOfUnknownLength = true;
+                    }
                 }
 
                 const funcArg: Arg | undefined = listElementType
@@ -11656,10 +11658,10 @@ export function createTypeEvaluator(
 
         let relevance = 0;
         if (matchedUnpackedListOfUnknownLength) {
-            // Lower the relevance if we made assumptions about the length
+            // Increase the relevance if we made assumptions about the length
             // of an unpacked argument. This will favor overloads that
             // associate this case with a *args parameter.
-            relevance--;
+            relevance++;
         }
 
         // Special-case the builtin isinstance and issubclass functions.

--- a/packages/pyright-internal/src/tests/samples/overloadCall5.py
+++ b/packages/pyright-internal/src/tests/samples/overloadCall5.py
@@ -80,3 +80,14 @@ def func3(*args: int) -> int | str:
 def test3(v: list[int]) -> None:
     r = func3(*v)
     reveal_type(r, expected_text="int")
+
+
+def test4(v: list[tuple[int, str]]):
+    z1 = zip(*v)
+    reveal_type(z1, expected_text="zip[tuple[Any, ...]]")
+
+    z2 = zip(v[0])
+    reveal_type(z2, expected_text="zip[tuple[int | str]]")
+
+    z3 = zip(v[0], v[1])
+    reveal_type(z3, expected_text="zip[tuple[int | str, int | str]]")


### PR DESCRIPTION
…rget certain overloads that include an `*args` parameter in the fallback (the last overload). In particular, this affected the `zip` constructor. This addresses #9876.