### PR TITLE
Fixed bug that leads to inconsistent behavior in certain cases involv…

### DIFF
--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -11537,28 +11537,20 @@ export function createTypeEvaluator(
                     if (param.category === ParamCategory.Simple && param.name) {
                         const entry = paramMap.get(param.name);
 
-                        if (entry && entry.argsNeeded === 0 && entry.argsReceived === 0) {
-                            const defaultArgType = paramInfo.defaultType;
-
-                            if (
-                                defaultArgType &&
-                                !isEllipsisType(defaultArgType) &&
-                                requiresSpecialization(paramInfo.declaredType)
-                            ) {
-                                validateArgTypeParams.push({
-                                    paramCategory: param.category,
-                                    paramType: paramInfo.type,
-                                    requiresTypeVarMatching: true,
-                                    argument: {
-                                        argCategory: ArgCategory.Simple,
-                                        typeResult: { type: defaultArgType },
-                                    },
-                                    isDefaultArg: true,
-                                    errorNode,
-                                    paramName: param.name,
-                                    isParamNameSynthesized: FunctionParam.isNameSynthesized(param),
-                                });
-                            }
+                        if (entry && entry.argsNeeded === 0 && entry.argsReceived === 0 && paramInfo.defaultType) {
+                            validateArgTypeParams.push({
+                                paramCategory: param.category,
+                                paramType: paramInfo.type,
+                                requiresTypeVarMatching: true,
+                                argument: {
+                                    argCategory: ArgCategory.Simple,
+                                    typeResult: { type: paramInfo.defaultType },
+                                },
+                                isDefaultArg: true,
+                                errorNode,
+                                paramName: param.name,
+                                isParamNameSynthesized: FunctionParam.isNameSynthesized(param),
+                            });
                         }
                     }
                 });

--- a/packages/pyright-internal/src/tests/samples/dataclassDescriptors1.py
+++ b/packages/pyright-internal/src/tests/samples/dataclassDescriptors1.py
@@ -7,12 +7,10 @@ from typing import Any, cast, overload
 
 class MyDescriptor:
     @overload
-    def __get__(self, __obj: None, __owner: Any) -> "MyDescriptor":
-        ...
+    def __get__(self, __obj: None, __owner: Any) -> "MyDescriptor": ...
 
     @overload
-    def __get__(self, __obj: object, __owner: Any) -> int:
-        ...
+    def __get__(self, __obj: object, __owner: Any) -> int: ...
 
     def __get__(self, __obj: object | None, __owner: Any) -> "int | MyDescriptor":
         if __obj is None:
@@ -39,5 +37,5 @@ reveal_type(Foo.y, expected_text="MyDescriptor")
 f2 = Foo("hi")
 
 
+# This should generate an error.
 f3 = Foo()
-reveal_type(f3.y, expected_text="int")

--- a/packages/pyright-internal/src/tests/samples/overloadCall6.py
+++ b/packages/pyright-internal/src/tests/samples/overloadCall6.py
@@ -10,17 +10,14 @@ _T = TypeVar("_T")
 
 
 @overload
-def overload1(x: int, y: float) -> float:
-    ...
+def overload1(x: int, y: float) -> float: ...
 
 
 @overload
-def overload1(x: str, y: float) -> str:
-    ...
+def overload1(x: str, y: float) -> str: ...
 
 
-def overload1(x: str | int, y: float) -> float | str:
-    ...
+def overload1(x: str | int, y: float) -> float | str: ...
 
 
 def func1(a: Any):
@@ -38,17 +35,14 @@ def func1(a: Any):
 
 
 @overload
-def overload2(x: int) -> Any:
-    ...
+def overload2(x: int) -> Any: ...
 
 
 @overload
-def overload2(x: str) -> str:
-    ...
+def overload2(x: str) -> str: ...
 
 
-def overload2(x: str | int) -> Any | str:
-    ...
+def overload2(x: str | int) -> Any | str: ...
 
 
 def func2(a: Any):
@@ -63,17 +57,14 @@ def func2(a: Any):
 
 
 @overload
-def overload3(x: LiteralString) -> LiteralString:
-    ...
+def overload3(x: LiteralString) -> LiteralString: ...
 
 
 @overload
-def overload3(x: str) -> str:
-    ...
+def overload3(x: str) -> str: ...
 
 
-def overload3(x: str) -> str:
-    ...
+def overload3(x: str) -> str: ...
 
 
 def func3(a: Any, b: str):
@@ -93,22 +84,18 @@ def func4(a: Any):
 
 
 @overload
-def overload4(x: str, *, flag: Literal[True]) -> int:
-    ...
+def overload4(x: str, *, flag: Literal[True]) -> int: ...
 
 
 @overload
-def overload4(x: str, *, flag: Literal[False] = ...) -> str:
-    ...
+def overload4(x: str, *, flag: Literal[False] = ...) -> str: ...
 
 
 @overload
-def overload4(x: str, *, flag: bool = ...) -> int | str:
-    ...
+def overload4(x: str, *, flag: bool) -> int | str: ...
 
 
-def overload4(x: str, *, flag: bool = False) -> int | str:
-    ...
+def overload4(x: str, *, flag: bool = False) -> int | str: ...
 
 
 reveal_type(overload4("0"), expected_text="str")
@@ -116,8 +103,7 @@ reveal_type(overload4("0", flag=True), expected_text="int")
 reveal_type(overload4("0", flag=False), expected_text="str")
 
 
-def unknown_any() -> Any:
-    ...
+def unknown_any() -> Any: ...
 
 
 def func5(a: Any):
@@ -126,13 +112,11 @@ def func5(a: Any):
 
 
 @overload
-def overload5(x: list[int]) -> list[int]:
-    ...
+def overload5(x: list[int]) -> list[int]: ...
 
 
 @overload
-def overload5(x: list[str]) -> list[str]:
-    ...
+def overload5(x: list[str]) -> list[str]: ...
 
 
 def overload5(x: list[str] | list[int]) -> list[str] | list[int]:
@@ -145,12 +129,10 @@ def func6(y: list[Any]):
 
 class ClassA(Generic[_T]):
     @overload
-    def m1(self: "ClassA[int]") -> "ClassA[int]":
-        ...
+    def m1(self: "ClassA[int]") -> "ClassA[int]": ...
 
     @overload
-    def m1(self: "ClassA[str]") -> "ClassA[str]":
-        ...
+    def m1(self: "ClassA[str]") -> "ClassA[str]": ...
 
     def m1(self) -> "ClassA[Any]":
         return self
@@ -162,12 +144,10 @@ def func7(a: ClassA[Any]):
 
 class ClassB(Generic[_T]):
     @overload
-    def m1(self: "ClassB[int]", obj: "int | ClassB[int]") -> "ClassB[int]":
-        ...
+    def m1(self: "ClassB[int]", obj: "int | ClassB[int]") -> "ClassB[int]": ...
 
     @overload
-    def m1(self: "ClassB[str]", obj: "str | ClassB[str]") -> "ClassB[str]":
-        ...
+    def m1(self: "ClassB[str]", obj: "str | ClassB[str]") -> "ClassB[str]": ...
 
     def m1(self, obj: Any) -> "ClassB[Any]":
         return self
@@ -182,18 +162,15 @@ _T2 = TypeVar("_T2")
 
 
 @overload
-def overload6(a: _T1, /) -> tuple[_T1]:
-    ...
+def overload6(a: _T1, /) -> tuple[_T1]: ...
 
 
 @overload
-def overload6(a: _T1, b: _T2, /) -> tuple[_T1, _T2]:
-    ...
+def overload6(a: _T1, b: _T2, /) -> tuple[_T1, _T2]: ...
 
 
 @overload
-def overload6(*args: _T1) -> tuple[_T1, ...]:
-    ...
+def overload6(*args: _T1) -> tuple[_T1, ...]: ...
 
 
 def overload6(*args: Any) -> tuple[Any, ...]:
@@ -205,17 +182,14 @@ def func9(*args: int):
 
 
 @overload
-def overload7(a: float = ..., *, b: Literal[True] = ...) -> float:
-    ...
+def overload7(a: float = ..., *, b: Literal[True] = ...) -> float: ...
 
 
 @overload
-def overload7(a: float = ..., *, b: bool) -> str:
-    ...
+def overload7(a: float = ..., *, b: bool) -> str: ...
 
 
-def overload7(a: float = 1.0, *, b: bool = True) -> float | str:
-    ...
+def overload7(a: float = 1.0, *, b: bool = True) -> float | str: ...
 
 
 def func10(kwargs_dict: dict[Any, Any]):
@@ -245,13 +219,11 @@ def func15(kwargs_dict: dict[str, str]):
 
 
 @overload
-def overload8(x: int = 3, **kwargs: int) -> int:
-    ...
+def overload8(x: int = 3, **kwargs: int) -> int: ...
 
 
 @overload
-def overload8(**kwargs: str) -> str:
-    ...
+def overload8(**kwargs: str) -> str: ...
 
 
 def overload8(*args, **kwargs) -> Any:
@@ -264,18 +236,15 @@ def func16(a: dict[str, Any], i: int):
 
 
 @overload
-def overload9(x: int, y: int) -> int:
-    ...
+def overload9(x: int, y: int) -> int: ...
 
 
 @overload
-def overload9(x: float, y: int, z: str) -> float:
-    ...
+def overload9(x: float, y: int, z: str) -> float: ...
 
 
 @overload
-def overload9(x: object, y: int, z: str, a: None) -> str:
-    ...
+def overload9(x: object, y: int, z: str, a: None) -> str: ...
 
 
 def overload9(x, y, z="", a=None) -> Any:
@@ -291,13 +260,11 @@ def func17(a: Any):
 
 
 @overload
-def overload10(x: list[int]) -> list[int]:
-    ...
+def overload10(x: list[int]) -> list[int]: ...
 
 
 @overload
-def overload10(x: list[Any]) -> list[Any]:
-    ...
+def overload10(x: list[Any]) -> list[Any]: ...
 
 
 def overload10(x) -> Any:
@@ -313,15 +280,12 @@ def func18(a: Any, b: list[Any], c: list[str], d: list[int]):
 
 class ClassC:
     @overload
-    def method1(self, k: Literal["hi"], default: Any) -> float:
-        ...
+    def method1(self, k: Literal["hi"], default: Any) -> float: ...
 
     @overload
-    def method1(self, k: str, default: _T) -> Any | _T:
-        ...
+    def method1(self, k: str, default: _T) -> Any | _T: ...
 
-    def method1(self, k: str, default: _T) -> Any | _T:
-        ...
+    def method1(self, k: str, default: _T) -> Any | _T: ...
 
 
 def func19(a: ClassC, b: list, c: Any):
@@ -341,13 +305,11 @@ def func19(a: ClassC, b: list, c: Any):
 
 
 @overload
-def overload11(x: str) -> TypeIs[str]:
-    ...
+def overload11(x: str) -> TypeIs[str]: ...
 
 
 @overload
-def overload11(x: int) -> TypeIs[int]:
-    ...
+def overload11(x: int) -> TypeIs[int]: ...
 
 
 def overload11(x: Any) -> Any:

--- a/packages/pyright-internal/src/tests/typeEvaluator4.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator4.test.ts
@@ -425,7 +425,7 @@ test('DataClassHash1', () => {
 test('DataClassDescriptors1', () => {
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['dataclassDescriptors1.py']);
 
-    TestUtils.validateResults(analysisResults, 1);
+    TestUtils.validateResults(analysisResults, 2);
 });
 
 test('DataClassDescriptors2', () => {


### PR DESCRIPTION
…ing the evaluation of a call whose target signature involves a parameter with a default argument value, notably where the type of the default value isn't assignable to the declared type of its parameter. This addresses #9901.