### PR TITLE
Extended the check for `isinstance` and `issubclass` argument validat…

### DIFF
--- a/packages/pyright-internal/src/analyzer/checker.ts
+++ b/packages/pyright-internal/src/analyzer/checker.ts
@@ -4068,6 +4068,13 @@ export class Checker extends ParseTreeWalker {
                     ) {
                         diag.addMessage(LocAddendum.annotatedNotAllowed());
                         isSupported = false;
+                    } else if (
+                        subtype.props?.specialForm &&
+                        isInstantiableClass(subtype.props.specialForm) &&
+                        ClassType.isBuiltIn(subtype.props.specialForm, 'Literal')
+                    ) {
+                        diag.addMessage(LocAddendum.literalNotAllowed());
+                        isSupported = false;
                     }
                     break;
 

--- a/packages/pyright-internal/src/localization/localize.ts
+++ b/packages/pyright-internal/src/localization/localize.ts
@@ -1333,6 +1333,7 @@ export namespace Localizer {
             new ParameterizedString<{ sourceType: string; destType: string }>(
                 getRawString('DiagnosticAddendum.literalAssignmentMismatch')
             );
+        export const literalNotAllowed = () => getRawString('DiagnosticAddendum.literalNotAllowed');
         export const matchIsNotExhaustiveType = () =>
             new ParameterizedString<{ type: string }>(getRawString('DiagnosticAddendum.matchIsNotExhaustiveType'));
         export const matchIsNotExhaustiveHint = () => getRawString('DiagnosticAddendum.matchIsNotExhaustiveHint');

--- a/packages/pyright-internal/src/localization/package.nls.en-us.json
+++ b/packages/pyright-internal/src/localization/package.nls.en-us.json
@@ -1842,6 +1842,10 @@
         "kwargsParamMissing": "Parameter \"**{paramName}\" has no corresponding parameter",
         "listAssignmentMismatch": "Type \"{type}\" is incompatible with target list",
         "literalAssignmentMismatch": "\"{sourceType}\" is not assignable to type \"{destType}\"",
+        "literalNotAllowed": {
+            "message": "\"Literal\" special form cannot be used with instance and class checks",
+            "comment": "{Locked='Literal'}"
+        },
         "matchIsNotExhaustiveHint": {
             "message": "If exhaustive handling is not intended, add \"case _: pass\"",
             "comment": "{Locked='case _: pass'}"

--- a/packages/pyright-internal/src/tests/samples/isinstance3.py
+++ b/packages/pyright-internal/src/tests/samples/isinstance3.py
@@ -112,3 +112,8 @@ if isinstance(1, TA1):
 # in an isinstance call.
 if isinstance(1, Any):
     pass
+
+# This should generate an error because Literal can't be used
+# in an isinstance call.
+if isinstance(1, Literal[1, 2]):
+    pass

--- a/packages/pyright-internal/src/tests/typeEvaluator2.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator2.test.ts
@@ -316,11 +316,11 @@ test('isInstance3', () => {
 
     configOptions.defaultPythonVersion = pythonVersion3_9;
     const analysisResults1 = TestUtils.typeAnalyzeSampleFiles(['isinstance3.py'], configOptions);
-    TestUtils.validateResults(analysisResults1, 6);
+    TestUtils.validateResults(analysisResults1, 7);
 
     configOptions.defaultPythonVersion = pythonVersion3_10;
     const analysisResults2 = TestUtils.typeAnalyzeSampleFiles(['isinstance3.py'], configOptions);
-    TestUtils.validateResults(analysisResults2, 6);
+    TestUtils.validateResults(analysisResults2, 7);
 });
 
 test('isInstance4', () => {


### PR DESCRIPTION
…ion to flag the `Literal` special form, which leads to a runtime error when used in the second argument. This addresses #10258.