### PR TITLE
Fixed bug that results in a false negative when a type variable with …

### DIFF
--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -27429,7 +27429,7 @@ export function createTypeEvaluator(
                                 baseParamDetails.params[i].type,
                                 diag?.createAddendum(),
                                 constraints,
-                                AssignTypeFlags.Contravariant
+                                AssignTypeFlags.Default
                             )
                         ) {
                             LocAddendum.overrideParamType().format({
@@ -27552,7 +27552,7 @@ export function createTypeEvaluator(
                                 baseParamType,
                                 diag?.createAddendum(),
                                 constraints,
-                                AssignTypeFlags.Contravariant
+                                AssignTypeFlags.Default
                             )
                         ) {
                             diag?.addMessage(
@@ -27614,7 +27614,7 @@ export function createTypeEvaluator(
                             baseParamType,
                             diag?.createAddendum(),
                             constraints,
-                            AssignTypeFlags.Contravariant
+                            AssignTypeFlags.Default
                         )
                     ) {
                         diag?.addMessage(
@@ -27659,7 +27659,7 @@ export function createTypeEvaluator(
                             paramInfo.type,
                             diag?.createAddendum(),
                             constraints,
-                            AssignTypeFlags.Contravariant
+                            AssignTypeFlags.Default
                         )
                     ) {
                         diag?.addMessage(

--- a/packages/pyright-internal/src/tests/samples/methodOverride4.py
+++ b/packages/pyright-internal/src/tests/samples/methodOverride4.py
@@ -42,3 +42,12 @@ class BaseB:
 
 class SubclassB1(BaseB):
     def f[T](self, v: T) -> T: ...
+
+
+class BaseC:
+    def method1[T: BaseC](self, x: T) -> T: ...
+
+
+class SubclassC(BaseC):
+    # This should generate an error because of the upper bound.
+    def method1[T: SubclassC](self, x: T) -> T: ...

--- a/packages/pyright-internal/src/tests/typeEvaluator3.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator3.test.ts
@@ -975,7 +975,7 @@ test('MethodOverride3', () => {
 
 test('MethodOverride4', () => {
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['methodOverride4.py']);
-    TestUtils.validateResults(analysisResults, 0);
+    TestUtils.validateResults(analysisResults, 1);
 });
 
 test('MethodOverride5', () => {


### PR DESCRIPTION
…an upper bound is used to annotate a parameter in a method override. This addresses #10197.