### PR TITLE
Fixed bug that results in a variable being displayed as "not accessed…

### DIFF
--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -9913,6 +9913,7 @@ export function createTypeEvaluator(
                 if (isNoneInstance(expandedCallType)) {
                     addDiagnostic(DiagnosticRule.reportOptionalCall, LocMessage.noneNotCallable(), errorNode);
 
+                    touchArgTypes();
                     return { argumentErrors: true };
                 }
 
@@ -9958,6 +9959,7 @@ export function createTypeEvaluator(
             case TypeCategory.Module: {
                 addDiagnostic(DiagnosticRule.reportCallIssue, LocMessage.moduleNotCallable(), errorNode);
 
+                touchArgTypes();
                 return { argumentErrors: true };
             }
         }


### PR DESCRIPTION
…" if it's used in an argument expression for a call expression whose base type is a module or `None`. This addresses pylance issue https://github.com/microsoft/pylance-release/issues/7054.