### PR TITLE
Reverted narrowing behavior for discriminating between TypedDicts. Th…

### DIFF
--- a/packages/pyright-internal/src/analyzer/typeGuards.ts
+++ b/packages/pyright-internal/src/analyzer/typeGuards.ts
@@ -2248,18 +2248,28 @@ function narrowTypeForTypedDictKey(
                 const tdEntry = entries.knownItems.get(literalKey.priv.literalValue as string) ?? entries.extraItems;
 
                 if (isPositiveTest) {
+                    // The code that is commented out below implements the behavior that is technically
+                    // correct, but until we PEP 728 is ratified and we have a way to express "extra items"
+                    // and closed TypedDicts, we'll preserve the older (less correct) behavior to enable
+                    // narrowing of TypedDicts based on checks for specific keys.
+                    // TODO - remove this behavior once PEP 728 is accepted and the feature is no
+                    // longer experimental.
                     if (!tdEntry) {
-                        // If there is no TD entry for this key and no "extra items" defined,
-                        // we have to assume that the TypedDict may contain extra items, so
-                        // narrowing it isn't possible in this case.
-                        return subtype;
-                    }
-
-                    if (isNever(tdEntry.valueType)) {
-                        // If the entry is typed as Never or the "extra items" is typed as Never,
-                        // then this key cannot be present in the TypedDict, and we can eliminate it.
                         return undefined;
                     }
+
+                    // if (!tdEntry) {
+                    //     // If there is no TD entry for this key and no "extra items" defined,
+                    //     // we have to assume that the TypedDict may contain extra items, so
+                    //     // narrowing it isn't possible in this case.
+                    //     return subtype;
+                    // }
+
+                    // if (isNever(tdEntry.valueType)) {
+                    //     // If the entry is typed as Never or the "extra items" is typed as Never,
+                    //     // then this key cannot be present in the TypedDict, and we can eliminate it.
+                    //     return undefined;
+                    // }
 
                     // If the entry is currently not required and not marked provided, we can mark
                     // it as provided after this guard expression confirms it is.

--- a/packages/pyright-internal/src/tests/samples/typeNarrowingIn1.py
+++ b/packages/pyright-internal/src/tests/samples/typeNarrowingIn1.py
@@ -141,7 +141,12 @@ T1 = TypeVar("T1", TD1, TD2)
 
 def func12(v: T1):
     if "x" in v:
-        reveal_type(v, expected_text="TD1* | TD2*")
+        # This should technically be TD1* | TD2*, but the
+        # current narrowing logic implements a not-entirely-safe
+        # narrowing behavior. We can fix this once PEP 728
+        # is accepted.
+        reveal_type(v, expected_text="TD1*")
+        # reveal_type(v, expected_text="TD1* | TD2*")
     else:
         reveal_type(v, expected_text="TD2*")
 

--- a/packages/pyright-internal/src/tests/samples/typeNarrowingTypedDict1.py
+++ b/packages/pyright-internal/src/tests/samples/typeNarrowingTypedDict1.py
@@ -21,7 +21,12 @@ class TD3(TypedDict, total=False):
 
 def f1(p: TD1 | TD2):
     if "b" in p:
-        reveal_type(p, expected_text="TD1 | TD2")
+        # This should technically be TD1 | TD2, but the
+        # current narrowing logic implements a not-entirely-safe
+        # narrowing behavior. We can fix this once PEP 728
+        # is accepted.
+        reveal_type(p, expected_text="TD1")
+        # reveal_type(p, expected_text="TD1 | TD2")
     else:
         reveal_type(p, expected_text="TD2")
 
@@ -30,12 +35,22 @@ def f2(p: TD1 | TD2):
     if "b" not in p:
         reveal_type(p, expected_text="TD2")
     else:
-        reveal_type(p, expected_text="TD1 | TD2")
+        # This should technically be TD1 | TD2, but the
+        # current narrowing logic implements a not-entirely-safe
+        # narrowing behavior. We can fix this once PEP 728
+        # is accepted.
+        reveal_type(p, expected_text="TD1")
+        # reveal_type(p, expected_text="TD1 | TD2")
 
 
 def f3(p: TD1 | TD3):
     if "d" in p:
-        reveal_type(p, expected_text="TD1 | TD3")
+        # This should technically be TD1 | TD3, but the
+        # current narrowing logic implements a not-entirely-safe
+        # narrowing behavior. We can fix this once PEP 728
+        # is accepted.
+        reveal_type(p, expected_text="TD3")
+        # reveal_type(p, expected_text="TD1 | TD3")
     else:
         reveal_type(p, expected_text="TD1 | TD3")
 
@@ -44,7 +59,12 @@ def f4(p: TD1 | TD3):
     if "d" not in p:
         reveal_type(p, expected_text="TD1 | TD3")
     else:
-        reveal_type(p, expected_text="TD1 | TD3")
+        # This should technically be TD1 | TD3, but the
+        # current narrowing logic implements a not-entirely-safe
+        # narrowing behavior. We can fix this once PEP 728
+        # is accepted.
+        reveal_type(p, expected_text="TD3")
+        # reveal_type(p, expected_text="TD1 | TD3")
 
 
 def f5(p: TD1 | TD3):
@@ -61,13 +81,23 @@ def f6(p: TD1 | TD2 | TD3):
     v2 = p.get("a")
 
     if "c" in p:
-        # This should generate an error for TD1 and TD3
+        # This should technicall generate two errors for TD1 and TD3
         v3 = p["c"]
-        reveal_type(v3, expected_text="Unknown | str")
+        # This should technically be Unknown | str, but the
+        # current narrowing logic implements a not-entirely-safe
+        # narrowing behavior. We can fix this once PEP 728
+        # is accepted.
+        reveal_type(v3, expected_text="str")
+        # reveal_type(v3, expected_text="Unknown | str")
 
     if "a" in p and "d" in p:
         v4 = p["a"]
-        reveal_type(v4, expected_text="str | int")
+        # This should technically be str | int, but the
+        # current narrowing logic implements a not-entirely-safe
+        # narrowing behavior. We can fix this once PEP 728
+        # is accepted.
+        reveal_type(v4, expected_text="int")
+        # reveal_type(v4, expected_text="str | int")
 
         # This should generate an error for TD1 and TD2
         v5 = p["d"]

--- a/packages/pyright-internal/src/tests/typeEvaluator1.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator1.test.ts
@@ -532,7 +532,7 @@ test('TypeNarrowingTuple1', () => {
 test('TypeNarrowingTypedDict1', () => {
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['typeNarrowingTypedDict1.py']);
 
-    TestUtils.validateResults(analysisResults, 8);
+    TestUtils.validateResults(analysisResults, 5);
 });
 
 test('TypeNarrowingTypedDict2', () => {


### PR DESCRIPTION
…is narrowing behavior isn't technically correct from a type safety standpoint, but until PEP 728 is accepted, it's the only practical way to do this form of discrimination. This addresses #10517.