### PR TITLE
Added check for mutable values of type list, dict, or set when used a…

### DIFF
--- a/packages/pyright-internal/src/analyzer/checker.ts
+++ b/packages/pyright-internal/src/analyzer/checker.ts
@@ -383,6 +383,8 @@ export class Checker extends ParseTreeWalker {
 
             this._validateDataClassPostInit(classTypeResult.classType);
 
+            this._validateDataClassDefaults(classTypeResult.classType);
+
             this._validateEnumMembers(classTypeResult.classType, node);
 
             if (ClassType.isTypedDictClass(classTypeResult.classType)) {
@@ -5090,6 +5092,30 @@ export class Checker extends ParseTreeWalker {
                         );
                     }
                 }
+            }
+        });
+    }
+
+    // If a class is a dataclass, verify that any default values for its
+    // fields are not list, dict, or set instances. These are disallowed
+    // at runtime.
+    private _validateDataClassDefaults(classType: ClassType) {
+        if (!ClassType.isDataClass(classType)) {
+            return;
+        }
+
+        classType.shared.dataClassEntries?.forEach((entry) => {
+            if (!entry.defaultExpr) {
+                return;
+            }
+
+            const typeResult = this._evaluator.getTypeOfExpression(entry.defaultExpr);
+            if (isClassInstance(typeResult.type) && ClassType.isBuiltIn(typeResult.type, ['list', 'dict', 'set'])) {
+                this._evaluator.addDiagnostic(
+                    DiagnosticRule.reportGeneralTypeIssues,
+                    LocMessage.dataClassDefaultValueMutable(),
+                    entry.defaultExpr
+                );
             }
         });
     }

--- a/packages/pyright-internal/src/localization/localize.ts
+++ b/packages/pyright-internal/src/localization/localize.ts
@@ -372,6 +372,7 @@ export namespace Localizer {
             new ParameterizedString<{ funcName: string; fieldType: string; fieldName: string }>(
                 getRawString('Diagnostic.dataClassConverterOverloads')
             );
+        export const dataClassDefaultValueMutable = () => getRawString('Diagnostic.dataClassDefaultValueMutable');
         export const dataClassFieldInheritedDefault = () =>
             new ParameterizedString<{ fieldName: string }>(getRawString('Diagnostic.dataClassFieldInheritedDefault'));
         export const dataClassFieldWithDefault = () => getRawString('Diagnostic.dataClassFieldWithDefault');

--- a/packages/pyright-internal/src/localization/package.nls.en-us.json
+++ b/packages/pyright-internal/src/localization/package.nls.en-us.json
@@ -229,6 +229,7 @@
         "dataClassBaseClassNotFrozen": "A frozen class cannot inherit from a class that is not frozen",
         "dataClassConverterFunction": "Argument of type \"{argType}\" is not a valid converter for field \"{fieldName}\" of type \"{fieldType}\"",
         "dataClassConverterOverloads": "No overloads of \"{funcName}\" are valid converters for field \"{fieldName}\" of type \"{fieldType}\"",
+        "dataClassDefaultValueMutable": "Default value for dataclass field cannot be a list, dict, or set instance",
         "dataClassFieldInheritedDefault": "\"{fieldName}\" overrides a field of the same name but is missing a default value",
         "dataClassFieldWithDefault": "Fields without default values cannot appear after fields with default values",
         "dataClassFieldWithPrivateName": "Dataclass field cannot use private name",

--- a/packages/pyright-internal/src/tests/samples/dataclass1.py
+++ b/packages/pyright-internal/src/tests/samples/dataclass1.py
@@ -1,7 +1,7 @@
 # This sample tests the handling of the @dataclass decorator.
 
 from dataclasses import dataclass, InitVar, field
-from typing import Callable, Generic, Literal, Sequence, TypeVar
+from typing import Any, Callable, Generic, Literal, Sequence, TypeVar
 
 
 @dataclass
@@ -116,7 +116,7 @@ v8_2 = DC8[str]()
 
 @dataclass
 class DC9(Generic[T1]):
-    x: Sequence[Literal["a", "b"]] = ["a"]
+    x: Sequence[Literal["a", "b"]] = ("a",)
 
 
 @dataclass
@@ -126,3 +126,22 @@ class DC10[T]:
 
 
 DC10(a=int)
+
+
+@dataclass
+class DC11:
+    # This should generate an error because lists are not allowed
+    # as default values.
+    a: list[int] = []
+
+    # This should generate an error because sets are not allowed
+    # as default values.
+    b: set[int] = set[int]()
+
+    # This should generate an error because dicts are not allowed
+    # as default values.
+    c: dict[str, str] = {}
+
+    # This should generate an error because lists are not allowed
+    # as default values.
+    d: Any = field(default=[])

--- a/packages/pyright-internal/src/tests/typeEvaluator4.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator4.test.ts
@@ -277,7 +277,7 @@ test('DataClassNamedTuple2', () => {
 test('DataClass1', () => {
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['dataclass1.py']);
 
-    TestUtils.validateResults(analysisResults, 11);
+    TestUtils.validateResults(analysisResults, 15);
 });
 
 test('DataClass2', () => {


### PR DESCRIPTION
…s default values for a dataclass field. These result in TypeErrors at runtime. This addresses #10553.