### PR TITLE
Pull diagnostics could get in a situation where it never responds

### DIFF
--- a/packages/pyright-internal/src/languageServerBase.ts
+++ b/packages/pyright-internal/src/languageServerBase.ts
@@ -1103,7 +1103,7 @@ export abstract class LanguageServerBase implements LanguageServerInterface, Dis
         let sourceFile = workspace.service.getSourceFile(uri);
         let diagnosticsVersion = sourceFile?.isCheckingRequired()
             ? UncomputedDiagnosticsVersion
-            : sourceFile?.getDiagnosticVersion() ?? UncomputedDiagnosticsVersion - 1;
+            : sourceFile?.getDiagnosticVersion() ?? UncomputedDiagnosticsVersion;
         const result: DocumentDiagnosticReport = {
             kind: 'full',
             resultId: sourceFile?.getDiagnosticVersion()?.toString(),
@@ -1149,11 +1149,15 @@ export abstract class LanguageServerBase implements LanguageServerInterface, Dis
                 (d) => d !== undefined
             ) as Diagnostic[];
 
-            result.resultId = diagnosticsVersionAfter.toString();
+            result.resultId =
+                diagnosticsVersionAfter === UncomputedDiagnosticsVersion
+                    ? undefined
+                    : diagnosticsVersionAfter.toString();
             result.items = lspDiagnostics;
         } else {
             (result as any).kind = 'unchanged';
-            result.resultId = diagnosticsVersion.toString();
+            result.resultId =
+                diagnosticsVersion === UncomputedDiagnosticsVersion ? undefined : diagnosticsVersion.toString();
             delete (result as any).items;
         }
 


### PR DESCRIPTION
After discussing with @debonte, it might be possible to send back -1 as the result id. We should never do that, but instead send back undefined so we get asked again.

-1 was supposed to indicate the diagnostics haven't been computed.