### PR TITLE
Fixed a bug that resulted in a spurious error under certain specific …

### DIFF
--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -23279,9 +23279,7 @@ export function createTypeEvaluator(
             returnType = makeTypeVarsFree(returnType, typeVarScopes);
 
             // Cache the type for next time.
-            if (!isIncomplete) {
-                type.priv.inferredReturnType = returnType;
-            }
+            type.priv.inferredReturnType = returnType;
         }
 
         // If the type is partially unknown and the function has one or more unannotated


### PR DESCRIPTION
…conditions involving a call to a function or method that doesn't have a return type and whose inferred return type is based on variables calculated in a loop. This addresses #9937.