### PR TITLE
Fixed a bug that results in incomplete renames when renaming a class …

### DIFF
--- a/packages/pyright-internal/src/languageService/referencesProvider.ts
+++ b/packages/pyright-internal/src/languageService/referencesProvider.ts
@@ -498,7 +498,15 @@ function isVisibleOutside(evaluator: TypeEvaluator, currentUri: Uri, node: NameN
     // Return true if the scope that contains the specified node is visible
     // outside of the current module, false if not.
     function isContainerExternallyVisible(node: NameNode, recursionCount: number) {
-        const scopingNode = ParseTreeUtils.getEvaluationScopeNode(node).node;
+        let scopingNodeInfo = ParseTreeUtils.getEvaluationScopeNode(node);
+        let scopingNode = scopingNodeInfo.node;
+
+        // If this is a type parameter scope, it acts as a proxy for
+        // its outer (parent) scope.
+        while (scopingNodeInfo.useProxyScope && scopingNodeInfo.node.parent) {
+            scopingNodeInfo = ParseTreeUtils.getEvaluationScopeNode(scopingNodeInfo.node.parent);
+            scopingNode = scopingNodeInfo.node;
+        }
 
         switch (scopingNode.nodeType) {
             case ParseNodeType.Class:

--- a/packages/pyright-internal/src/tests/fourslash/rename.typeParams.fourslash.ts
+++ b/packages/pyright-internal/src/tests/fourslash/rename.typeParams.fourslash.ts
@@ -1,0 +1,29 @@
+/// <reference path="typings/fourslash.d.ts" />
+
+// @filename: pyrightconfig.json
+//// {
+////   "useLibraryCodeForTypes": true
+//// }
+
+// @filename: test.py
+//// class [|Test1|][T]:
+////    def M(self, a: '[|Test1|]'):
+////     pass
+
+// @filename: test2.py
+//// from test import [|Test1|]
+////
+//// b = [|[|/*marker*/Test1|]|]()
+
+{
+    const ranges = helper.getRanges().filter((r) => !r.marker);
+
+    helper.verifyRename({
+        marker: {
+            newName: 'NewTest1',
+            changes: ranges.map((r) => {
+                return { filePath: r.fileName, range: helper.convertPositionRange(r), replacementText: 'NewTest1' };
+            }),
+        },
+    });
+}


### PR DESCRIPTION
…or function that uses PEP 695 type parameter syntax. This addresses https://github.com/microsoft/pylance-release/issues/6893.