### PR TITLE
Fixed a bug that results in noncompliance with the typing spec when a…

### DIFF
--- a/packages/pyright-internal/src/analyzer/constructors.ts
+++ b/packages/pyright-internal/src/analyzer/constructors.ts
@@ -33,7 +33,6 @@ import {
     combineTypes,
     findSubtype,
     isAny,
-    isAnyOrUnknown,
     isClass,
     isClassInstance,
     isFunction,
@@ -288,8 +287,8 @@ function validateNewAndInitMethods(
         // (cls, *args, **kwargs) -> Self, allow the __init__ method to
         // determine the specialized type of the class.
         newMethodReturnType = ClassType.cloneAsInstance(type);
-    } else if (isAnyOrUnknown(newMethodReturnType)) {
-        // If the __new__ method returns Any or Unknown, we'll ignore its return
+    } else if (isUnknown(newMethodReturnType) || (newMethodTypeResult && isAny(newMethodTypeResult.type))) {
+        // If the __new__ method returns Unknown, we'll ignore its return
         // type and assume that it returns Self.
         newMethodReturnType = applySolvedTypeVars(ClassType.cloneAsInstance(type), new ConstraintSolution(), {
             replaceUnsolved: {

--- a/packages/pyright-internal/src/tests/samples/constructor7.py
+++ b/packages/pyright-internal/src/tests/samples/constructor7.py
@@ -2,7 +2,7 @@
 # a type that differs from the class that contains it.
 
 
-from typing import Callable, ParamSpec, TypeVar
+from typing import Any, Callable, ParamSpec, Self, TypeVar
 
 
 class ClassA:
@@ -29,3 +29,23 @@ class ClassB:
 
 v2 = ClassB(func1)
 reveal_type(v2, expected_text="(a: int) -> int")
+
+
+class ClassC:
+    def __new__(cls) -> Any:
+        return 1
+
+    def __init__(self, a: int) -> None: ...
+
+
+ClassC()
+
+
+class ClassD:
+    def __new__(cls) -> Self | Any:
+        return 1
+
+    def __init__(self, a: int) -> None: ...
+
+
+ClassD()


### PR DESCRIPTION
… `__new__` method has an explicit `Any` return type annotation. In this case, type checkers should assume that the return type of `__new__` is _not_ a subtype of the containing class and should therefore ignore the `__init__` method. This addresses #9909.