### PR TITLE
Added additional special-casing to `x in y` type guard logic to handl…

### DIFF
--- a/packages/pyright-internal/src/analyzer/typeGuards.ts
+++ b/packages/pyright-internal/src/analyzer/typeGuards.ts
@@ -76,6 +76,7 @@ import {
     getTypeVarScopeIds,
     getUnknownTypeForCallable,
     isInstantiableMetaclass,
+    isLiteralLikeType,
     isLiteralType,
     isLiteralTypeOrUnion,
     isMaybeDescriptorInstance,
@@ -2074,7 +2075,7 @@ export function narrowTypeForContainerElementType(evaluator: TypeEvaluator, refe
             // If one of the two types is a literal, we can narrow to that type.
             if (
                 isClassInstance(elementSubtype) &&
-                (isLiteralType(elementSubtype) || isNoneInstance(elementSubtype)) &&
+                (isLiteralLikeType(elementSubtype) || isNoneInstance(elementSubtype)) &&
                 evaluator.assignType(referenceSubtype, elementSubtype)
             ) {
                 return stripTypeForm(addConditionToType(elementSubtype, referenceSubtype.props?.condition));
@@ -2082,7 +2083,7 @@ export function narrowTypeForContainerElementType(evaluator: TypeEvaluator, refe
 
             if (
                 isClassInstance(referenceSubtype) &&
-                (isLiteralType(referenceSubtype) || isNoneInstance(referenceSubtype)) &&
+                (isLiteralLikeType(referenceSubtype) || isNoneInstance(referenceSubtype)) &&
                 evaluator.assignType(elementSubtype, referenceSubtype)
             ) {
                 return stripTypeForm(addConditionToType(referenceSubtype, elementSubtype.props?.condition));

--- a/packages/pyright-internal/src/tests/samples/typeNarrowingIn1.py
+++ b/packages/pyright-internal/src/tests/samples/typeNarrowingIn1.py
@@ -1,6 +1,15 @@
 # This sample tests type narrowing for the "in" operator.
 
-from typing import Any, Callable, Generic, Literal, ParamSpec, TypeVar, TypedDict
+from typing import (
+    Any,
+    Callable,
+    Generic,
+    Literal,
+    LiteralString,
+    ParamSpec,
+    TypeVar,
+    TypedDict,
+)
 import random
 
 
@@ -204,3 +213,9 @@ def func21(x: int, y: list[Literal[0, True]]):
 def func22(x: bool, y: list[Literal[0, 1]]):
     if x in y:
         reveal_type(x, expected_text="bool")
+
+
+def func23[T: LiteralString](x: str, y: tuple[T, ...]) -> T:
+    if x in y:
+        return x
+    raise ValueError(f"Invalid value {x!r}")


### PR DESCRIPTION
…e `LiteralString` values. This addresses #10026.