### PR TITLE
Fixed a bug in the type narrowing logic for the `S in D` type guard p…

### DIFF
--- a/packages/pyright-internal/src/analyzer/typeGuards.ts
+++ b/packages/pyright-internal/src/analyzer/typeGuards.ts
@@ -2227,6 +2227,15 @@ function narrowTypeForTypedDictKey(
 
                 if (isPositiveTest) {
                     if (!tdEntry) {
+                        // If there is no TD entry for this key and no "extra items" defined,
+                        // we have to assume that the TypedDict may contain extra items, so
+                        // narrowing it isn't possible in this case.
+                        return subtype;
+                    }
+
+                    if (isNever(tdEntry.valueType)) {
+                        // If the entry is typed as Never or the "extra items" is typed as Never,
+                        // then this key cannot be present in the TypedDict, and we can eliminate it.
                         return undefined;
                     }
 

--- a/packages/pyright-internal/src/tests/samples/typeNarrowingIn1.py
+++ b/packages/pyright-internal/src/tests/samples/typeNarrowingIn1.py
@@ -141,7 +141,7 @@ T1 = TypeVar("T1", TD1, TD2)
 
 def func12(v: T1):
     if "x" in v:
-        reveal_type(v, expected_text="TD1*")
+        reveal_type(v, expected_text="TD1* | TD2*")
     else:
         reveal_type(v, expected_text="TD2*")
 

--- a/packages/pyright-internal/src/tests/samples/typeNarrowingTypedDict1.py
+++ b/packages/pyright-internal/src/tests/samples/typeNarrowingTypedDict1.py
@@ -21,7 +21,7 @@ class TD3(TypedDict, total=False):
 
 def f1(p: TD1 | TD2):
     if "b" in p:
-        reveal_type(p, expected_text="TD1")
+        reveal_type(p, expected_text="TD1 | TD2")
     else:
         reveal_type(p, expected_text="TD2")
 
@@ -30,12 +30,12 @@ def f2(p: TD1 | TD2):
     if "b" not in p:
         reveal_type(p, expected_text="TD2")
     else:
-        reveal_type(p, expected_text="TD1")
+        reveal_type(p, expected_text="TD1 | TD2")
 
 
 def f3(p: TD1 | TD3):
     if "d" in p:
-        reveal_type(p, expected_text="TD3")
+        reveal_type(p, expected_text="TD1 | TD3")
     else:
         reveal_type(p, expected_text="TD1 | TD3")
 
@@ -44,7 +44,7 @@ def f4(p: TD1 | TD3):
     if "d" not in p:
         reveal_type(p, expected_text="TD1 | TD3")
     else:
-        reveal_type(p, expected_text="TD3")
+        reveal_type(p, expected_text="TD1 | TD3")
 
 
 def f5(p: TD1 | TD3):
@@ -61,15 +61,17 @@ def f6(p: TD1 | TD2 | TD3):
     v2 = p.get("a")
 
     if "c" in p:
+        # This should generate an error for TD1 and TD3
         v3 = p["c"]
-        reveal_type(v3, expected_text="str")
+        reveal_type(v3, expected_text="Unknown | str")
 
     if "a" in p and "d" in p:
         v4 = p["a"]
-        reveal_type(v4, expected_text="int")
+        reveal_type(v4, expected_text="str | int")
 
+        # This should generate an error for TD1 and TD2
         v5 = p["d"]
-        reveal_type(v5, expected_text="str")
+        reveal_type(v5, expected_text="Unknown | str")
 
     # This should generate three errors, two for TD1 and TD2 (because
     # "d" is not a valid key) and one for TD3 (because "d" is not required).

--- a/packages/pyright-internal/src/tests/typeEvaluator1.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator1.test.ts
@@ -532,7 +532,7 @@ test('TypeNarrowingTuple1', () => {
 test('TypeNarrowingTypedDict1', () => {
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['typeNarrowingTypedDict1.py']);
 
-    TestUtils.validateResults(analysisResults, 4);
+    TestUtils.validateResults(analysisResults, 8);
 });
 
 test('TypeNarrowingTypedDict2', () => {


### PR DESCRIPTION
…attern (where S is a string literal and D is a TypedDict). If the TypedDict is not closed, the absence of the key within the TypedDict definition cannot eliminate the type during narrowing. This addresses #10376.