### PR TITLE
Fixed bug that results in a false positive `reportUnusedVariable` err…

### DIFF
--- a/packages/pyright-internal/src/analyzer/codeFlowEngine.ts
+++ b/packages/pyright-internal/src/analyzer/codeFlowEngine.ts
@@ -1485,7 +1485,7 @@ export function getCodeFlowEngine(
 
         // Protect against infinite recursion.
         if (isReachableRecursionSet.has(flowNode.id)) {
-            return Reachability.UnreachableByAnalysis;
+            return Reachability.Reachable;
         }
         isReachableRecursionSet.add(flowNode.id);
 


### PR DESCRIPTION
…or under specific conditions when an expression's local type has a circular dependency. This addresses #10512.