### PR TITLE
Fixed bug that leads to a false negative when evaluating a call expre…

### DIFF
--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -9868,12 +9868,22 @@ export function createTypeEvaluator(
             case TypeCategory.Never:
             case TypeCategory.Unknown:
             case TypeCategory.Any: {
-                // Touch all of the args so they're marked accessed. Don't bother
-                // doing this if the call type is incomplete because this will need
-                // to be done again once it is complete.
-                touchArgTypes();
+                // Create a dummy callable that accepts all arguments and validate
+                // that the argument expressions are valid.
+                const dummyFunctionType = FunctionType.createInstance('', '', '', FunctionTypeFlags.None);
+                FunctionType.addDefaultParams(dummyFunctionType);
 
-                return { returnType: expandedCallType };
+                const dummyCallResult = validateCallForFunction(
+                    errorNode,
+                    argList,
+                    dummyFunctionType,
+                    isCallTypeIncomplete,
+                    constraints,
+                    skipUnknownArgCheck,
+                    inferenceContext
+                );
+
+                return { ...dummyCallResult, returnType: expandedCallType };
             }
 
             case TypeCategory.Function: {

--- a/packages/pyright-internal/src/tests/samples/call2.py
+++ b/packages/pyright-internal/src/tests/samples/call2.py
@@ -1,7 +1,7 @@
 # This sample tests function parameter matching logic.
 
 
-from typing import Any, Literal
+from typing import Any, Callable, Literal
 
 
 def func1(a: int, *b: int):
@@ -168,3 +168,8 @@ func_args2: dict[Literal["a", "b", "c"], str] = {
 
 # This should generate an error.
 func13(**func_args2)
+
+
+def func14(cb1: Callable[..., Any], cb2: Any, x: None):
+    cb1(**x)  # This should generate an error
+    cb2(**x)  # This should generate an error

--- a/packages/pyright-internal/src/tests/typeEvaluator1.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator1.test.ts
@@ -784,7 +784,7 @@ test('Call1', () => {
 test('Call2', () => {
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['call2.py']);
 
-    TestUtils.validateResults(analysisResults, 18);
+    TestUtils.validateResults(analysisResults, 20);
 });
 
 test('Call3', () => {


### PR DESCRIPTION
…ssion where the callable type is `Any` and an argument expression uses dictionary unpacking but the operands type is not a mapping. This addresses #10061.