### PR TITLE
Extended `reportUnknownVariableType` check to include cases where a v…

### DIFF
--- a/packages/pyright-internal/src/tests/samples/assignment12.py
+++ b/packages/pyright-internal/src/tests/samples/assignment12.py
@@ -2,13 +2,17 @@
 # is assigned an unknown value or partially-unknown value.
 
 
-def a_test(x: int):
-    u = x.upper()  # type: ignore
+def a_test(x1: int, x2: list):
+    u = x1.upper()  # type: ignore
     reveal_type(u, expected_text="Unknown")
 
     # This should generate an error if reportUnknownVariableType is enabled.
     y: str = u
     reveal_type(y, expected_text="Unknown | str")
+
+    # This should generate an error if reportUnknownVariableType is enabled.
+    z: list[str] = x2
+    reveal_type(z, expected_text="list[str]")
 
 
 def b_test(x: int | str):

--- a/packages/pyright-internal/src/tests/typeEvaluator2.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator2.test.ts
@@ -153,7 +153,7 @@ test('Assignment12', () => {
 
     configOptions.diagnosticRuleSet.reportUnknownVariableType = 'error';
     const analysisResults2 = TestUtils.typeAnalyzeSampleFiles(['assignment12.py'], configOptions);
-    TestUtils.validateResults(analysisResults2, 2);
+    TestUtils.validateResults(analysisResults2, 3);
 });
 
 test('AugmentedAssignment1', () => {


### PR DESCRIPTION
…alue whose type is a generic class parameterized by `Unknown` is assigned to a variable with a declared type. This addresses #10214.