### PR TITLE
Don't use CFS with branches from forks

### DIFF
--- a/.github/actions/cfs-npm-install/action.yml
+++ b/.github/actions/cfs-npm-install/action.yml
@@ -1,7 +1,7 @@
 # Does an npm install using our private Azure Artifacts registry which requires OIDC authentication.
 # Workflows that use this action must add the id-token: write permission.
 
-name: npm install via CFS
+name: npm install (CFS)
 
 on:
   workflow_call:
@@ -43,6 +43,8 @@ runs:
       with:
         working-directory: packages/vscode-pyright
         token: ${{ steps.npm-auth.outputs.token }}
+
+    - uses: ./.github/actions/cfs-npm-cache
 
     - run: npm run install:all
       shell: bash

--- a/.github/actions/choose-npm-install/action.yml
+++ b/.github/actions/choose-npm-install/action.yml
@@ -1,0 +1,19 @@
+# Accessing the CFS feed requires OIDC authentication which is not allowed on branches from forks.
+# https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication#permissions-for-the-github_token
+# This action decides whether to use CFS based on the source of the branch in play.
+
+name: npm install (consider using CFS)
+
+on:
+  workflow_call:
+
+runs:
+  using: composite
+  steps:
+    - name: CFS npm install
+      if: github.event.pull_request.head.repo.fork != true
+      uses: ./.github/actions/cfs-npm-install
+
+    - name: Standard npm install
+      if: github.event.pull_request.head.repo.fork == true
+      uses: ./.github/actions/standard-npm-install

--- a/.github/actions/standard-npm-install/action.yml
+++ b/.github/actions/standard-npm-install/action.yml
@@ -1,0 +1,26 @@
+# Standard npm install using the public npm registry.
+
+name: npm install (public registry)
+
+on:
+  workflow_call:
+
+runs:
+  using: composite
+  steps:
+    - name: Get npm cache directory
+      id: npm-cache
+      shell: bash
+      run: |
+        echo "dir=$(npm config get cache)" >> $GITHUB_OUTPUT
+
+    - uses: actions/cache@v4
+      with:
+        path: ${{ steps.npm-cache.outputs.dir }}
+        key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+        restore-keys: |
+          ${{ runner.os }}-node-
+
+    - name: Standard npm install
+      shell: bash
+      run: npm run install:all

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -168,8 +168,7 @@ jobs:
         with:
           node-version: ${{ env.NODE_VERSION }}
 
-      - uses: ./.github/actions/cfs-npm-cache
-      - uses: ./.github/actions/cfs-npm-install
+      - uses: ./.github/actions/choose-npm-install
 
       - run: npm publish --dry-run
         working-directory: packages/pyright


### PR DESCRIPTION
For security reasons the `id-token` permission for GitHub Actions can never be any value other than `none` when running against a branch from a fork. This is to prevent untrusted users from modifying one of our action YML files in a PR to do something nefarious using our service principal's credentials.

HeeJae was the first person to submit a PR from a fork since I [enabled CFS in validation builds](https://github.com/microsoft/pyright/pull/9837) and the build was consistently failing on [that PR](https://github.com/microsoft/pyright/pull/9993) complaining that the `ACTIONS_ID_TOKEN_REQUEST_URL` environment variable wasn't set which implied that `id-token: write` permission was not granted.

I've modified the npm install logic for validation builds to only use CFS if the source branch is not from a fork. For fork branches it does a standard install from the public registry. This means that you'll only get failures from CFS in CI builds and branches in `microsoft/pyrx` (which implies they were created by trusted admins).

I also moved the usage of `cfs-npm-cache` to be after the `.npmrc` files are generated in `cfs-npm-install` since the cache uses the hash of the `.npmrc` files as part of its key. This is unrelated, but was definitely wrong.