### PR TITLE
Fixed bug that leads to a false positive in the `reportUnnecessaryCom…

### DIFF
--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -25692,8 +25692,15 @@ export function createTypeEvaluator(
 
         const isLeftCallable = isFunction(leftType) || isOverloaded(leftType);
         const isRightCallable = isFunction(rightType) || isOverloaded(rightType);
-        if (isLeftCallable !== isRightCallable) {
-            return false;
+
+        // If either type is a function, assume that it may be comparable. The other
+        // operand might be a callable object, an 'object' instance, etc. We could
+        // make this more precise for specific cases (e.g. if the other operand is
+        // None or a literal or an instance of a nominal class that doesn't override
+        // __call__ and is marked final, etc.), but coming up with a comprehensive
+        // list is probably not feasible.
+        if (isLeftCallable || isRightCallable) {
+            return true;
         }
 
         if (isInstantiableClass(leftType) || (isClassInstance(leftType) && ClassType.isBuiltIn(leftType, 'type'))) {

--- a/packages/pyright-internal/src/tests/samples/comparison2.py
+++ b/packages/pyright-internal/src/tests/samples/comparison2.py
@@ -2,7 +2,7 @@
 # when applied to functions that appear within a conditional expression.
 
 
-from typing import Any, Coroutine, Protocol
+from typing import Any, Callable, Coroutine, Protocol
 from dataclasses import dataclass
 
 
@@ -136,3 +136,7 @@ def func11(a: A, b: SupportsBool, c: object):
 
     if c is None:
         pass
+
+
+def func12(a: object, b: Callable[..., int]) -> bool:
+    return a is b


### PR DESCRIPTION
…parison` check when one operand's type is a callable and the other is not. This addresses #10253.