### PR TITLE
Make sure full source text doesn't kept alive in memory

### DIFF
--- a/packages/pyright-internal/src/common/core.ts
+++ b/packages/pyright-internal/src/common/core.ts
@@ -187,6 +187,16 @@ export function containsOnlyWhitespace(text: string, span?: TextRange) {
     return /^\s*$/.test(text);
 }
 
+export function cloneStr(str: string): string {
+    // Ensure we get a copy of the string that is not shared with the original string.
+    // Node.js has an internal optimization where it uses sliced strings for `substring`, `slice`, `substr`
+    // when it deems appropriate. Most of the time, this optimization is beneficial, but in this case, we want
+    // to ensure we get a copy of the string to prevent the original string from being retained in memory.
+    // For example, the import resolution cache in importResolver might hold onto the full original file content
+    // because seemingly innocent the import name  (e.g., `foo` in `import foo`) is in the cache.
+    return Buffer.from(str, 'utf8').toString('utf8');
+}
+
 export namespace Disposable {
     export function is(value: any): value is { dispose(): void } {
         return value && typeof value.dispose === 'function';

--- a/packages/pyright-internal/src/parser/tokenizer.ts
+++ b/packages/pyright-internal/src/parser/tokenizer.ts
@@ -13,6 +13,7 @@
 import { isWhitespace } from '../analyzer/parseTreeUtils';
 import { IPythonMode } from '../analyzer/sourceFile';
 import { Char } from '../common/charCodes';
+import { cloneStr } from '../common/core';
 import { TextRange } from '../common/textRange';
 import { TextRangeCollection } from '../common/textRangeCollection';
 import {
@@ -888,7 +889,7 @@ export class Tokenizer {
                     KeywordToken.create(start, this._cs.position - start, _keywords.get(value)!, this._getComments())
                 );
             } else {
-                this._tokens.push(IdentifierToken.create(start, this._cs.position - start, value, this._getComments()));
+                this._tokens.push(IdentifierToken.create(start, this._cs.position - start, cloneStr(value), this._getComments()));
             }
             return true;
         }
@@ -1346,7 +1347,7 @@ export class Tokenizer {
             if (endTrimmed.length > 0) {
                 commentRules.push({
                     range: { start: currentOffset, length: endTrimmed.length },
-                    text: endTrimmed,
+                    text: cloneStr(endTrimmed),
                 });
             }
 

--- a/packages/pyright-internal/src/parser/tokenizer.ts
+++ b/packages/pyright-internal/src/parser/tokenizer.ts
@@ -889,7 +889,9 @@ export class Tokenizer {
                     KeywordToken.create(start, this._cs.position - start, _keywords.get(value)!, this._getComments())
                 );
             } else {
-                this._tokens.push(IdentifierToken.create(start, this._cs.position - start, cloneStr(value), this._getComments()));
+                this._tokens.push(
+                    IdentifierToken.create(start, this._cs.position - start, cloneStr(value), this._getComments())
+                );
             }
             return true;
         }


### PR DESCRIPTION
Node.js’s V8 has a string optimization that we can't control, where it uses a *sliced string* for `substring`, `slice`, `substr`, etc., if it deems appropriate, as shown below.  

![image](https://github.com/user-attachments/assets/49f24fa4-9b42-40bb-8297-3d78ba7fa063)

![image](https://github.com/user-attachments/assets/bd633eee-daee-486e-9dad-7caae4674bee)

![image](https://github.com/user-attachments/assets/da50b582-4fba-4e18-982c-0f71608fb01e)

This means that the original text from which the *sliced string* is created will remain in memory until all *sliced string* are garbage collected.  

This optimization is usually beneficial, but in some cases, it keeps the original text in memory unnecessarily. For example, in `aws-cdk`, the `import resolver`'s cache can cause `13MB` of source text to remain in memory.  

This PR implements a `targeted fix` to ensure that new strings are created for cases where they are frequently used in long-term caches (e.g., identifiers or rule names in `ignore` comments).  

Here is the memory usage before the change:  

![image](https://github.com/user-attachments/assets/63f64038-4a4d-42fd-b7f6-044d5cd063b9)

And here is the memory usage after the change: 
![image](https://github.com/user-attachments/assets/5b2e9551-3501-496c-8542-1b7ebb518583)

Approximately a **200MB reduction**.  

The memory savings come from two areas:  

1. The `import resolver cache` no longer indirectly holds onto the *original text* through *sliced strings*.  
2. `Rule names` in the `source file` no longer retain the *original text* in memory even after calling `drop parse tree/binding info`.  

Previously, due to *sliced strings*, nearly the entire source text (either through references in the import resolver cache or heavy use of `ignore` comments in `aws-cdk`) remained in memory.  

There are other places, such as the `symbol table`, but since its lifetime typically matches that of the source text, it doesn’t cause the text to remain in memory unnecessarily.

That said, this fix is highly specific to the implementation. Unfortunately, there’s no simple way to address it universally. The only general solution would be to ensure that any text from the source file used in the cache (aside from the two cases I specifically fixed) is cloned using `cloneStr` rather than directly referencing the original text.

There may be other instances of this issue, but for now, these two cases are the most evident.

The reason I didn’t clone every string that would be exposed through a token or parse node is that slicing is much cheaper than creating a new string. So there’s a trade-off. The two cases I fixed are small enough that their overhead doesn’t show up in CPU profiling.

By the way, it also seems that we’re not the only ones facing this problem—others have reported the same issue.

https://github.com/nodejs/help/issues/711


