### PR TITLE
Partially eliminated inconsistent error reporting when calling a func…

### DIFF
--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -11571,7 +11571,7 @@ export function createTypeEvaluator(
                             if (
                                 defaultArgType &&
                                 !isEllipsisType(defaultArgType) &&
-                                requiresSpecialization(paramInfo.declaredType)
+                                requiresSpecialization(paramInfo.declaredType, {ignorePseudoGeneric: true})
                             ) {
                                 validateArgTypeParams.push({
                                     paramCategory: param.category,


### PR DESCRIPTION
…tion with a default argument that is not assignable to the declared parameter type. An error will still be reported in the case where the declared parameter type includes an unsolved type variable in most cases, but it will no longer be reported if the unsolved type variable is due to a pseudo-generic class. This addresses #9901.