### PR TITLE
Extended "type(x) is C" type narrowing logic to support cases where `…

### DIFF
--- a/packages/pyright-internal/src/tests/samples/typeNarrowingTypeIs1.py
+++ b/packages/pyright-internal/src/tests/samples/typeNarrowingTypeIs1.py
@@ -136,3 +136,18 @@ def func9[T: H](x: type[T], y: H) -> T:
         reveal_type(y, expected_text="H*")
         return y
     return x(y)
+
+
+class I:
+    pass
+
+
+class J:
+    pass
+
+
+def func10[T: I | J](items: list[I | J], kind: type[T]) -> T | None:
+    for i in items:
+        if type(i) is kind:
+            reveal_type(i, expected_text="I* | J*")
+            return i


### PR DESCRIPTION
…C` is a union of types or a type variable with a union upper bound. This addresses #10288.