### PR TITLE
Fixed bug that results in incorrect type narrowing when a value whose…

### DIFF
--- a/packages/pyright-internal/src/tests/samples/typeNarrowingIsinstance5.py
+++ b/packages/pyright-internal/src/tests/samples/typeNarrowingIsinstance5.py
@@ -1,24 +1,20 @@
 # This sample tests isinstance type narrowing when the class list
 # includes "Callable".
 
-from typing import Callable, Sequence, TypeVar
+from typing import Callable, Sequence, TypeVar, final
 
 
-class A:
-    ...
+class A: ...
 
 
 class B:
-    def __call__(self, x: str) -> int:
-        ...
+    def __call__(self, x: str) -> int: ...
 
 
-class C:
-    ...
+class C: ...
 
 
-class D(C):
-    ...
+class D(C): ...
 
 
 TCall1 = TypeVar("TCall1", bound=Callable[..., int])
@@ -39,3 +35,32 @@ def func1(
         reveal_type(obj, expected_text="((int, str) -> int) | B | TCall1@func1")
     else:
         reveal_type(obj, expected_text="list[int] | C | D | A")
+
+
+class CB1:
+    def __call__(self, x: str) -> None: ...
+
+
+def func2(c1: Callable[[int], None], c2: Callable[..., None]):
+    if isinstance(c1, CB1):
+        reveal_type(c1, expected_text="Never")
+
+    if isinstance(c2, CB1):
+        reveal_type(c2, expected_text="CB1")
+
+
+class IsNotFinal: ...
+
+
+def func3(c1: Callable[[int], None]):
+    if isinstance(c1, IsNotFinal):
+        reveal_type(c1, expected_text="(int) -> None")
+
+
+@final
+class IsFinal: ...
+
+
+def func4(c1: Callable[[int], None]):
+    if isinstance(c1, IsFinal):
+        reveal_type(c1, expected_text="Never")


### PR DESCRIPTION
… type is a non-callable (and non-final) class is passed as the second argument to an `isinstance` call and the first argument is a callable type. In this case, a subclass could provide a compatible `__call__` method, so the type shouldn't be narrowed to `Never`. This addresses #10171.