### PR TITLE
Added check for named tuple field names that begin with an underscore…

### DIFF
--- a/packages/pyright-internal/src/analyzer/dataClasses.ts
+++ b/packages/pyright-internal/src/analyzer/dataClasses.ts
@@ -272,7 +272,7 @@ export function synthesizeDataClassMethods(
 
                 // If the RHS of the assignment is assigning a field instance where the
                 // "init" parameter is set to false, do not include it in the init method.
-                if (statement.d.rightExpr.nodeType === ParseNodeType.Call) {
+                if (!isNamedTuple && statement.d.rightExpr.nodeType === ParseNodeType.Call) {
                     const callTypeResult = evaluator.getTypeOfExpression(
                         statement.d.rightExpr.d.leftExpr,
                         EvalFlags.CallBaseDefaults
@@ -391,6 +391,16 @@ export function synthesizeDataClassMethods(
 
             if (variableNameNode && variableTypeEvaluator) {
                 const variableName = variableNameNode.d.value;
+
+                // Named tuples don't allow attributes that begin with an underscore.
+                if (isNamedTuple && variableName.startsWith('_')) {
+                    evaluator.addDiagnostic(
+                        DiagnosticRule.reportGeneralTypeIssues,
+                        LocMessage.namedTupleFieldUnderscore(),
+                        variableNameNode
+                    );
+                    return;
+                }
 
                 // Don't include class vars. PEP 557 indicates that they shouldn't
                 // be considered data class entries.
@@ -512,7 +522,7 @@ export function synthesizeDataClassMethods(
 
             // If the RHS of the assignment is assigning a field instance where the
             // "init" parameter is set to false, do not include it in the init method.
-            if (statement.d.rightExpr.nodeType === ParseNodeType.Call) {
+            if (!isNamedTuple && statement.d.rightExpr.nodeType === ParseNodeType.Call) {
                 const callType = evaluator.getTypeOfExpression(
                     statement.d.rightExpr.d.leftExpr,
                     EvalFlags.CallBaseDefaults

--- a/packages/pyright-internal/src/analyzer/namedTuples.ts
+++ b/packages/pyright-internal/src/analyzer/namedTuples.ts
@@ -179,6 +179,16 @@ export function createNamedTupleType(
                 entries.forEach((entryName, index) => {
                     entryName = entryName.trim();
                     if (entryName) {
+                        // Named tuples don't allow leading underscores in the field names.
+                        if (entryName.startsWith('_')) {
+                            evaluator.addDiagnostic(
+                                DiagnosticRule.reportGeneralTypeIssues,
+                                LocMessage.namedTupleFieldUnderscore(),
+                                entriesArg.valueExpression!
+                            );
+                            return;
+                        }
+
                         entryName = renameKeyword(
                             evaluator,
                             entryName,
@@ -279,6 +289,16 @@ export function createNamedTupleType(
                                     entryNameNode
                                 );
                             } else {
+                                // Named tuples don't allow leading underscores in the field names.
+                                if (entryName.startsWith('_')) {
+                                    evaluator.addDiagnostic(
+                                        DiagnosticRule.reportGeneralTypeIssues,
+                                        LocMessage.namedTupleFieldUnderscore(),
+                                        entryNameNode
+                                    );
+                                    return;
+                                }
+
                                 entryName = renameKeyword(evaluator, entryName, allowRename, entryNameNode, index);
                             }
                         } else {

--- a/packages/pyright-internal/src/localization/localize.ts
+++ b/packages/pyright-internal/src/localization/localize.ts
@@ -683,6 +683,7 @@ export namespace Localizer {
             new ParameterizedString<{ name: string; className: string }>(
                 getRawString('Diagnostic.namedTupleEntryRedeclared')
             );
+        export const namedTupleFieldUnderscore = () => getRawString('Diagnostic.namedTupleFieldUnderscore');
         export const namedTupleFirstArg = () => getRawString('Diagnostic.namedTupleFirstArg');
         export const namedTupleMultipleInheritance = () => getRawString('Diagnostic.namedTupleMultipleInheritance');
         export const namedTupleNameKeyword = () => getRawString('Diagnostic.namedTupleNameKeyword');

--- a/packages/pyright-internal/src/localization/package.nls.en-us.json
+++ b/packages/pyright-internal/src/localization/package.nls.en-us.json
@@ -773,6 +773,10 @@
             "message": "Cannot override \"{name}\" because parent class \"{className}\" is a named tuple",
             "comment": "{Locked='tuple'}"
         },
+        "namedTupleFieldUnderscore": {
+            "message": "Named tuple field names cannot start with an underscore",
+            "comment": "{Locked='Named','tuple'}"
+        },
         "namedTupleFirstArg": {
             "message": "Expected named tuple class name as first argument",
             "comment": "{Locked='tuple'}"
@@ -792,7 +796,7 @@
         },
         "namedTupleNoTypes": {
             "message": "\"namedtuple\" provides no types for tuple entries; use \"NamedTuple\" instead",
-            "comment": "{Locked='namedtuple\";'tuple','NamedTuple'}"
+            "comment": "{Locked='namedtuple','tuple','NamedTuple'}"
         },
         "namedTupleSecondArg": {
             "message": "Expected named tuple entry list as second argument",

--- a/packages/pyright-internal/src/tests/samples/namedTuple11.py
+++ b/packages/pyright-internal/src/tests/samples/namedTuple11.py
@@ -1,0 +1,19 @@
+# This sample tests that named tuple field names beginning with
+# an underscore is flagged as an error.
+
+from collections import namedtuple
+from typing import NamedTuple
+
+# This should generate an error because a field name starting with an
+# underscore isn't allowed.
+NT1 = namedtuple("NT1", ["_oops"])
+
+# This should generate an error because a field name starting with an
+# underscore isn't allowed.
+NT2 = namedtuple("NT2", "a, b, _oops")
+
+
+class NT3(NamedTuple):
+    # This should generate an error because a field name starting with an
+    # underscore isn't allowed.
+    _oops: int

--- a/packages/pyright-internal/src/tests/typeEvaluator8.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator8.test.ts
@@ -611,6 +611,12 @@ test('NamedTuple10', () => {
     TestUtils.validateResults(analysisResults, 1);
 });
 
+test('NamedTuple11', () => {
+    const analysisResults = TestUtils.typeAnalyzeSampleFiles(['namedTuple11.py']);
+
+    TestUtils.validateResults(analysisResults, 3);
+});
+
 test('Slots1', () => {
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['slots1.py']);
 


### PR DESCRIPTION
…. These result in a runtime exception. This addresses #10351.