### PR TITLE
Improved modeling of bound and unbound methods so they properly use `…

### DIFF
--- a/packages/pyright-internal/src/analyzer/typeEvaluatorTypes.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluatorTypes.ts
@@ -210,6 +210,7 @@ export interface PrefetchedTypes {
     unionTypeClass: Type;
     awaitableClass: Type;
     functionClass: Type;
+    methodClass: Type;
     tupleClass: Type;
     boolClass: Type;
     intClass: Type;

--- a/packages/pyright-internal/src/analyzer/types.ts
+++ b/packages/pyright-internal/src/analyzer/types.ts
@@ -3267,6 +3267,32 @@ export function isFunctionOrOverloaded(type: Type): type is FunctionType | Overl
     return type.category === TypeCategory.Function || type.category === TypeCategory.Overloaded;
 }
 
+export function isMethodType(type: FunctionType | OverloadedType): boolean {
+    let funcType: FunctionType | undefined;
+
+    if (isFunction(type)) {
+        funcType = type;
+    } else {
+        if (type.priv._overloads.length === 0) {
+            return false;
+        }
+        funcType = type.priv._overloads[0];
+    }
+
+    // __new__ methods are never really bound at runtime.
+    if (
+        funcType.priv.preBoundFlags !== undefined &&
+        (funcType.priv.preBoundFlags & FunctionTypeFlags.ConstructorMethod) !== 0
+    ) {
+        return false;
+    }
+
+    // If the function type has a stripped first parameter type, it was
+    // bound to class or object and is therefore a MethodType rather
+    // a FunctionType.
+    return !!funcType.priv.strippedFirstParamType;
+}
+
 export function getTypeAliasInfo(type: Type) {
     if (type.props?.typeAliasInfo) {
         return type.props.typeAliasInfo;

--- a/packages/pyright-internal/src/tests/samples/functionMember2.py
+++ b/packages/pyright-internal/src/tests/samples/functionMember2.py
@@ -4,6 +4,9 @@
 # pyright: reportFunctionMemberAccess=error
 
 
+from typing import Protocol
+
+
 def func1(a: int) -> str: ...
 
 
@@ -39,3 +42,20 @@ s5 = A().method3.__self__
 
 # This should generate an error because method3 is static.
 s6 = A.method3.__self__
+
+
+class HasSelf(Protocol):
+    @property
+    def __self__(self, /) -> object: ...
+
+
+f1: HasSelf
+f1 = A.method2
+f1 = A().method1
+f1 = A().method2
+
+# These three should generate an error because they are not
+# MethodTypes but are instead FunctionTypes.
+f1 = A.method1
+f1 = A.method3
+f1 = A().method3

--- a/packages/pyright-internal/src/tests/typeEvaluator1.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator1.test.ts
@@ -987,7 +987,7 @@ test('FunctionMember1', () => {
 test('FunctionMember2', () => {
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['functionMember2.py']);
 
-    TestUtils.validateResults(analysisResults, 3);
+    TestUtils.validateResults(analysisResults, 6);
 });
 
 test('Annotations1', () => {


### PR DESCRIPTION
…types.MethodType` or `types.FunctionType`. This addresses #10514.