### PR TITLE
Changed type evaluation logic for multi-part module imports to ensure…

### DIFF
--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -22540,19 +22540,33 @@ export function createTypeEvaluator(
 
             if (loaderActions.implicitImports) {
                 loaderActions.implicitImports.forEach((implicitImport, name) => {
+                    const existingLoaderField = moduleType.priv.loaderFields.get(name);
+
                     // Recursively apply loader actions.
                     let symbolType: Type;
 
                     if (implicitImport.isUnresolved) {
                         symbolType = UnknownType.create();
                     } else {
-                        const moduleName = moduleType.priv.moduleName ? moduleType.priv.moduleName + '.' + name : '';
-                        const importedModuleType = ModuleType.create(moduleName, implicitImport.uri);
+                        let importedModuleType: ModuleType;
+
+                        const existingType = existingLoaderField?.getSynthesizedType();
+                        if (existingType?.type && isModule(existingType.type)) {
+                            importedModuleType = existingType.type;
+                        } else {
+                            const moduleName = moduleType.priv.moduleName
+                                ? moduleType.priv.moduleName + '.' + name
+                                : '';
+                            importedModuleType = ModuleType.create(moduleName, implicitImport.uri);
+                        }
+
                         symbolType = applyLoaderActionsToModuleType(importedModuleType, implicitImport, importLookup);
                     }
 
-                    const importedModuleSymbol = Symbol.createWithType(SymbolFlags.None, symbolType);
-                    moduleType.priv.loaderFields.set(name, importedModuleSymbol);
+                    if (!existingLoaderField) {
+                        const importedModuleSymbol = Symbol.createWithType(SymbolFlags.None, symbolType);
+                        moduleType.priv.loaderFields.set(name, importedModuleSymbol);
+                    }
                 });
             }
 
@@ -22563,9 +22577,26 @@ export function createTypeEvaluator(
         // is pointing at a module, and we need to synthesize a
         // module type.
         if (resolvedDecl.type === DeclarationType.Alias) {
+            let moduleType: ModuleType | undefined;
+
+            // See if this is an import that shares a ModuleType with another
+            // import statement. If so, used the cached type. This happens when
+            // multiple import statements start with the same module name, such
+            // as "import a.b" and "import a.c".
+            if (resolvedDecl.node.nodeType === ParseNodeType.ImportAs) {
+                const cachedType = readTypeCache(resolvedDecl.node, EvalFlags.None);
+                if (cachedType && isModule(cachedType)) {
+                    moduleType = cachedType;
+                }
+            }
+
             // Build a module type that corresponds to the declaration and
             // its associated loader actions.
-            const moduleType = ModuleType.create(resolvedDecl.moduleName, resolvedDecl.uri);
+            if (!moduleType) {
+                moduleType = ModuleType.create(resolvedDecl.moduleName, resolvedDecl.uri);
+                writeTypeCache(resolvedDecl.node, { type: moduleType }, EvalFlags.None);
+            }
+
             if (resolvedDecl.symbolName && resolvedDecl.submoduleFallback) {
                 return applyLoaderActionsToModuleType(moduleType, resolvedDecl.submoduleFallback, importLookup);
             } else {

--- a/packages/pyright-internal/src/tests/samples/import2.py
+++ b/packages/pyright-internal/src/tests/samples/import2.py
@@ -13,8 +13,8 @@ from .package1 import foo
 b = foo()
 
 # This should generate an error because there is no
-# directory or file named package2.
-from . import package2 as p2
+# directory or file named packageXXX.
+from . import packageXXX as p2
 
 from .package1.sub import subfoo
 # subfoo should resolve to the package1/sub/__init__.py,


### PR DESCRIPTION
… that a module type imported in one statement is shared with another statement that targets the same module. This partly addresses #9622.