### PR TITLE
Improved handling of `__slots__` members to correctly model the case …

### DIFF
--- a/packages/pyright-internal/src/analyzer/binder.ts
+++ b/packages/pyright-internal/src/analyzer/binder.ts
@@ -2445,8 +2445,16 @@ export class Binder extends ParseTreeWalker {
             }
 
             let symbol = this._currentScope.lookUpSymbol(slotName);
-            if (!symbol) {
-                symbol = this._currentScope.addSymbol(slotName, SymbolFlags.InitiallyUnbound | SymbolFlags.ClassMember);
+            if (symbol) {
+                symbol.setIsSlotsMember();
+            } else {
+                symbol = this._currentScope.addSymbol(
+                    slotName,
+                    SymbolFlags.InitiallyUnbound |
+                        SymbolFlags.ClassMember |
+                        SymbolFlags.InstanceMember |
+                        SymbolFlags.SlotsMember
+                );
                 const honorPrivateNaming = this._fileInfo.diagnosticRuleSet.reportPrivateUsage !== 'none';
                 if (isPrivateOrProtectedName(slotName) && honorPrivateNaming) {
                     symbol.setIsPrivateMember();

--- a/packages/pyright-internal/src/analyzer/symbol.ts
+++ b/packages/pyright-internal/src/analyzer/symbol.ts
@@ -33,6 +33,12 @@ export const enum SymbolFlags {
     // Indicates that the symbol is an instance member of a class.
     InstanceMember = 1 << 3,
 
+    // Indicates that the symbol is specified in the __slots__
+    // declaration of a class. Such symbols act like instance members
+    // in some respects but are actually implemented as class members
+    // using descriptor objects.
+    SlotsMember = 1 << 4,
+
     // Indicates that the symbol is considered "private" to the
     // class or module and should not be accessed outside or overridden.
     PrivateMember = 1 << 5,
@@ -152,6 +158,14 @@ export class Symbol {
 
     isInstanceMember() {
         return !!(this._flags & SymbolFlags.InstanceMember);
+    }
+
+    setIsSlotsMember() {
+        this._flags |= SymbolFlags.ClassMember | SymbolFlags.InstanceMember | SymbolFlags.SlotsMember;
+    }
+
+    isSlotsMember() {
+        return !!(this._flags & SymbolFlags.SlotsMember);
     }
 
     setIsClassVar() {

--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -6229,7 +6229,7 @@ export function createTypeEvaluator(
             type,
             (subtype) => {
                 const concreteSubtype = makeTopLevelTypeVarsConcrete(subtype);
-                const isClassMember = !memberInfo || memberInfo.isClassMember;
+                const isClassMember = !memberInfo || (memberInfo.isClassMember && !memberInfo.isSlotsMember);
                 let resultType: Type;
 
                 if (isClass(concreteSubtype) && isClassMember && errorNode) {

--- a/packages/pyright-internal/src/analyzer/typeUtils.ts
+++ b/packages/pyright-internal/src/analyzer/typeUtils.ts
@@ -89,6 +89,9 @@ export interface ClassMember {
     isInstanceMember: boolean;
     isClassMember: boolean;
 
+    // Is the member in __slots__?
+    isSlotsMember: boolean;
+
     // True if explicitly declared as "ClassVar" and therefore is
     // a type violation if it is overwritten by an instance variable
     isClassVar: boolean;
@@ -1644,6 +1647,7 @@ export function getProtocolSymbolsRecursive(
                 unspecializedClassType: classType,
                 isInstanceMember: symbol.isInstanceMember(),
                 isClassMember: symbol.isClassMember(),
+                isSlotsMember: symbol.isSlotsMember(),
                 isClassVar: isEffectivelyClassVar(symbol, /* isDataclass */ false),
                 isReadOnly: false,
                 isTypeDeclared: symbol.hasTypedDeclarations(),
@@ -1784,6 +1788,7 @@ export function* getClassMemberIterator(
                         isInstanceMember: false,
                         isClassMember: true,
                         isClassVar: false,
+                        isSlotsMember: false,
                         classType,
                         unspecializedClassType: classType,
                         isReadOnly: false,
@@ -1815,6 +1820,7 @@ export function* getClassMemberIterator(
                             symbol,
                             isInstanceMember: true,
                             isClassMember: symbol.isClassMember(),
+                            isSlotsMember: symbol.isSlotsMember(),
                             isClassVar: isEffectivelyClassVar(symbol, ClassType.isDataClass(specializedMroClass)),
                             classType: specializedMroClass,
                             unspecializedClassType: mroClass,
@@ -1870,6 +1876,7 @@ export function* getClassMemberIterator(
                             symbol,
                             isInstanceMember,
                             isClassMember,
+                            isSlotsMember: symbol.isSlotsMember(),
                             isClassVar: isEffectivelyClassVar(symbol, isDataclass),
                             classType: specializedMroClass,
                             unspecializedClassType: mroClass,
@@ -1891,6 +1898,7 @@ export function* getClassMemberIterator(
             symbol: Symbol.createWithType(SymbolFlags.None, classType),
             isInstanceMember: false,
             isClassMember: true,
+            isSlotsMember: false,
             isClassVar: false,
             classType,
             unspecializedClassType: classType,
@@ -1987,6 +1995,7 @@ export function getClassFieldsRecursive(classType: ClassType): Map<string, Class
                         symbol,
                         isInstanceMember: symbol.isInstanceMember(),
                         isClassMember: symbol.isClassMember(),
+                        isSlotsMember: symbol.isSlotsMember(),
                         isClassVar: isEffectivelyClassVar(symbol, ClassType.isDataClass(specializedMroClass)),
                         isReadOnly: isMemberReadOnly(specializedMroClass, name),
                         isTypeDeclared: true,

--- a/packages/pyright-internal/src/tests/samples/slots4.py
+++ b/packages/pyright-internal/src/tests/samples/slots4.py
@@ -1,0 +1,33 @@
+# This sample tests the case where a descriptor is assigned to an
+# instance variable that is included in __slots__.
+
+from typing import Self, overload
+
+
+class A:
+    pass
+
+
+class Descriptor:
+    name: str
+
+    @overload
+    def __get__(self, obj: None, objtype: type[A] | None = None) -> Self: ...
+
+    @overload
+    def __get__(self, obj: A, objtype: type[A] | None = None) -> int: ...
+
+    def __get__(self, obj: A | None, objtype: type[A] | None = None) -> Self | int: ...
+
+    def __set__(self, obj: A, value: int): ...
+
+
+class B:
+    __slots__ = "descriptor"
+
+    def __init__(self, descriptor: Descriptor):
+        self.descriptor = descriptor
+
+
+v1 = B(descriptor=Descriptor())
+reveal_type(v1.descriptor.name, expected_text="str")

--- a/packages/pyright-internal/src/tests/typeEvaluator8.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator8.test.ts
@@ -635,6 +635,12 @@ test('Slots3', () => {
     TestUtils.validateResults(analysisResults, 0);
 });
 
+test('Slots4', () => {
+    const analysisResults = TestUtils.typeAnalyzeSampleFiles(['slots4.py']);
+
+    TestUtils.validateResults(analysisResults, 0);
+});
+
 test('Parameters1', () => {
     const configOptions = new ConfigOptions(Uri.empty());
 


### PR DESCRIPTION
…where a descriptor object is stored in a `__slots__` variable. This addresses #10370.