### PR TITLE
Changed internal caching of inferred return types so it is shared amo…

### DIFF
--- a/packages/pyright-internal/src/analyzer/constructorTransform.ts
+++ b/packages/pyright-internal/src/analyzer/constructorTransform.ts
@@ -478,7 +478,7 @@ function applyPartialTransformToFunction(
 
     newCallMemberType.shared.declaredReturnType = specializedFunctionType.shared.declaredReturnType
         ? FunctionType.getEffectiveReturnType(specializedFunctionType)
-        : specializedFunctionType.priv.inferredReturnType?.type;
+        : specializedFunctionType.shared.inferredReturnType?.type;
     newCallMemberType.shared.declaration = partialCallMemberType.shared.declaration;
     newCallMemberType.shared.typeVarScopeId = specializedFunctionType.shared.typeVarScopeId;
 

--- a/packages/pyright-internal/src/analyzer/constructors.ts
+++ b/packages/pyright-internal/src/analyzer/constructors.ts
@@ -1106,7 +1106,13 @@ function isDefaultNewMethod(newMethod?: Type): boolean {
         return false;
     }
 
-    const returnType = newMethod.shared.declaredReturnType ?? newMethod.priv.inferredReturnType?.type;
+    let returnType: Type | undefined;
+    if (newMethod.shared.declaredReturnType) {
+        returnType = newMethod.shared.declaredReturnType;
+    } else {
+        returnType = newMethod.priv.specializedTypes?.returnType ?? newMethod.shared.inferredReturnType?.type;
+    }
+
     if (!returnType || !isTypeVar(returnType) || !TypeVarType.isSelf(returnType)) {
         return false;
     }

--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -14966,7 +14966,7 @@ export function createTypeEvaluator(
                         makeInferenceContext(expectedReturnType)
                     );
 
-                    functionType.priv.inferredReturnType = {
+                    functionType.shared.inferredReturnType = {
                         type: returnTypeResult.type,
                     };
                     if (returnTypeResult.isIncomplete) {
@@ -19344,7 +19344,7 @@ export function createTypeEvaluator(
                 FunctionType.isGenerator(functionType)
             );
         } else {
-            awaitableFunctionType.priv.inferredReturnType = {
+            awaitableFunctionType.shared.inferredReturnType = {
                 type: createAwaitableReturnType(
                     node,
                     getInferredReturnType(functionType),
@@ -23331,8 +23331,8 @@ export function createTypeEvaluator(
 
         // If the return type has already been lazily evaluated,
         // don't bother computing it again.
-        if (type.priv.inferredReturnType && !type.priv.inferredReturnType.isIncomplete) {
-            returnType = type.priv.inferredReturnType.type;
+        if (type.shared.inferredReturnType && !type.shared.inferredReturnType.isIncomplete) {
+            returnType = type.shared.inferredReturnType.type;
         } else {
             // Don't bother inferring the return type of __init__ because it's
             // always None.
@@ -23390,7 +23390,7 @@ export function createTypeEvaluator(
             returnType = makeTypeVarsFree(returnType, typeVarScopes);
 
             // Cache the type for next time.
-            type.priv.inferredReturnType = { type: returnType, isIncomplete };
+            type.shared.inferredReturnType = { type: returnType, isIncomplete };
         }
 
         // If the type is partially unknown and the function has one or more unannotated

--- a/packages/pyright-internal/src/analyzer/typeUtils.ts
+++ b/packages/pyright-internal/src/analyzer/typeUtils.ts
@@ -2973,8 +2973,8 @@ function _requiresSpecialization(type: Type, options?: RequiresSpecializationOpt
                 if (requiresSpecialization(declaredReturnType, options, recursionCount)) {
                     return true;
                 }
-            } else if (type.priv.inferredReturnType) {
-                if (requiresSpecialization(type.priv.inferredReturnType?.type, options, recursionCount)) {
+            } else if (type.shared.inferredReturnType) {
+                if (requiresSpecialization(type.shared.inferredReturnType?.type, options, recursionCount)) {
                     return true;
                 }
             }
@@ -3842,9 +3842,13 @@ export class TypeVarTransformer {
             }
 
             let specializedInferredReturnType: Type | undefined;
-            if (functionType.priv.inferredReturnType) {
-                specializedInferredReturnType = this.apply(functionType.priv.inferredReturnType?.type, recursionCount);
-                if (specializedInferredReturnType !== functionType.priv.inferredReturnType?.type) {
+            if (functionType.shared.inferredReturnType) {
+                specializedInferredReturnType = this.apply(
+                    functionType.shared.inferredReturnType?.type,
+                    recursionCount
+                );
+                if (specializedInferredReturnType !== functionType.shared.inferredReturnType?.type) {
+                    specializedParams.returnType = specializedInferredReturnType;
                     typesRequiredSpecialization = true;
                 }
             }
@@ -3876,7 +3880,7 @@ export class TypeVarTransformer {
 
             // If there was no unpacked variadic type variable, we're done.
             if (!variadicTypesToUnpack) {
-                return FunctionType.specialize(functionType, specializedParams, specializedInferredReturnType);
+                return FunctionType.specialize(functionType, specializedParams);
             }
 
             // Unpack the tuple and synthesize a new function in the process.

--- a/packages/pyright-internal/src/analyzer/typeWalker.ts
+++ b/packages/pyright-internal/src/analyzer/typeWalker.ts
@@ -149,7 +149,7 @@ export class TypeWalker {
         }
 
         if (!this._isWalkCanceled && !FunctionType.isParamSpecValue(type) && !FunctionType.isParamSpecValue(type)) {
-            const returnType = type.shared.declaredReturnType ?? type.priv.inferredReturnType?.type;
+            const returnType = type.shared.declaredReturnType ?? type.shared.inferredReturnType?.type;
             if (returnType) {
                 this.walk(returnType);
             }


### PR DESCRIPTION
…ng all types that derive from a given function. This reduces compute and memory consumption somewhat. It's also necessary (but not sufficient) to address #10000.