### PR TITLE
Fixed a bug that results in a false negative when the specialization …

### DIFF
--- a/packages/pyright-internal/src/tests/samples/typeVarTuple3.py
+++ b/packages/pyright-internal/src/tests/samples/typeVarTuple3.py
@@ -1,7 +1,7 @@
 # This sample tests the TypeVar matching logic related to
 # variadic type variables.
 
-from typing import Any, Generic, Literal, TypeVar, overload
+from typing import Any, Generic, Literal, TypeAlias, TypeVar, overload
 from typing_extensions import (  # pyright: ignore[reportMissingModuleSource]
     TypeVarTuple,
     Unpack,
@@ -104,3 +104,26 @@ def func5(a1: Array[Literal["a", "b"]], a2: Array[Literal["a"], Literal["b"]]):
 
 def func6(a: Array):
     reveal_type(a, expected_text="Array[*tuple[Unknown, ...]]")
+
+
+def func7():
+    x1: Array[*tuple[int, str], *tuple[str]]
+    x2: Array[*tuple[int, ...], *tuple[str]]
+    x3: Array[*tuple[str], *tuple[int, ...], *tuple[str]]
+
+    # This should generate an error because only one unpacked unbounded
+    # tuple can be used.
+    x4: Array[*tuple[str, ...], *tuple[int, ...], *tuple[str]]
+
+
+ArrayAlias: TypeAlias = Array[Unpack[_Xs]]
+
+
+def func8():
+    x1: ArrayAlias[*tuple[int, str], *tuple[str]]
+    x2: ArrayAlias[*tuple[int, ...], *tuple[str]]
+    x3: ArrayAlias[*tuple[str], *tuple[int, ...], *tuple[str]]
+
+    # This should generate an error because only one unpacked unbounded
+    # tuple can be used.
+    x4: ArrayAlias[*tuple[str, ...], *tuple[int, ...], *tuple[str]]

--- a/packages/pyright-internal/src/tests/typeEvaluator6.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator6.test.ts
@@ -223,7 +223,7 @@ test('TypeVarTuple3', () => {
 
     configOptions.defaultPythonVersion = pythonVersion3_11;
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['typeVarTuple3.py'], configOptions);
-    TestUtils.validateResults(analysisResults, 4);
+    TestUtils.validateResults(analysisResults, 6);
 });
 
 test('TypeVarTuple4', () => {


### PR DESCRIPTION
…of a TypeVarTuple includes multiple unpacked tuples of unknown length. This addresses #10219.