### PR TITLE
Extended `deprecateTypingAliases` feature to support symbols imported…

### DIFF
--- a/packages/pyright-internal/src/analyzer/checker.ts
+++ b/packages/pyright-internal/src/analyzer/checker.ts
@@ -1488,11 +1488,9 @@ export class Checker extends ParseTreeWalker {
         const type = typeResult?.type ?? UnknownType.create();
 
         const leftExprType = this._evaluator.getType(node.d.leftExpr);
-        this._reportDeprecatedUseForType(
-            node.d.member,
-            type,
-            leftExprType && isModule(leftExprType) && leftExprType.priv.moduleName === 'typing'
-        );
+        const moduleName = leftExprType && isModule(leftExprType) ? leftExprType.priv.moduleName : undefined;
+        const isImportedFromTyping = moduleName === 'typing' || moduleName === 'typing_extensions';
+        this._reportDeprecatedUseForType(node.d.member, type, isImportedFromTyping);
 
         if (typeResult?.memberAccessDeprecationInfo) {
             this._reportDeprecatedUseForMemberAccess(node.d.member, typeResult.memberAccessDeprecationInfo);
@@ -1596,7 +1594,8 @@ export class Checker extends ParseTreeWalker {
         let isImportFromTyping = false;
         if (node.parent?.nodeType === ParseNodeType.ImportFrom) {
             if (node.parent.d.module.d.leadingDots === 0 && node.parent.d.module.d.nameParts.length === 1) {
-                if (node.parent.d.module.d.nameParts[0].d.value === 'typing') {
+                const namePart = node.parent.d.module.d.nameParts[0].d.value;
+                if (namePart === 'typing' || namePart === 'typing_extensions') {
                     isImportFromTyping = true;
                 }
             }

--- a/packages/pyright-internal/src/tests/checker.test.ts
+++ b/packages/pyright-internal/src/tests/checker.test.ts
@@ -528,50 +528,96 @@ test('UninitializedVariable2', () => {
     TestUtils.validateResults(analysisResults, 3);
 });
 
-test('Deprecated1', () => {
+test('DeprecatedAlias1', () => {
     const configOptions = new ConfigOptions(Uri.empty());
 
     configOptions.defaultPythonVersion = pythonVersion3_8;
-    const analysisResults1 = TestUtils.typeAnalyzeSampleFiles(['deprecated1.py'], configOptions);
+    const analysisResults1 = TestUtils.typeAnalyzeSampleFiles(['deprecatedAlias1.py'], configOptions);
     TestUtils.validateResults(analysisResults1, 0, 0, 0, undefined, undefined, 0);
 
     configOptions.defaultPythonVersion = pythonVersion3_9;
-    const analysisResults2 = TestUtils.typeAnalyzeSampleFiles(['deprecated1.py'], configOptions);
+    const analysisResults2 = TestUtils.typeAnalyzeSampleFiles(['deprecatedAlias1.py'], configOptions);
     TestUtils.validateResults(analysisResults2, 0, 0, 0, undefined, undefined, 0);
 
     configOptions.defaultPythonVersion = pythonVersion3_10;
-    const analysisResults3 = TestUtils.typeAnalyzeSampleFiles(['deprecated1.py'], configOptions);
+    const analysisResults3 = TestUtils.typeAnalyzeSampleFiles(['deprecatedAlias1.py'], configOptions);
     TestUtils.validateResults(analysisResults3, 0, 0, 0, undefined, undefined, 0);
 
     // Now enable the deprecateTypingAliases setting.
     configOptions.diagnosticRuleSet.deprecateTypingAliases = true;
 
     configOptions.defaultPythonVersion = pythonVersion3_8;
-    const analysisResults4 = TestUtils.typeAnalyzeSampleFiles(['deprecated1.py'], configOptions);
+    const analysisResults4 = TestUtils.typeAnalyzeSampleFiles(['deprecatedAlias1.py'], configOptions);
     TestUtils.validateResults(analysisResults4, 0, 0, 0, undefined, undefined, 0);
 
     configOptions.defaultPythonVersion = pythonVersion3_9;
-    const analysisResults5 = TestUtils.typeAnalyzeSampleFiles(['deprecated1.py'], configOptions);
+    const analysisResults5 = TestUtils.typeAnalyzeSampleFiles(['deprecatedAlias1.py'], configOptions);
     TestUtils.validateResults(analysisResults5, 0, 0, 0, undefined, undefined, 45);
 
     configOptions.defaultPythonVersion = pythonVersion3_10;
-    const analysisResults6 = TestUtils.typeAnalyzeSampleFiles(['deprecated1.py'], configOptions);
+    const analysisResults6 = TestUtils.typeAnalyzeSampleFiles(['deprecatedAlias1.py'], configOptions);
     TestUtils.validateResults(analysisResults6, 0, 0, 0, undefined, undefined, 49);
 
     // Now change reportDeprecated to emit an error.
     configOptions.diagnosticRuleSet.reportDeprecated = 'error';
 
     configOptions.defaultPythonVersion = pythonVersion3_8;
-    const analysisResults7 = TestUtils.typeAnalyzeSampleFiles(['deprecated1.py'], configOptions);
+    const analysisResults7 = TestUtils.typeAnalyzeSampleFiles(['deprecatedAlias1.py'], configOptions);
     TestUtils.validateResults(analysisResults7, 0, 0, 0, undefined, undefined, 0);
 
     configOptions.defaultPythonVersion = pythonVersion3_9;
-    const analysisResults8 = TestUtils.typeAnalyzeSampleFiles(['deprecated1.py'], configOptions);
+    const analysisResults8 = TestUtils.typeAnalyzeSampleFiles(['deprecatedAlias1.py'], configOptions);
     TestUtils.validateResults(analysisResults8, 45, 0, 0, undefined, undefined, 0);
 
     configOptions.defaultPythonVersion = pythonVersion3_10;
-    const analysisResults9 = TestUtils.typeAnalyzeSampleFiles(['deprecated1.py'], configOptions);
+    const analysisResults9 = TestUtils.typeAnalyzeSampleFiles(['deprecatedAlias1.py'], configOptions);
     TestUtils.validateResults(analysisResults9, 49, 0, 0, undefined, undefined, 0);
+});
+
+test('DeprecatedAlias2', () => {
+    const configOptions = new ConfigOptions(Uri.empty());
+
+    configOptions.defaultPythonVersion = pythonVersion3_8;
+    const analysisResults1 = TestUtils.typeAnalyzeSampleFiles(['deprecatedAlias2.py'], configOptions);
+    TestUtils.validateResults(analysisResults1, 0, 0, 0, undefined, undefined, 0);
+
+    configOptions.defaultPythonVersion = pythonVersion3_9;
+    const analysisResults2 = TestUtils.typeAnalyzeSampleFiles(['deprecatedAlias2.py'], configOptions);
+    TestUtils.validateResults(analysisResults2, 0, 0, 0, undefined, undefined, 0);
+
+    configOptions.defaultPythonVersion = pythonVersion3_10;
+    const analysisResults3 = TestUtils.typeAnalyzeSampleFiles(['deprecatedAlias2.py'], configOptions);
+    TestUtils.validateResults(analysisResults3, 0, 0, 0, undefined, undefined, 0);
+
+    // Now enable the deprecateTypingAliases setting.
+    configOptions.diagnosticRuleSet.deprecateTypingAliases = true;
+
+    configOptions.defaultPythonVersion = pythonVersion3_8;
+    const analysisResults4 = TestUtils.typeAnalyzeSampleFiles(['deprecatedAlias2.py'], configOptions);
+    TestUtils.validateResults(analysisResults4, 0, 0, 0, undefined, undefined, 0);
+
+    configOptions.defaultPythonVersion = pythonVersion3_9;
+    const analysisResults5 = TestUtils.typeAnalyzeSampleFiles(['deprecatedAlias2.py'], configOptions);
+    TestUtils.validateResults(analysisResults5, 0, 0, 0, undefined, undefined, 42);
+
+    configOptions.defaultPythonVersion = pythonVersion3_10;
+    const analysisResults6 = TestUtils.typeAnalyzeSampleFiles(['deprecatedAlias2.py'], configOptions);
+    TestUtils.validateResults(analysisResults6, 0, 0, 0, undefined, undefined, 46);
+
+    // Now change reportDeprecated to emit an error.
+    configOptions.diagnosticRuleSet.reportDeprecated = 'error';
+
+    configOptions.defaultPythonVersion = pythonVersion3_8;
+    const analysisResults7 = TestUtils.typeAnalyzeSampleFiles(['deprecatedAlias2.py'], configOptions);
+    TestUtils.validateResults(analysisResults7, 0, 0, 0, undefined, undefined, 0);
+
+    configOptions.defaultPythonVersion = pythonVersion3_9;
+    const analysisResults8 = TestUtils.typeAnalyzeSampleFiles(['deprecatedAlias2.py'], configOptions);
+    TestUtils.validateResults(analysisResults8, 42, 0, 0, undefined, undefined, 0);
+
+    configOptions.defaultPythonVersion = pythonVersion3_10;
+    const analysisResults9 = TestUtils.typeAnalyzeSampleFiles(['deprecatedAlias2.py'], configOptions);
+    TestUtils.validateResults(analysisResults9, 46, 0, 0, undefined, undefined, 0);
 });
 
 test('Deprecated2', () => {

--- a/packages/pyright-internal/src/tests/samples/deprecatedAlias1.py
+++ b/packages/pyright-internal/src/tests/samples/deprecatedAlias1.py
@@ -1,0 +1,62 @@
+# This sample tests the detection of deprecated classes from the typing
+# module.
+
+from typing import (
+    ChainMap as CM1,
+    Counter as CT1,
+    DefaultDict,
+    Deque,
+    Dict,
+    FrozenSet,
+    List,
+    Optional,
+    OrderedDict as OD1,
+    Set,
+    Tuple,
+    Type,
+    Union,
+    Awaitable,
+    Coroutine,
+    AsyncIterable,
+    AsyncGenerator,
+    Iterable,
+    Iterator,
+    Generator,
+    Reversible,
+    Container,
+    Collection as C1,
+    Callable,
+    AbstractSet,
+    MutableSet,
+    Mapping,
+    MutableMapping,
+    Sequence,
+    MutableSequence,
+    ByteString as BS1,
+    MappingView,
+    KeysView,
+    ItemsView,
+    ValuesView,
+    ContextManager as CM1,
+    AsyncContextManager,
+    Pattern as P1,
+    Match as M1,
+)
+
+from collections.abc import Collection, ByteString, Set as AS
+from contextlib import AbstractContextManager
+from re import Pattern, Match
+
+# These should be marked deprecated for Python >= 3.9
+v1: List[int] = [1, 2, 3]
+v2: Dict[int, str] = {}
+v3: Set[int] = set()
+v4: Tuple[int] = (3,)
+v5: FrozenSet[int] = frozenset()
+v6: Type[int] = int
+v7 = Deque()
+v8 = DefaultDict()
+
+# These should be marked deprecated for Python >= 3.10
+v20: Union[int, str]
+v21: Optional[int]

--- a/packages/pyright-internal/src/tests/samples/deprecatedAlias2.py
+++ b/packages/pyright-internal/src/tests/samples/deprecatedAlias2.py
@@ -1,8 +1,9 @@
-# This sample tests the detection of deprecated classes from the typing
-# module.
+# This sample tests the detection of deprecated classes from the
+# typing_extensions module.
 
+# This test is heavily derived from deprecatedAlias1.py.
 
-from typing import (
+from typing_extensions import (  # pyright: ignore[reportMissingModuleSource]
     ChainMap as CM1,
     Counter as CT1,
     DefaultDict,
@@ -33,13 +34,13 @@ from typing import (
     MutableMapping,
     Sequence,
     MutableSequence,
-    ByteString as BS1,
+    # ByteString as BS1, # This symbol doesn't exist in typing_extensions
     MappingView,
     KeysView,
     ItemsView,
     ValuesView,
-    ContextManager as CM1,
-    AsyncContextManager,
+    ContextManager as CM1,  # This symbol is reexported from contextlib
+    AsyncContextManager,  # This symbol is reexported from contextlib
     Pattern as P1,
     Match as M1,
 )


### PR DESCRIPTION
… from `typing_extensions`. This addresses #10190.