### PR TITLE
Fixed a bug that results in a false negative when a class that derive…

### DIFF
--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -24965,22 +24965,20 @@ export function createTypeEvaluator(
                 // Determine if the metaclass can be assigned to the object.
                 const metaclass = concreteSrcType.shared.effectiveMetaclass;
                 if (metaclass) {
-                    if (isAnyOrUnknown(metaclass)) {
-                        return true;
-                    }
-
-                    if (
-                        assignClass(
-                            ClassType.cloneAsInstantiable(destType),
-                            metaclass,
-                            /* diag */ undefined,
-                            constraints,
-                            flags,
-                            recursionCount,
-                            /* reportErrorsUsingObjType */ true
-                        )
-                    ) {
-                        return true;
+                    if (!isAnyOrUnknown(metaclass)) {
+                        if (
+                            assignClass(
+                                ClassType.cloneAsInstantiable(destType),
+                                metaclass,
+                                /* diag */ undefined,
+                                constraints,
+                                flags,
+                                recursionCount,
+                                /* reportErrorsUsingObjType */ true
+                            )
+                        ) {
+                            return true;
+                        }
                     }
                 }
             } else if (isAnyOrUnknown(concreteSrcType) && !concreteSrcType.props?.specialForm) {


### PR DESCRIPTION
…s from `type[Any]` is assigned to any other type. This addresses #10185.