### PR TITLE
Added missing check for unquoted self references when calling `TypeAl…

### DIFF
--- a/packages/pyright-internal/src/analyzer/types.ts
+++ b/packages/pyright-internal/src/analyzer/types.ts
@@ -131,10 +131,8 @@ export interface TypeAliasSharedInfo {
 
     typeVarScopeId: TypeVarScopeId;
 
-    // Indicates whether the type alias was declared with the
-    // "type" syntax introduced in PEP 695 or was created by a direct
-    // call to the TypeAliasType constructor.
-    isPep695Syntax: boolean;
+    // Is the type alias a PEP 695 TypeAliasType instance?
+    isTypeAliasType: boolean;
 
     // Type parameters, if type alias is generic
     typeParams: TypeVarType[] | undefined;

--- a/packages/pyright-internal/src/tests/samples/typeAliasType2.py
+++ b/packages/pyright-internal/src/tests/samples/typeAliasType2.py
@@ -12,14 +12,14 @@ T = TypeVar("T", bound=str)
 P = ParamSpec("P")
 Ts = TypeVarTuple("Ts")
 
-TA1 = TypeAliasType("TA1", T1 | list[TA1[T1]], type_params=(T1,))
+TA1 = TypeAliasType("TA1", "T1 | list[TA1[T1]]", type_params=(T1,))
 
 x1: TA1[int] = 1
 x2: TA1[int] = [1]
 
 TA2 = TypeAliasType(
     "TA2",
-    Callable[P, T] | list[S] | list[TA2[S, T, P]] | tuple[*Ts],
+    "Callable[P, T] | list[S] | list[TA2[S, T, P]] | tuple[*Ts]",
     type_params=(S, T, P, Ts),
 )
 
@@ -38,15 +38,17 @@ x6: TA2[int, str, [int, str], *tuple[int, str, int]]
 TA3 = TypeAliasType("TA3", TA3)
 
 # This should generate an error because it is unresolvable.
-TA4 = TypeAliasType("TA4", T | TA4[str], type_params=(T,))
+TA4 = TypeAliasType("TA4", "T | TA4[str]", type_params=(T,))
 
-TA5 = TypeAliasType("TA5", T | list[TA5[T]], type_params=(T,))
+TA5 = TypeAliasType("TA5", "T | list[TA5[T]]", type_params=(T,))
 
 # This should generate an error because it is unresolvable.
-TA6 = TypeAliasType("TA6", TA7)
-TA7 = TypeAliasType("TA7", TA6)
+TA6 = TypeAliasType("TA6", "TA7")
+TA7 = TypeAliasType("TA7", "TA6")
 
-JSONNode = TypeAliasType("JSONNode", list[JSONNode] | dict[str, JSONNode] | str | float)
+JSONNode = TypeAliasType(
+    "JSONNode", "list[JSONNode] | dict[str, JSONNode] | str | float"
+)
 
 
 class A(Generic[T1]):
@@ -72,3 +74,8 @@ class B:
 
 
 b1: B.TA9[int]
+
+
+# This should generate an error because TA9 refers to itself
+# and is not quoted.
+TA9 = TypeAliasType("TA9", list[TA9])

--- a/packages/pyright-internal/src/tests/typeEvaluator5.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator5.test.ts
@@ -335,7 +335,7 @@ test('TypeAliasType1', () => {
 
 test('TypeAliasType2', () => {
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['typeAliasType2.py']);
-    TestUtils.validateResults(analysisResults, 6);
+    TestUtils.validateResults(analysisResults, 7);
 });
 
 test('TypedDictReadOnly1', () => {


### PR DESCRIPTION
…iasType` constructor manually (as opposed to using the PEP 695 `type` syntax). This addresses #10475.