### PR TITLE
Removed special-casing for async functions that skips check for impli…

### DIFF
--- a/packages/pyright-internal/src/analyzer/checker.ts
+++ b/packages/pyright-internal/src/analyzer/checker.ts
@@ -4789,11 +4789,7 @@ export class Checker extends ParseTreeWalker {
                     // If the function consists entirely of "...", assume that it's
                     // an abstract method or a protocol method and don't require that
                     // the return type matches. This check can also be skipped for an overload.
-                    if (
-                        !ParseTreeUtils.isSuiteEmpty(node.d.suite) &&
-                        !FunctionType.isOverloaded(functionType) &&
-                        !FunctionType.isAsync(functionType)
-                    ) {
+                    if (!ParseTreeUtils.isSuiteEmpty(node.d.suite) && !FunctionType.isOverloaded(functionType)) {
                         this._evaluator.addDiagnostic(
                             DiagnosticRule.reportReturnType,
                             LocMessage.noReturnReturnsNone(),


### PR DESCRIPTION
…cit return when the return type is `NoReturn`. This addresses #10160.