### PR TITLE
Fixed bug that results in incorrect variance inference when a propert…

### DIFF
--- a/packages/pyright-internal/src/analyzer/properties.ts
+++ b/packages/pyright-internal/src/analyzer/properties.ts
@@ -521,29 +521,29 @@ export function assignProperty(
                 destAccessType = applySolvedTypeVars(destAccessType, selfSolution) as FunctionType;
             }
 
-            const boundDestAccessType = evaluator.bindFunctionToClassOrObject(
-                destObjectToBind,
-                destAccessType,
-                /* memberClass */ undefined,
-                /* treatConstructorAsClassMethod */ undefined,
-                /* firstParamType */ undefined,
-                diag?.createAddendum(),
-                recursionCount
-            );
+            const boundDestAccessType =
+                evaluator.bindFunctionToClassOrObject(
+                    destObjectToBind,
+                    destAccessType,
+                    /* memberClass */ undefined,
+                    /* treatConstructorAsClassMethod */ undefined,
+                    /* firstParamType */ undefined,
+                    diag?.createAddendum(),
+                    recursionCount
+                ) ?? destAccessType;
 
-            const boundSrcAccessType = evaluator.bindFunctionToClassOrObject(
-                srcObjectToBind,
-                srcAccessType,
-                /* memberClass */ undefined,
-                /* treatConstructorAsClassMethod */ undefined,
-                /* firstParamType */ undefined,
-                diag?.createAddendum(),
-                recursionCount
-            );
+            const boundSrcAccessType =
+                evaluator.bindFunctionToClassOrObject(
+                    srcObjectToBind,
+                    srcAccessType,
+                    /* memberClass */ undefined,
+                    /* treatConstructorAsClassMethod */ undefined,
+                    /* firstParamType */ undefined,
+                    diag?.createAddendum(),
+                    recursionCount
+                ) ?? srcAccessType;
 
             if (
-                !boundDestAccessType ||
-                !boundSrcAccessType ||
                 !evaluator.assignType(
                     boundDestAccessType,
                     boundSrcAccessType,

--- a/packages/pyright-internal/src/tests/samples/autoVariance1.py
+++ b/packages/pyright-internal/src/tests/samples/autoVariance1.py
@@ -2,7 +2,7 @@
 # autovariance.
 
 from dataclasses import dataclass
-from typing import Iterator, Sequence
+from typing import Final, Iterator, Sequence
 
 
 class ShouldBeCovariant1[T]:
@@ -57,6 +57,19 @@ class ShouldBeCovariant5[T]:
 vo5_1: ShouldBeCovariant5[float] = ShouldBeCovariant5[int](1)
 # This should generate an error based on variance.
 vo5_2: ShouldBeCovariant5[int] = ShouldBeCovariant5[float](1)
+
+
+class ShouldBeCovariant6[T]:
+    def f1[T2: int](self: "ShouldBeCovariant6[T2]") -> T2: ...
+
+    @property
+    def f2[T2: int](self: "ShouldBeCovariant6[T2]") -> T2: ...
+
+
+# This should generate an error based on variance.
+vo6_1: ShouldBeCovariant6[int] = ShouldBeCovariant6[float]()
+
+vo6_2: ShouldBeCovariant6[float] = ShouldBeCovariant6[int]()
 
 
 class ShouldBeInvariant1[T]:

--- a/packages/pyright-internal/src/tests/typeEvaluator5.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator5.test.ts
@@ -86,7 +86,7 @@ test('AutoVariance1', () => {
     configOptions.defaultPythonVersion = pythonVersion3_12;
 
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['autoVariance1.py'], configOptions);
-    TestUtils.validateResults(analysisResults, 16);
+    TestUtils.validateResults(analysisResults, 17);
 });
 
 test('AutoVariance2', () => {


### PR DESCRIPTION
…y access method uses a method-local type variable to annotate the `self` parameter. This addresses #10367.