### PR TITLE
Fixed a bug that results in a spurious error when `__class__()` is as…

### DIFF
--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -22185,7 +22185,9 @@ export function createTypeEvaluator(
                     const classTypeInfo = getTypeOfClass(classNode);
                     return {
                         type: classTypeInfo
-                            ? synthesizeTypeVarForSelfCls(classTypeInfo.classType, /* isClsParam */ true)
+                            ? TypeVarType.cloneAsBound(
+                                  synthesizeTypeVarForSelfCls(classTypeInfo.classType, /* isClsParam */ true)
+                              )
                             : UnknownType.create(),
                     };
                 }

--- a/packages/pyright-internal/src/tests/samples/classes1.py
+++ b/packages/pyright-internal/src/tests/samples/classes1.py
@@ -2,7 +2,7 @@
 # handle various class definition cases.
 
 
-from typing import Any, TypeVar
+from typing import Any, Self, TypeVar
 
 
 T = TypeVar("T")
@@ -38,8 +38,9 @@ class F(E):
 
 
 class G(E, metaclass=type):
-    def my_method(self):
+    def my_method(self) -> Self:
         reveal_type(__class__, expected_text="type[Self@G]")
+        return __class__()
 
 
 # This should generate an error because only one metaclass is supported.


### PR DESCRIPTION
…signed to `Self`. This addresses #10451.