### PR TITLE
Fixed bug that results in incorrect behavior when a type variable is …

### DIFF
--- a/packages/pyright-internal/src/analyzer/typedDicts.ts
+++ b/packages/pyright-internal/src/analyzer/typedDicts.ts
@@ -877,10 +877,15 @@ export function getTypedDictMembersForClass(
         });
     }
 
-    return {
-        knownItems: entries,
-        extraItems: classType.shared.typedDictEntries?.extraItems,
-    };
+    let extraItems = classType.shared.typedDictEntries?.extraItems;
+    if (extraItems) {
+        extraItems = {
+            ...extraItems,
+            valueType: applySolvedTypeVars(extraItems.valueType, solution),
+        };
+    }
+
+    return { knownItems: entries, extraItems };
 }
 
 // If the TypedDict class is consistent with Mapping[str, T] where T

--- a/packages/pyright-internal/src/tests/samples/typedDictClosed10.py
+++ b/packages/pyright-internal/src/tests/samples/typedDictClosed10.py
@@ -1,0 +1,15 @@
+# This sample tests the case where a type variable is used to define
+# the extra_items in a TypedDict.
+
+from typing_extensions import TypedDict  # pyright: ignore[reportMissingModuleSource]
+
+
+class TD1[T](TypedDict, extra_items=T):
+    a: T
+
+
+d1: TD1 = {"a": 1}
+d2: TD1[int] = {"a": 1}
+
+reveal_type(d1["other"], expected_text="Unknown")
+reveal_type(d2["other"], expected_text="int")

--- a/packages/pyright-internal/src/tests/typeEvaluator5.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator5.test.ts
@@ -424,6 +424,14 @@ test('TypedDictClosed9', () => {
     TestUtils.validateResults(analysisResults, 1);
 });
 
+test('TypedDictClosed10', () => {
+    const configOptions = new ConfigOptions(Uri.empty());
+    configOptions.diagnosticRuleSet.enableExperimentalFeatures = true;
+
+    const analysisResults = TestUtils.typeAnalyzeSampleFiles(['typedDictClosed10.py'], configOptions);
+    TestUtils.validateResults(analysisResults, 0);
+});
+
 test('DataclassTransform1', () => {
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['dataclassTransform1.py']);
 


### PR DESCRIPTION
…used to define the `extra_items` type for a generic TypedDict. This addresses #10545.