### PR TITLE
Added `reportUnreachable` diagnostic check. If enabled, it emits a di…

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -58,7 +58,7 @@ The following settings determine how different types should be evaluated.
 
 - <a name="deprecateTypingAliases"></a> **deprecateTypingAliases** [boolean]: PEP 585 indicates that aliases to types in standard collections that were introduced solely to support generics are deprecated as of Python 3.9. This switch controls whether these are treated as deprecated. This applies only when pythonVersion is 3.9 or newer. The default value for this setting is `false` but may be switched to `true` in the future.
 
-- <a name="enableReachabilityAnalysis"></a> **enableReachabilityAnalysis** [boolean]: If enabled, code that is determined to be unreachable by type analysis is reported using a tagged hint. This setting does not affect code that is determined to be unreachable regardless of type analysis; such code is always reported as unreachable. This setting also has no effect when using the command-line version of pyright because it never emits tagged hints for unreachable code.
+- <a name="enableReachabilityAnalysis"></a> **enableReachabilityAnalysis** [boolean]: If enabled, code that is determined to be unreachable by type analysis is reported using a tagged hint. This setting does not affect code that is determined to be unreachable independent of type analysis; such code is always reported as unreachable using a tagged hint. This setting also has no effect when using the command-line version of pyright because it never emits tagged hints for unreachable code.
 
 - <a name="enableExperimentalFeatures"></a> **enableExperimentalFeatures** [boolean]: Enables a set of experimental (mostly undocumented) features that correspond to proposed or exploratory changes to the Python typing standard. These features will likely change or be removed, so they should not be used except for experimentation purposes. The default value for this setting is `false`.
 
@@ -232,6 +232,8 @@ The following settings allow more fine grained control over the **typeCheckingMo
 - <a name="reportUnnecessaryTypeIgnoreComment"></a> **reportUnnecessaryTypeIgnoreComment** [boolean or string, optional]: Generate or suppress diagnostics for a `# type: ignore` or `# pyright: ignore` comment that would have no effect if removed. The default value for this setting is `"none"`.
 
 - <a name="reportMatchNotExhaustive"></a> **reportMatchNotExhaustive** [boolean or string, optional]: Generate or suppress diagnostics for a `match` statement that does not provide cases that exhaustively match against all potential types of the target expression. The default value for this setting is `"none"`.
+
+- <a name="reportUnreachable"></a> **reportUnreachable** [boolean or string, optional]: Generate or suppress diagnostics for code that is determined to be structurally unreachable or unreachable by type analysis. The default value for this setting is `"none"`.
 
 - <a name="reportImplicitOverride"></a> **reportImplicitOverride** [boolean or string, optional]: Generate or suppress diagnostics for overridden methods in a class that are missing an explicit `@override` decorator. The default value for this setting is `"none"`.
 
@@ -439,6 +441,7 @@ The following table lists the default severity levels for each diagnostic rule w
 | reportShadowedImports                     | "none"     | "none"     | "none"     | "none"     |
 | reportUninitializedInstanceVariable       | "none"     | "none"     | "none"     | "none"     |
 | reportUnnecessaryTypeIgnoreComment        | "none"     | "none"     | "none"     | "none"     |
+| reportUnreachable                         | "none"     | "none"     | "none"     | "none"     |
 | reportUnusedCallResult                    | "none"     | "none"     | "none"     | "none"     |
 
 ## Overriding settings (in VS Code)

--- a/docs/type-concepts-advanced.md
+++ b/docs/type-concepts-advanced.md
@@ -601,9 +601,9 @@ If one of these conditional expressions evaluates statically to false, pyright d
 
 
 ### Reachability
-Pyright performs “reachability analysis” to determine whether statements will be executed at runtime.
+Pyright performs “reachability analysis” to determine whether statements will be executed at runtime and whether it should analyze and report errors in code.
 
-Reachability analysis is based on both non-type and type information. Non-type information includes statements that unconditionally affect code flow such as `continue`, `raise` and `return`. It also includes conditional statements (`if`, `elif`, or `while`) where the conditional expression is one of these [supported expression forms](type-concepts-advanced#static-conditional-evaluation). Type analysis is not performed on code determined to be unreachable using non-type information. Therefore, language server features like completion suggestions are not available for this code.
+Reachability analysis is based on both non-type and type information. Non-type information includes statements that affect code structure such as `continue`, `raise` and `return`. It also includes conditional statements (`if`, `elif`, or `while`) where the conditional expression is one of these [supported expression forms](type-concepts-advanced#static-conditional-evaluation). Type analysis is not performed on code determined to be unreachable using non-type information. Therefore, language server features like completion suggestions are not available for this code.
 
 Here are some examples of code determined to be unreachable using non-type information.
 

--- a/packages/pyright-internal/src/analyzer/analyzerNodeInfo.ts
+++ b/packages/pyright-internal/src/analyzer/analyzerNodeInfo.ts
@@ -212,7 +212,7 @@ export function isCodeUnreachable(node: ParseNode): boolean {
     while (curNode) {
         const flowNode = getFlowNode(curNode);
         if (flowNode) {
-            return !!(flowNode.flags & FlowFlags.Unreachable);
+            return (flowNode.flags & (FlowFlags.UnreachableStaticCondition | FlowFlags.UnreachableStructural)) !== 0;
         }
         curNode = curNode.parent;
     }

--- a/packages/pyright-internal/src/analyzer/codeFlowTypes.ts
+++ b/packages/pyright-internal/src/analyzer/codeFlowTypes.ts
@@ -33,14 +33,15 @@ import {
 import { OperatorType } from '../parser/tokenizerTypes';
 
 export enum FlowFlags {
-    Unreachable = 1 << 0, // Unreachable code
-    Start = 1 << 1, // Entry point
-    BranchLabel = 1 << 2, // Junction for forward control flow
-    LoopLabel = 1 << 3, // Junction for backward control flow
-    Assignment = 1 << 4, // Assignment statement
-    Unbind = 1 << 5, // Used with assignment to indicate target should be unbound
-    WildcardImport = 1 << 6, // For "from X import *" statements
-    TrueCondition = 1 << 7, // Condition known to be true
+    UnreachableStructural = 1 << 0, // Code that is structurally unreachable (e.g. following a return statement)
+    UnreachableStaticCondition = 1 << 1, // code that is unreachable due to a condition that the binder evaluates to False
+    Start = 1 << 2, // Entry point
+    BranchLabel = 1 << 3, // Junction for forward control flow
+    LoopLabel = 1 << 4, // Junction for backward control flow
+    Assignment = 1 << 5, // Assignment statement
+    Unbind = 1 << 6, // Used with assignment to indicate target should be unbound
+    WildcardImport = 1 << 7, // For "from X import *" statements
+    TrueCondition = 1 << 8, // Condition known to be true
     FalseCondition = 1 << 9, // Condition known to be false
     Call = 1 << 10, // Call node
     PreFinallyGate = 1 << 11, // Injected edge that links pre-finally label and pre-try flow

--- a/packages/pyright-internal/src/analyzer/codeFlowUtils.ts
+++ b/packages/pyright-internal/src/analyzer/codeFlowUtils.ts
@@ -253,7 +253,8 @@ export function formatControlFlowGraph(flowNode: FlowNode) {
         if (flags & FlowFlags.TrueCondition) return 'True';
         if (flags & FlowFlags.FalseCondition) return 'False';
         if (flags & FlowFlags.Call) return 'Call';
-        if (flags & FlowFlags.Unreachable) return 'Unreachable';
+        if (flags & FlowFlags.UnreachableStaticCondition) return 'UnreachableStaticCondition';
+        if (flags & FlowFlags.UnreachableStructural) return 'UnreachableStructural';
         if (flags & FlowFlags.WildcardImport) return 'Wildcard';
         if (flags & FlowFlags.PreFinallyGate) return 'PreFinal';
         if (flags & FlowFlags.PostFinally) return 'PostFinal';

--- a/packages/pyright-internal/src/analyzer/typeEvaluatorTypes.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluatorTypes.ts
@@ -500,7 +500,20 @@ export interface SolveConstraintsOptions {
 
 export enum Reachability {
     Reachable,
-    UnreachableAlways,
+
+    // The node is unreachable in the code flow graph and
+    // should be reported as an error. This includes situations
+    // like code after return statements.
+    UnreachableStructural,
+
+    // The node is unreachable in the code flow graph due to
+    // a statically-evaluated condition such as a TYPE_CHECKER
+    // or Python version check.
+    UnreachableStaticCondition,
+
+    // The node is unreachable according to code flow analysis.
+    // The type of one or more expressions has been narrowed to
+    // never.
     UnreachableByAnalysis,
 }
 
@@ -839,7 +852,6 @@ export interface TypeEvaluator {
     isExplicitTypeAliasDeclaration: (decl: Declaration) => boolean;
 
     addInformation: (message: string, node: ParseNode, range?: TextRange) => Diagnostic | undefined;
-    addUnusedCode: (node: ParseNode, textRange: TextRange) => void;
     addUnreachableCode: (node: ParseNode, reachability: Reachability, textRange: TextRange) => void;
     addDeprecated: (message: string, node: ParseNode) => void;
 

--- a/packages/pyright-internal/src/common/configOptions.ts
+++ b/packages/pyright-internal/src/common/configOptions.ts
@@ -390,6 +390,9 @@ export interface DiagnosticRuleSet {
     // covering all possible cases.
     reportMatchNotExhaustive: DiagnosticLevel;
 
+    // Report code that is determined to be unreachable via type analysis.
+    reportUnreachable: DiagnosticLevel;
+
     // Report files that match stdlib modules.
     reportShadowedImports: DiagnosticLevel;
 
@@ -510,6 +513,7 @@ export function getDiagLevelDiagnosticRules() {
         DiagnosticRule.reportUnusedExpression,
         DiagnosticRule.reportUnnecessaryTypeIgnoreComment,
         DiagnosticRule.reportMatchNotExhaustive,
+        DiagnosticRule.reportUnreachable,
         DiagnosticRule.reportShadowedImports,
         DiagnosticRule.reportImplicitOverride,
     ];
@@ -617,6 +621,7 @@ export function getOffDiagnosticRuleSet(): DiagnosticRuleSet {
         reportUnusedExpression: 'none',
         reportUnnecessaryTypeIgnoreComment: 'none',
         reportMatchNotExhaustive: 'none',
+        reportUnreachable: 'none',
         reportShadowedImports: 'none',
         reportImplicitOverride: 'none',
     };
@@ -720,6 +725,7 @@ export function getBasicDiagnosticRuleSet(): DiagnosticRuleSet {
         reportUnusedExpression: 'warning',
         reportUnnecessaryTypeIgnoreComment: 'none',
         reportMatchNotExhaustive: 'none',
+        reportUnreachable: 'none',
         reportShadowedImports: 'none',
         reportImplicitOverride: 'none',
     };
@@ -823,6 +829,7 @@ export function getStandardDiagnosticRuleSet(): DiagnosticRuleSet {
         reportUnusedExpression: 'warning',
         reportUnnecessaryTypeIgnoreComment: 'none',
         reportMatchNotExhaustive: 'none',
+        reportUnreachable: 'none',
         reportShadowedImports: 'none',
         reportImplicitOverride: 'none',
     };
@@ -926,6 +933,7 @@ export function getStrictDiagnosticRuleSet(): DiagnosticRuleSet {
         reportUnusedExpression: 'error',
         reportUnnecessaryTypeIgnoreComment: 'none',
         reportMatchNotExhaustive: 'error',
+        reportUnreachable: 'none',
         reportShadowedImports: 'none',
         reportImplicitOverride: 'none',
     };

--- a/packages/pyright-internal/src/common/diagnosticRules.ts
+++ b/packages/pyright-internal/src/common/diagnosticRules.ts
@@ -101,6 +101,7 @@ export enum DiagnosticRule {
     reportUnusedExpression = 'reportUnusedExpression',
     reportUnnecessaryTypeIgnoreComment = 'reportUnnecessaryTypeIgnoreComment',
     reportMatchNotExhaustive = 'reportMatchNotExhaustive',
+    reportUnreachable = 'reportUnreachable',
     reportShadowedImports = 'reportShadowedImports',
     reportImplicitOverride = 'reportImplicitOverride',
 }

--- a/packages/pyright-internal/src/localization/localize.ts
+++ b/packages/pyright-internal/src/localization/localize.ts
@@ -1209,7 +1209,8 @@ export namespace Localizer {
         export const unpackNotAllowed = () => getRawString('Diagnostic.unpackNotAllowed');
         export const unpackOperatorNotAllowed = () => getRawString('Diagnostic.unpackOperatorNotAllowed');
         export const unpackTuplesIllegal = () => getRawString('Diagnostic.unpackTuplesIllegal');
-        export const unreachableCode = () => getRawString('Diagnostic.unreachableCode');
+        export const unreachableCodeCondition = () => getRawString('Diagnostic.unreachableCodeCondition');
+        export const unreachableCodeStructure = () => getRawString('Diagnostic.unreachableCodeStructure');
         export const unreachableCodeType = () => getRawString('Diagnostic.unreachableCodeType');
         export const unreachableExcept = () => getRawString('Diagnostic.unreachableExcept');
         export const unsupportedDunderAllOperation = () => getRawString('Diagnostic.unsupportedDunderAllOperation');

--- a/packages/pyright-internal/src/localization/package.nls.cs.json
+++ b/packages/pyright-internal/src/localization/package.nls.cs.json
@@ -635,7 +635,6 @@
         "unpackedSubscriptIllegal": "Operátor rozbalení v dolním indexu vyžaduje Python 3.11 nebo novější",
         "unpackedTypeVarTupleExpected": "Byl očekáván rozbalený typ TypeVarTuple; použijte Unpack[{name1}] nebo *{name2}",
         "unpackedTypedDictArgument": "Nepovedlo se spárovat nebalený argument TypedDict s parametry",
-        "unreachableCode": "Kód je nedostupný",
         "unreachableCodeType": "Analýza typů indikuje, že kód není dostupný.",
         "unreachableExcept": "Klauzule Except je nedosažitelná, protože výjimka je již zpracována",
         "unsupportedDunderAllOperation": "Operace s __all__ se nepodporuje, takže exportovaný seznam symbolů nemusí být správný",

--- a/packages/pyright-internal/src/localization/package.nls.de.json
+++ b/packages/pyright-internal/src/localization/package.nls.de.json
@@ -635,7 +635,6 @@
         "unpackedSubscriptIllegal": "Das Entpacken des Operators im Tiefstellungsskript erfordert Python 3.11 oder höher.",
         "unpackedTypeVarTupleExpected": "Nicht gepackter TypeVarTuple erwartet; verwenden Sie Unpack[{name1}] oder *{name2}",
         "unpackedTypedDictArgument": "Das entpackte TypedDict-Argument kann nicht mit Parametern abgelichen werden.",
-        "unreachableCode": "Der Code ist nicht erreichbar.",
         "unreachableCodeType": "Typanalyse weist darauf hin, dass Code nicht erreichbar ist",
         "unreachableExcept": "Die except-Klausel ist nicht erreichbar, weil die Ausnahme bereits behandelt wird.",
         "unsupportedDunderAllOperation": "Der Vorgang für \"__all__\" wird nicht unterstützt, daher ist die exportierte Symbolliste möglicherweise falsch.",

--- a/packages/pyright-internal/src/localization/package.nls.en-us.json
+++ b/packages/pyright-internal/src/localization/package.nls.en-us.json
@@ -1723,7 +1723,8 @@
             "message": "Unable to match unpacked TypedDict argument to parameters",
             "comment": "{Locked='TypedDict'}"
         },
-        "unreachableCode": "Code is unreachable",
+        "unreachableCodeCondition": "Code is not analyzed because condition is statically evaluated as false",
+        "unreachableCodeStructure": "Code is structurally unreachable",
         "unreachableCodeType": "Type analysis indicates code is unreachable",
         "unreachableExcept": {
             "message": "Except clause is unreachable because exception is already handled",

--- a/packages/pyright-internal/src/localization/package.nls.es.json
+++ b/packages/pyright-internal/src/localization/package.nls.es.json
@@ -635,7 +635,6 @@
         "unpackedSubscriptIllegal": "El operador de desempaquetado en el subíndice requiere Python 3.11 o posterior.",
         "unpackedTypeVarTupleExpected": "Se espera un TypeVarTuple desempaquetado; use Unpack[{name1}] o *{name2}",
         "unpackedTypedDictArgument": "No se puede emparejar el argumento TypedDict desempaquetado con los parámetros",
-        "unreachableCode": "El código es inalcanzable",
         "unreachableCodeType": "El análisis de tipos indica que no se puede acceder al código",
         "unreachableExcept": "La cláusula Excepto es inalcanzable porque la excepción ya está administrada",
         "unsupportedDunderAllOperation": "No se admite la operación en \"__all__\", por lo que la lista de símbolos exportada puede ser incorrecta.",

--- a/packages/pyright-internal/src/localization/package.nls.fr.json
+++ b/packages/pyright-internal/src/localization/package.nls.fr.json
@@ -635,7 +635,6 @@
         "unpackedSubscriptIllegal": "L’opérateur de décompression en indice requiert Python 3.11 ou version ultérieure",
         "unpackedTypeVarTupleExpected": "TypeVarTuple décompressé attendu ; utiliser Unpack[{name1}] ou *{name2}",
         "unpackedTypedDictArgument": "Impossible de faire correspondre l’argument TypedDict décompressé aux paramètres",
-        "unreachableCode": "Le code est inaccessible",
         "unreachableCodeType": "L’analyse de type indique que le code est inaccessible",
         "unreachableExcept": "La clause Except est inaccessible, car l’exception est déjà gérée",
         "unsupportedDunderAllOperation": "L’opération sur « __all__ » n’est pas prise en charge. Par conséquent, la liste de symboles exportée peut être incorrecte",

--- a/packages/pyright-internal/src/localization/package.nls.it.json
+++ b/packages/pyright-internal/src/localization/package.nls.it.json
@@ -635,7 +635,6 @@
         "unpackedSubscriptIllegal": "L'operatore di decompressione nel pedice richiede Python 3.11 o versione successiva",
         "unpackedTypeVarTupleExpected": "Previsto TypeVarTuple decompresso; usa Unpack[{name1}] o *{name2}",
         "unpackedTypedDictArgument": "Impossibile trovare una corrispondenza tra l'argomento TypedDict non compresso e i parametri",
-        "unreachableCode": "Il codice non è raggiungibile",
         "unreachableCodeType": "L’analisi dei tipi indica che il codice non è raggiungibile.",
         "unreachableExcept": "La clausola Except non è raggiungibile perché l'eccezione è già gestita",
         "unsupportedDunderAllOperation": "L'operazione su \"__all__\" non è supportata, di conseguenza l'elenco dei simboli esportati potrebbe non essere corretto",

--- a/packages/pyright-internal/src/localization/package.nls.ja.json
+++ b/packages/pyright-internal/src/localization/package.nls.ja.json
@@ -635,7 +635,6 @@
         "unpackedSubscriptIllegal": "下付き文字の Unpack 演算子には Python 3.11 以降が必要です",
         "unpackedTypeVarTupleExpected": "アンパックされた TypeVarTuple が必要です。Unpack[{name1}] または *{name2} を使用してください",
         "unpackedTypedDictArgument": "アンパックされた TypedDict 引数をパラメーターと一致させることはできません",
-        "unreachableCode": "コードに到達できません",
         "unreachableCodeType": "型分析はコードに到達不能であることを示します",
         "unreachableExcept": "例外が既に処理されているため、Except 句に到達できません",
         "unsupportedDunderAllOperation": "\"__all__\" に対する操作はサポートされていないため、エクスポートされたシンボル リストが正しくない可能性があります",

--- a/packages/pyright-internal/src/localization/package.nls.ko.json
+++ b/packages/pyright-internal/src/localization/package.nls.ko.json
@@ -635,7 +635,6 @@
         "unpackedSubscriptIllegal": "아래 첨자의 압축 풀기 연산자에는 Python 3.11 이상이 필요합니다.",
         "unpackedTypeVarTupleExpected": "압축 해제된 TypeVarTuple이 필요합니다. Unpack[{name1}] 또는 *{name2} 사용",
         "unpackedTypedDictArgument": "압축되지 않은 TypedDict 인수를 매개 변수와 일치시킬 수 없습니다.",
-        "unreachableCode": "코드에 접근할 수 없습니다.",
         "unreachableCodeType": "형식 분석을 통해 코드에 연결할 수 없음을 나타냅니다.",
         "unreachableExcept": "예외가 이미 처리되었으므로 Except 절에 연결할 수 없습니다.",
         "unsupportedDunderAllOperation": "\"__all__\"에 대한 작업이 지원되지 않으므로 내보낸 기호 목록이 잘못되었을 수 있습니다.",

--- a/packages/pyright-internal/src/localization/package.nls.pl.json
+++ b/packages/pyright-internal/src/localization/package.nls.pl.json
@@ -635,7 +635,6 @@
         "unpackedSubscriptIllegal": "Operator rozpakowywania w indeksie dolnym wymaga języka Python w wersji 3.11 lub nowszej",
         "unpackedTypeVarTupleExpected": "Oczekiwano nierozpakowanego typu TypeVarTuple; użyj Unpack[{name1}] lub *{name2}",
         "unpackedTypedDictArgument": "Nie można dopasować nierozpakowanego argumentu TypedDict do parametrów",
-        "unreachableCode": "Kod jest nieosiągalny",
         "unreachableCodeType": "Analiza typów wskazuje, że kod jest nieosiągalny",
         "unreachableExcept": "Klauzula Except jest nieosiągalna, ponieważ wyjątek jest już obsługiwany",
         "unsupportedDunderAllOperation": "Operacja na elemencie „__all__” nie jest obsługiwana, więc wyeksportowana lista symboli może być nieprawidłowa",

--- a/packages/pyright-internal/src/localization/package.nls.pt-br.json
+++ b/packages/pyright-internal/src/localization/package.nls.pt-br.json
@@ -635,7 +635,6 @@
         "unpackedSubscriptIllegal": "O operador Unpack no subscrito requer o Python 3.11 ou mais recente",
         "unpackedTypeVarTupleExpected": "Esperava-se TypeVarTuple desempacotada. Use Unpack[{name1}] ou *{name2}",
         "unpackedTypedDictArgument": "Não é possível corresponder o argumento TypedDict desempacotado aos parâmetros",
-        "unreachableCode": "O código está inacessível.",
         "unreachableCodeType": "A análise de tipo indica que o código está inacessível",
         "unreachableExcept": "A cláusula Except está inacessível porque a exceção já foi tratada",
         "unsupportedDunderAllOperation": "A operação em \"__all__\" não é compatível, portanto, a lista de símbolos exportada pode estar incorreta",

--- a/packages/pyright-internal/src/localization/package.nls.qps-ploc.json
+++ b/packages/pyright-internal/src/localization/package.nls.qps-ploc.json
@@ -635,7 +635,6 @@
         "unpackedSubscriptIllegal": "[2CpZz][นั้Üñpæçk øpërætør ïñ sµþsçrïpt rëqµïrës Pÿthøñ 3.11 ør ñëwërẤğ倪İЂҰक्र्तिृまẤğ倪İЂҰक्र्นั้ढूँ]",
         "unpackedTypeVarTupleExpected": "[tgdHs][นั้Ëxpëçtëð µñpæçkëð TypeVarTuple; µsë Unpack[{name1}] ør *{name2}Ấğ倪İЂҰक्र्तिृまẤğ倪İЂҰक्र्तिृนั้ढूँ]",
         "unpackedTypedDictArgument": "[iCgjR][นั้Üñæþlë tø mætçh µñpæçkëð TypedDict ærgµmëñt tø pæræmëtërsẤğ倪İЂҰक्र्तिृまẤğ倪İЂҰक्र्นั้ढूँ]",
-        "unreachableCode": "[bpJSK][นั้Çøðë ïs µñrëæçhæþlëẤğ倪İЂҰक्นั้ढूँ]",
         "unreachableCodeType": "[v80nR][นั้Tÿpë æñælÿsïs ïñðïçætës çøðë ïs µñrëæçhæþlëẤğ倪İЂҰक्र्तिृまẤğ倪นั้ढूँ]",
         "unreachableExcept": "[zFMWg][นั้Except çlæµsë ïs µñrëæçhæþlë þëçæµsë ëxçëptïøñ ïs ælrëæðÿ hæñðlëðẤğ倪İЂҰक्र्तिृまẤğ倪İЂҰक्र्तिृนั้ढूँ]",
         "unsupportedDunderAllOperation": "[KsX0f][นั้Øpërætïøñ øñ \"__all__\" ïs ñøt sµppørtëð, sø ëxpørtëð sÿmþøl lïst mæÿ þë ïñçørrëçtẤğ倪İЂҰक्र्तिृまẤğ倪İЂҰक्र्तिृまẤğ倪İนั้ढूँ]",

--- a/packages/pyright-internal/src/localization/package.nls.ru.json
+++ b/packages/pyright-internal/src/localization/package.nls.ru.json
@@ -635,7 +635,6 @@
         "unpackedSubscriptIllegal": "Оператор распаковки в операции взятия подстроки можно использовать в Python версии не ниже 3.11",
         "unpackedTypeVarTupleExpected": "Ожидается распакованный TypeVarTuple; используйте Unpack[{name1}] или *{name2}",
         "unpackedTypedDictArgument": "Не удалось сопоставить распакованный аргумент TypedDict с параметрами",
-        "unreachableCode": "Код недоступен",
         "unreachableCodeType": "Анализ типа показывает, что код недоступен",
         "unreachableExcept": "Предложение Except недоступно, так как исключение уже обработано",
         "unsupportedDunderAllOperation": "Операция на \"__all__\" не поддерживается, поэтому список экспортируемых символов может быть неправильным",

--- a/packages/pyright-internal/src/localization/package.nls.tr.json
+++ b/packages/pyright-internal/src/localization/package.nls.tr.json
@@ -635,7 +635,6 @@
         "unpackedSubscriptIllegal": "Alt simgede açma işleci için Python 3.11 veya daha yeni bir sürümü gerekiyor",
         "unpackedTypeVarTupleExpected": "Paketlenmemiş TypeVarTuple bekleniyordu; Unpack[{name1}] veya *{name2} kullanın",
         "unpackedTypedDictArgument": "Paketlenmemiş TypedDict bağımsız değişkeni parametrelerle eşlenemiyor",
-        "unreachableCode": "Koda ulaşılamıyor",
         "unreachableCodeType": "Tür analizi koda erişilemediğini gösteriyor",
         "unreachableExcept": "Except clause is unreachable because exception is already handled",
         "unsupportedDunderAllOperation": "\"__all__\" üzerinde işlem desteklenmiyor, bu nedenle dışarı aktarılan sembol listesi yanlış olabilir",

--- a/packages/pyright-internal/src/localization/package.nls.zh-cn.json
+++ b/packages/pyright-internal/src/localization/package.nls.zh-cn.json
@@ -635,7 +635,6 @@
         "unpackedSubscriptIllegal": "下标中的解包运算符需要 Python 3.11 或更高版本",
         "unpackedTypeVarTupleExpected": "应为未打包的 TypeVarTuple；使用 Unpack[{name1}] 或 *{name2}",
         "unpackedTypedDictArgument": "无法将解压缩的 TypedDict 参数与参数匹配",
-        "unreachableCode": "代码无法访问",
         "unreachableCodeType": "类型分析指示代码不可访问",
         "unreachableExcept": "无法访问 Except 子句，因为已处理异常",
         "unsupportedDunderAllOperation": "不支持对“__all__”执行操作，因此导出的符号列表可能不正确",

--- a/packages/pyright-internal/src/localization/package.nls.zh-tw.json
+++ b/packages/pyright-internal/src/localization/package.nls.zh-tw.json
@@ -635,7 +635,6 @@
         "unpackedSubscriptIllegal": "下標中的解壓縮運算子需要 Python 3.11 或更新版本",
         "unpackedTypeVarTupleExpected": "預期為解壓縮的 TypeVarTuple; 使用 Unpack[{name1}] 或 *{name2}",
         "unpackedTypedDictArgument": "無法比對解壓縮的 TypedDict 引數與參數",
-        "unreachableCode": "無法連線到程式碼",
         "unreachableCodeType": "類型分析指出程式碼無法連線",
         "unreachableExcept": "無法連接 Except 子句，因為例外已處理",
         "unsupportedDunderAllOperation": "不支援 \"__all__\" 上的作業，因此匯出的符號清單可能不正確",

--- a/packages/pyright-internal/src/parser/parseNodes.ts
+++ b/packages/pyright-internal/src/parser/parseNodes.ts
@@ -213,6 +213,7 @@ export namespace SuiteNode {
 
 export interface IfNode extends ParseNodeBase<ParseNodeType.If> {
     d: {
+        firstToken: Token;
         testExpr: ExpressionNode;
         ifSuite: SuiteNode;
         elseSuite: SuiteNode | IfNode | undefined;
@@ -229,6 +230,7 @@ export namespace IfNode {
             parent: undefined,
             a: undefined,
             d: {
+                firstToken: ifOrElifToken,
                 testExpr,
                 ifSuite: ifSuite,
                 elseSuite: elseSuite,
@@ -251,6 +253,7 @@ export namespace IfNode {
 
 export interface WhileNode extends ParseNodeBase<ParseNodeType.While> {
     d: {
+        firstToken: Token;
         testExpr: ExpressionNode;
         whileSuite: SuiteNode;
         elseSuite?: SuiteNode | undefined;
@@ -267,6 +270,7 @@ export namespace WhileNode {
             parent: undefined,
             a: undefined,
             d: {
+                firstToken: whileToken,
                 testExpr,
                 whileSuite,
             },
@@ -283,6 +287,7 @@ export namespace WhileNode {
 
 export interface ForNode extends ParseNodeBase<ParseNodeType.For> {
     d: {
+        firstToken: Token;
         isAsync?: boolean;
         asyncToken?: Token;
         targetExpr: ExpressionNode;
@@ -308,6 +313,7 @@ export namespace ForNode {
             parent: undefined,
             a: undefined,
             d: {
+                firstToken: forToken,
                 targetExpr,
                 iterableExpr,
                 forSuite,
@@ -388,6 +394,7 @@ export namespace ComprehensionIfNode {
 
 export interface TryNode extends ParseNodeBase<ParseNodeType.Try> {
     d: {
+        firstToken: Token;
         trySuite: SuiteNode;
         exceptClauses: ExceptNode[];
         elseSuite?: SuiteNode | undefined;
@@ -405,6 +412,7 @@ export namespace TryNode {
             parent: undefined,
             a: undefined,
             d: {
+                firstToken: tryToken,
                 trySuite: trySuite,
                 exceptClauses: [],
             },
@@ -424,6 +432,7 @@ export interface ExceptNode extends ParseNodeBase<ParseNodeType.Except> {
         name?: NameNode | undefined;
         exceptSuite: SuiteNode;
         isExceptGroup: boolean;
+        exceptToken: Token;
     };
 }
 
@@ -439,6 +448,7 @@ export namespace ExceptNode {
             d: {
                 exceptSuite: exceptSuite,
                 isExceptGroup: isExceptGroup,
+                exceptToken,
             },
         };
 
@@ -452,6 +462,7 @@ export namespace ExceptNode {
 
 export interface FunctionNode extends ParseNodeBase<ParseNodeType.Function> {
     d: {
+        firstToken: Token;
         decorators: DecoratorNode[];
         isAsync: boolean;
         name: NameNode;
@@ -473,6 +484,7 @@ export namespace FunctionNode {
             parent: undefined,
             a: undefined,
             d: {
+                firstToken: defToken,
                 decorators: [],
                 isAsync: false,
                 name: name,
@@ -537,6 +549,7 @@ export namespace ParameterNode {
 
 export interface ClassNode extends ParseNodeBase<ParseNodeType.Class> {
     d: {
+        firstToken: Token;
         decorators: DecoratorNode[];
         name: NameNode;
         typeParams: TypeParameterListNode | undefined;
@@ -555,6 +568,7 @@ export namespace ClassNode {
             parent: undefined,
             a: undefined,
             d: {
+                firstToken: classToken,
                 decorators: [],
                 name: name,
                 typeParams,
@@ -587,6 +601,12 @@ export namespace ClassNode {
             parent: undefined,
             a: undefined,
             d: {
+                firstToken: {
+                    type: TokenType.Keyword,
+                    start: 0,
+                    length: 0,
+                    comments: [],
+                },
                 decorators,
                 name: {
                     start: decorators[0].start,
@@ -634,6 +654,7 @@ export namespace ClassNode {
 
 export interface WithNode extends ParseNodeBase<ParseNodeType.With> {
     d: {
+        firstToken: Token;
         isAsync?: boolean;
         asyncToken?: Token;
         withItems: WithItemNode[];
@@ -652,6 +673,7 @@ export namespace WithNode {
             parent: undefined,
             a: undefined,
             d: {
+                firstToken: withToken,
                 withItems: [],
                 suite: suite,
             },
@@ -718,6 +740,7 @@ export namespace DecoratorNode {
 
 export interface StatementListNode extends ParseNodeBase<ParseNodeType.StatementList> {
     d: {
+        firstToken: Token;
         statements: ParseNode[];
     };
 }
@@ -731,7 +754,7 @@ export namespace StatementListNode {
             id: _nextNodeId++,
             parent: undefined,
             a: undefined,
-            d: { statements: [] },
+            d: { firstToken: atToken, statements: [] },
         };
 
         return node;
@@ -1103,6 +1126,7 @@ export namespace TypeParameterListNode {
 
 export interface TypeAliasNode extends ParseNodeBase<ParseNodeType.TypeAlias> {
     d: {
+        firstToken: Token;
         name: NameNode;
         typeParams?: TypeParameterListNode;
         expr: ExpressionNode;
@@ -1124,6 +1148,7 @@ export namespace TypeAliasNode {
             parent: undefined,
             a: undefined,
             d: {
+                firstToken: typeToken,
                 name,
                 typeParams,
                 expr,
@@ -2340,13 +2365,14 @@ export namespace RaiseNode {
 
 export interface MatchNode extends ParseNodeBase<ParseNodeType.Match> {
     d: {
+        firstToken: Token;
         expr: ExpressionNode;
         cases: CaseNode[];
     };
 }
 
 export namespace MatchNode {
-    export function create(matchToken: TextRange, expr: ExpressionNode) {
+    export function create(matchToken: Token, expr: ExpressionNode) {
         const node: MatchNode = {
             start: matchToken.start,
             length: matchToken.length,
@@ -2355,6 +2381,7 @@ export namespace MatchNode {
             parent: undefined,
             a: undefined,
             d: {
+                firstToken: matchToken,
                 expr,
                 cases: [],
             },

--- a/packages/pyright-internal/src/tests/samples/unreachable1.py
+++ b/packages/pyright-internal/src/tests/samples/unreachable1.py
@@ -75,7 +75,8 @@ def func6(foo: Foo):
 def func7(foo: Foo):
     foo.method5()
 
-    # This should be marked as unreachable
+    # This should be marked as unreachable.
+    # If reportUnreachable is enabled, it should generate a diagnostic.
     return 3
 
 
@@ -87,6 +88,7 @@ def func9():
     func8()
 
     # This should be marked unreachable.
+    # If reportUnreachable is enabled, it should generate a diagnostic.
     return 3
 
 
@@ -108,6 +110,7 @@ def func10():
 
     return
     # This should be marked unreachable.
+    # If reportUnreachable is enabled, it should generate a diagnostic.
     b = e.errno
 
 
@@ -116,6 +119,7 @@ def func11(obj: str) -> list:
         return []
     else:
         # This should be marked as unreachable.
+        # If reportUnreachable is enabled, it should generate a diagnostic.
         return obj
 
 
@@ -124,4 +128,5 @@ def func12(obj: str) -> list:
         return []
 
     # This should be marked as unreachable.
+    # If reportUnreachable is enabled, it should generate a diagnostic.
     return obj

--- a/packages/pyright-internal/src/tests/typeEvaluator1.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator1.test.ts
@@ -26,9 +26,18 @@ import { Uri } from '../common/uri/uri';
 import * as TestUtils from './testUtils';
 
 test('Unreachable1', () => {
-    const analysisResults = TestUtils.typeAnalyzeSampleFiles(['unreachable1.py']);
+    const configOptions = new ConfigOptions(Uri.empty());
 
-    TestUtils.validateResults(analysisResults, 0, 0, 2, 1, 6);
+    const analysisResults1 = TestUtils.typeAnalyzeSampleFiles(['unreachable1.py'], configOptions);
+    TestUtils.validateResults(analysisResults1, 0, 0, 2, 1, 6);
+
+    configOptions.diagnosticRuleSet.reportUnreachable = 'error';
+    const analysisResults2 = TestUtils.typeAnalyzeSampleFiles(['unreachable1.py'], configOptions);
+    TestUtils.validateResults(analysisResults2, 5, 0, 2, 1, 6);
+
+    configOptions.diagnosticRuleSet.reportUnreachable = 'warning';
+    const analysisResults3 = TestUtils.typeAnalyzeSampleFiles(['unreachable1.py'], configOptions);
+    TestUtils.validateResults(analysisResults3, 0, 5, 2, 1, 6);
 });
 
 test('Builtins1', () => {

--- a/packages/vscode-pyright/package.json
+++ b/packages/vscode-pyright/package.json
@@ -1455,6 +1455,22 @@
                                 false
                             ]
                         },
+                        "reportUnreachable": {
+                            "type": [
+                                "string",
+                                "boolean"
+                            ],
+                            "description": "Diagnostics for code that is determined by type analysis to be unreachable.",
+                            "default": "none",
+                            "enum": [
+                                "none",
+                                "information",
+                                "warning",
+                                "error",
+                                true,
+                                false
+                            ]
+                        },
                         "reportShadowedImports": {
                             "type": [
                                 "string",

--- a/packages/vscode-pyright/schemas/pyrightconfig.schema.json
+++ b/packages/vscode-pyright/schemas/pyrightconfig.schema.json
@@ -494,6 +494,11 @@
       "title": "Controls reporting of 'match' statements that do not exhaustively match all possible values",
       "default": "none"
     },
+    "reportUnreachable": {
+      "$ref": "#/definitions/diagnostic",
+      "title": "Controls reporting of code that is determined by type analysis to be unreachable",
+      "default": "none"
+    },
     "reportShadowedImports": {
       "$ref": "#/definitions/diagnostic",
       "title": "Controls reporting of shadowed imports of stdlib modules",
@@ -855,6 +860,9 @@
     "reportMatchNotExhaustive": {
       "$ref": "#/definitions/reportMatchNotExhaustive"
     },
+    "reportUnreachable": {
+      "$ref": "#/definitions/reportUnreachable"
+    },
     "reportShadowedImports": {
       "$ref": "#/definitions/reportShadowedImports"
     },
@@ -1172,6 +1180,9 @@
           },
           "reportMatchNotExhaustive": {
             "$ref": "#/definitions/reportMatchNotExhaustive"
+          },
+          "reportUnreachable": {
+            "$ref": "#/definitions/reportUnreachable"
           },
           "reportShadowedImports": {
             "$ref": "#/definitions/reportShadowedImports"


### PR DESCRIPTION
…agnostic for code that is determined to be structurally unreachable or unreachable via type analysis. It does not report code that is within a code block that is gated by a conditional that is statically determined to be false, such as `TYPE_CHECKING` and version checks. This diagnostic check is off by default even in strict mode because there are legitimate reasons for unreachable code to exist in Python code.

This change also modifies the messages that accompany tagged hints (the mechanism by which unreachable or unanalyzed code is displayed as "dimmed" in an editor). The message now distinguishes between code that is structurally unreachable (e.g. after a `return` or `raise` statement) and code that is not analyzed because it is in a conditional block that is statically evaluated as false.

This addresses #10284.