### PR TITLE
Fixed bug that results in a spurious error when an `isinstance` or `i…

### DIFF
--- a/packages/pyright-internal/src/analyzer/types.ts
+++ b/packages/pyright-internal/src/analyzer/types.ts
@@ -1449,6 +1449,18 @@ export namespace ClassType {
             return true;
         }
 
+        // Handle the case where the subclass is a type[type[T]] and the parent
+        // class is type.
+        const subclassDepth = TypeBase.getInstantiableDepth(subclassType);
+        if (subclassDepth > 0) {
+            if (isBuiltIn(parentClassType, 'type') && TypeBase.getInstantiableDepth(parentClassType) < subclassDepth) {
+                if (inheritanceChain) {
+                    inheritanceChain.push(parentClassType);
+                }
+                return true;
+            }
+        }
+
         // Handle the case where both source and dest are property objects. This
         // special case is needed because we synthesize a new class for each
         // property declaration.

--- a/packages/pyright-internal/src/tests/samples/typeNarrowingIsinstance3.py
+++ b/packages/pyright-internal/src/tests/samples/typeNarrowingIsinstance3.py
@@ -86,3 +86,8 @@ def func3(val: _T1) -> _T1:
 def func4(val: D):
     if isinstance(val, A):
         reveal_type(val, expected_text="Never")
+
+
+def func5(val: type[int]):
+    if isinstance(val, str):
+        x: type = val


### PR DESCRIPTION
…ssubclass` type guard results in a narrowed type that is synthesized as a subclass of `type` and some other class. This addresses #9971.