### PR TITLE
Fixed bug that results in a false negative when a return statement co…

### DIFF
--- a/packages/pyright-internal/src/analyzer/binder.ts
+++ b/packages/pyright-internal/src/analyzer/binder.ts
@@ -1273,6 +1273,7 @@ export class Binder extends ParseTreeWalker {
         }
 
         if (node.d.expr) {
+            AnalyzerNodeInfo.setFlowNode(node.d.expr, this._currentFlowNode!);
             this.walk(node.d.expr);
         }
 

--- a/packages/pyright-internal/src/tests/checker.test.ts
+++ b/packages/pyright-internal/src/tests/checker.test.ts
@@ -135,7 +135,7 @@ test('Constants1', () => {
 test('NoReturn1', () => {
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['noreturn1.py']);
 
-    TestUtils.validateResults(analysisResults, 4);
+    TestUtils.validateResults(analysisResults, 5);
 });
 
 test('NoReturn2', () => {

--- a/packages/pyright-internal/src/tests/samples/noreturn1.py
+++ b/packages/pyright-internal/src/tests/samples/noreturn1.py
@@ -82,3 +82,11 @@ def func12() -> NoReturn:
 def func13() -> NoReturn:
     # This should generate an error.
     func11(0)
+
+
+def func14(x: int) -> NoReturn: ...
+
+
+def func15():
+    # This should generate an error.
+    return func14()


### PR DESCRIPTION
…ntains a call expression that invokes a `NoReturn` call and the argument list contains errors. This addresses #10260.