### PR TITLE
Fixed a bug that results in a spurious error when an unpacked iterabl…

### DIFF
--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -10940,6 +10940,15 @@ export function createTypeEvaluator(
                     if (paramInfo.param.category === ParamCategory.ArgsList) {
                         matchedUnpackedListOfUnknownLength = true;
                     }
+
+                    if (isParamVariadic && listElementType) {
+                        isArgCompatibleWithVariadic = true;
+                        listElementType = makeTupleObject(
+                            evaluatorInterface,
+                            [{ type: listElementType, isUnbounded: true }],
+                            /* isUnpacked */ true
+                        );
+                    }
                 }
 
                 const funcArg: Arg | undefined = listElementType

--- a/packages/pyright-internal/src/tests/samples/typeVarTuple3.py
+++ b/packages/pyright-internal/src/tests/samples/typeVarTuple3.py
@@ -18,16 +18,13 @@ class Array(Generic[Unpack[_Xs]]):
         reveal_type(args, expected_text="tuple[*_Xs@Array]")
 
     # This should generate an error because _Xs is not unpacked.
-    def foo(self, *args: _Xs) -> None:
-        ...
+    def foo(self, *args: _Xs) -> None: ...
 
 
-def linearize(value: Array[Unpack[_Xs]]) -> tuple[Unpack[_Xs]]:
-    ...
+def linearize(value: Array[Unpack[_Xs]]) -> tuple[Unpack[_Xs]]: ...
 
 
-def array_to_tuple(value: Array[Unpack[_Xs]]) -> tuple[complex, Unpack[_Xs]]:
-    ...
+def array_to_tuple(value: Array[Unpack[_Xs]]) -> tuple[complex, Unpack[_Xs]]: ...
 
 
 def func1(x: Array[int, str, str, float], y: Array[()]):
@@ -80,9 +77,8 @@ def func2(p1: tuple[str, int], p2: list[str]):
     v7 = Array(1, *p1, "")
     reveal_type(v7, expected_text="Array[int, str, int, str]")
 
-    # This should generate an error because open-ended
-    # tuple types should not be allowed.
     v8 = Array(*p2)
+    reveal_type(v8, expected_text="Array[*tuple[str, ...]]")
 
 
 def func3(x: Array[Unpack[_Xs]]) -> Array[Unpack[_Xs]]:
@@ -91,17 +87,14 @@ def func3(x: Array[Unpack[_Xs]]) -> Array[Unpack[_Xs]]:
 
 
 @overload
-def func4(signal: Array[*_Xs], *args: *_Xs) -> None:
-    ...
+def func4(signal: Array[*_Xs], *args: *_Xs) -> None: ...
 
 
 @overload
-def func4(signal: str, *args: Any) -> None:
-    ...
+def func4(signal: str, *args: Any) -> None: ...
 
 
-def func4(signal: Array[*_Xs] | str, *args: *_Xs) -> None:
-    ...
+def func4(signal: Array[*_Xs] | str, *args: *_Xs) -> None: ...
 
 
 def func5(a1: Array[Literal["a", "b"]], a2: Array[Literal["a"], Literal["b"]]):

--- a/packages/pyright-internal/src/tests/typeEvaluator6.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator6.test.ts
@@ -223,7 +223,7 @@ test('TypeVarTuple3', () => {
 
     configOptions.defaultPythonVersion = pythonVersion3_11;
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['typeVarTuple3.py'], configOptions);
-    TestUtils.validateResults(analysisResults, 5);
+    TestUtils.validateResults(analysisResults, 4);
 });
 
 test('TypeVarTuple4', () => {


### PR DESCRIPTION
…e argument expression supplies the objects for an `*args` parameter that is annotated with an unpacked TypeVarTuple. This addresses #9980.