### PR TITLE
Switched internal usage of `builtins.function`, `typing.AwaitableGene…

### DIFF
--- a/packages/pyright-internal/src/analyzer/checker.ts
+++ b/packages/pyright-internal/src/analyzer/checker.ts
@@ -2259,7 +2259,9 @@ export class Checker extends ParseTreeWalker {
         ) {
             // Handle the old-style (pre-await) generator case
             // if the return type explicitly uses AwaitableGenerator.
-            generatorType = this._evaluator.getTypingType(node, 'AwaitableGenerator');
+            generatorType =
+                this._evaluator.getTypeCheckerInternalsType(node, 'AwaitableGenerator') ??
+                this._evaluator.getTypingType(node, 'AwaitableGenerator');
         } else {
             generatorType = this._evaluator.getTypingType(node, node.d.isAsync ? 'AsyncGenerator' : 'Generator');
         }
@@ -6757,7 +6759,7 @@ export class Checker extends ParseTreeWalker {
                 // Special-case overrides of methods in '_TypedDict', since
                 // TypedDict attributes aren't manifest as attributes but rather
                 // as named keys.
-                if (ClassType.isBuiltIn(baseClass, '_TypedDict')) {
+                if (ClassType.isBuiltIn(baseClass, ['_TypedDict', 'TypedDictFallback'])) {
                     return;
                 }
 
@@ -7499,7 +7501,9 @@ export class Checker extends ParseTreeWalker {
         ) {
             // Handle the old-style (pre-await) generator case
             // if the return type explicitly uses AwaitableGenerator.
-            generatorType = this._evaluator.getTypingType(node, 'AwaitableGenerator');
+            generatorType =
+                this._evaluator.getTypeCheckerInternalsType(node, 'AwaitableGenerator') ??
+                this._evaluator.getTypingType(node, 'AwaitableGenerator');
         } else {
             generatorType = this._evaluator.getTypingType(
                 node,

--- a/packages/pyright-internal/src/analyzer/sourceFile.ts
+++ b/packages/pyright-internal/src/analyzer/sourceFile.ts
@@ -275,7 +275,10 @@ export class SourceFile {
         this._isTypingStubFile =
             this._isStubFile && (this._uri.pathEndsWith('stdlib/typing.pyi') || fileName === 'typing_extensions.pyi');
         this._isTypingExtensionsStubFile = this._isStubFile && fileName === 'typing_extensions.pyi';
-        this._isTypeshedStubFile = this._isStubFile && this._uri.pathEndsWith('stdlib/_typeshed/__init__.pyi');
+        this._isTypeshedStubFile =
+            this._isStubFile &&
+            (this._uri.pathEndsWith('stdlib/_typeshed/__init__.pyi') ||
+                this._uri.pathEndsWith('stdlib/_typeshed/_type_checker_internals.pyi'));
 
         this._isBuiltInStubFile = false;
         if (this._isStubFile) {

--- a/packages/pyright-internal/src/analyzer/typeEvaluatorTypes.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluatorTypes.ts
@@ -820,6 +820,7 @@ export interface TypeEvaluator {
     getUnionClassType(): Type;
     getTypeClassType(): ClassType | undefined;
     getTypingType: (node: ParseNode, symbolName: string) => Type | undefined;
+    getTypeCheckerInternalsType: (node: ParseNode, symbolName: string) => Type | undefined;
     inferReturnTypeIfNecessary: (type: Type) => void;
     inferVarianceForClass: (type: ClassType) => void;
     assignTypeArgs: (

--- a/packages/pyright-internal/src/tests/fourslash/completions.declNames.method.fourslash.ts
+++ b/packages/pyright-internal/src/tests/fourslash/completions.declNames.method.fourslash.ts
@@ -15,14 +15,14 @@
 //// async def a1[|/*marker6*/|]():
 ////     pass
 ////
-//// def method(p[|/*marker7*/|]):
+//// def method(x[|/*marker7*/|]):
 ////     pass
-//// def method(p:[|/*marker8*/|]):
+//// def method(x:[|/*marker8*/|]):
 ////     pass
 ////
-//// def method(p, p2[|/*marker9*/|]):
+//// def method(x, x2[|/*marker9*/|]):
 ////     pass
-//// def method(p, p2:[|/*marker10*/|]):
+//// def method(x, x2:[|/*marker10*/|]):
 ////     pass
 
 // @filename: test1.py
@@ -32,14 +32,14 @@
 ////     def a2[|/*marker12*/|]():
 ////         pass
 ////
-////     def method(p[|/*marker13*/|]):
+////     def method(x[|/*marker13*/|]):
 ////         pass
-////     def method(p:[|/*marker14*/|]):
+////     def method(x:[|/*marker14*/|]):
 ////         pass
 ////
-////     def method(p, p2[|/*marker15*/|]):
+////     def method(x, x2[|/*marker15*/|]):
 ////         pass
-////     def method(p, p2:[|/*marker16*/|]):
+////     def method(x, x2:[|/*marker16*/|]):
 ////         pass
 
 {

--- a/packages/pyright-internal/src/tests/samples/coroutines3.py
+++ b/packages/pyright-internal/src/tests/samples/coroutines3.py
@@ -1,7 +1,8 @@
 # This sample tests old-style (pre-await) awaitable generators.
 
 import asyncio
-from typing import Any, AwaitableGenerator
+from typing import Any
+from _typeshed._type_checker_internals import AwaitableGenerator
 
 
 @asyncio.coroutine

--- a/packages/pyright-internal/src/tests/samples/memberAccess4.py
+++ b/packages/pyright-internal/src/tests/samples/memberAccess4.py
@@ -106,7 +106,7 @@ class EvilProto1(Protocol):
 EvilProto1.__call__
 
 
-# This should generate two errors and not hang.
+# This should generate an error and not hang.
 p: EvilProto1 = curry(lambda a, b: a(b(a)))
 
 

--- a/packages/pyright-internal/src/tests/typeEvaluator4.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator4.test.ts
@@ -139,7 +139,7 @@ test('MemberAccess3', () => {
 
 test('MemberAccess4', () => {
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['memberAccess4.py']);
-    TestUtils.validateResults(analysisResults, 6);
+    TestUtils.validateResults(analysisResults, 5);
 });
 
 test('MemberAccess5', () => {


### PR DESCRIPTION
…rator`, and `typing._TypedDict` to `types.FunctionType`, `_typeshed._type_checker_internals.AwaitableGenerator`, and `_typeshed._type_checker_internals.TypedDictFallback`, respectively. This addresses #10437.