### PR TITLE
Handle typecheckingmode changing while in pull mode

### DIFF
--- a/packages/pyright-internal/src/analyzer/service.ts
+++ b/packages/pyright-internal/src/analyzer/service.ts
@@ -501,6 +501,10 @@ export class AnalyzerService {
     }
 
     protected applyConfigOptions(host: Host) {
+        // Indicate that we are about to reanalyze because of this config change.
+        if (this.options.onInvalidated) {
+            this.options.onInvalidated(InvalidatedReason.Reanalyzed);
+        }
         // Allocate a new import resolver because the old one has information
         // cached based on the previous config options.
         const importResolver = this._importResolverFactory(


### PR DESCRIPTION
While debugging pylance pull diagnostics, I noticed that we don't refresh errors when changing typechecking mode. 

This is because invalidate isn't called on a config change and we only request new errors when invalidating.