### PR TITLE
Fixed bug that results in an incorrect error under certain circumstan…

### DIFF
--- a/packages/pyright-internal/src/tests/samples/returnTypes2.py
+++ b/packages/pyright-internal/src/tests/samples/returnTypes2.py
@@ -50,3 +50,10 @@ class Grammar:
     @staticmethod
     def L():
         return Grammar.B
+
+
+async def func1(a):
+    if a == 0:
+        return
+    r = await func1(a - 1)
+    return r


### PR DESCRIPTION
…ces when inferring the return type of a recursive function that has a decorator or is `async`. This addresses #10242.