### PR TITLE
DO NOT REVIEW -- Testing validation workflow (2)

### DIFF
--- a/.github/actions/cfs-npm-install/action.yml
+++ b/.github/actions/cfs-npm-install/action.yml
@@ -1,7 +1,7 @@
 # Does an npm install using our private Azure Artifacts registry which requires OIDC authentication.
 # Workflows that use this action must add the id-token: write permission.
 
-name: npm install via CFS
+name: npm install (CFS)
 
 on:
   workflow_call:
@@ -43,6 +43,8 @@ runs:
       with:
         working-directory: packages/vscode-pyright
         token: ${{ steps.npm-auth.outputs.token }}
+
+    - uses: ./.github/actions/cfs-npm-cache
 
     - run: npm run install:all
       shell: bash

--- a/.github/actions/choose-npm-install/action.yml
+++ b/.github/actions/choose-npm-install/action.yml
@@ -1,0 +1,19 @@
+# Accessing the CFS feed requires OIDC authentication which is not allowed on branches from forks.
+# https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication#permissions-for-the-github_token
+# This action decides whether to use CFS based on the source of the branch in play.
+
+name: npm install (consider using CFS)
+
+on:
+  workflow_call:
+
+runs:
+  using: composite
+  steps:
+    - name: CFS npm install
+      if: github.event.pull_request.head.repo.fork != true
+      uses: ./.github/actions/cfs-npm-install
+
+    - name: Standard npm install
+      if: github.event.pull_request.head.repo.fork == true
+      uses: ./.github/actions/standard-npm-install

--- a/.github/actions/standard-npm-install/action.yml
+++ b/.github/actions/standard-npm-install/action.yml
@@ -1,0 +1,26 @@
+# Standard npm install using the public npm registry.
+
+name: npm install (public registry)
+
+on:
+  workflow_call:
+
+runs:
+  using: composite
+  steps:
+    - name: Get npm cache directory
+      id: npm-cache
+      shell: bash
+      run: |
+        echo "dir=$(npm config get cache)" >> $GITHUB_OUTPUT
+
+    - uses: actions/cache@v4
+      with:
+        path: ${{ steps.npm-cache.outputs.dir }}
+        key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+        restore-keys: |
+          ${{ runner.os }}-node-
+
+    - name: Standard npm install
+      shell: bash
+      run: npm run install:all

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -168,8 +168,7 @@ jobs:
         with:
           node-version: ${{ env.NODE_VERSION }}
 
-      - uses: ./.github/actions/cfs-npm-cache
-      - uses: ./.github/actions/cfs-npm-install
+      - uses: ./.github/actions/choose-npm-install
 
       - run: npm publish --dry-run
         working-directory: packages/pyright


### PR DESCRIPTION
Testing a theory. I noticed that despite the validation build failing consistently on [HeeJae's PR](https://github.com/microsoft/pyright/pull/9993), when it ran on main after he merged the PR, it passed. I also noticed that the validation builds for all of Eric's recent PRs (which also passed) were from `microsoft/pyright` branches rather than branches from his fork. So perhaps the failure only occurs when running on branches from forks. The PR where I added CFS authentication was also from an upstream (rather than fork) branch -- https://github.com/microsoft/pyright/pull/9837.

This test PR is based on a branch that I pushed to `microsoft/pyright` rather than my fork.