### PR TITLE
Fix problem with partial stub service not being part of Pyright CLI

### DIFF
--- a/packages/pyright-internal/src/analyzer/importResolver.ts
+++ b/packages/pyright-internal/src/analyzer/importResolver.ts
@@ -16,7 +16,6 @@ import { Host } from '../common/host';
 import { stubsSuffix } from '../common/pathConsts';
 import { stripFileExtension } from '../common/pathUtils';
 import { PythonVersion, pythonVersion3_0 } from '../common/pythonVersion';
-import { ServiceKeys } from '../common/serviceKeys';
 import { ServiceProvider } from '../common/serviceProvider';
 import * as StringUtils from '../common/stringUtils';
 import { equateStringsCaseInsensitive } from '../common/stringUtils';
@@ -125,7 +124,7 @@ export class ImportResolver {
     }
 
     get partialStubs() {
-        return this.serviceProvider.tryGet(ServiceKeys.partialStubs);
+        return this.serviceProvider.partialStubs();
     }
 
     static isSupportedImportSourceFile(uri: Uri) {

--- a/packages/pyright-internal/src/common/serviceProviderExtensions.ts
+++ b/packages/pyright-internal/src/common/serviceProviderExtensions.ts
@@ -8,16 +8,16 @@
 import { CacheManager } from '../analyzer/cacheManager';
 import { ISourceFileFactory } from '../analyzer/programTypes';
 import { IPythonMode, SourceFile, SourceFileEditMode } from '../analyzer/sourceFile';
-import { ServiceKeys } from './serviceKeys';
+import { PartialStubService, SupportPartialStubs } from '../partialStubService';
 import { CaseSensitivityDetector } from './caseSensitivityDetector';
 import { ConsoleInterface } from './console';
+import { DocStringService, PyrightDocStringService } from './docStringService';
 import { FileSystem, TempFile } from './fileSystem';
+import { CommandService, WindowService } from './languageServerInterface';
 import { LogTracker } from './logTracker';
+import { ServiceKeys } from './serviceKeys';
 import { ServiceProvider } from './serviceProvider';
 import { Uri } from './uri/uri';
-import { DocStringService, PyrightDocStringService } from './docStringService';
-import { CommandService, WindowService } from './languageServerInterface';
-import { SupportPartialStubs } from '../partialStubService';
 
 declare module './serviceProvider' {
     interface ServiceProvider {
@@ -77,6 +77,10 @@ ServiceProvider.prototype.console = function () {
     return this.get(ServiceKeys.console);
 };
 ServiceProvider.prototype.partialStubs = function () {
+    const result = this.tryGet(ServiceKeys.partialStubs);
+    if (!result) {
+        this.add(ServiceKeys.partialStubs, new PartialStubService(this.fs()));
+    }
     return this.get(ServiceKeys.partialStubs);
 };
 ServiceProvider.prototype.tmp = function () {


### PR DESCRIPTION
A recent push from Pylance broke partial stub support in the pyright CLI.

The root cause we separated out the partial stub support into a separate class (we wanted to use the linking of directories in a file system for other things too), but we didn't ensure that the partial stub support was always available. 

Addresses: https://github.com/microsoft/pyright/issues/10018