### PR TITLE
Changed algorithm for applying type narrowing upon assignment when on…

### DIFF
--- a/packages/pyright-internal/src/tests/samples/assignment10.py
+++ b/packages/pyright-internal/src/tests/samples/assignment10.py
@@ -20,8 +20,7 @@ class A:
 T = TypeVar("T")
 
 
-class B(Generic[T]):
-    ...
+class B(Generic[T]): ...
 
 
 def func1(v1: list[Any | None], v2: list[int | str]):
@@ -54,15 +53,15 @@ def func3(y: list[int]):
     reveal_type(x2, expected_text="list[int]")
 
     x3: Iterable[Any] = y
-    reveal_type(x3, expected_text="list[Any]")
+    reveal_type(x3, expected_text="list[int]")
 
 
 def func4(y: list[Any]):
     x1: Iterable[int | B[Any]] = y
-    reveal_type(x1, expected_text="list[int | B[Any]]")
+    reveal_type(x1, expected_text="list[Any]")
 
     x2: Iterable[Any | B[Any]] = y
-    reveal_type(x2, expected_text="list[Any | B[Any]]")
+    reveal_type(x2, expected_text="list[Any]")
 
     x3: Iterable[Any] = y
     reveal_type(x3, expected_text="list[Any]")

--- a/packages/pyright-internal/src/tests/samples/constructor2.py
+++ b/packages/pyright-internal/src/tests/samples/constructor2.py
@@ -69,7 +69,7 @@ def s4():
 
 def s5():
     a: Animal[Any, Any] = Bear[int]()
-    reveal_type(a, expected_text="Bear[Any]")
+    reveal_type(a, expected_text="Bear[int]")
 
 
 def s6():
@@ -94,7 +94,7 @@ def s9(p: dict[str, str]):
 
 def s10(p: list[str]):
     a: Iterable[Any] = p
-    reveal_type(a, expected_text="list[Any]")
+    reveal_type(a, expected_text="list[str]")
     b: Iterable[str] = []
     reveal_type(b, expected_text="list[str]")
     c: Iterable[str] = list()
@@ -108,7 +108,7 @@ def s11():
 
 def s12(p: Bear[_T1], b: _T1):
     a: Animal[Any, int] = p
-    reveal_type(a, expected_text="Bear[Any]")
+    reveal_type(a, expected_text="Bear[_T1@s12]")
 
 
 def s13(p: Bat):
@@ -178,8 +178,7 @@ def s18():
 
 
 class Plant(Generic[_T1]):
-    def __new__(cls, o: _T1) -> Self:
-        ...
+    def __new__(cls, o: _T1) -> Self: ...
 
 
 plant: Plant[float] = Plant(0)

--- a/packages/pyright-internal/src/tests/samples/constructor4.py
+++ b/packages/pyright-internal/src/tests/samples/constructor4.py
@@ -16,10 +16,10 @@ _T = TypeVar("_T")
 
 def foo(value: Type[_T], b: _T) -> None:
     val1: "DefaultDict[str, list[_T]]" = defaultdict(list)
-    reveal_type(val1, expected_text="defaultdict[str, list[_T@foo]]")
+    reveal_type(val1, expected_text="DefaultDict[str, list[_T@foo]]")
 
     val2: "DefaultDict[str, list[_T]]" = defaultdict(List[_T])
-    reveal_type(val2, expected_text="defaultdict[str, list[_T@foo]]")
+    reveal_type(val2, expected_text="DefaultDict[str, list[_T@foo]]")
 
     # This should generate an error because the type is incompatible.
     val3: "DefaultDict[str, list[_T]]" = defaultdict(list[int])


### PR DESCRIPTION
…e or both of the declared type or assigned type contain "Any". This addresses bug #9953 and generally makes pyright's behavior more like mypy's in this regard.