### PR TITLE
Fixed bug that results in incorrect "literal math" result when dividi…

### DIFF
--- a/packages/pyright-internal/src/analyzer/operations.ts
+++ b/packages/pyright-internal/src/analyzer/operations.ts
@@ -1037,7 +1037,7 @@ function calcLiteralForBinaryOp(operator: OperatorType, leftType: Type, rightTyp
                             // infinity, so we need to adjust the result if the signs
                             // of the operands are different.
                             if (leftLiteralValue !== rightLiteralValue) {
-                                if (leftLiteralValue < BigInt(0) !== rightLiteralValue < BigInt(0)) {
+                                if (leftLiteralValue <= BigInt(0) !== rightLiteralValue <= BigInt(0)) {
                                     newValue -= BigInt(1);
                                 }
                             }

--- a/packages/pyright-internal/src/tests/samples/operator8.py
+++ b/packages/pyright-internal/src/tests/samples/operator8.py
@@ -65,6 +65,9 @@ def func1(a: Literal[1, 2], b: Literal[0, 4], c: Literal[3, 4]):
     c8 = 10 // -6
     reveal_type(c8, expected_text="Literal[-2]")
 
+    c9 = 0 // -6
+    reveal_type(c9, expected_text="Literal[0]")
+
 
 def func2(cond: bool):
     c1 = "Hi " + ("Steve" if cond else "Amy")


### PR DESCRIPTION
…ng `Literal[0]` by a negative literal int value. This addresses #10154.