### PR TITLE
Added error check for member access expressions that attempt to bind …

### DIFF
--- a/packages/pyright-internal/src/localization/localize.ts
+++ b/packages/pyright-internal/src/localization/localize.ts
@@ -280,6 +280,8 @@ export namespace Localizer {
             );
         export const baseClassUnknown = () => getRawString('Diagnostic.baseClassUnknown');
         export const binaryOperationNotAllowed = () => getRawString('Diagnostic.binaryOperationNotAllowed');
+        export const bindParamMissing = () =>
+            new ParameterizedString<{ methodName: string }>(getRawString('Diagnostic.bindParamMissing'));
         export const bindTypeMismatch = () =>
             new ParameterizedString<{ type: string; methodName: string; paramName: string }>(
                 getRawString('Diagnostic.bindTypeMismatch')

--- a/packages/pyright-internal/src/localization/package.nls.en-us.json
+++ b/packages/pyright-internal/src/localization/package.nls.en-us.json
@@ -103,6 +103,10 @@
         "baseClassUnknown": "Base class type is unknown, obscuring type of derived class",
         "baseClassVariableTypeIncompatible": "Base classes for class \"{classType}\" define variable \"{name}\" in incompatible way",
         "binaryOperationNotAllowed": "Binary operator not allowed in type expression",
+        "bindParamMissing": {
+            "message": "Could not bind method \"{methodName}\" because it is missing a \"self\" or \"cls\" parameter",
+            "comment": "Binding is the process through which Pyright determines what object a name refers to"
+        },
         "bindTypeMismatch": {
             "message": "Could not bind method \"{methodName}\" because \"{type}\" is not assignable to parameter \"{paramName}\"",
             "comment": "Binding is the process through which Pyright determines what object a name refers to"

--- a/packages/pyright-internal/src/tests/fourslash/completions.autoimport.shadow.fourslash.ts
+++ b/packages/pyright-internal/src/tests/fourslash/completions.autoimport.shadow.fourslash.ts
@@ -11,12 +11,12 @@
 // @filename: testLib/__init__.pyi
 // @library: true
 //// class MyShadow:
-////     def method(): ...
+////     def method(self): ...
 
 // @filename: testLib/__init__.py
 // @library: true
 //// class MyShadow:
-////     def method():
+////     def method(self):
 ////         'doc string'
 ////         pass
 

--- a/packages/pyright-internal/src/tests/fourslash/completions.wildcardimports.fourslash.ts
+++ b/packages/pyright-internal/src/tests/fourslash/completions.wildcardimports.fourslash.ts
@@ -12,7 +12,7 @@
 ////     pass
 ////
 //// class MyType:
-////     def func2():
+////     def func2(self):
 ////         '''func2 docs'''
 ////         pass
 
@@ -58,7 +58,7 @@
 ////
 //// func: ufunc
 //// class MyType:
-////     def func2() -> None : ...
+////     def func2(self) -> None : ...
 //// func3: ufunc
 //// func4: ufunc
 //// func5: ufunc

--- a/packages/pyright-internal/src/tests/fourslash/hover.wildcardimports.fourslash.ts
+++ b/packages/pyright-internal/src/tests/fourslash/hover.wildcardimports.fourslash.ts
@@ -16,7 +16,7 @@
 ////     pass
 ////
 //// class MyType2:
-////     def func2():
+////     def func2(self):
 ////         '''func2 docs'''
 ////         pass
 
@@ -61,7 +61,7 @@
 //// func: Any
 //// MyType: Any
 //// class MyType2:
-////     def func2() -> None : ...
+////     def func2(self) -> None : ...
 //// func3: Any
 //// func4: Any
 //// func5: Any

--- a/packages/pyright-internal/src/tests/fourslash/signature.docstrings.wildcardimports.fourslash.ts
+++ b/packages/pyright-internal/src/tests/fourslash/signature.docstrings.wildcardimports.fourslash.ts
@@ -12,7 +12,7 @@
 ////     pass
 ////
 //// class MyType:
-////     def func2():
+////     def func2(self):
 ////         '''func2 docs'''
 ////         pass
 
@@ -58,7 +58,7 @@
 ////
 //// func: ufunc
 //// class MyType:
-////     def func2() -> None : ...
+////     def func2(self) -> None : ...
 //// func3: ufunc
 //// func4: ufunc
 //// func5: ufunc

--- a/packages/pyright-internal/src/tests/samples/enum1.py
+++ b/packages/pyright-internal/src/tests/samples/enum1.py
@@ -179,19 +179,19 @@ reveal_type(te11_A, expected_text="Literal[TestEnum11.A]")
 reveal_type(te11_A.value, expected_text="int")
 
 
-def func3() -> None:
+def func3(self) -> None:
     pass
 
 
 class TestEnum12(Enum):
     a = 1
-    b = lambda: None
+    b = lambda self: None
     c = func3
 
 
 reveal_type(TestEnum12.a, expected_text="Literal[TestEnum12.a]")
-reveal_type(TestEnum12.b, expected_text="() -> None")
-reveal_type(TestEnum12.c, expected_text="() -> None")
+reveal_type(TestEnum12.b, expected_text="(self: Unknown) -> None")
+reveal_type(TestEnum12.c, expected_text="(self: Unknown) -> None")
 
 
 class TestEnum13(metaclass=CustomEnumMeta1):


### PR DESCRIPTION
…an instance or class method to an object or class when the method accepts no "self" or "cls" parameter. This addresses #9942.