### PR TITLE
Extended the `reportUnnecessaryComparision` check to support the patt…

### DIFF
--- a/packages/pyright-internal/src/analyzer/checker.ts
+++ b/packages/pyright-internal/src/analyzer/checker.ts
@@ -2128,6 +2128,7 @@ export class Checker extends ParseTreeWalker {
     // have overlapping types.
     private _validateComparisonTypes(node: BinaryOperationNode) {
         let rightExpression = node.d.rightExpr;
+        const assumeIsOperator = node.d.operator === OperatorType.Is || node.d.operator === OperatorType.IsNot;
 
         // Check for chained comparisons.
         if (
@@ -2203,7 +2204,7 @@ export class Checker extends ParseTreeWalker {
                         return;
                     }
 
-                    if (this._evaluator.isTypeComparable(leftSubtype, rightSubtype)) {
+                    if (this._evaluator.isTypeComparable(leftSubtype, rightSubtype, assumeIsOperator)) {
                         isComparable = true;
                     }
 

--- a/packages/pyright-internal/src/analyzer/typeEvaluatorTypes.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluatorTypes.ts
@@ -778,7 +778,7 @@ export interface TypeEvaluator {
     getCallSignatureInfo: (node: CallNode, activeIndex: number, activeOrFake: boolean) => CallSignatureInfo | undefined;
     getAbstractSymbols: (classType: ClassType) => AbstractSymbol[];
     narrowConstrainedTypeVar: (node: ParseNode, typeVar: TypeVarType) => Type | undefined;
-    isTypeComparable: (leftType: Type, rightType: Type) => boolean;
+    isTypeComparable: (leftType: Type, rightType: Type, assumeIsOperator?: boolean) => boolean;
 
     assignType: (
         destType: Type,

--- a/packages/pyright-internal/src/tests/samples/comparison2.py
+++ b/packages/pyright-internal/src/tests/samples/comparison2.py
@@ -2,7 +2,7 @@
 # when applied to functions that appear within a conditional expression.
 
 
-from typing import Any, Coroutine
+from typing import Any, Coroutine, Protocol
 from dataclasses import dataclass
 
 
@@ -115,4 +115,22 @@ def func9(x: object, y: type[object]):
 
 def func10(x: object, y: type[object]):
     if x is not y:
+        pass
+
+class SupportsBool(Protocol):
+        def __bool__(self) -> Any: ...
+
+def func11(a: A, b: SupportsBool, c: object):
+    # This should generate an error if reportUnnecessaryComparison is enabled.
+    if a is None:
+        pass
+    
+    # This should generate an error if reportUnnecessaryComparison is enabled.
+    if a is not None:
+        pass
+    
+    if b is None:
+        pass
+    
+    if c is None:
         pass

--- a/packages/pyright-internal/src/tests/typeEvaluator6.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator6.test.ts
@@ -629,7 +629,7 @@ test('Comparison2', () => {
 
     configOptions.diagnosticRuleSet.reportUnnecessaryComparison = 'error';
     const analysisResults2 = TestUtils.typeAnalyzeSampleFiles(['comparison2.py'], configOptions);
-    TestUtils.validateResults(analysisResults2, 15);
+    TestUtils.validateResults(analysisResults2, 17);
 });
 
 test('EmptyContainers1', () => {


### PR DESCRIPTION
…erns `x is None` and `x is not None` in cases where `x` is provably disjoint in type. This addresses #10141.