### PR TITLE
Added support for PEP 765, which makes it a syntax error (or warning)…

### DIFF
--- a/packages/pyright-internal/src/localization/localize.ts
+++ b/packages/pyright-internal/src/localization/localize.ts
@@ -519,6 +519,9 @@ export namespace Localizer {
             new ParameterizedString<{ type: string }>(getRawString('Diagnostic.finalClassIsAbstract'));
         export const finalContext = () => getRawString('Diagnostic.finalContext');
         export const finalInLoop = () => getRawString('Diagnostic.finalInLoop');
+        export const finallyBreak = () => getRawString('Diagnostic.finallyBreak');
+        export const finallyContinue = () => getRawString('Diagnostic.finallyContinue');
+        export const finallyReturn = () => getRawString('Diagnostic.finallyReturn');
         export const finalMethodOverride = () =>
             new ParameterizedString<{ name: string; className: string }>(
                 getRawString('Diagnostic.finalMethodOverride')

--- a/packages/pyright-internal/src/localization/package.nls.en-us.json
+++ b/packages/pyright-internal/src/localization/package.nls.en-us.json
@@ -484,6 +484,18 @@
             "message": "A \"Final\" variable cannot be assigned within a loop",
             "comment": "{Locked='Final'}"
         },
+        "finallyBreak": {
+            "message": "A \"break\" cannot be used to exit a \"finally\" block",
+            "comment": "{Locked='break', 'finally'}"
+        },
+        "finallyContinue": {
+            "message": "A \"continue\" cannot be used to exit a \"finally\" block",
+            "comment": "{Locked='continue', 'finally'}"
+        },
+        "finallyReturn": {
+            "message": "A \"return\" cannot be used to exit a \"finally\" block",
+            "comment": "{Locked='return', 'finally'}"
+        },
         "finalMethodOverride": {
             "message": "Method \"{name}\" cannot override final method defined in class \"{className}\"",
             "comment": "{Locked='final'}"

--- a/packages/pyright-internal/src/tests/parser.test.ts
+++ b/packages/pyright-internal/src/tests/parser.test.ts
@@ -11,8 +11,11 @@
 import * as assert from 'assert';
 
 import { findNodeByOffset, getFirstAncestorOrSelfOfKind } from '../analyzer/parseTreeUtils';
+import { ExecutionEnvironment, getStandardDiagnosticRuleSet } from '../common/configOptions';
 import { DiagnosticSink } from '../common/diagnosticSink';
+import { pythonVersion3_13, pythonVersion3_14 } from '../common/pythonVersion';
 import { TextRange } from '../common/textRange';
+import { UriEx } from '../common/uri/uriUtils';
 import { ParseNodeType, StatementListNode } from '../parser/parseNodes';
 import { getNodeAtMarker, parseAndGetTestState } from './harness/fourslash/testState';
 import * as TestUtils from './testUtils';
@@ -130,4 +133,25 @@ test('ParserRecovery3', () => {
     const node = findNodeByOffset(parseResults.parserOutput.parseTree, parseResults.text.length - 2);
     const functionNode = getFirstAncestorOrSelfOfKind(node, ParseNodeType.Function);
     assert.equal(functionNode!.parent!.nodeType, ParseNodeType.Module);
+});
+
+test('FinallyExit1', () => {
+    const execEnvironment = new ExecutionEnvironment(
+        'python',
+        UriEx.file('.'),
+        getStandardDiagnosticRuleSet(),
+        /* defaultPythonVersion */ undefined,
+        /* defaultPythonPlatform */ undefined,
+        /* defaultExtraPaths */ undefined
+    );
+
+    const diagSink1 = new DiagnosticSink();
+    execEnvironment.pythonVersion = pythonVersion3_13;
+    TestUtils.parseSampleFile('finallyExit1.py', diagSink1, execEnvironment);
+    assert.strictEqual(diagSink1.getErrors().length, 0);
+
+    const diagSink2 = new DiagnosticSink();
+    execEnvironment.pythonVersion = pythonVersion3_14;
+    TestUtils.parseSampleFile('finallyExit1.py', diagSink2, execEnvironment);
+    assert.strictEqual(diagSink2.getErrors().length, 5);
 });

--- a/packages/pyright-internal/src/tests/samples/finallyExit1.py
+++ b/packages/pyright-internal/src/tests/samples/finallyExit1.py
@@ -1,0 +1,69 @@
+# This sample tests that pyright's parser correctly identifies
+# illegal exits from a finally block as specified in PEP 765.
+
+
+def func1():
+    try:
+        return
+    finally:
+        # This should generate an error if using Python 3.14 or later.
+        return
+
+
+def func2():
+    try:
+        return
+    finally:
+
+        def inner():
+            return
+
+
+def func3():
+    while True:
+        try:
+            return
+        finally:
+            if 1 < 1:
+                # This should generate an error if using Python 3.14 or later.
+                break
+
+            if 1 > 2:
+                # This should generate an error if using Python 3.14 or later.
+                continue
+
+    for x in (1, 2):
+        try:
+            return
+        finally:
+            if 1 < 1:
+                # This should generate an error if using Python 3.14 or later.
+                break
+
+            if 1 > 2:
+                # This should generate an error if using Python 3.14 or later.
+                continue
+
+
+def func4():
+    try:
+        return
+    finally:
+        while 1 < 2:
+            if 1 < 1:
+                break
+
+            if 1 > 2:
+                continue
+
+
+def func5():
+    try:
+        return
+    finally:
+        for x in (1, 2):
+            if 1 < 1:
+                break
+
+            if 1 > 2:
+                continue

--- a/packages/pyright-internal/src/tests/testUtils.ts
+++ b/packages/pyright-internal/src/tests/testUtils.ts
@@ -86,7 +86,7 @@ export function parseSampleFile(
         parseOptions.isStubFile = true;
     }
     parseOptions.pythonVersion = execEnvironment.pythonVersion;
-    return parseText(text, diagSink);
+    return parseText(text, diagSink, parseOptions);
 }
 
 export function typeAnalyzeSampleFiles(


### PR DESCRIPTION
… in Python 3.14 if a `return`, `break` or `continue` is used to exit a `finally` clause. This addresses #10319.