### PR TITLE
Temporarily disable npm publishing in `azure-pipelines-release.yml`

### DIFF
--- a/build/azuredevops/azure-pipelines-release.yml
+++ b/build/azuredevops/azure-pipelines-release.yml
@@ -274,32 +274,32 @@ extends:
                     $aadToken = az account get-access-token --query accessToken --resource 499b84ac-1321-427f-aa17-267ca6975798 -o tsv
                     vsce publish --pat $aadToken --packagePath $(System.ArtifactsDirectory)/$(VSIX_NAME) --noVerify --manifestPath $(System.ArtifactsDirectory)/extension.manifest --signaturePath $(System.ArtifactsDirectory)/extension.signature.p7s
 
-      - stage: PublishToNpm
-        dependsOn: WaitForValidation
-        jobs:
-          - job: publish_package
-            displayName: Publish package to NPM
+      # - stage: PublishToNpm
+      #   dependsOn: WaitForValidation
+      #   jobs:
+      #     - job: publish_package
+      #       displayName: Publish package to NPM
 
-            pool:
-              name: VSEngSS-MicroBuild2022-1ES # This pool is required to have the certs needed to publish using ESRP.
-              os: windows
-              image: server2022-microbuildVS2022-1es
+      #       pool:
+      #         name: VSEngSS-MicroBuild2022-1ES # This pool is required to have the certs needed to publish using ESRP.
+      #         os: windows
+      #         image: server2022-microbuildVS2022-1es
 
-            templateContext:
-              type: releaseJob
-              isProduction: true
-              inputs:
-                - input: pipelineArtifact
-                  artifactName: $(ARTIFACT_NAME_PACKAGE)
-                  targetPath: $(Build.StagingDirectory)/dist
+      #       templateContext:
+      #         type: releaseJob
+      #         isProduction: true
+      #         inputs:
+      #           - input: pipelineArtifact
+      #             artifactName: $(ARTIFACT_NAME_PACKAGE)
+      #             targetPath: $(Build.StagingDirectory)/dist
 
-            steps:
-              - template: MicroBuild.Publish.yml@MicroBuildTemplate
-                parameters:
-                  intent: PackageDistribution
-                  contentType: npm
-                  contentSource: Folder
-                  folderLocation: $(Build.StagingDirectory)/dist
-                  waitForReleaseCompletion: true
-                  owners: erikd@microsoft.com
-                  approvers: grwheele@microsoft.com
+      #       steps:
+      #         - template: MicroBuild.Publish.yml@MicroBuildTemplate
+      #           parameters:
+      #             intent: PackageDistribution
+      #             contentType: npm
+      #             contentSource: Folder
+      #             folderLocation: $(Build.StagingDirectory)/dist
+      #             waitForReleaseCompletion: true
+      #             owners: erikd@microsoft.com
+      #             approvers: grwheele@microsoft.com


### PR DESCRIPTION
I'm still investigating #10350. Simply moving the `BuildNpm` stage to a Linux box did not fix the issue. So I'm disabling automatic npm publishing while I continue to investigate.

@erictraut, once this PR is merged, you should go back to manual npm publishing until I fix #10350.