### PR TITLE
Fixed bug that results in incorrect type narrowing of a variable that…

### DIFF
--- a/packages/pyright-internal/src/tests/samples/codeFlow9.py
+++ b/packages/pyright-internal/src/tests/samples/codeFlow9.py
@@ -1,0 +1,19 @@
+# This sample tests the case where a comprehension-scoped variable
+# shadows a variable of the same name in an outer scope and is
+# narrowed within the comprehension.
+
+def func1(m: list[str | int]) -> None:
+    print(
+        [
+            reveal_type(value, expected_text="str")
+            for value in m
+            if isinstance(value, str)
+        ]
+    )
+
+    reveal_type(value, expected_text="() -> None")
+    value()
+
+
+def value() -> None:
+    pass

--- a/packages/pyright-internal/src/tests/typeEvaluator8.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator8.test.ts
@@ -189,6 +189,12 @@ test('CodeFlow8', () => {
     TestUtils.validateResults(analysisResults, 0);
 });
 
+test('CodeFlow9', () => {
+    const analysisResults = TestUtils.typeAnalyzeSampleFiles(['codeFlow9.py']);
+
+    TestUtils.validateResults(analysisResults, 0);
+});
+
 test('CapturedVariable1', () => {
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['capturedVariable1.py']);
 


### PR DESCRIPTION
… is shadowed in an inner-scoped comprehension. This addresses #10301.