### PR TITLE
typed-libraries.md - split paragraphs into sublists for readibility

### DIFF
--- a/docs/typed-libraries.md
+++ b/docs/typed-libraries.md
@@ -34,8 +34,13 @@ If a “py.typed” module is present, a type checker will treat all modules wit
 Each module exposes a set of symbols. Some of these symbols are considered “private” — implementation details that are not part of the library’s interface. Type checkers like pyright use the following rules to determine which symbols are visible outside of the package.
 
 * Symbols whose names begin with an underscore (but are not dunder names) are considered private.
-* Imported symbols are considered private by default. If they use the “import A as A” (a redundant module alias), “from X import A as A” (a redundant symbol alias), or “from . import A” forms, symbol “A” is not private unless the name begins with an underscore. If a file `__init__.py` uses the form “from .A import X”, symbol “A” is not private unless the name begins with an underscore (but “X” is still private). If a wildcard import (of the form “from X import *”) is used, all symbols referenced by the wildcard are not private.
-* A module can expose an `__all__` symbol at the module level that provides a list of names that are considered part of the interface. The `__all__` symbol indicates which symbols are included in a wildcard import. All symbols included in the `__all__` list are considered public even if the other rules above would otherwise indicate that they were private. For example, this allows symbols whose names begin with an underscore to be included in the interface.
+* Imported symbols are considered private by default. Exceptions:
+  * If they use the “import A as A” (a redundant module alias), “from X import A as A” (a redundant symbol alias), or “from . import A” forms, symbol “A” is not private unless the name begins with an underscore.
+  * If a file `__init__.py` uses the form “from .A import X”, symbol “A” is not private unless the name begins with an underscore (but “X” is still private).
+  * If a wildcard import (of the form “from X import *”) is used, all symbols referenced by the wildcard are not private.
+* A module can expose an `__all__` symbol at the module level that provides a list of names that are considered part of the interface:
+  * The `__all__` symbol indicates which symbols are included in a wildcard import.
+  * All symbols included in the `__all__` list are considered public even if the other rules above would otherwise indicate that they were private. For example, this allows symbols whose names begin with an underscore to be included in the interface.
 * Local variables within a function (including nested functions) are always considered private.
 
 The following idioms are supported for defining the values contained within `__all__`. These restrictions allow type checkers to statically determine the value of `__all__`.


### PR DESCRIPTION
No other changes besides changing the paragraphs structure.
Sublists are helping breaking down dense paragraphs to make them more readable.

Before:
![image](https://github.com/user-attachments/assets/aa7d83c7-0e2b-4025-8d6b-938511d3a56e)

After:
![image](https://github.com/user-attachments/assets/81f7f5ab-fbaa-49ae-bdfb-86eee5ee23df)
