### PR TITLE
Mark `Pyright-Release` pipeline as a "release job"

### DIFF
--- a/build/azuredevops/azure-pipelines-release.yml
+++ b/build/azuredevops/azure-pipelines-release.yml
@@ -128,7 +128,6 @@ extends:
                   targetPath: $(Pipeline.Workspace)/$(ARTIFACT_NAME_VSIX)
             steps:
               - checkout: none
-              - download: current
               - task: GitHubRelease@1 #https://learn.microsoft.com/en-us/azure/devops/pipelines/tasks/reference/github-release-v1?view=azure-pipelines
                 displayName: 'Create GitHub Release'
                 inputs:

--- a/build/azuredevops/azure-pipelines-release.yml
+++ b/build/azuredevops/azure-pipelines-release.yml
@@ -23,7 +23,7 @@ extends:
   parameters:
     sdl:
       codeSignValidation:
-        enabled: true
+        enabled: false
         additionalTargetsGlobPattern: -|**/gdn-vscode-pyright.vsix/**
       codeql:
         compiled:
@@ -45,7 +45,7 @@ extends:
             templateContext:
               mb:
                 signing:
-                  enabled: true
+                  enabled: false
                   signType: 'real'
               outputs:
                 - output: pipelineArtifact
@@ -106,39 +106,11 @@ extends:
                   restoreSolution: '$(Build.SourcesDirectory)/packages/vscode-pyright/packages.config'
                   restoreDirectory: '$(Build.SourcesDirectory)/packages/vscode-pyright/packages'
 
-              - task: MSBuild@1
-                displayName: 'Sign binaries'
-                inputs:
-                  solution: 'packages/vscode-pyright/sign.proj'
-                  msbuildArguments: '/verbosity:diagnostic /p:SignType=real'
-
-              - task: PowerShell@2
-                displayName: 'Compare extension.manifest and extension.signature.p7s'
-                inputs:
-                  targetType: 'inline'
-                  script: |
-                    $manifestPath = "$(Build.SourcesDirectory)\packages\vscode-pyright\extension.manifest"
-                    $signaturePath = "$(Build.SourcesDirectory)\packages\vscode-pyright\extension.signature.p7s"
-                    $compareResult = Compare-Object (Get-Content $manifestPath) (Get-Content $signaturePath)
-                    if ($compareResult -eq $null) {
-                      Write-Error "Files are identical. Failing the build."
-                      exit 1
-                    } else {
-                      Write-Output "Files are different."
-                    }
-
               - task: CopyFiles@2
                 displayName: 'Copy extension.manifest'
                 inputs:
                   SourceFolder: 'packages/vscode-pyright'
                   Contents: 'extension.manifest'
-                  TargetFolder: build_output
-
-              - task: CopyFiles@2
-                displayName: 'Copy extension.signature.p7s'
-                inputs:
-                  SourceFolder: 'packages/vscode-pyright'
-                  Contents: 'extension.signature.p7s'
                   TargetFolder: build_output
 
       - stage: CreateRelease
@@ -180,39 +152,3 @@ extends:
                   notifyUsers: 'plseng@microsoft.com,eric@traut.com'
                   instructions: 'In the next 2 hours please test the latest draft release of Pyright, then Publish the release in GitHub.'
                   onTimeout: 'reject' # require sign-off
-
-      - stage: PublishExtension
-        dependsOn:
-          - WaitForValidation
-        jobs:
-          - job: publish_extension
-            displayName: Publish extension to marketplace
-            steps:
-              - checkout: none
-              - task: NodeTool@0
-                inputs:
-                  versionSpec: 18.x
-              - task: DownloadPipelineArtifact@2
-                displayName: 'Download Artifacts from Validation Job'
-                inputs:
-                  buildType: 'current'
-                  artifactName: '$(ARTIFACT_NAME_VSIX)'
-                  targetPath: '$(System.ArtifactsDirectory)'
-              # https://code.visualstudio.com/api/working-with-extensions/publishing-extension
-              # Install dependencies and VS Code Extension Manager (vsce >= v2.26.1 needed)
-              - script: |
-                  npm install -g @vscode/vsce
-                displayName: 'Install vsce and dependencies'
-              # https://code.visualstudio.com/api/working-with-extensions/publishing-extension#get-a-personal-access-token
-              # Publish to Marketplace
-              # see. stackoverflow.com/collectives/ci-cd/articles/76873787/publish-azure-devops-extensions-using-azure-workload-identity
-              # az rest -u https://app.vssps.visualstudio.com/_apis/profile/profiles/me --resource 499b84ac-1321-427f-aa17-267ca6975798
-              - task: AzureCLI@2
-                displayName: 'Publishing with Managed Identity'
-                inputs:
-                  azureSubscription: PyrightPublishPipelineSecureConnectionWithManagedIdentity
-                  scriptType: 'pscore'
-                  scriptLocation: 'inlineScript'
-                  inlineScript: |
-                    $aadToken = az account get-access-token --query accessToken --resource 499b84ac-1321-427f-aa17-267ca6975798 -o tsv
-                    vsce publish --pat $aadToken --packagePath $(System.ArtifactsDirectory)/$(VSIX_NAME) --noVerify --manifestPath $(System.ArtifactsDirectory)/extension.manifest --signaturePath $(System.ArtifactsDirectory)/extension.signature.p7s

--- a/build/azuredevops/azure-pipelines-release.yml
+++ b/build/azuredevops/azure-pipelines-release.yml
@@ -23,7 +23,7 @@ extends:
   parameters:
     sdl:
       codeSignValidation:
-        enabled: false
+        enabled: true
         additionalTargetsGlobPattern: -|**/gdn-vscode-pyright.vsix/**
       codeql:
         compiled:
@@ -45,7 +45,7 @@ extends:
             templateContext:
               mb:
                 signing:
-                  enabled: false
+                  enabled: true
                   signType: 'real'
               outputs:
                 - output: pipelineArtifact
@@ -106,11 +106,39 @@ extends:
                   restoreSolution: '$(Build.SourcesDirectory)/packages/vscode-pyright/packages.config'
                   restoreDirectory: '$(Build.SourcesDirectory)/packages/vscode-pyright/packages'
 
+              - task: MSBuild@1
+                displayName: 'Sign binaries'
+                inputs:
+                  solution: 'packages/vscode-pyright/sign.proj'
+                  msbuildArguments: '/verbosity:diagnostic /p:SignType=real'
+
+              - task: PowerShell@2
+                displayName: 'Compare extension.manifest and extension.signature.p7s'
+                inputs:
+                  targetType: 'inline'
+                  script: |
+                    $manifestPath = "$(Build.SourcesDirectory)\packages\vscode-pyright\extension.manifest"
+                    $signaturePath = "$(Build.SourcesDirectory)\packages\vscode-pyright\extension.signature.p7s"
+                    $compareResult = Compare-Object (Get-Content $manifestPath) (Get-Content $signaturePath)
+                    if ($compareResult -eq $null) {
+                      Write-Error "Files are identical. Failing the build."
+                      exit 1
+                    } else {
+                      Write-Output "Files are different."
+                    }
+
               - task: CopyFiles@2
                 displayName: 'Copy extension.manifest'
                 inputs:
                   SourceFolder: 'packages/vscode-pyright'
                   Contents: 'extension.manifest'
+                  TargetFolder: build_output
+
+              - task: CopyFiles@2
+                displayName: 'Copy extension.signature.p7s'
+                inputs:
+                  SourceFolder: 'packages/vscode-pyright'
+                  Contents: 'extension.signature.p7s'
                   TargetFolder: build_output
 
       - stage: CreateRelease
@@ -158,3 +186,39 @@ extends:
                   notifyUsers: 'plseng@microsoft.com,eric@traut.com'
                   instructions: 'In the next 2 hours please test the latest draft release of Pyright, then Publish the release in GitHub.'
                   onTimeout: 'reject' # require sign-off
+
+      - stage: PublishExtension
+        dependsOn:
+          - WaitForValidation
+        jobs:
+          - job: publish_extension
+            displayName: Publish extension to marketplace
+            steps:
+              - checkout: none
+              - task: NodeTool@0
+                inputs:
+                  versionSpec: 18.x
+              - task: DownloadPipelineArtifact@2
+                displayName: 'Download Artifacts from Validation Job'
+                inputs:
+                  buildType: 'current'
+                  artifactName: '$(ARTIFACT_NAME_VSIX)'
+                  targetPath: '$(System.ArtifactsDirectory)'
+              # https://code.visualstudio.com/api/working-with-extensions/publishing-extension
+              # Install dependencies and VS Code Extension Manager (vsce >= v2.26.1 needed)
+              - script: |
+                  npm install -g @vscode/vsce
+                displayName: 'Install vsce and dependencies'
+              # https://code.visualstudio.com/api/working-with-extensions/publishing-extension#get-a-personal-access-token
+              # Publish to Marketplace
+              # see. stackoverflow.com/collectives/ci-cd/articles/76873787/publish-azure-devops-extensions-using-azure-workload-identity
+              # az rest -u https://app.vssps.visualstudio.com/_apis/profile/profiles/me --resource 499b84ac-1321-427f-aa17-267ca6975798
+              - task: AzureCLI@2
+                displayName: 'Publishing with Managed Identity'
+                inputs:
+                  azureSubscription: PyrightPublishPipelineSecureConnectionWithManagedIdentity
+                  scriptType: 'pscore'
+                  scriptLocation: 'inlineScript'
+                  inlineScript: |
+                    $aadToken = az account get-access-token --query accessToken --resource 499b84ac-1321-427f-aa17-267ca6975798 -o tsv
+                    vsce publish --pat $aadToken --packagePath $(System.ArtifactsDirectory)/$(VSIX_NAME) --noVerify --manifestPath $(System.ArtifactsDirectory)/extension.manifest --signaturePath $(System.ArtifactsDirectory)/extension.signature.p7s

--- a/build/azuredevops/azure-pipelines-release.yml
+++ b/build/azuredevops/azure-pipelines-release.yml
@@ -162,6 +162,10 @@ extends:
                   title: 'Published $(Build.SourceBranchName)'
                   assets: |
                     $(Pipeline.Workspace)/$(ARTIFACT_NAME_VSIX)/$(VSIX_NAME)
+              - script: |
+                  echo "Just want to test through GitHub Release creation"
+                  exit 1
+                displayName: 'Force job failure'
       - stage: WaitForValidation
         dependsOn:
           - CreateRelease

--- a/build/azuredevops/azure-pipelines-release.yml
+++ b/build/azuredevops/azure-pipelines-release.yml
@@ -119,6 +119,9 @@ extends:
         jobs:
           - job: create_release
             displayName: Create GitHub Release
+            templateContext:
+              type: releaseJob # This makes a job a release job
+              isProduction: true # Indicates a production release
             steps:
               - checkout: none
               - download: current

--- a/build/azuredevops/azure-pipelines-release.yml
+++ b/build/azuredevops/azure-pipelines-release.yml
@@ -120,8 +120,12 @@ extends:
           - job: create_release
             displayName: Create GitHub Release
             templateContext:
-              type: releaseJob # This makes a job a release job
-              isProduction: true # Indicates a production release
+              type: releaseJob
+              isProduction: true
+              inputs:
+                - input: pipelineArtifact
+                  artifactName: $(ARTIFACT_NAME_VSIX)
+                  targetPath: $(Pipeline.Workspace)/$(ARTIFACT_NAME_VSIX)
             steps:
               - checkout: none
               - download: current

--- a/build/azuredevops/azure-pipelines-release.yml
+++ b/build/azuredevops/azure-pipelines-release.yml
@@ -168,10 +168,6 @@ extends:
                   title: 'Published $(Build.SourceBranchName)'
                   assets: |
                     $(Pipeline.Workspace)/$(ARTIFACT_NAME_VSIX)/$(VSIX_NAME)
-              - script: |
-                  echo "Just want to test through GitHub Release creation"
-                  exit 1
-                displayName: 'Force job failure'
       - stage: WaitForValidation
         dependsOn:
           - CreateRelease

--- a/build/azuredevops/azure-pipelines-release.yml
+++ b/build/azuredevops/azure-pipelines-release.yml
@@ -125,8 +125,8 @@ extends:
               - task: GitHubRelease@1 #https://learn.microsoft.com/en-us/azure/devops/pipelines/tasks/reference/github-release-v1?view=azure-pipelines
                 displayName: 'Create GitHub Release'
                 inputs:
-                  gitHubConnection: 'Github-Pylance' # The name of the GitHub service connection
-                  repositoryName: 'microsoft/pyright' # The name of your GitHub repository
+                  gitHubConnection: 'Github-sarif-tools' # The name of the GitHub service connection
+                  repositoryName: 'debonte/pyright' # The name of your GitHub repository
                   action: 'create'
                   isDraft: true
                   isPreRelease: false

--- a/build/azuredevops/azure-pipelines-release.yml
+++ b/build/azuredevops/azure-pipelines-release.yml
@@ -131,8 +131,8 @@ extends:
               - task: GitHubRelease@1 #https://learn.microsoft.com/en-us/azure/devops/pipelines/tasks/reference/github-release-v1?view=azure-pipelines
                 displayName: 'Create GitHub Release'
                 inputs:
-                  gitHubConnection: 'Github-sarif-tools' # The name of the GitHub service connection
-                  repositoryName: 'debonte/pyright' # The name of your GitHub repository
+                  gitHubConnection: 'Github-Pylance' # The name of the GitHub service connection
+                  repositoryName: 'microsoft/pyright' # The name of your GitHub repository
                   action: 'create'
                   isDraft: true
                   isPreRelease: false

--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -11571,7 +11571,7 @@ export function createTypeEvaluator(
                             if (
                                 defaultArgType &&
                                 !isEllipsisType(defaultArgType) &&
-                                requiresSpecialization(paramInfo.declaredType, {ignorePseudoGeneric: true})
+                                requiresSpecialization(paramInfo.declaredType, { ignorePseudoGeneric: true })
                             ) {
                                 validateArgTypeParams.push({
                                     paramCategory: param.category,


### PR DESCRIPTION
Recent Pyright-Release pipeline runs show the following error (ex. [1.1.396](https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=11104436&view=results)) which needed to be fixed by the end of March:

```##[error]1ES PT Non-Blocking Error: Job 'create_release' uses the release tasks ["GitHubRelease@1"] but is not marked as a release job. Release tasks will soon be disallowed outside of release jobs. This is currently a non-blocking error (does not break pipeline runs), and will be turned as blocking error by the end of Mar 2025. More details: https://aka.ms/1espt/release-tasks-enforcement```

After adding the required `releaseJob` metadata I was getting the following error:

```/v1/Steps/UserProvidedReleaseSteps.yml@1ESPipelineTemplates (Line: 265, Col: 7): Unexpected value 'step `-download: artifact` is not allowed. Please use `pipelineArtifact` input or `1ES.DownloadPipelineArtifact@1` task instead. See https://aka.ms/1espt/inputs for more details.'```

...which I fixed by switching from the AzDO [built-in download step](https://learn.microsoft.com/en-us/azure/devops/pipelines/yaml-schema/steps-download?view=azure-pipelines) to the 1ES template's [pipeline artifacts](https://aka.ms/1espt/inputs).

This closely matches Pylance's release pipeline.