### PR TITLE
Fixed bug that results in incorrect type narrowing behavior when the …

### DIFF
--- a/packages/pyright-internal/src/analyzer/operations.ts
+++ b/packages/pyright-internal/src/analyzer/operations.ts
@@ -866,7 +866,7 @@ function createUnionType(
     let newUnion = combineTypes([adjustedLeftType, adjustedRightType], { skipElideRedundantLiterals: true });
 
     const unionClass = evaluator.getUnionClassType();
-    if (unionClass && isInstantiableClass(unionClass)) {
+    if (unionClass && isInstantiableClass(unionClass) && (flags & EvalFlags.IsinstanceArg) === 0) {
         newUnion = TypeBase.cloneAsSpecialForm(newUnion, ClassType.cloneAsInstance(unionClass));
     }
 

--- a/packages/pyright-internal/src/tests/samples/typeNarrowingIsinstance1.py
+++ b/packages/pyright-internal/src/tests/samples/typeNarrowingIsinstance1.py
@@ -279,3 +279,13 @@ def func15(x: Base15[T]):
 
         reveal_type(x, expected_text="Child15")
         reveal_type(x.value, expected_text="int")
+
+
+def func16(x: Any):
+    if isinstance(x, (int, int)):
+        reveal_type(x, expected_text="int")
+
+
+def func17(x: Any):
+    if isinstance(x, (Union[int, int])):
+        reveal_type(x, expected_text="int")


### PR DESCRIPTION
…second argument to an `isinstance` call includes a union (specifically with the `|` operator) within a tuple expression. This addresses #10426.