### PR TITLE
Added support for PEP 758, which allows Python 3.14 and newer to supp…

### DIFF
--- a/packages/pyright-internal/src/localization/localize.ts
+++ b/packages/pyright-internal/src/localization/localize.ts
@@ -469,6 +469,8 @@ export namespace Localizer {
             new ParameterizedString<{ type: string }>(getRawString('Diagnostic.exceptionTypeNotClass'));
         export const exceptionTypeNotInstantiable = () =>
             new ParameterizedString<{ type: string }>(getRawString('Diagnostic.exceptionTypeNotInstantiable'));
+        export const exceptRequiresParens = () => getRawString('Diagnostic.exceptRequiresParens');
+        export const exceptWithAsRequiresParens = () => getRawString('Diagnostic.exceptWithAsRequiresParens');
         export const expectedAfterDecorator = () => getRawString('Diagnostic.expectedAfterDecorator');
         export const expectedArrow = () => getRawString('Diagnostic.expectedArrow');
         export const expectedAsAfterException = () => getRawString('Diagnostic.expectedAsAfterException');

--- a/packages/pyright-internal/src/localization/package.nls.en-us.json
+++ b/packages/pyright-internal/src/localization/package.nls.en-us.json
@@ -372,6 +372,8 @@
         },
         "exceptionTypeNotClass": "\"{type}\" is not a valid exception class",
         "exceptionTypeNotInstantiable": "Constructor for exception type \"{type}\" requires one or more arguments",
+        "exceptWithAsRequiresParens": "Multiple exception types must be parenthesized when using \"as\"",
+        "exceptRequiresParens": "Multiple exception types must be parenthesized prior to Python 3.14",
         "expectedAfterDecorator": "Expected function or class declaration after decorator",
         "expectedArrow": "Expected \"->\" followed by return type annotation",
         "expectedAsAfterException": {

--- a/packages/pyright-internal/src/tests/checker.test.ts
+++ b/packages/pyright-internal/src/tests/checker.test.ts
@@ -414,7 +414,7 @@ test('ParamType1', () => {
 test('Python2', () => {
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['python2.py']);
 
-    TestUtils.validateResults(analysisResults, 7);
+    TestUtils.validateResults(analysisResults, 8);
 });
 
 test('InconsistentSpaceTab1', () => {

--- a/packages/pyright-internal/src/tests/samples/python2.py
+++ b/packages/pyright-internal/src/tests/samples/python2.py
@@ -13,7 +13,8 @@ exec 3 + 4
 
 try:
     bar = 3
-# This should generate an error.
+# This should generate one error on Python 3.14 and newer
+# and two errors on older versions.
 except NameError, 'error caused':
     pass
 

--- a/packages/pyright-internal/src/tests/samples/tryExcept12.py
+++ b/packages/pyright-internal/src/tests/samples/tryExcept12.py
@@ -1,0 +1,16 @@
+# This sample tests that multi-exception lists are parsed correctly
+# based on PEP 758 in Python 3.14.
+
+def func1():
+    try:
+        pass
+    # This should generate an error for Python 3.13 or earlier.
+    except ZeroDivisionError, TypeError:
+        raise
+
+def func2():
+    try:
+        pass
+    # This should generate an error because an "as" clause always requires parens.
+    except ZeroDivisionError, TypeError as e:
+        raise

--- a/packages/pyright-internal/src/tests/typeEvaluator7.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator7.test.ts
@@ -14,6 +14,7 @@ import {
     pythonVersion3_11,
     pythonVersion3_12,
     pythonVersion3_13,
+    pythonVersion3_14,
     pythonVersion3_8,
 } from '../common/pythonVersion';
 import { Uri } from '../common/uri/uri';
@@ -998,6 +999,18 @@ test('TryExcept10', () => {
 test('TryExcept11', () => {
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['tryExcept11.py']);
     TestUtils.validateResults(analysisResults, 0);
+});
+
+test('TryExcept12', () => {
+    const configOptions = new ConfigOptions(Uri.empty());
+
+    configOptions.defaultPythonVersion = pythonVersion3_13;
+    const analysisResults1 = TestUtils.typeAnalyzeSampleFiles(['tryExcept12.py'], configOptions);
+    TestUtils.validateResults(analysisResults1, 3);
+
+    configOptions.defaultPythonVersion = pythonVersion3_14;
+    const analysisResults2 = TestUtils.typeAnalyzeSampleFiles(['tryExcept12.py'], configOptions);
+    TestUtils.validateResults(analysisResults2, 1);
 });
 
 test('exceptionGroup1', () => {


### PR DESCRIPTION
…ort multiple exceptions in an `except` clause without surrounding parentheses. This addresses #10546.