### PR TITLE
Removed errant check for `@final` consistency when it is applied to `…

### DIFF
--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -23646,16 +23646,6 @@ export function createTypeEvaluator(
                     return false;
                 }
 
-                if (ClassType.isFinal(destType) !== ClassType.isFinal(srcType)) {
-                    diag?.addMessage(
-                        LocAddendum.typedDictFinalMismatch().format({
-                            sourceType: printType(convertToInstance(srcType)),
-                            destType: printType(convertToInstance(destType)),
-                        })
-                    );
-                    return false;
-                }
-
                 // If invariance is being enforced, the two TypedDicts must be assignable to each other.
                 if ((flags & AssignTypeFlags.Invariant) !== 0) {
                     return assignTypedDictToTypedDict(

--- a/packages/pyright-internal/src/localization/localize.ts
+++ b/packages/pyright-internal/src/localization/localize.ts
@@ -1566,10 +1566,6 @@ export namespace Localizer {
             new ParameterizedString<{ name: string; type: string }>(
                 getRawString('DiagnosticAddendum.typedDictFieldUndefined')
             );
-        export const typedDictFinalMismatch = () =>
-            new ParameterizedString<{ sourceType: string; destType: string }>(
-                getRawString('DiagnosticAddendum.typedDictFinalMismatch')
-            );
         export const typedDictKeyAccess = () =>
             new ParameterizedString<{ name: string }>(getRawString('DiagnosticAddendum.typedDictKeyAccess'));
         export const typedDictNotAllowed = () => getRawString('DiagnosticAddendum.typedDictNotAllowed');

--- a/packages/pyright-internal/src/localization/package.nls.cs.json
+++ b/packages/pyright-internal/src/localization/package.nls.cs.json
@@ -814,7 +814,6 @@
         "typedDictFieldRequired": "{name} se vyžaduje v {type}",
         "typedDictFieldTypeMismatch": "Typ {type} se nedá přiřadit k položce {name}",
         "typedDictFieldUndefined": "{name} je nedefinovaná položka v typu {type}",
-        "typedDictFinalMismatch": "{sourceType} není kompatibilní s {destType} z důvodu neshody @final",
         "typedDictKeyAccess": "Použít [\"{name}\"] k odkazování na položku v TypedDict",
         "typedDictNotAllowed": "TypedDict se nedá použít pro kontroly instancí nebo tříd.",
         "unhashableType": "Typ „{type}“ nejde zatřiďovat",

--- a/packages/pyright-internal/src/localization/package.nls.de.json
+++ b/packages/pyright-internal/src/localization/package.nls.de.json
@@ -814,7 +814,6 @@
         "typedDictFieldRequired": "\"{name}\" ist in \"{type}\" erforderlich.",
         "typedDictFieldTypeMismatch": "Der Typ „{type}“ kann dem Element „{name}“ nicht zugewiesen werden.",
         "typedDictFieldUndefined": "„{name}“ ist ein nicht definiertes Element im Typ „{type}“.",
-        "typedDictFinalMismatch": "\"{sourceType}\" ist aufgrund eines @final-Konflikts nicht mit \"{destType}\" kompatibel.",
         "typedDictKeyAccess": "[\"{name}\"] verwenden, um in TypedDict auf ein Element zu verweisen",
         "typedDictNotAllowed": "TypedDict kann nicht für Instanzen- oder Klassenüberprüfungen verwendet werden.",
         "unhashableType": "Der Typ \"{type}\" kann nicht mit einem Hash erstellt werden.",

--- a/packages/pyright-internal/src/localization/package.nls.en-us.json
+++ b/packages/pyright-internal/src/localization/package.nls.en-us.json
@@ -2069,10 +2069,6 @@
         "typedDictFieldRequired": "\"{name}\" is required in \"{type}\"",
         "typedDictFieldTypeMismatch": "Type \"{type}\" is not assignable to item \"{name}\"",
         "typedDictFieldUndefined": "\"{name}\" is an undefined item in type \"{type}\"",
-        "typedDictFinalMismatch": {
-            "message": "\"{sourceType}\" is incompatible with \"{destType}\" because of a @final mismatch",
-            "comment": "{Locked='@final'}"
-        },
         "typedDictKeyAccess": {
             "message": "Use [\"{name}\"] to reference item in TypedDict",
             "comment": "{Locked='TypedDict'}"

--- a/packages/pyright-internal/src/localization/package.nls.es.json
+++ b/packages/pyright-internal/src/localization/package.nls.es.json
@@ -814,7 +814,6 @@
         "typedDictFieldRequired": "\"{name}\" es obligatorio en \"{type}\"",
         "typedDictFieldTypeMismatch": "El tipo \"{type}\" no se puede asignar al elemento \"{name}\"",
         "typedDictFieldUndefined": "\"{name}\" es un elemento no definido en el tipo \"{type}\"",
-        "typedDictFinalMismatch": "\"{sourceType}\" no es compatible con \"{destType}\" debido a una discrepancia @final",
         "typedDictKeyAccess": "Utilizar [\"{name}\"] para hacer referencia al elemento en TypedDict",
         "typedDictNotAllowed": "No se puede usar TypedDict para comprobaciones de instancia o clase",
         "unhashableType": "El tipo \"{type}\" no admite hash",

--- a/packages/pyright-internal/src/localization/package.nls.fr.json
+++ b/packages/pyright-internal/src/localization/package.nls.fr.json
@@ -814,7 +814,6 @@
         "typedDictFieldRequired": "« {name} » est obligatoire dans « {type} »",
         "typedDictFieldTypeMismatch": "Le type « {type} » n'est pas attribuable à l’élément « {name} »",
         "typedDictFieldUndefined": "« {name} » est un élément non défini dans le type « {type} »",
-        "typedDictFinalMismatch": "« {sourceType} » n’est pas compatible avec « {destType} » en raison d’une incompatibilité de @final",
         "typedDictKeyAccess": "Utilisez [« {name} »] pour référencer l’élément dans TypedDict",
         "typedDictNotAllowed": "TypedDict ne peut pas être utilisé pour les vérifications d’instance ou de classe",
         "unhashableType": "Le type \"{type}\" n'est pas hachable",

--- a/packages/pyright-internal/src/localization/package.nls.it.json
+++ b/packages/pyright-internal/src/localization/package.nls.it.json
@@ -814,7 +814,6 @@
         "typedDictFieldRequired": "\"{name}\" è obbligatorio in \"{type}\"",
         "typedDictFieldTypeMismatch": "Il tipo \"{type}\" non può essere assegnato all’elemento \"{name}\"",
         "typedDictFieldUndefined": "\"{name}\" è un elemento non definito nel tipo \"{type}\"",
-        "typedDictFinalMismatch": "\"{sourceType}\" non è compatibile con \"{destType}\" a causa di una @final mancata corrispondenza",
         "typedDictKeyAccess": "Usare [\"{name}\"] per fare riferimento all'elemento in TypedDict",
         "typedDictNotAllowed": "Non è possibile usare TypedDict per i controlli di istanze o classi",
         "unhashableType": "Il tipo \"{type}\" non è hashable",

--- a/packages/pyright-internal/src/localization/package.nls.ja.json
+++ b/packages/pyright-internal/src/localization/package.nls.ja.json
@@ -814,7 +814,6 @@
         "typedDictFieldRequired": "\"{name}\" は \"{type}\" に必要です",
         "typedDictFieldTypeMismatch": "型 \"{type}\" は、アイテム \"{name}\" に割り当てできません",
         "typedDictFieldUndefined": "\"{name}\" は型 \"{type}\" の未定義のアイテムです",
-        "typedDictFinalMismatch": "@final が一致しないため、\"{sourceType}\" は \"{destType}\" と互換性がありません",
         "typedDictKeyAccess": "[\"{name}\"] を使用して TypedDict の項目を参照する",
         "typedDictNotAllowed": "TypedDict はインスタンスまたはクラスのチェックには使用できません",
         "unhashableType": "型 \"{type}\" はハッシュ可能ではありません",

--- a/packages/pyright-internal/src/localization/package.nls.ko.json
+++ b/packages/pyright-internal/src/localization/package.nls.ko.json
@@ -814,7 +814,6 @@
         "typedDictFieldRequired": "\"{type}\"에 \"{name}\"이(가) 필요합니다.",
         "typedDictFieldTypeMismatch": "\"{type}\" 형식은 \"{name}\" 항목에 할당할 수 없습니다.",
         "typedDictFieldUndefined": "\"{name}\"은(는) \"{type}\" 형식의 정의되지 않은 항목입니다.",
-        "typedDictFinalMismatch": "@final 불일치로 인해 \"{sourceType}\"이(가) \"{destType}\"과(와) 호환되지 않습니다.",
         "typedDictKeyAccess": "TypedDict에서 항목을 참조하려면 [\"{name}\"]을(를) 사용하세요.",
         "typedDictNotAllowed": "TypedDict는 인스턴스 또는 클래스 검사에 사용할 수 없습니다.",
         "unhashableType": "‘{type}’ 형식을 해시할 수 없습니다.",

--- a/packages/pyright-internal/src/localization/package.nls.pl.json
+++ b/packages/pyright-internal/src/localization/package.nls.pl.json
@@ -814,7 +814,6 @@
         "typedDictFieldRequired": "Nazwa „{name}” jest wymagana w typie „{type}”",
         "typedDictFieldTypeMismatch": "Nie można przypisać typu „{type}” do elementu „{name}”",
         "typedDictFieldUndefined": "Nazwa „{name}” jest niezdefiniowanym elementem w typie „{type}”",
-        "typedDictFinalMismatch": "Typ „{sourceType}” jest niezgodny z typem „{destType}” z powodu niezgodności @final",
         "typedDictKeyAccess": "Użyj elementu [\"{name}\"], aby odwołać się do elementu w TypedDict",
         "typedDictNotAllowed": "Funkcja TypedDict nie może być używana do sprawdzania wystąpień lub klas",
         "unhashableType": "Typ „{type}” nie jest wartością skrótu",

--- a/packages/pyright-internal/src/localization/package.nls.pt-br.json
+++ b/packages/pyright-internal/src/localization/package.nls.pt-br.json
@@ -814,7 +814,6 @@
         "typedDictFieldRequired": "\"{name}\" é necessário em \"{type}\"",
         "typedDictFieldTypeMismatch": "O tipo \"{type}\" não é atribuível ao item \"{name}\"",
         "typedDictFieldUndefined": "\"{name}\" é um item indefinido no tipo \"{type}\"",
-        "typedDictFinalMismatch": "\"{sourceType}\" é incompatível com \"{destType}\" devido a uma @final incompatível",
         "typedDictKeyAccess": "Usar [\"{name}\"] para fazer referência ao item em TypedDict",
         "typedDictNotAllowed": "TypedDict não pode ser usado para verificações de instância ou de classe",
         "unhashableType": "O tipo \"{type}\" não é pode fazer hash",

--- a/packages/pyright-internal/src/localization/package.nls.qps-ploc.json
+++ b/packages/pyright-internal/src/localization/package.nls.qps-ploc.json
@@ -814,7 +814,6 @@
         "typedDictFieldRequired": "[ckyH4][นั้\"{ñæmë}\" ïs rëqµïrëð ïñ \"{tÿpë}\"Ấğ倪İЂҰक्र्तिृนั้ढूँ]",
         "typedDictFieldTypeMismatch": "[XYIBH][นั้Tÿpë \"{tÿpë}\" ïs ñøt æssïgñæþlë tø ïtëm \"{ñæmë}\"Ấğ倪İЂҰक्र्तिृまẤğ倪İЂนั้ढूँ]",
         "typedDictFieldUndefined": "[UsDC9][นั้\"{ñæmë}\" ïs æñ µñðëfïñëð ïtëm ïñ tÿpë \"{tÿpë}\"Ấğ倪İЂҰक्र्तिृまẤğ倪İนั้ढूँ]",
-        "typedDictFinalMismatch": "[tFb04][นั้\"{søµrçëTÿpë}\" ïs ïñçømpætïþlë wïth \"{ðëstTÿpë}\" þëçæµsë øf æ @final mïsmætçhẤğ倪İЂҰक्र्तिृまẤğ倪İЂҰक्र्तिृまẤğ倪นั้ढूँ]",
         "typedDictKeyAccess": "[67DLq][นั้Üsë [\"{ñæmë}\"] tø rëfërëñçë ïtëm ïñ TypedDictẤğ倪İЂҰक्र्तिृまẤğ倪İนั้ढूँ]",
         "typedDictNotAllowed": "[eTsPP][นั้TypedDict çæññøt þë µsëð før ïñstæñçë ør çlæss çhëçksẤğ倪İЂҰक्र्तिृまẤğ倪İЂҰक्นั้ढूँ]",
         "unhashableType": "[IJEeq][นั้Tÿpë \"{tÿpë}\" ïs ñøt hæshæþlëẤğ倪İЂҰक्र्तिृนั้ढूँ]",

--- a/packages/pyright-internal/src/localization/package.nls.ru.json
+++ b/packages/pyright-internal/src/localization/package.nls.ru.json
@@ -814,7 +814,6 @@
         "typedDictFieldRequired": "\"{name}\" является обязательным в \"{type}\"",
         "typedDictFieldTypeMismatch": "Тип \"{type}\" нельзя присвоить полю \"{name}\"",
         "typedDictFieldUndefined": "Элемент \"{name}\" не определен в типе \"{type}\"",
-        "typedDictFinalMismatch": "\"{sourceType}\" несовместим с \"{destType}\" из-за несоответствия @final",
         "typedDictKeyAccess": "Использовать [\"{name}\"] для ссылки на элемент в TypedDict",
         "typedDictNotAllowed": "TypedDict не может использоваться для проверок экземпляров или классов",
         "unhashableType": "Тип \"{type}\" не является хэшируемым",

--- a/packages/pyright-internal/src/localization/package.nls.tr.json
+++ b/packages/pyright-internal/src/localization/package.nls.tr.json
@@ -814,7 +814,6 @@
         "typedDictFieldRequired": "\"{type}\" içinde \"{name}\" gerekiyor",
         "typedDictFieldTypeMismatch": "\"{type}\" türü \"{name}\" öğesine atanamaz",
         "typedDictFieldUndefined": "\"{name}\", \"{type}\" türündeki tanımsız bir öğedir",
-        "typedDictFinalMismatch": "\"{sourceType}\" @final uyumsuzluğu nedeniyle \"{destType}\" ile uyumsuz",
         "typedDictKeyAccess": "TypedDict’te öğeye başvurmak için [\"{name}\"] değerini kullanın",
         "typedDictNotAllowed": "TypedDict örnek veya sınıf kontrolleri için kullanılamaz",
         "unhashableType": "\"{type}\" türü karmalanabilir değil",

--- a/packages/pyright-internal/src/localization/package.nls.zh-cn.json
+++ b/packages/pyright-internal/src/localization/package.nls.zh-cn.json
@@ -814,7 +814,6 @@
         "typedDictFieldRequired": "\"{type}\"中需要\"{name}\"",
         "typedDictFieldTypeMismatch": "类型“{type}”不可分配给项“{name}”",
         "typedDictFieldUndefined": "“{name}”是类型“{type}”中的未定义项",
-        "typedDictFinalMismatch": "\"{sourceType}\"与\"{destType}\"不兼容，因为@final不匹配",
         "typedDictKeyAccess": "使用 [\"{name}\"] 引用 TypedDict 中的项",
         "typedDictNotAllowed": "不能对实例或类检查使用 TypedDict",
         "unhashableType": "类型“{type}”不可哈希",

--- a/packages/pyright-internal/src/localization/package.nls.zh-tw.json
+++ b/packages/pyright-internal/src/localization/package.nls.zh-tw.json
@@ -814,7 +814,6 @@
         "typedDictFieldRequired": "\"{type}\" 中需要 \"{name}\"",
         "typedDictFieldTypeMismatch": "型別 \"{type}\" 無法指派給項目 \"{name}\"",
         "typedDictFieldUndefined": "\"{name}\" 是型別 \"{type}\" 中未定義的項目",
-        "typedDictFinalMismatch": "\"{sourceType}\" 與 \"{destType}\" 不相容，因為@final 不符",
         "typedDictKeyAccess": "使用 [\"{name}\"] 參考 TypedDict 中的項目",
         "typedDictNotAllowed": "執行個體或類別檢查無法使用 TypedDict",
         "unhashableType": "型別 \"{type}\" 無法雜湊",

--- a/packages/pyright-internal/src/tests/samples/typedDict16.py
+++ b/packages/pyright-internal/src/tests/samples/typedDict16.py
@@ -79,26 +79,3 @@ v24: list[TD20] = [v21]
 # This should generate an error.
 v25: list[TD21] = v24
 
-
-@final
-class TD30(TypedDict):
-    value: str
-
-
-@final
-class TD31(TypedDict):
-    value: str
-
-
-class TD32(TypedDict):
-    value: str
-
-
-v30: TD30 = TD31(value="")
-v31: TD31 = TD30(value="")
-
-# This should generate an error because of a @final mismatch.
-v32: TD32 = TD30(value="")
-
-# This should generate an error because of a @final mismatch.
-v33: TD30 = TD32(value="")

--- a/packages/pyright-internal/src/tests/typeEvaluator7.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator7.test.ts
@@ -716,7 +716,7 @@ test('TypedDict15', () => {
 test('TypedDict16', () => {
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['typedDict16.py']);
 
-    TestUtils.validateResults(analysisResults, 9);
+    TestUtils.validateResults(analysisResults, 7);
 });
 
 test('TypedDict17', () => {


### PR DESCRIPTION
…TypedDict`. This addresses #9884.