### PR TITLE
Alternative fix for recent regression related to `_type_checker_internals.pyi`

### DIFF
--- a/packages/pyright-internal/src/analyzer/sourceFile.ts
+++ b/packages/pyright-internal/src/analyzer/sourceFile.ts
@@ -1406,6 +1406,8 @@ export class SourceFile {
             builtinsImportResult = resolveAndAddIfNotSelf(['builtins']);
         }
 
+        resolveAndAddIfNotSelf(['_typeshed', '_type_checker_internals'], /* skipMissingImport */ true);
+
         for (const moduleImport of moduleImports) {
             const importResult = importResolver.resolveImport(this._uri, execEnv, {
                 leadingDots: moduleImport.leadingDots,


### PR DESCRIPTION
Alternative to https://github.com/microsoft/pyright/pull/10494, since that change wasn't sufficient to address the analysis-related telemetry issue we were seeing in Pylance.

https://github.com/microsoft/pyright/pull/10494 ensured that `_type_checker_internals.pyi` was not flagged as a user file, but since the file was added to the `Program` via `addTrackedFile`, it was included in the `getFilesToAnalyzeCount` count. This prevented the following check in Pylance's telemetry code from detecting that analysis was complete:

```typescript
        const isComplete =
            (results.requiringAnalysisCount.files + results.requiringAnalysisCount.cells === 0 &&
                results.elapsedTime !== 0) ||
            results.fatalErrorOccurred;
```

This addresses https://github.com/microsoft/pyright/issues/10484 and https://github.com/microsoft/pyright/issues/10487.