### PR TITLE
Fixed bug where `isUserCode` returned true for `stdlib/string/templatelib.pyi`

### DIFF
--- a/packages/pyright-internal/src/analyzer/program.ts
+++ b/packages/pyright-internal/src/analyzer/program.ts
@@ -348,7 +348,7 @@ export class Program {
         );
         sourceFileInfo = new SourceFileInfo(
             sourceFile,
-            /* isTypeshedFile */ false,
+            sourceFile.isTypingStubFile() || sourceFile.isTypeshedStubFile() || sourceFile.isBuiltInStubFile(),
             isThirdPartyImport,
             isInPyTypedPackage,
             this._editModeTracker,

--- a/packages/pyright-internal/src/analyzer/sourceFile.ts
+++ b/packages/pyright-internal/src/analyzer/sourceFile.ts
@@ -292,6 +292,7 @@ export class SourceFile {
                 this._uri.pathEndsWith('stdlib/abc.pyi') ||
                 this._uri.pathEndsWith('stdlib/enum.pyi') ||
                 this._uri.pathEndsWith('stdlib/queue.pyi') ||
+                this._uri.pathEndsWith('stdlib/string/templatelib.pyi') ||
                 this._uri.pathEndsWith('stdlib/types.pyi') ||
                 this._uri.pathEndsWith('stdlib/warnings.pyi')
             ) {
@@ -335,6 +336,14 @@ export class SourceFile {
 
     isTypingStubFile() {
         return this._isTypingStubFile;
+    }
+
+    isTypeshedStubFile() {
+        return this._isTypeshedStubFile;
+    }
+
+    isBuiltInStubFile() {
+        return this._isBuiltInStubFile;
     }
 
     isThirdPartyPyTypedPresent() {

--- a/packages/pyright-internal/src/tests/sourceFile.test.ts
+++ b/packages/pyright-internal/src/tests/sourceFile.test.ts
@@ -15,8 +15,8 @@ import { FullAccessHost } from '../common/fullAccessHost';
 import { combinePaths } from '../common/pathUtils';
 import { RealTempFile, createFromRealFileSystem } from '../common/realFileSystem';
 import { createServiceProvider } from '../common/serviceProviderExtensions';
-import { parseAndGetTestState } from './harness/fourslash/testState';
 import { Uri } from '../common/uri/uri';
+import { parseAndGetTestState } from './harness/fourslash/testState';
 
 test('Empty', () => {
     const filePath = combinePaths(process.cwd(), 'tests/samples/test_file1.py');
@@ -50,4 +50,24 @@ test('Empty Open file', () => {
 
     state.workspace.service.updateOpenFileContents(marker.fileUri, 1, '');
     assert.strictEqual(state.workspace.service.test_program.getSourceFile(marker.fileUri)?.getFileContent(), '');
+});
+
+test('No unexpected user files', () => {
+    const code = `
+// @filename: pyrightconfig.json
+//// {
+////   "pythonVersion": "3.14"
+//// }
+
+// @filename: test.py
+//// [|/*marker*/x: int = 1|]
+    `;
+
+    const state = parseAndGetTestState(code).state;
+    const marker = state.getMarkerByName('marker');
+    while (state.workspace.service.test_program.analyze());
+
+    const userFiles = state.workspace.service.test_program.getUserFiles();
+    assert.strictEqual(userFiles.length, 1);
+    assert.strictEqual(userFiles[0].uri.toString(), marker.fileUri.toString());
 });


### PR DESCRIPTION
After pulling the changes in 1.1.402 into Pylance, I was seeing a test failure where we enumerated the user code subtypes of `object` and some of the results were in `stdlib/string/templatelib.pyi` (not user code). This was because `addTrackedFile` was always passing false for `isTypeshedFile`.

Fix expands upon https://github.com/microsoft/pyright/pull/10494/files. I also added a unit test that should detect this sort of issue in the future.