### PR TITLE
Fixed bug that results in a false positive when accessing a generic a…

### DIFF
--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -23698,6 +23698,7 @@ export function createTypeEvaluator(
             errorNode &&
             selfClass &&
             isClass(selfClass) &&
+            !selfClass.priv.includeSubclasses &&
             member.isInstanceMember &&
             isClass(member.unspecializedClassType) &&
             (flags & MemberAccessFlags.DisallowGenericInstanceVariableAccess) !== 0 &&

--- a/packages/pyright-internal/src/tests/samples/memberAccess25.py
+++ b/packages/pyright-internal/src/tests/samples/memberAccess25.py
@@ -73,3 +73,7 @@ ClassC.x
 del ClassC.x
 ClassC.x
 del ClassC.x
+
+
+def func1(a: type[ClassA]):
+    print(a.x)


### PR DESCRIPTION
…ttribute from an object whose type is `type[X]`. This addresses #10304.