### PR TITLE
Added code to deallocate memory associated with code flow analyzers a…

### DIFF
--- a/packages/pyright-internal/src/analyzer/checker.ts
+++ b/packages/pyright-internal/src/analyzer/checker.ts
@@ -285,6 +285,10 @@ export class Checker extends ParseTreeWalker {
         this._reportUnusedMultipartImports();
 
         this._reportDuplicateImports();
+
+        // We don't need the cached code flow analyzer for this execution
+        // scope any more, so drop it to free up memory.
+        this._evaluator.dropCodeFlowAnalyzer(this._moduleNode);
     }
 
     override walk(node: ParseNode) {
@@ -746,6 +750,10 @@ export class Checker extends ParseTreeWalker {
             this._validateOverloadAttributeConsistency(node, functionTypeResult.decoratedType);
         }
 
+        // We don't need the cached code flow analyzer for this execution
+        // scope any more, so drop it to free up memory.
+        this._evaluator.dropCodeFlowAnalyzer(node);
+
         return false;
     }
 
@@ -796,6 +804,10 @@ export class Checker extends ParseTreeWalker {
         }
 
         this._scopedNodes.push(node);
+
+        // We don't need the cached code flow analyzer for this execution
+        // scope any more, so drop it to free up memory.
+        this._evaluator.dropCodeFlowAnalyzer(node);
 
         return false;
     }
@@ -1625,6 +1637,11 @@ export class Checker extends ParseTreeWalker {
 
     override visitTypeParameterList(node: TypeParameterListNode): boolean {
         this._typeParamLists.push(node);
+
+        // We don't need the cached code flow analyzer for this execution
+        // scope any more, so drop it to free up memory.
+        this._evaluator.dropCodeFlowAnalyzer(node);
+
         return true;
     }
 

--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -20864,6 +20864,13 @@ export function createTypeEvaluator(
         return undefined;
     }
 
+    // Call this function once an execution scope has been fully analyzed
+    // and all diagnostics generated. This frees up the code flow analyzer
+    // and any cached information it has accumulated.
+    function dropCodeFlowAnalyzer(node: ExecutionScopeNode) {
+        codeFlowAnalyzerCache.delete(node.id);
+    }
+
     function getCodeFlowAnalyzerForNode(
         node: ExecutionScopeNode,
         typeAtStart: TypeResult | undefined
@@ -28621,6 +28628,7 @@ export function createTypeEvaluator(
         useSpeculativeMode,
         isSpeculativeModeInUse,
         setTypeResultForNode,
+        dropCodeFlowAnalyzer,
         checkForCancellation,
         printControlFlowGraph,
     };

--- a/packages/pyright-internal/src/analyzer/typeEvaluatorTypes.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluatorTypes.ts
@@ -20,6 +20,7 @@ import {
     CaseNode,
     ClassNode,
     DecoratorNode,
+    ExecutionScopeNode,
     ExpressionNode,
     FunctionNode,
     MatchNode,
@@ -868,6 +869,8 @@ export interface TypeEvaluator {
     ) => T;
     isSpeculativeModeInUse: (node: ParseNode | undefined) => boolean;
     setTypeResultForNode: (node: ParseNode, typeResult: TypeResult, flags?: EvalFlags) => void;
+
+    dropCodeFlowAnalyzer: (node: ExecutionScopeNode) => void;
 
     checkForCancellation: () => void;
     printControlFlowGraph: (


### PR DESCRIPTION
…nd their caches once an execution scope has been fully analyzed and all diagnostics reported. This should theoretically reduce peak memory usage when type checking many files.