### PR TITLE
Fixed a bug that results in a false positive error when calling a fun…

### DIFF
--- a/packages/pyright-internal/src/analyzer/checker.ts
+++ b/packages/pyright-internal/src/analyzer/checker.ts
@@ -2685,7 +2685,10 @@ export class Checker extends ParseTreeWalker {
             return false;
         }
 
-        let flags = AssignTypeFlags.SkipReturnTypeCheck | AssignTypeFlags.OverloadOverlap;
+        let flags =
+            AssignTypeFlags.SkipReturnTypeCheck |
+            AssignTypeFlags.OverloadOverlap |
+            AssignTypeFlags.DisallowExtraKwargsForTd;
         if (partialOverlap) {
             flags |= AssignTypeFlags.PartialOverloadOverlap;
         }
@@ -2745,7 +2748,10 @@ export class Checker extends ParseTreeWalker {
             implBound,
             diag,
             constraints,
-            AssignTypeFlags.SkipReturnTypeCheck | AssignTypeFlags.Contravariant | AssignTypeFlags.SkipSelfClsTypeCheck
+            AssignTypeFlags.SkipReturnTypeCheck |
+                AssignTypeFlags.Contravariant |
+                AssignTypeFlags.SkipSelfClsTypeCheck |
+                AssignTypeFlags.DisallowExtraKwargsForTd
         );
 
         // Now check the return types.

--- a/packages/pyright-internal/src/analyzer/parameterUtils.ts
+++ b/packages/pyright-internal/src/analyzer/parameterUtils.ts
@@ -277,16 +277,23 @@ export function getParamListDetails(type: FunctionType, options?: ParamListDetai
                     );
                 });
 
-                const extraItemsType = paramType.shared.typedDictEntries.extraItems?.valueType ?? AnyType.create();
+                const extraItemsType = paramType.shared.typedDictEntries.extraItems?.valueType;
+
+                let addKwargsForExtraItems: boolean;
+                if (extraItemsType) {
+                    addKwargsForExtraItems = !isNever(extraItemsType);
+                } else {
+                    addKwargsForExtraItems = !options?.disallowExtraKwargsForTd;
+                }
 
                 // Unless the TypedDict is completely closed (i.e. is not allowed to
                 // have any extra items), add a virtual **kwargs parameter to represent
                 // any additional items.
-                if (!isNever(extraItemsType) && !options?.disallowExtraKwargsForTd) {
+                if (addKwargsForExtraItems) {
                     addVirtualParam(
                         FunctionParam.create(
                             ParamCategory.KwargsDict,
-                            extraItemsType,
+                            extraItemsType ?? AnyType.create(),
                             FunctionParamFlags.TypeDeclared,
                             'kwargs'
                         ),

--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -26342,8 +26342,12 @@ export function createTypeEvaluator(
             srcType = FunctionType.cloneRemoveParamSpecArgsKwargs(srcType);
         }
 
-        const destParamDetails = getParamListDetails(destType);
-        const srcParamDetails = getParamListDetails(srcType);
+        const destParamDetails = getParamListDetails(destType, {
+            disallowExtraKwargsForTd: (flags & AssignTypeFlags.DisallowExtraKwargsForTd) !== 0,
+        });
+        const srcParamDetails = getParamListDetails(srcType, {
+            disallowExtraKwargsForTd: (flags & AssignTypeFlags.DisallowExtraKwargsForTd) !== 0,
+        });
 
         adjustSourceParamDetailsForDestVariadic(
             isContra ? destParamDetails : srcParamDetails,

--- a/packages/pyright-internal/src/analyzer/typeEvaluatorTypes.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluatorTypes.ts
@@ -622,6 +622,10 @@ export const enum AssignTypeFlags {
     // Normally a protocol class object cannot be used as a source type. This
     // option overrides this behavior.
     AllowProtocolClassSource = 1 << 16,
+
+    // When assigning callables, should a kwargs with an unpacked TypedDict
+    // disallow additional named arguments if it does not have extraItems?
+    DisallowExtraKwargsForTd = 1 << 17,
 }
 
 export interface TypeEvaluator {

--- a/packages/pyright-internal/src/tests/samples/typedDictClosed2.py
+++ b/packages/pyright-internal/src/tests/samples/typedDictClosed2.py
@@ -24,13 +24,6 @@ def func2(**kwargs: Unpack[Movie2]) -> None: ...
 
 func2(name="")
 
-# It's not clear whether this is allowed from the spec,
-# but based on a reading of PEP 692, extra (non-specified)
-# items should not be allowed as explicit keyword arguments.
-# This is consistent with the original TypedDict PEP
-# that disallows extra items to be present in a literal dict
-# expression that is assigned to a TypedDict type.
-# We'll therefore assume this should generate an error.
 func2(name="", foo=1)
 
 # This should generate an error.

--- a/packages/pyright-internal/src/tests/typeEvaluator5.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator5.test.ts
@@ -365,7 +365,7 @@ test('TypedDictClosed2', () => {
     configOptions.diagnosticRuleSet.enableExperimentalFeatures = true;
 
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['typedDictClosed2.py'], configOptions);
-    TestUtils.validateResults(analysisResults, 5);
+    TestUtils.validateResults(analysisResults, 4);
 });
 
 test('TypedDictClosed3', () => {


### PR DESCRIPTION
…ction with an unpacked TypedDict with `extra_items` when additional keyword args are passed. This addresses #10352.