### PR TITLE
Change npm publishing owner from plseng to me

### DIFF
--- a/build/azuredevops/azure-pipelines-release.yml
+++ b/build/azuredevops/azure-pipelines-release.yml
@@ -301,5 +301,5 @@ extends:
                   contentSource: Folder
                   folderLocation: $(Build.StagingDirectory)/dist
                   waitForReleaseCompletion: true
-                  owners: plseng@microsoft.com
+                  owners: erikd@microsoft.com
                   approvers: grwheele@microsoft.com


### PR DESCRIPTION
ESRP team says that the npm publishing step yesterday failed because I had listed a DL as the owner instead of a human. They believe that after fixing this, our next publishing attempt will work.

Apparently MicroBuild is using an old version of the ESRP release task. If they updated, the details of this error would have been available in our pipeline log.