### PR TITLE
Fixed a bug that results in incorrect "literal math" results when usi…

### DIFF
--- a/packages/pyright-internal/src/analyzer/operations.ts
+++ b/packages/pyright-internal/src/analyzer/operations.ts
@@ -1032,6 +1032,15 @@ function calcLiteralForBinaryOp(operator: OperatorType, leftType: Type, rightTyp
                     } else if (operator === OperatorType.FloorDivide) {
                         if (rightLiteralValue !== BigInt(0)) {
                             newValue = leftLiteralValue / rightLiteralValue;
+
+                            // BigInt rounds to zero, but floor divide rounds to negative
+                            // infinity, so we need to adjust the result if the signs
+                            // of the operands are different.
+                            if (leftLiteralValue !== rightLiteralValue) {
+                                if (leftLiteralValue < 0n !== rightLiteralValue < 0n) {
+                                    newValue -= 1n;
+                                }
+                            }
                         }
                     } else if (operator === OperatorType.Mod) {
                         if (rightLiteralValue !== BigInt(0)) {

--- a/packages/pyright-internal/src/tests/samples/operator8.py
+++ b/packages/pyright-internal/src/tests/samples/operator8.py
@@ -59,6 +59,12 @@ def func1(a: Literal[1, 2], b: Literal[0, 4], c: Literal[3, 4]):
         c6 += a
         reveal_type(c6, expected_text="int")
 
+    c7 = -10 // 8
+    reveal_type(c7, expected_text="Literal[-2]")
+
+    c8 = 10 // -6
+    reveal_type(c8, expected_text="Literal[-2]")
+
 
 def func2(cond: bool):
     c1 = "Hi " + ("Steve" if cond else "Amy")


### PR DESCRIPTION
…ng a floor divide `//` operator with literal operands whose signs differ. This addresses #10076.