### PR TITLE
Implement support for pull diagnostics in Pyright

### DIFF
--- a/packages/pyright-internal/src/languageServerBase.ts
+++ b/packages/pyright-internal/src/languageServerBase.ts
@@ -563,10 +563,12 @@ export abstract class LanguageServerBase implements LanguageServerInterface, Dis
             );
         this.client.hasPullDiagnosticsCapability =
             !!capabilities.textDocument?.diagnostic?.dynamicRegistration &&
-            initializationOptions?.diagnosticMode !== 'workspace';
+            initializationOptions?.diagnosticMode !== 'workspace' &&
+            initializationOptions?.disablePullDiagnostics !== true;
         this.client.hasPullRelatedInformationCapability =
             !!capabilities.textDocument?.diagnostic?.relatedInformation &&
-            initializationOptions?.diagnosticMode !== 'workspace';
+            initializationOptions?.diagnosticMode !== 'workspace' &&
+            initializationOptions?.disablePullDiagnostics !== true;
 
         // Create a service instance for each of the workspace folders.
         this.workspaceFactory.handleInitialize(params);

--- a/packages/pyright-internal/src/languageServerBase.ts
+++ b/packages/pyright-internal/src/languageServerBase.ts
@@ -1103,7 +1103,7 @@ export abstract class LanguageServerBase implements LanguageServerInterface, Dis
         let sourceFile = workspace.service.getSourceFile(uri);
         let diagnosticsVersion = sourceFile?.isCheckingRequired()
             ? UncomputedDiagnosticsVersion
-            : sourceFile?.getDiagnosticVersion() ?? UncomputedDiagnosticsVersion;
+            : sourceFile?.getDiagnosticVersion() ?? UncomputedDiagnosticsVersion - 1;
         const result: DocumentDiagnosticReport = {
             kind: 'full',
             resultId: sourceFile?.getDiagnosticVersion()?.toString(),

--- a/packages/pyright-internal/src/languageServerBase.ts
+++ b/packages/pyright-internal/src/languageServerBase.ts
@@ -1138,7 +1138,8 @@ export abstract class LanguageServerBase implements LanguageServerInterface, Dis
                     ? await workspace.service.getDiagnosticsForRange(uri, sourceFile.getRange(), token)
                     : [];
 
-                // If any text edits came in, make sure we reanalyze the file.
+                // If any text edits came in, make sure we reanalyze the file. Diagnostics version should be reset to zero
+                // if a text edit comes in.
                 const sourceFileAfter = workspace.service.getSourceFile(uri);
                 diagnosticsVersionAfter = sourceFileAfter?.getDiagnosticVersion() ?? UncomputedDiagnosticsVersion;
             }

--- a/packages/pyright-internal/src/languageServerBase.ts
+++ b/packages/pyright-internal/src/languageServerBase.ts
@@ -1148,7 +1148,7 @@ export abstract class LanguageServerBase implements LanguageServerInterface, Dis
                 (d) => d !== undefined
             ) as Diagnostic[];
 
-            result.resultId = diagnosticsVersion.toString();
+            result.resultId = diagnosticsVersionAfter.toString();
             result.items = lspDiagnostics;
         } else {
             (result as any).kind = 'unchanged';

--- a/packages/pyright-internal/src/languageServerBase.ts
+++ b/packages/pyright-internal/src/languageServerBase.ts
@@ -42,6 +42,8 @@ import {
     DidCloseTextDocumentParams,
     DidOpenTextDocumentParams,
     Disposable,
+    DocumentDiagnosticParams,
+    DocumentDiagnosticReport,
     DocumentHighlight,
     DocumentHighlightParams,
     DocumentSymbol,
@@ -50,6 +52,7 @@ import {
     HoverParams,
     InitializeParams,
     InitializeResult,
+    LSPObject,
     Location,
     MarkupKind,
     PrepareRenameParams,
@@ -57,18 +60,20 @@ import {
     ReferenceParams,
     RemoteWindow,
     RenameParams,
+    ResultProgressReporter,
     SignatureHelp,
     SignatureHelpParams,
     SymbolInformation,
     TextDocumentPositionParams,
     TextDocumentSyncKind,
     WorkDoneProgressReporter,
+    WorkspaceDiagnosticParams,
+    WorkspaceDocumentDiagnosticReport,
     WorkspaceEdit,
     WorkspaceFoldersChangeEvent,
     WorkspaceSymbol,
     WorkspaceSymbolParams,
 } from 'vscode-languageserver';
-import { ResultProgressReporter } from 'vscode-languageserver';
 
 import { TextDocument } from 'vscode-languageserver-textdocument';
 import { AnalysisResults } from './analyzer/analysis';
@@ -76,7 +81,7 @@ import { BackgroundAnalysisProgram, InvalidatedReason } from './analyzer/backgro
 import { ImportResolver } from './analyzer/importResolver';
 import { MaxAnalysisTime } from './analyzer/program';
 import { AnalyzerService, LibraryReanalysisTimeProvider, getNextServiceId } from './analyzer/service';
-import { IPythonMode } from './analyzer/sourceFile';
+import { IPythonMode, SourceFile } from './analyzer/sourceFile';
 import type { IBackgroundAnalysis } from './backgroundAnalysisBase';
 import { CommandResult } from './commands/commandResult';
 import { CancelAfter } from './common/cancellationUtils';
@@ -121,8 +126,10 @@ import { SignatureHelpProvider } from './languageService/signatureHelpProvider';
 import { WorkspaceSymbolProvider } from './languageService/workspaceSymbolProvider';
 import { Localizer, setLocaleOverride } from './localization/localize';
 import { ParseFileResults } from './parser/parser';
+import { ClientCapabilities, InitializationOptions } from './types';
 import { InitStatus, WellKnownWorkspaceKinds, Workspace, WorkspaceFactory } from './workspaceFactory';
-import { ClientCapabilities } from './types';
+
+const UncomputedDiagnosticsVersion = -1;
 
 export abstract class LanguageServerBase implements LanguageServerInterface, Disposable {
     // We support running only one "find all reference" at a time.
@@ -256,20 +263,26 @@ export abstract class LanguageServerBase implements LanguageServerInterface, Dis
         this.console.info(`Starting service instance "${name}"`);
 
         const serviceId = getNextServiceId(name);
-        const service = new AnalyzerService(name, this.serverOptions.serviceProvider, {
-            console: this.console,
-            hostFactory: this.createHost.bind(this),
-            importResolverFactory: this.createImportResolver.bind(this),
-            backgroundAnalysis: services
-                ? services.backgroundAnalysis
-                : this.createBackgroundAnalysis(serviceId, workspaceRoot),
-            maxAnalysisTime: this.serverOptions.maxAnalysisTimeInForeground,
-            backgroundAnalysisProgramFactory: this.createBackgroundAnalysisProgram.bind(this),
-            cancellationProvider: this.serverOptions.cancellationProvider,
-            libraryReanalysisTimeProvider,
-            serviceId,
-            fileSystem: services?.fs ?? this.serverOptions.serviceProvider.fs(),
-        });
+        const service = new AnalyzerService(
+            name,
+            this.serverOptions.serviceProvider,
+            {
+                console: this.console,
+                hostFactory: this.createHost.bind(this),
+                importResolverFactory: this.createImportResolver.bind(this),
+                backgroundAnalysis: services
+                    ? services.backgroundAnalysis
+                    : this.createBackgroundAnalysis(serviceId, workspaceRoot),
+                maxAnalysisTime: this.serverOptions.maxAnalysisTimeInForeground,
+                backgroundAnalysisProgramFactory: this.createBackgroundAnalysisProgram.bind(this),
+                cancellationProvider: this.serverOptions.cancellationProvider,
+                libraryReanalysisTimeProvider,
+                serviceId,
+                fileSystem: services?.fs ?? this.serverOptions.serviceProvider.fs(),
+                usingPullDiagnostics: this.client.hasPullDiagnosticsCapability,
+            },
+            this.connection
+        );
 
         service.setCompletionCallback((results) => this.onAnalysisCompletedHandler(service.fs, results));
         return service;
@@ -484,6 +497,10 @@ export abstract class LanguageServerBase implements LanguageServerInterface, Dis
         this.connection.onDidCloseTextDocument(async (params) => this.onDidCloseTextDocument(params));
         this.connection.onDidChangeWatchedFiles((params) => this.onDidChangeWatchedFiles(params));
 
+        this.connection.languages.diagnostics.on(async (params, token) => this.onDiagnostics(params, token));
+        this.connection.languages.diagnostics.onWorkspace(async (params, token) =>
+            this.onWorkspaceDiagnostics(params, token)
+        );
         this.connection.onExecuteCommand(async (params, token, reporter) =>
             this.onExecuteCommand(params, token, reporter)
         );
@@ -499,6 +516,7 @@ export abstract class LanguageServerBase implements LanguageServerInterface, Dis
             setLocaleOverride(params.locale);
         }
 
+        const initializationOptions = (params.initializationOptions ?? {}) as LSPObject & InitializationOptions;
         const capabilities = params.capabilities;
         this.client.hasConfigurationCapability = !!capabilities.workspace?.configuration;
         this.client.hasWatchFileCapability = !!capabilities.workspace?.didChangeWatchedFiles?.dynamicRegistration;
@@ -543,6 +561,12 @@ export abstract class LanguageServerBase implements LanguageServerInterface, Dis
             !!capabilities.textDocument?.completion?.completionItem?.resolveSupport?.properties.some(
                 (p) => p === 'additionalTextEdits'
             );
+        this.client.hasPullDiagnosticsCapability =
+            !!capabilities.textDocument?.diagnostic?.dynamicRegistration &&
+            initializationOptions?.diagnosticMode !== 'workspace';
+        this.client.hasPullRelatedInformationCapability =
+            !!capabilities.textDocument?.diagnostic?.relatedInformation &&
+            initializationOptions?.diagnosticMode !== 'workspace';
 
         // Create a service instance for each of the workspace folders.
         this.workspaceFactory.handleInitialize(params);
@@ -601,6 +625,15 @@ export abstract class LanguageServerBase implements LanguageServerInterface, Dis
                 },
             },
         };
+
+        if (this.client.hasPullDiagnosticsCapability) {
+            result.capabilities.diagnosticProvider = {
+                identifier: 'pyright',
+                documentSelector: null,
+                interFileDependencies: true,
+                workspaceDiagnostics: initializationOptions.diagnosticMode === 'workspace',
+            };
+        }
 
         return result;
     }
@@ -1061,6 +1094,85 @@ export abstract class LanguageServerBase implements LanguageServerInterface, Dis
         this.openFileMap.delete(uri.key);
     }
 
+    protected async onDiagnostics(params: DocumentDiagnosticParams, token: CancellationToken) {
+        const uri = this.convertLspUriStringToUri(params.textDocument.uri);
+        const workspace = await this.getWorkspaceForFile(uri);
+        let sourceFile = workspace.service.getSourceFile(uri);
+        let diagnosticsVersion = sourceFile?.isCheckingRequired()
+            ? UncomputedDiagnosticsVersion
+            : sourceFile?.getDiagnosticVersion() ?? UncomputedDiagnosticsVersion;
+        const result: DocumentDiagnosticReport = {
+            kind: 'full',
+            resultId: sourceFile?.getDiagnosticVersion()?.toString(),
+            items: [],
+        };
+        if (
+            workspace.disableLanguageServices ||
+            !canNavigateToFile(workspace.service.fs, uri) ||
+            token.isCancellationRequested
+        ) {
+            return result;
+        }
+
+        // Reanalyze the file if it's not up to date.
+        if (params.previousResultId !== diagnosticsVersion.toString() && sourceFile) {
+            let diagnosticsVersionAfter = UncomputedDiagnosticsVersion - 1; // Just has to be different
+            let serverDiagnostics: AnalyzerDiagnostic[] = [];
+
+            // Loop until we analyze the same version that we started with.
+            while (diagnosticsVersion !== diagnosticsVersionAfter && !token.isCancellationRequested) {
+                // Reset the version we're analyzing
+                sourceFile = workspace.service.getSourceFile(uri);
+                diagnosticsVersion = sourceFile?.getDiagnosticVersion() ?? UncomputedDiagnosticsVersion;
+
+                // Then reanalyze the file (this should go to the background thread so this thread can handle other requests).
+                await workspace.service.analyzeFile(uri, token);
+
+                // Then pick up the diagnostics created.
+                serverDiagnostics = sourceFile
+                    ? await workspace.service.getDiagnosticsForRange(uri, sourceFile.getRange(), token)
+                    : [];
+
+                // If any text edits came in, make sure we reanalyze the file.
+                const sourceFileAfter = workspace.service.getSourceFile(uri);
+                diagnosticsVersionAfter = sourceFileAfter?.getDiagnosticVersion() ?? UncomputedDiagnosticsVersion;
+            }
+
+            // Then convert the diagnostics to the LSP format.
+            const lspDiagnostics = this._convertDiagnostics(workspace.service.fs, serverDiagnostics).filter(
+                (d) => d !== undefined
+            ) as Diagnostic[];
+
+            result.resultId = diagnosticsVersion.toString();
+            result.items = lspDiagnostics;
+        } else {
+            (result as any).kind = 'unchanged';
+            result.resultId = diagnosticsVersion.toString();
+            delete (result as any).items;
+        }
+
+        return result;
+    }
+
+    protected async onWorkspaceDiagnostics(params: WorkspaceDiagnosticParams, token: CancellationToken) {
+        const workspaces = await this.getWorkspaces();
+        const promises: Promise<WorkspaceDocumentDiagnosticReport>[] = [];
+        workspaces.forEach((workspace) => {
+            if (!workspace.disableLanguageServices) {
+                const files = workspace.service.getOwnedFiles();
+                files.forEach((file) => {
+                    const sourceFile = workspace.service.getSourceFile(file)!;
+                    if (canNavigateToFile(workspace.service.fs, sourceFile.getUri())) {
+                        promises.push(this._getWorkspaceDocumentDiagnostics(params, sourceFile, workspace, token));
+                    }
+                });
+            }
+        });
+        return {
+            items: await Promise.all(promises),
+        };
+    }
+
     protected onDidChangeWatchedFiles(params: DidChangeWatchedFilesParams) {
         params.changes.forEach((change) => {
             const filePath = this.fs.realCasePath(this.convertLspUriStringToUri(change.uri));
@@ -1151,6 +1263,11 @@ export abstract class LanguageServerBase implements LanguageServerInterface, Dis
     }
 
     protected onAnalysisCompletedHandler(fs: FileSystem, results: AnalysisResults): void {
+        // If we're in pull mode, disregard any 'tracking' results. They're not necessary.
+        if (this.client.hasPullDiagnosticsCapability && results.reason === 'tracking') {
+            return;
+        }
+
         // Send the computed diagnostics to the client.
         results.diagnostics.forEach((fileDiag) => {
             if (!this.canNavigateToFile(fileDiag.fileUri, fs)) {
@@ -1314,6 +1431,32 @@ export abstract class LanguageServerBase implements LanguageServerInterface, Dis
         }
 
         return MarkupKind.PlainText;
+    }
+    private async _getWorkspaceDocumentDiagnostics(
+        params: WorkspaceDiagnosticParams,
+        sourceFile: SourceFile,
+        workspace: Workspace,
+        token: CancellationToken
+    ) {
+        const originalUri = workspace.service.fs.getOriginalUri(sourceFile.getUri());
+        const result: WorkspaceDocumentDiagnosticReport = {
+            uri: originalUri.toString(),
+            version: sourceFile.getClientVersion() ?? null,
+            kind: 'full',
+            items: [],
+        };
+        const previousId = params.previousResultIds.find((x) => x.uri === originalUri.toString());
+        const documentResult = await this.onDiagnostics(
+            { previousResultId: previousId?.value, textDocument: { uri: result.uri } },
+            token
+        );
+        if (documentResult.kind === 'full') {
+            result.items = documentResult.items;
+        } else {
+            (result as any).kind = documentResult.kind;
+            delete (result as any).items;
+        }
+        return result;
     }
 
     private _convertDiagnostics(fs: FileSystem, diags: AnalyzerDiagnostic[]): Diagnostic[] {

--- a/packages/pyright-internal/src/languageServerBase.ts
+++ b/packages/pyright-internal/src/languageServerBase.ts
@@ -1098,7 +1098,6 @@ export abstract class LanguageServerBase implements LanguageServerInterface, Dis
     }
 
     protected async onDiagnostics(params: DocumentDiagnosticParams, token: CancellationToken) {
-        this.console.log(`Received diagnostics request for ${params.textDocument.uri}`);
         const uri = this.convertLspUriStringToUri(params.textDocument.uri);
         const workspace = await this.getWorkspaceForFile(uri);
         let sourceFile = workspace.service.getSourceFile(uri);
@@ -1149,12 +1148,10 @@ export abstract class LanguageServerBase implements LanguageServerInterface, Dis
 
             result.resultId = diagnosticsVersion.toString();
             result.items = lspDiagnostics;
-            this.console.log(`Updated diagnostics request for ${params.textDocument.uri}`);
         } else {
             (result as any).kind = 'unchanged';
             result.resultId = diagnosticsVersion.toString();
             delete (result as any).items;
-            this.console.log(`Using old diagnostics request for ${params.textDocument.uri}`);
         }
 
         return result;

--- a/packages/pyright-internal/src/languageServerBase.ts
+++ b/packages/pyright-internal/src/languageServerBase.ts
@@ -1123,7 +1123,7 @@ export abstract class LanguageServerBase implements LanguageServerInterface, Dis
             let serverDiagnostics: AnalyzerDiagnostic[] = [];
 
             // Loop until we analyze the same version that we started with.
-            while (diagnosticsVersion !== diagnosticsVersionAfter && !token.isCancellationRequested) {
+            while (diagnosticsVersion !== diagnosticsVersionAfter && !token.isCancellationRequested && sourceFile) {
                 // Reset the version we're analyzing
                 sourceFile = workspace.service.getSourceFile(uri);
                 diagnosticsVersion = sourceFile?.getDiagnosticVersion() ?? UncomputedDiagnosticsVersion;

--- a/packages/pyright-internal/src/tests/languageServer.test.ts
+++ b/packages/pyright-internal/src/tests/languageServer.test.ts
@@ -153,6 +153,9 @@ describe(`Basic language server tests`, () => {
 
     [false, true].forEach((supportsPullDiagnostics) => {
         describe(`Diagnostics ${supportsPullDiagnostics ? 'pull' : 'push'}`, () => {
+            // Background analysis takes longer than 5 seconds sometimes, so we need to
+            // increase the timeout.
+            jest.setTimeout(15000);
             test('background thread diagnostics', async () => {
                 const code = `
 // @filename: root/test.py

--- a/packages/pyright-internal/src/tests/languageServer.test.ts
+++ b/packages/pyright-internal/src/tests/languageServer.test.ts
@@ -41,7 +41,8 @@ describe(`Basic language server tests`, () => {
         callInitialize = true,
         extraSettings?: { item: ConfigurationItem; value: any }[],
         pythonVersion: PythonVersion = pythonVersion3_10,
-        supportsBackgroundThread?: boolean
+        supportsBackgroundThread?: boolean,
+        supportsPullDiagnostics?: boolean
     ) {
         const result = await runPyrightServer(
             projectRoots,
@@ -49,7 +50,8 @@ describe(`Basic language server tests`, () => {
             callInitialize,
             extraSettings,
             pythonVersion,
-            supportsBackgroundThread
+            supportsBackgroundThread,
+            supportsPullDiagnostics
         );
         serverInfo = result;
         return result;
@@ -71,7 +73,7 @@ describe(`Basic language server tests`, () => {
 // @filename: test.py
 //// # empty file
         `;
-        const serverInfo = await runLanguageServer(DEFAULT_WORKSPACE_ROOT, code, /* callInitialize */ false);
+        serverInfo = await runLanguageServer(DEFAULT_WORKSPACE_ROOT, code, /* callInitialize */ false);
 
         const initializeResult = await initializeLanguageServer(serverInfo);
 
@@ -149,90 +151,140 @@ describe(`Basic language server tests`, () => {
         assert(completionItem);
     });
 
-    test('background thread diagnostics', async () => {
-        const code = `
+    [false, true].forEach((supportsPullDiagnostics) => {
+        describe(`Diagnostics ${supportsPullDiagnostics ? 'pull' : 'push'}`, () => {
+            test('background thread diagnostics', async () => {
+                const code = `
 // @filename: root/test.py
 //// from math import cos, sin
 //// import sys
 //// [|/*marker*/|]
         `;
-        const settings = [
-            {
-                item: {
-                    scopeUri: `file://${normalizeSlashes(DEFAULT_WORKSPACE_ROOT, '/')}`,
-                    section: 'python.analysis',
-                },
-                value: {
-                    typeCheckingMode: 'strict',
-                    diagnosticMode: 'workspace',
-                },
-            },
-        ];
+                const settings = [
+                    {
+                        item: {
+                            scopeUri: `file://${normalizeSlashes(DEFAULT_WORKSPACE_ROOT, '/')}`,
+                            section: 'python.analysis',
+                        },
+                        value: {
+                            typeCheckingMode: 'strict',
+                            diagnosticMode: 'workspace',
+                        },
+                    },
+                ];
 
-        const info = await runLanguageServer(
-            DEFAULT_WORKSPACE_ROOT,
-            code,
-            /* callInitialize */ true,
-            settings,
-            undefined,
-            /* supportsBackgroundThread */ true
-        );
+                const info = await runLanguageServer(
+                    DEFAULT_WORKSPACE_ROOT,
+                    code,
+                    /* callInitialize */ true,
+                    settings,
+                    undefined,
+                    /* supportsBackgroundThread */ true,
+                    supportsPullDiagnostics
+                );
 
-        // get the file containing the marker that also contains our task list comments
-        await openFile(info, 'marker');
+                // get the file containing the marker that also contains our task list comments
+                await openFile(info, 'marker');
 
-        // Wait for the diagnostics to publish
-        const diagnostics = await waitForDiagnostics(info);
-        const diagnostic = diagnostics.find((d) => d.uri.includes('root/test.py'));
-        assert(diagnostic);
-        assert.equal(diagnostic.diagnostics.length, 6);
+                // Wait for the diagnostics to publish
+                const diagnostics = await waitForDiagnostics(info);
+                const diagnostic = diagnostics.find((d) => d.uri.includes('root/test.py'));
+                assert(diagnostic);
+                assert.equal(diagnostic.diagnostics.length, 6);
 
-        // Make sure the error has a special rule
-        assert.equal(diagnostic.diagnostics[1].code, 'reportUnusedImport');
-        assert.equal(diagnostic.diagnostics[3].code, 'reportUnusedImport');
-        assert.equal(diagnostic.diagnostics[5].code, 'reportUnusedImport');
-    });
+                // Make sure the error has a special rule
+                assert.equal(diagnostic.diagnostics[1].code, 'reportUnusedImport');
+                assert.equal(diagnostic.diagnostics[3].code, 'reportUnusedImport');
+                assert.equal(diagnostic.diagnostics[5].code, 'reportUnusedImport');
+            });
 
-    test('Diagnostic severity overrides test', async () => {
-        const code = `
+            test('background thread diagnostics open mode', async () => {
+                const code = `
+// @filename: root/test.py
+//// from math import cos, sin
+//// import sys
+//// [|/*marker*/|]
+        `;
+                const settings = [
+                    {
+                        item: {
+                            scopeUri: `file://${normalizeSlashes(DEFAULT_WORKSPACE_ROOT, '/')}`,
+                            section: 'python.analysis',
+                        },
+                        value: {
+                            typeCheckingMode: 'strict',
+                        },
+                    },
+                ];
+
+                const info = await runLanguageServer(
+                    DEFAULT_WORKSPACE_ROOT,
+                    code,
+                    /* callInitialize */ true,
+                    settings,
+                    undefined,
+                    /* supportsBackgroundThread */ true,
+                    supportsPullDiagnostics
+                );
+
+                // get the file containing the marker that also contains our task list comments
+                await openFile(info, 'marker');
+
+                // Wait for the diagnostics to publish
+                const diagnostics = await waitForDiagnostics(info);
+                const diagnostic = diagnostics.find((d) => d.uri.includes('root/test.py'));
+                assert(diagnostic);
+                assert.equal(diagnostic.diagnostics.length, 6);
+
+                // Make sure the error has a special rule
+                assert.equal(diagnostic.diagnostics[1].code, 'reportUnusedImport');
+                assert.equal(diagnostic.diagnostics[3].code, 'reportUnusedImport');
+                assert.equal(diagnostic.diagnostics[5].code, 'reportUnusedImport');
+            });
+
+            test('Diagnostic severity overrides test', async () => {
+                const code = `
 // @filename: test.py
 //// def test([|/*marker*/x|]): ...
 //// 
 // @filename: pyproject.toml
 //// 
     `;
-        const settings = [
-            {
-                item: {
-                    scopeUri: `file://${normalizeSlashes(DEFAULT_WORKSPACE_ROOT, '/')}`,
-                    section: 'python.analysis',
-                },
-                value: {
-                    diagnosticSeverityOverrides: {
-                        reportUnknownParameterType: 'warning',
+                const settings = [
+                    {
+                        item: {
+                            scopeUri: `file://${normalizeSlashes(DEFAULT_WORKSPACE_ROOT, '/')}`,
+                            section: 'python.analysis',
+                        },
+                        value: {
+                            diagnosticSeverityOverrides: {
+                                reportUnknownParameterType: 'warning',
+                            },
+                        },
                     },
-                },
-            },
-        ];
+                ];
 
-        const info = await runLanguageServer(
-            DEFAULT_WORKSPACE_ROOT,
-            code,
-            /* callInitialize */ true,
-            settings,
-            undefined,
-            /* supportsBackgroundThread */ true
-        );
+                const info = await runLanguageServer(
+                    DEFAULT_WORKSPACE_ROOT,
+                    code,
+                    /* callInitialize */ true,
+                    settings,
+                    undefined,
+                    /* supportsBackgroundThread */ true,
+                    supportsPullDiagnostics
+                );
 
-        // get the file containing the marker that also contains our task list comments
-        await openFile(info, 'marker');
+                // get the file containing the marker that also contains our task list comments
+                await openFile(info, 'marker');
 
-        // Wait for the diagnostics to publish
-        const diagnostics = await waitForDiagnostics(info);
-        const diagnostic = diagnostics.find((d) => d.uri.includes('test.py'));
-        assert(diagnostic);
+                // Wait for the diagnostics to publish
+                const diagnostics = await waitForDiagnostics(info);
+                const diagnostic = diagnostics.find((d) => d.uri.includes('test.py'));
+                assert(diagnostic);
 
-        // Make sure the error has a special rule
-        assert.equal(diagnostic.diagnostics[0].code, 'reportUnknownParameterType');
+                // Make sure the error has a special rule
+                assert.equal(diagnostic.diagnostics[0].code, 'reportUnknownParameterType');
+            });
+        });
     });
 });

--- a/packages/pyright-internal/src/tests/lsp/customLsp.ts
+++ b/packages/pyright-internal/src/tests/lsp/customLsp.ts
@@ -55,6 +55,7 @@ export namespace CustomLSP {
 
     export enum Requests {
         GetDiagnostics = 'test/getDiagnostics',
+        GetOpenFiles = 'test/getOpenFiles',
     }
 
     export enum Notifications {
@@ -86,6 +87,7 @@ export namespace CustomLSP {
 
     interface Params {
         [Requests.GetDiagnostics]: { uri: string };
+        [Requests.GetOpenFiles]: { uri: string };
         [Notifications.CacheDirCreate]: { uri: string };
         [Notifications.CacheFileWrite]: { uri: string; contents: string; overwrite: boolean };
         [Notifications.SetStatusBarMessage]: string;
@@ -102,6 +104,7 @@ export namespace CustomLSP {
 
     interface Response {
         [Requests.GetDiagnostics]: { diagnostics: string };
+        [Requests.GetOpenFiles]: { files: string };
     }
 
     // Interface for returning config options as we cannot return a

--- a/packages/pyright-internal/src/tests/lsp/languageServer.ts
+++ b/packages/pyright-internal/src/tests/lsp/languageServer.ts
@@ -207,7 +207,7 @@ async function runServer(
             CustomLSP.onRequest(connection, CustomLSP.Requests.GetOpenFiles, async (params) => {
                 const workspace = await server.getWorkspaceForFile(Uri.parse(params.uri, server.serviceProvider));
                 const files = serialize(workspace.service.test_program.getOpened().map((f) => f.sourceFile.getUri()));
-                return { files: serialize(files) };
+                return { files: files };
             })
         );
 

--- a/packages/pyright-internal/src/tests/lsp/languageServer.ts
+++ b/packages/pyright-internal/src/tests/lsp/languageServer.ts
@@ -203,6 +203,11 @@ async function runServer(
                 const file = workspace.service.test_program.getBoundSourceFile(filePath);
                 const diagnostics = file?.getDiagnostics(workspace.service.test_program.configOptions) || [];
                 return { diagnostics: serialize(diagnostics) };
+            }),
+            CustomLSP.onRequest(connection, CustomLSP.Requests.GetOpenFiles, async (params) => {
+                const workspace = await server.getWorkspaceForFile(Uri.parse(params.uri, server.serviceProvider));
+                const files = serialize(workspace.service.test_program.getOpened().map((f) => f.sourceFile.getUri()));
+                return { files: serialize(files) };
             })
         );
 
@@ -403,3 +408,13 @@ export async function run() {
         stateManager.run();
     }
 }
+
+process.on('uncaughtException', (err) => {
+    console.error('Uncaught exception in worker:', err);
+    process.exit(10); // Exit the worker process
+});
+
+process.on('unhandledRejection', (reason, promise) => {
+    console.error('Unhandled rejection in worker:', reason);
+    process.exit(11); // Exit the worker process
+});

--- a/packages/pyright-internal/src/tests/lsp/languageServerTestUtils.ts
+++ b/packages/pyright-internal/src/tests/lsp/languageServerTestUtils.ts
@@ -990,6 +990,10 @@ export function getInitializeParams(
                         properties: ['tooltip', 'textEdits', 'label.tooltip', 'label.location', 'label.command'],
                     },
                 },
+                diagnostic: {
+                    dynamicRegistration: true,
+                    relatedDocumentSupport: false,
+                },
             },
             window: {
                 showMessage: {
@@ -1031,16 +1035,10 @@ export function getInitializeParams(
         initializationOptions: {
             autoFormatStrings: true,
             diagnosticMode: diagnosticMode ?? 'openFilesOnly',
+            disablePullDiagnostics: !supportsPullDiagnostics,
         },
         workspaceFolders,
     };
-
-    if (supportsPullDiagnostics) {
-        params.capabilities.textDocument!.diagnostic = {
-            dynamicRegistration: true,
-            relatedDocumentSupport: false,
-        };
-    }
 
     return params;
 }

--- a/packages/pyright-internal/src/tests/lsp/languageServerTestUtils.ts
+++ b/packages/pyright-internal/src/tests/lsp/languageServerTestUtils.ts
@@ -16,9 +16,13 @@ import {
     CancellationToken,
     ConfigurationItem,
     ConfigurationRequest,
+    DiagnosticRefreshRequest,
     DidChangeWorkspaceFoldersNotification,
     DidOpenTextDocumentNotification,
     Disposable,
+    DocumentDiagnosticReport,
+    DocumentDiagnosticRequest,
+    FullDocumentDiagnosticReport,
     InitializedNotification,
     InitializeParams,
     InitializeRequest,
@@ -32,7 +36,10 @@ import {
     SemanticTokensRefreshRequest,
     ShutdownRequest,
     TelemetryEventNotification,
+    UnchangedDocumentDiagnosticReport,
     UnregistrationRequest,
+    WorkspaceDiagnosticReport,
+    WorkspaceDiagnosticRequest,
 } from 'vscode-languageserver-protocol';
 import {
     Connection,
@@ -52,6 +59,7 @@ import {
 } from 'vscode-languageserver/node';
 import { PythonPathResult } from '../../analyzer/pythonPathUtils';
 import { IPythonMode } from '../../analyzer/sourceFile';
+import { deserialize } from '../../backgroundThreadBase';
 import { PythonPlatform } from '../../common/configOptions';
 import { toBoolean } from '../../common/core';
 import { createDeferred, Deferred } from '../../common/deferred';
@@ -100,6 +108,7 @@ export interface PyrightServerInfo {
     progressReporterStatus: Map<string, number>;
     progressParts: Map<string, TestProgressPart>;
     telemetry: any[];
+    supportsPullDiagnostics: boolean;
     diagnostics: PublishDiagnosticsParams[];
     diagnosticsEvent: Event<PublishDiagnosticsParams>;
     workspaceEdits: ApplyWorkspaceEditParams[];
@@ -188,6 +197,7 @@ function createServerWorker(file: string, testServerData: CustomLSP.TestServerSt
     });
     serverWorker.on('exit', (code) => {
         logToDisk(`Worker exit: ${code}`, testServerData.logFile);
+        serverWorker = undefined;
     });
     return serverWorker;
 }
@@ -268,21 +278,131 @@ function createServerConnection(testServerData: CustomLSP.TestServerStartOptions
     return connection;
 }
 
-export async function waitForDiagnostics(info: PyrightServerInfo, timeout = 10000) {
+function getProjectRootString(info: PyrightServerInfo, projectRoot?: Uri) {
+    return projectRoot ? projectRoot.toString() : info.projectRoots.length > 0 ? info.projectRoots[0].toString() : '';
+}
+
+export async function getOpenFiles(info: PyrightServerInfo, projectRoot?: Uri): Promise<Uri[]> {
+    const uri = getProjectRootString(info, projectRoot);
+    const result = await CustomLSP.sendRequest(info.connection, CustomLSP.Requests.GetOpenFiles, { uri });
+    return deserialize(result.files);
+}
+
+async function waitForPushDiagnostics(
+    info: PyrightServerInfo,
+    clearFirst: boolean,
+    numberOfFiles = 1,
+    timeout = 10000
+): Promise<PublishDiagnosticsParams[]> {
+    if (clearFirst) {
+        info.diagnostics = [];
+    }
+
+    // We may already have the necessary diagnostics.
+    const currentCount = info.diagnostics.filter((d) => d.diagnostics.length > 0).length;
+    if (currentCount >= numberOfFiles) {
+        return info.diagnostics;
+    }
+
+    // Otherwise we have to get called back with the diagnostics.
+    let eventCount = 0;
+    await waitForEvent(
+        info.diagnosticsEvent,
+        'diagnostics',
+        (params) => {
+            if (params.diagnostics.length > 0) {
+                eventCount++;
+                if (eventCount >= numberOfFiles) {
+                    return true;
+                }
+            }
+
+            return false;
+        },
+        timeout
+    );
+    return info.diagnostics;
+}
+
+export async function waitForEvent<T>(event: Event<T>, name: string, condition: (p: T) => boolean, timeout = 10000) {
     const deferred = createDeferred<void>();
-    const disposable = info.diagnosticsEvent((params) => {
-        if (params.diagnostics.length > 0) {
+    const disposable = event((params) => {
+        if (condition(params)) {
             deferred.resolve();
         }
     });
-    const timer = setTimeout(() => deferred.reject('Timed out waiting for diagnostics'), timeout);
+
+    const timer = setTimeout(() => deferred.reject(`Timed out waiting for ${name} event`), timeout);
+
     try {
         await deferred.promise;
     } finally {
         clearTimeout(timer);
         disposable.dispose();
     }
-    return info.diagnostics;
+}
+
+function convertDiagnosticReportItem(
+    uri: string,
+    item: FullDocumentDiagnosticReport | UnchangedDocumentDiagnosticReport
+): PublishDiagnosticsParams {
+    if (item.kind === 'unchanged') {
+        return {
+            uri,
+            diagnostics: [],
+        };
+    }
+
+    return {
+        uri,
+        diagnostics: item.items,
+    };
+}
+export function convertDiagnosticReport(
+    uri: string | undefined,
+    report: DocumentDiagnosticReport | WorkspaceDiagnosticReport
+): PublishDiagnosticsParams[] {
+    if (!(report as any).kind || !uri) {
+        const workspaceReport = report as WorkspaceDiagnosticReport;
+        return workspaceReport.items.map((item) => convertDiagnosticReportItem(item.uri, item));
+    }
+    const documentReport = report as DocumentDiagnosticReport;
+    return [convertDiagnosticReportItem(uri, documentReport)];
+}
+
+async function waitForPullDiagnostics(info: PyrightServerInfo): Promise<PublishDiagnosticsParams[]> {
+    const openFiles = await getOpenFiles(info);
+    if (openFiles.length <= 0) {
+        const results = await info.connection.sendRequest(WorkspaceDiagnosticRequest.type, {
+            identifier: 'Pylance',
+            previousResultIds: [],
+        });
+        return convertDiagnosticReport(undefined, results);
+    } else {
+        const results: PublishDiagnosticsParams[] = [];
+        for (const openFile of openFiles) {
+            const result = await info.connection.sendRequest(DocumentDiagnosticRequest.type, {
+                textDocument: {
+                    uri: openFile.toString(),
+                },
+            });
+            results.push(convertDiagnosticReport(openFile.toString(), result)[0]);
+        }
+        return results;
+    }
+}
+
+export async function waitForDiagnostics(
+    info: PyrightServerInfo,
+    clearFirst: boolean = false,
+    numberOfFiles = 1,
+    timeout = 10000
+) {
+    if (info.supportsPullDiagnostics) {
+        // Timeout doesn't apply on pull because we can actually ask for them.
+        return waitForPullDiagnostics(info);
+    }
+    return waitForPushDiagnostics(info, clearFirst, numberOfFiles, timeout);
 }
 
 interface ProgressPart {}
@@ -329,7 +449,8 @@ export async function runPyrightServer(
     callInitialize = true,
     extraSettings?: { item: ConfigurationItem; value: any }[],
     pythonVersion: PythonVersion = pythonVersion3_10,
-    backgroundAnalysis?: boolean
+    backgroundAnalysis?: boolean,
+    supportPullDiagnostics?: boolean
 ): Promise<PyrightServerInfo> {
     // Setup the test data we need to send for Test server startup.
     const projectRootsArray = Array.isArray(projectRoots) ? projectRoots : [projectRoots];
@@ -372,6 +493,7 @@ export async function runPyrightServer(
     const serverStarted = createDeferred<string>();
     const diagnosticsEmitter = new Emitter<PublishDiagnosticsParams>();
     const workspaceEditsEmitter = new Emitter<ApplyWorkspaceEditParams>();
+    const diagnosticsMode = extraSettings?.find((s) => s.item.section === 'python.analysis')?.value?.diagnosticMode;
 
     // Setup the server info.
     const info: PyrightServerInfo = {
@@ -386,16 +508,19 @@ export async function runPyrightServer(
         testData,
         testName: testServerData.testName,
         telemetry: [],
+        supportsPullDiagnostics: (supportPullDiagnostics && diagnosticsMode !== 'workspace') ?? false,
         projectRoots: testServerData.projectRoots,
         diagnostics: [],
         diagnosticsEvent: diagnosticsEmitter.event,
         workspaceEdits: [],
         workspaceEditsEvent: workspaceEditsEmitter.event,
-        getInitializeParams: () => getInitializeParams(testServerData.projectRoots),
+        getInitializeParams: () => getInitializeParams(testServerData.projectRoots, diagnosticsMode),
         convertPathToUri: (path: string) => UriEx.file(path, !ignoreCase),
         dispose: async () => {
             // Send shutdown. This should disconnect the dispatcher and kill the server.
-            await connection.sendRequest(ShutdownRequest.type, undefined);
+            if (serverWorker) {
+                await connection.sendRequest(ShutdownRequest.type, undefined);
+            }
 
             // Now we can dispose the connection.
             disposables.forEach((d) => d.dispose());
@@ -422,6 +547,7 @@ export async function runPyrightServer(
         info.connection.onRequest(InlayHintRefreshRequest.type, () => {
             // Empty. Silently ignore for now.
         }),
+        info.connection.onRequest(DiagnosticRefreshRequest.type, () => {}),
         info.connection.onRequest(ApplyWorkspaceEditRequest.type, (p) => {
             info.workspaceEdits.push(p);
             workspaceEditsEmitter.fire(p);
@@ -574,7 +700,7 @@ export async function hover(info: PyrightServerInfo, markerName: string) {
     return hoverResult;
 }
 
-export function getInitializeParams(projectRoots: Uri[]) {
+export function getInitializeParams(projectRoots: Uri[], diagnosticMode: string | undefined = undefined) {
     // cloned vscode "1.71.0-insider"'s initialize params.
     const workspaceFolders = projectRoots
         ? projectRoots.map((root, i) => ({ name: root.fileName, uri: projectRoots[i].toString() }))
@@ -927,6 +1053,7 @@ export function getInitializeParams(projectRoots: Uri[]) {
         },
         initializationOptions: {
             autoFormatStrings: true,
+            diagnosticMode: diagnosticMode ?? 'openFilesOnly',
         },
         workspaceFolders,
     };

--- a/packages/pyright-internal/src/types.ts
+++ b/packages/pyright-internal/src/types.ts
@@ -32,3 +32,7 @@ export interface ClientCapabilities {
     hasPullDiagnosticsCapability: boolean;
     hasPullRelatedInformationCapability: boolean;
 }
+
+export type InitializationOptions = {
+    diagnosticMode?: string;
+};

--- a/packages/pyright-internal/src/types.ts
+++ b/packages/pyright-internal/src/types.ts
@@ -35,4 +35,5 @@ export interface ClientCapabilities {
 
 export type InitializationOptions = {
     diagnosticMode?: string;
+    disablePullDiagnostics?: boolean;
 };

--- a/packages/pyright-internal/src/types.ts
+++ b/packages/pyright-internal/src/types.ts
@@ -29,8 +29,8 @@ export interface ClientCapabilities {
     supportsUnnecessaryDiagnosticTag: boolean;
     supportsTaskItemDiagnosticTag: boolean;
     completionItemResolveSupportsAdditionalTextEdits: boolean;
-    hasPullDiagnosticsCapability: boolean;
-    hasPullRelatedInformationCapability: boolean;
+    usingPullDiagnostics: boolean;
+    requiresPullRelatedInformationCapability: boolean;
 }
 
 export type InitializationOptions = {

--- a/packages/vscode-pyright/package.json
+++ b/packages/vscode-pyright/package.json
@@ -1545,6 +1545,12 @@
                     "description": "Disables the “Organize Imports” command.",
                     "scope": "resource"
                 },
+                "pyright.disablePullDiagnostics": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Disables the use of pull diagnostics from VS Code.",
+                    "scope": "machine"
+                },
                 "python.pythonPath": {
                     "type": "string",
                     "default": "python",

--- a/packages/vscode-pyright/src/extension.ts
+++ b/packages/vscode-pyright/src/extension.ts
@@ -175,6 +175,11 @@ export async function activate(context: ExtensionContext) {
                 },
             },
         },
+        initializationOptions: {
+            // Send the initial diagnostic mode to the server.
+            // This is used to determine whether to run in pull or push mode for diagnostics.
+            diagnosticMode: workspace.getConfiguration('python.analysis').get('diagnosticMode'),
+        },
     };
 
     // Create the language client and start the client.

--- a/packages/vscode-pyright/src/extension.ts
+++ b/packages/vscode-pyright/src/extension.ts
@@ -176,9 +176,8 @@ export async function activate(context: ExtensionContext) {
             },
         },
         initializationOptions: {
-            // Send the initial diagnostic mode to the server.
-            // This is used to determine whether to run in pull or push mode for diagnostics.
             diagnosticMode: workspace.getConfiguration('python.analysis').get('diagnosticMode'),
+            disablePullDiagnostics: workspace.getConfiguration('pyright').get('disablePullDiagnostics'),
         },
     };
 


### PR DESCRIPTION
## Description

Currently whenever a file is opened or changed, Pyright analyzes the changed file (and its dependencies) on the BG thread and then sends a notification to the client with the list of diagnostics found. This is called 'push diagnostics'. https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_publishDiagnostics

This works fine as long as the associated file is actually open in the client. In some cases, the file may be open, but the user hasn't clicked on a tab or even the file may have been closed but we weren't told about it. 

See this issue for reference (which we already fixed in Pylance but not Pyright)
See https://github.com/microsoft/pylance-release/issues/5402

This causes issues with the problems list being out of sync with the actual state of the client. 

Additionally, Pyright has no notion of which files are more important than others to analyze (like maybe the one with the cursor in it).

This can be solved by using pull diagnostics instead:
https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_pullDiagnostics

Pull diagnostics lets the client decide what files it wants the list of diagnostics for. This allows it to prioritize say the actively editing file over other open tabs. It lets it remove diagnostics for files that are no longer open but maybe without having the LS server close the file (so that the next open will get diagnostics faster).

## Implementation

We already have an 'analyzeFile' and 'analyze' message for a per file diagnostics request, so implementation was just calling those methods. 

I also added two ways that pull will not be used. 

- diagnosticMode = 'workspace'. In this mode I left Pyright to analyze all of the files in the workspace itself and push notifications. 
- disablePullDiagnostics - this setting is a safety valve in case this breaks something. Users can enable this setting and we'll go back to the old method for diagnostics.

## Testing

I changed the languageServer.test.ts to have more tests that used pull diagnostics and tested myself with diagnosticMode on and off.

