### PR TITLE
Add documentation and example files for building and testing Pyright

### DIFF
--- a/packages/pyright-internal/src/analyzer/importResolver.ts
+++ b/packages/pyright-internal/src/analyzer/importResolver.ts
@@ -155,6 +155,13 @@ export class ImportResolver {
         execEnv: ExecutionEnvironment,
         moduleDescriptor: ImportedModuleDescriptor
     ): ImportResult {
+        this.serviceProvider
+            .console()
+            .info(
+                `[ImportResolver] Attempting to resolve import: '${
+                    moduleDescriptor.nameParts
+                }' from file: ${sourceFileUri.toUserVisibleString()}`
+            );
         // Wrap internal call to resolveImportInternal() to prevent calling any
         // child class version of resolveImport().
         return this.resolveImportInternal(sourceFileUri, execEnv, moduleDescriptor);
@@ -616,7 +623,19 @@ export class ImportResolver {
             const console = this.serviceProvider.console();
             localImportFailureInfo.forEach((diag) => console.log(diag));
         }
-
+        if (importResult.isImportFound) {
+            this.serviceProvider
+                .console()
+                .info(
+                    `[Copilot Debug] ImportResolver.resolveImportInternal: Resolved '${importName}' to ${importResult.resolvedUris
+                        .map((u) => u.toString())
+                        .join(', ')} (isStubFile: ${importResult.isStubFile}, importType: ${importResult.importType})`
+                );
+        } else {
+            this.serviceProvider
+                .console()
+                .info(`[Copilot Debug] ImportResolver.resolveImportInternal: Failed to resolve '${importName}'`);
+        }
         return importResult;
     }
 

--- a/packages/pyright-internal/src/analyzer/program.ts
+++ b/packages/pyright-internal/src/analyzer/program.ts
@@ -1657,6 +1657,7 @@ export class Program {
         if (!this._isFileNeeded(fileToParse, skipFileNeededCheck) || !fileToParse.sourceFile.isParseRequired()) {
             return;
         }
+        this._console.info(`[Copilot Debug] Program._parseFile: Parsing ${fileToParse.uri.toString()}`);
 
         // SourceFile.parse should only be called here in the program, as calling it
         // elsewhere could break the entire dependency graph maintained by the program.

--- a/packages/pyright-internal/src/analyzer/sourceFile.ts
+++ b/packages/pyright-internal/src/analyzer/sourceFile.ts
@@ -643,6 +643,9 @@ export class SourceFile {
                 logState.suppress();
                 return false;
             }
+            this._console.info(
+                `[SourceFile.parse] --- Preparing to parse content for file: ${this._uri.toUserVisibleString()} ---`
+            ); // Your new log line
 
             const diagSink = this.createDiagnosticSink();
             let fileContents = this.getOpenFileContents();
@@ -820,6 +823,7 @@ export class SourceFile {
         assert(this.isBindingRequired(), 'Bind called unnecessarily');
         assert(!this._writableData.isBindingInProgress, 'Bind called while binding in progress');
         assert(this._writableData.parserOutput !== undefined, 'Parse results not available');
+        this._console.info(`[SourceFile.bind] *** Starting binding for file: ${this._uri.toUserVisibleString()} ***`); // Your new log line
 
         return this._logTracker.log(`binding: ${this._getPathForLogging(this._uri)}`, () => {
             try {
@@ -901,6 +905,9 @@ export class SourceFile {
         assert(!this._writableData.isBindingInProgress, 'Check called while binding in progress');
         assert(this.isCheckingRequired(), 'Check called unnecessarily');
         assert(this._writableData.parserOutput !== undefined, 'Parse results not available');
+        this._console.info(
+            `[SourceFile.check] +++ Starting type check for file: ${this._uri.toUserVisibleString()} +++`
+        ); // Your new log line
 
         return this._logTracker.log(`checking: ${this._getPathForLogging(this._uri)}`, () => {
             try {
@@ -1456,6 +1463,7 @@ export class SourceFile {
         // Use the configuration options to determine the environment zin which
         // this source file will be executed.
         const execEnvironment = configOptions.findExecEnvironment(fileUri);
+        this._console.info(`[Program._parseFile] === Attempting to process file: ${fileUri.toUserVisibleString()} ===`);
 
         const parseOptions = new ParseOptions();
         parseOptions.useNotebookMode = useNotebookMode;

--- a/packages/pyright/Jdebug_output.txt
+++ b/packages/pyright/Jdebug_output.txt
@@ -1,0 +1,258 @@
+Loading configuration file at /home/kuggix/pyright/packages/pyright/pyrightconfig.json
+Auto-excluding **/node_modules
+Auto-excluding **/__pycache__
+Auto-excluding **/.*
+Assuming Python version 3.12.9.final.0
+Execution environment: python
+  Extra paths:
+    /home/kuggix/pyright/packages/pyright/src
+  Python version: 3.12.9.final.0
+  Python platform: Linux
+  Search paths:
+    /home/kuggix/pyright/packages/pyright/dist/typeshed-fallback/stdlib
+    /home/kuggix/pyright/packages/pyright
+    /home/kuggix/pyright/packages/pyright/src
+    /home/kuggix/pyright/packages/pyright/typings
+    /home/kuggix/pyright/packages/pyright/dist/typeshed-fallback/stubs/...
+    /opt/ros/humble/lib/python3.10/site-packages
+    /opt/ros/humble/local/lib/python3.10/dist-packages
+    /home/kuggix/miniconda3/envs/jac/lib/python3.12
+    /home/kuggix/miniconda3/envs/jac/lib/python3.12/lib-dynload
+    /home/kuggix/miniconda3/envs/jac/lib/python3.12/site-packages
+    /home/kuggix/jaseci/jac
+Found 1 source file
+[Copilot Debug] Program._parseFile: Parsing file:///home/kuggix/pyright/packages/pyright/your_python_file.py
+[SourceFile.parse] --- Preparing to parse content for file: /home/kuggix/pyright/packages/pyright/your_python_file.py ---
+[Program._parseFile] === Attempting to process file: /home/kuggix/pyright/packages/pyright/your_python_file.py ===
+[ImportResolver] Attempting to resolve import: '__builtins__' from file: /home/kuggix/pyright/packages/pyright/your_python_file.py
+[Copilot Debug] ImportResolver.resolveImportInternal: Failed to resolve '__builtins__'
+[ImportResolver] Attempting to resolve import: 'builtins' from file: /home/kuggix/pyright/packages/pyright/your_python_file.py
+[ImportResolver] Attempting to resolve import: '_typeshed,_type_checker_internals' from file: /home/kuggix/pyright/packages/pyright/your_python_file.py
+[ImportResolver] Attempting to resolve import: 'concurrent,futures' from file: /home/kuggix/pyright/packages/pyright/your_python_file.py
+[ImportResolver] Attempting to resolve import: 'typing' from file: /home/kuggix/pyright/packages/pyright/your_python_file.py
+[Copilot Debug] Program._parseFile: Parsing file:///home/kuggix/pyright/packages/pyright/dist/typeshed-fallback/stdlib/builtins.pyi
+[SourceFile.parse] --- Preparing to parse content for file: /home/kuggix/pyright/packages/pyright/dist/typeshed-fallback/stdlib/builtins.pyi ---
+[Program._parseFile] === Attempting to process file: /home/kuggix/pyright/packages/pyright/dist/typeshed-fallback/stdlib/builtins.pyi ===
+[ImportResolver] Attempting to resolve import: 'builtins' from file: /home/kuggix/pyright/packages/pyright/dist/typeshed-fallback/stdlib/builtins.pyi
+[ImportResolver] Attempting to resolve import: '_typeshed,_type_checker_internals' from file: /home/kuggix/pyright/packages/pyright/dist/typeshed-fallback/stdlib/builtins.pyi
+[ImportResolver] Attempting to resolve import: '_ast' from file: /home/kuggix/pyright/packages/pyright/dist/typeshed-fallback/stdlib/builtins.pyi
+[ImportResolver] Attempting to resolve import: '_sitebuiltins' from file: /home/kuggix/pyright/packages/pyright/dist/typeshed-fallback/stdlib/builtins.pyi
+[ImportResolver] Attempting to resolve import: '_typeshed' from file: /home/kuggix/pyright/packages/pyright/dist/typeshed-fallback/stdlib/builtins.pyi
+[ImportResolver] Attempting to resolve import: 'sys' from file: /home/kuggix/pyright/packages/pyright/dist/typeshed-fallback/stdlib/builtins.pyi
+[ImportResolver] Attempting to resolve import: 'types' from file: /home/kuggix/pyright/packages/pyright/dist/typeshed-fallback/stdlib/builtins.pyi
+[ImportResolver] Attempting to resolve import: '_collections_abc' from file: /home/kuggix/pyright/packages/pyright/dist/typeshed-fallback/stdlib/builtins.pyi
+[ImportResolver] Attempting to resolve import: '_typeshed' from file: /home/kuggix/pyright/packages/pyright/dist/typeshed-fallback/stdlib/builtins.pyi
+[ImportResolver] Attempting to resolve import: 'collections,abc' from file: /home/kuggix/pyright/packages/pyright/dist/typeshed-fallback/stdlib/builtins.pyi
+[ImportResolver] Attempting to resolve import: 'io' from file: /home/kuggix/pyright/packages/pyright/dist/typeshed-fallback/stdlib/builtins.pyi
+[ImportResolver] Attempting to resolve import: 'os' from file: /home/kuggix/pyright/packages/pyright/dist/typeshed-fallback/stdlib/builtins.pyi
+[ImportResolver] Attempting to resolve import: 'types' from file: /home/kuggix/pyright/packages/pyright/dist/typeshed-fallback/stdlib/builtins.pyi
+[ImportResolver] Attempting to resolve import: 'typing' from file: /home/kuggix/pyright/packages/pyright/dist/typeshed-fallback/stdlib/builtins.pyi
+[ImportResolver] Attempting to resolve import: 'typing_extensions' from file: /home/kuggix/pyright/packages/pyright/dist/typeshed-fallback/stdlib/builtins.pyi
+[ImportResolver] Attempting to resolve import: '_typeshed' from file: /home/kuggix/pyright/packages/pyright/dist/typeshed-fallback/stdlib/builtins.pyi
+[ImportResolver] Attempting to resolve import: 'types' from file: /home/kuggix/pyright/packages/pyright/dist/typeshed-fallback/stdlib/builtins.pyi
+[SourceFile.bind] *** Starting binding for file: /home/kuggix/pyright/packages/pyright/dist/typeshed-fallback/stdlib/builtins.pyi ***
+[SourceFile.bind] *** Starting binding for file: /home/kuggix/pyright/packages/pyright/your_python_file.py ***
+[SourceFile.check] +++ Starting type check for file: /home/kuggix/pyright/packages/pyright/your_python_file.py +++
+[ImportResolver] Attempting to resolve import: 'types' from file: /home/kuggix/pyright/packages/pyright/your_python_file.py
+[Copilot Debug] Program._parseFile: Parsing file:///home/kuggix/pyright/packages/pyright/dist/typeshed-fallback/stdlib/types.pyi
+[SourceFile.parse] --- Preparing to parse content for file: /home/kuggix/pyright/packages/pyright/dist/typeshed-fallback/stdlib/types.pyi ---
+[Program._parseFile] === Attempting to process file: /home/kuggix/pyright/packages/pyright/dist/typeshed-fallback/stdlib/types.pyi ===
+[ImportResolver] Attempting to resolve import: 'builtins' from file: /home/kuggix/pyright/packages/pyright/dist/typeshed-fallback/stdlib/types.pyi
+[ImportResolver] Attempting to resolve import: '_typeshed,_type_checker_internals' from file: /home/kuggix/pyright/packages/pyright/dist/typeshed-fallback/stdlib/types.pyi
+[ImportResolver] Attempting to resolve import: 'sys' from file: /home/kuggix/pyright/packages/pyright/dist/typeshed-fallback/stdlib/types.pyi
+[ImportResolver] Attempting to resolve import: '_typeshed' from file: /home/kuggix/pyright/packages/pyright/dist/typeshed-fallback/stdlib/types.pyi
+[ImportResolver] Attempting to resolve import: '_typeshed,importlib' from file: /home/kuggix/pyright/packages/pyright/dist/typeshed-fallback/stdlib/types.pyi
+[ImportResolver] Attempting to resolve import: 'collections,abc' from file: /home/kuggix/pyright/packages/pyright/dist/typeshed-fallback/stdlib/types.pyi
+[ImportResolver] Attempting to resolve import: 'importlib,machinery' from file: /home/kuggix/pyright/packages/pyright/dist/typeshed-fallback/stdlib/types.pyi
+[ImportResolver] Attempting to resolve import: 'typing' from file: /home/kuggix/pyright/packages/pyright/dist/typeshed-fallback/stdlib/types.pyi
+[ImportResolver] Attempting to resolve import: 'typing_extensions' from file: /home/kuggix/pyright/packages/pyright/dist/typeshed-fallback/stdlib/types.pyi
+[ImportResolver] Attempting to resolve import: '_typeshed' from file: /home/kuggix/pyright/packages/pyright/dist/typeshed-fallback/stdlib/types.pyi
+[ImportResolver] Attempting to resolve import: 'builtins' from file: /home/kuggix/pyright/packages/pyright/dist/typeshed-fallback/stdlib/types.pyi
+[SourceFile.bind] *** Starting binding for file: /home/kuggix/pyright/packages/pyright/dist/typeshed-fallback/stdlib/types.pyi ***
+[Copilot Debug] Program._parseFile: Parsing file:///home/kuggix/pyright/packages/pyright/dist/typeshed-fallback/stdlib/typing.pyi
+[SourceFile.parse] --- Preparing to parse content for file: /home/kuggix/pyright/packages/pyright/dist/typeshed-fallback/stdlib/typing.pyi ---
+[Program._parseFile] === Attempting to process file: /home/kuggix/pyright/packages/pyright/dist/typeshed-fallback/stdlib/typing.pyi ===
+[ImportResolver] Attempting to resolve import: 'builtins' from file: /home/kuggix/pyright/packages/pyright/dist/typeshed-fallback/stdlib/typing.pyi
+[ImportResolver] Attempting to resolve import: '_typeshed,_type_checker_internals' from file: /home/kuggix/pyright/packages/pyright/dist/typeshed-fallback/stdlib/typing.pyi
+[ImportResolver] Attempting to resolve import: 'collections' from file: /home/kuggix/pyright/packages/pyright/dist/typeshed-fallback/stdlib/typing.pyi
+[ImportResolver] Attempting to resolve import: 'sys' from file: /home/kuggix/pyright/packages/pyright/dist/typeshed-fallback/stdlib/typing.pyi
+[ImportResolver] Attempting to resolve import: 'typing_extensions' from file: /home/kuggix/pyright/packages/pyright/dist/typeshed-fallback/stdlib/typing.pyi
+[ImportResolver] Attempting to resolve import: '_collections_abc' from file: /home/kuggix/pyright/packages/pyright/dist/typeshed-fallback/stdlib/typing.pyi
+[ImportResolver] Attempting to resolve import: '_typeshed' from file: /home/kuggix/pyright/packages/pyright/dist/typeshed-fallback/stdlib/typing.pyi
+[ImportResolver] Attempting to resolve import: 'abc' from file: /home/kuggix/pyright/packages/pyright/dist/typeshed-fallback/stdlib/typing.pyi
+[ImportResolver] Attempting to resolve import: 're' from file: /home/kuggix/pyright/packages/pyright/dist/typeshed-fallback/stdlib/typing.pyi
+[ImportResolver] Attempting to resolve import: 'types' from file: /home/kuggix/pyright/packages/pyright/dist/typeshed-fallback/stdlib/typing.pyi
+[ImportResolver] Attempting to resolve import: 'typing_extensions' from file: /home/kuggix/pyright/packages/pyright/dist/typeshed-fallback/stdlib/typing.pyi
+[ImportResolver] Attempting to resolve import: '_typeshed' from file: /home/kuggix/pyright/packages/pyright/dist/typeshed-fallback/stdlib/typing.pyi
+[ImportResolver] Attempting to resolve import: 'annotationlib' from file: /home/kuggix/pyright/packages/pyright/dist/typeshed-fallback/stdlib/typing.pyi
+[ImportResolver] Attempting to resolve import: 'types' from file: /home/kuggix/pyright/packages/pyright/dist/typeshed-fallback/stdlib/typing.pyi
+[ImportResolver] Attempting to resolve import: 'contextlib' from file: /home/kuggix/pyright/packages/pyright/dist/typeshed-fallback/stdlib/typing.pyi
+[ImportResolver] Attempting to resolve import: 'contextlib' from file: /home/kuggix/pyright/packages/pyright/dist/typeshed-fallback/stdlib/typing.pyi
+[ImportResolver] Attempting to resolve import: 'annotationlib' from file: /home/kuggix/pyright/packages/pyright/dist/typeshed-fallback/stdlib/typing.pyi
+[SourceFile.bind] *** Starting binding for file: /home/kuggix/pyright/packages/pyright/dist/typeshed-fallback/stdlib/typing.pyi ***
+[ImportResolver] Attempting to resolve import: 'types' from file: /home/kuggix/pyright/packages/pyright/your_python_file.py
+[ImportResolver] Attempting to resolve import: 'types' from file: /home/kuggix/pyright/packages/pyright/your_python_file.py
+[ImportResolver] Attempting to resolve import: 'typing' from file: /home/kuggix/pyright/packages/pyright/your_python_file.py
+[ImportResolver] Attempting to resolve import: '_typeshed' from file: /home/kuggix/pyright/packages/pyright/your_python_file.py
+[Copilot Debug] Program._parseFile: Parsing file:///home/kuggix/pyright/packages/pyright/dist/typeshed-fallback/stdlib/_typeshed/__init__.pyi
+[SourceFile.parse] --- Preparing to parse content for file: /home/kuggix/pyright/packages/pyright/dist/typeshed-fallback/stdlib/_typeshed/__init__.pyi ---
+[Program._parseFile] === Attempting to process file: /home/kuggix/pyright/packages/pyright/dist/typeshed-fallback/stdlib/_typeshed/__init__.pyi ===
+[ImportResolver] Attempting to resolve import: 'builtins' from file: /home/kuggix/pyright/packages/pyright/dist/typeshed-fallback/stdlib/_typeshed/__init__.pyi
+[ImportResolver] Attempting to resolve import: '_typeshed,_type_checker_internals' from file: /home/kuggix/pyright/packages/pyright/dist/typeshed-fallback/stdlib/_typeshed/__init__.pyi
+[ImportResolver] Attempting to resolve import: 'sys' from file: /home/kuggix/pyright/packages/pyright/dist/typeshed-fallback/stdlib/_typeshed/__init__.pyi
+[ImportResolver] Attempting to resolve import: 'collections,abc' from file: /home/kuggix/pyright/packages/pyright/dist/typeshed-fallback/stdlib/_typeshed/__init__.pyi
+[ImportResolver] Attempting to resolve import: 'dataclasses' from file: /home/kuggix/pyright/packages/pyright/dist/typeshed-fallback/stdlib/_typeshed/__init__.pyi
+[ImportResolver] Attempting to resolve import: 'os' from file: /home/kuggix/pyright/packages/pyright/dist/typeshed-fallback/stdlib/_typeshed/__init__.pyi
+[ImportResolver] Attempting to resolve import: 'types' from file: /home/kuggix/pyright/packages/pyright/dist/typeshed-fallback/stdlib/_typeshed/__init__.pyi
+[ImportResolver] Attempting to resolve import: 'typing' from file: /home/kuggix/pyright/packages/pyright/dist/typeshed-fallback/stdlib/_typeshed/__init__.pyi
+[ImportResolver] Attempting to resolve import: 'typing_extensions' from file: /home/kuggix/pyright/packages/pyright/dist/typeshed-fallback/stdlib/_typeshed/__init__.pyi
+[ImportResolver] Attempting to resolve import: 'types' from file: /home/kuggix/pyright/packages/pyright/dist/typeshed-fallback/stdlib/_typeshed/__init__.pyi
+[ImportResolver] Attempting to resolve import: 'enum' from file: /home/kuggix/pyright/packages/pyright/dist/typeshed-fallback/stdlib/_typeshed/__init__.pyi
+[ImportResolver] Attempting to resolve import: 'enum' from file: /home/kuggix/pyright/packages/pyright/dist/typeshed-fallback/stdlib/_typeshed/__init__.pyi
+[ImportResolver] Attempting to resolve import: 'annotationlib' from file: /home/kuggix/pyright/packages/pyright/dist/typeshed-fallback/stdlib/_typeshed/__init__.pyi
+[SourceFile.bind] *** Starting binding for file: /home/kuggix/pyright/packages/pyright/dist/typeshed-fallback/stdlib/_typeshed/__init__.pyi ***
+[ImportResolver] Attempting to resolve import: 'typing' from file: /home/kuggix/pyright/packages/pyright/your_python_file.py
+[ImportResolver] Attempting to resolve import: 'typing' from file: /home/kuggix/pyright/packages/pyright/your_python_file.py
+[Copilot Debug] Program._parseFile: Parsing file:///home/kuggix/pyright/packages/pyright/dist/typeshed-fallback/stdlib/abc.pyi
+[SourceFile.parse] --- Preparing to parse content for file: /home/kuggix/pyright/packages/pyright/dist/typeshed-fallback/stdlib/abc.pyi ---
+[Program._parseFile] === Attempting to process file: /home/kuggix/pyright/packages/pyright/dist/typeshed-fallback/stdlib/abc.pyi ===
+[ImportResolver] Attempting to resolve import: 'builtins' from file: /home/kuggix/pyright/packages/pyright/dist/typeshed-fallback/stdlib/abc.pyi
+[ImportResolver] Attempting to resolve import: '_typeshed,_type_checker_internals' from file: /home/kuggix/pyright/packages/pyright/dist/typeshed-fallback/stdlib/abc.pyi
+[ImportResolver] Attempting to resolve import: '_typeshed' from file: /home/kuggix/pyright/packages/pyright/dist/typeshed-fallback/stdlib/abc.pyi
+[ImportResolver] Attempting to resolve import: 'sys' from file: /home/kuggix/pyright/packages/pyright/dist/typeshed-fallback/stdlib/abc.pyi
+[ImportResolver] Attempting to resolve import: '_typeshed' from file: /home/kuggix/pyright/packages/pyright/dist/typeshed-fallback/stdlib/abc.pyi
+[ImportResolver] Attempting to resolve import: 'collections,abc' from file: /home/kuggix/pyright/packages/pyright/dist/typeshed-fallback/stdlib/abc.pyi
+[ImportResolver] Attempting to resolve import: 'typing' from file: /home/kuggix/pyright/packages/pyright/dist/typeshed-fallback/stdlib/abc.pyi
+[ImportResolver] Attempting to resolve import: 'typing_extensions' from file: /home/kuggix/pyright/packages/pyright/dist/typeshed-fallback/stdlib/abc.pyi
+[SourceFile.bind] *** Starting binding for file: /home/kuggix/pyright/packages/pyright/dist/typeshed-fallback/stdlib/abc.pyi ***
+[ImportResolver] Attempting to resolve import: '_typeshed,_type_checker_internals' from file: /home/kuggix/pyright/packages/pyright/your_python_file.py
+[Copilot Debug] Program._parseFile: Parsing file:///home/kuggix/pyright/packages/pyright/dist/typeshed-fallback/stdlib/_typeshed/_type_checker_internals.pyi
+[SourceFile.parse] --- Preparing to parse content for file: /home/kuggix/pyright/packages/pyright/dist/typeshed-fallback/stdlib/_typeshed/_type_checker_internals.pyi ---
+[Program._parseFile] === Attempting to process file: /home/kuggix/pyright/packages/pyright/dist/typeshed-fallback/stdlib/_typeshed/_type_checker_internals.pyi ===
+[ImportResolver] Attempting to resolve import: 'builtins' from file: /home/kuggix/pyright/packages/pyright/dist/typeshed-fallback/stdlib/_typeshed/_type_checker_internals.pyi
+[ImportResolver] Attempting to resolve import: '_typeshed,_type_checker_internals' from file: /home/kuggix/pyright/packages/pyright/dist/typeshed-fallback/stdlib/_typeshed/_type_checker_internals.pyi
+[ImportResolver] Attempting to resolve import: 'sys' from file: /home/kuggix/pyright/packages/pyright/dist/typeshed-fallback/stdlib/_typeshed/_type_checker_internals.pyi
+[ImportResolver] Attempting to resolve import: 'typing_extensions' from file: /home/kuggix/pyright/packages/pyright/dist/typeshed-fallback/stdlib/_typeshed/_type_checker_internals.pyi
+[ImportResolver] Attempting to resolve import: '_collections_abc' from file: /home/kuggix/pyright/packages/pyright/dist/typeshed-fallback/stdlib/_typeshed/_type_checker_internals.pyi
+[ImportResolver] Attempting to resolve import: 'abc' from file: /home/kuggix/pyright/packages/pyright/dist/typeshed-fallback/stdlib/_typeshed/_type_checker_internals.pyi
+[ImportResolver] Attempting to resolve import: 'collections,abc' from file: /home/kuggix/pyright/packages/pyright/dist/typeshed-fallback/stdlib/_typeshed/_type_checker_internals.pyi
+[ImportResolver] Attempting to resolve import: 'typing' from file: /home/kuggix/pyright/packages/pyright/dist/typeshed-fallback/stdlib/_typeshed/_type_checker_internals.pyi
+[ImportResolver] Attempting to resolve import: 'typing_extensions' from file: /home/kuggix/pyright/packages/pyright/dist/typeshed-fallback/stdlib/_typeshed/_type_checker_internals.pyi
+[SourceFile.bind] *** Starting binding for file: /home/kuggix/pyright/packages/pyright/dist/typeshed-fallback/stdlib/_typeshed/_type_checker_internals.pyi ***
+[Copilot Debug] Program._parseFile: Parsing file:///home/kuggix/pyright/packages/pyright/dist/typeshed-fallback/stdlib/collections/abc.pyi
+[SourceFile.parse] --- Preparing to parse content for file: /home/kuggix/pyright/packages/pyright/dist/typeshed-fallback/stdlib/collections/abc.pyi ---
+[Program._parseFile] === Attempting to process file: /home/kuggix/pyright/packages/pyright/dist/typeshed-fallback/stdlib/collections/abc.pyi ===
+[ImportResolver] Attempting to resolve import: 'builtins' from file: /home/kuggix/pyright/packages/pyright/dist/typeshed-fallback/stdlib/collections/abc.pyi
+[ImportResolver] Attempting to resolve import: '_typeshed,_type_checker_internals' from file: /home/kuggix/pyright/packages/pyright/dist/typeshed-fallback/stdlib/collections/abc.pyi
+[ImportResolver] Attempting to resolve import: '_collections_abc' from file: /home/kuggix/pyright/packages/pyright/dist/typeshed-fallback/stdlib/collections/abc.pyi
+[ImportResolver] Attempting to resolve import: '_collections_abc' from file: /home/kuggix/pyright/packages/pyright/dist/typeshed-fallback/stdlib/collections/abc.pyi
+[SourceFile.bind] *** Starting binding for file: /home/kuggix/pyright/packages/pyright/dist/typeshed-fallback/stdlib/collections/abc.pyi ***
+[Copilot Debug] Program._parseFile: Parsing file:///home/kuggix/pyright/packages/pyright/dist/typeshed-fallback/stdlib/_collections_abc.pyi
+[SourceFile.parse] --- Preparing to parse content for file: /home/kuggix/pyright/packages/pyright/dist/typeshed-fallback/stdlib/_collections_abc.pyi ---
+[Program._parseFile] === Attempting to process file: /home/kuggix/pyright/packages/pyright/dist/typeshed-fallback/stdlib/_collections_abc.pyi ===
+[ImportResolver] Attempting to resolve import: 'builtins' from file: /home/kuggix/pyright/packages/pyright/dist/typeshed-fallback/stdlib/_collections_abc.pyi
+[ImportResolver] Attempting to resolve import: '_typeshed,_type_checker_internals' from file: /home/kuggix/pyright/packages/pyright/dist/typeshed-fallback/stdlib/_collections_abc.pyi
+[ImportResolver] Attempting to resolve import: 'sys' from file: /home/kuggix/pyright/packages/pyright/dist/typeshed-fallback/stdlib/_collections_abc.pyi
+[ImportResolver] Attempting to resolve import: 'abc' from file: /home/kuggix/pyright/packages/pyright/dist/typeshed-fallback/stdlib/_collections_abc.pyi
+[ImportResolver] Attempting to resolve import: 'types' from file: /home/kuggix/pyright/packages/pyright/dist/typeshed-fallback/stdlib/_collections_abc.pyi
+[ImportResolver] Attempting to resolve import: 'typing' from file: /home/kuggix/pyright/packages/pyright/dist/typeshed-fallback/stdlib/_collections_abc.pyi
+[ImportResolver] Attempting to resolve import: 'typing' from file: /home/kuggix/pyright/packages/pyright/dist/typeshed-fallback/stdlib/_collections_abc.pyi
+[SourceFile.bind] *** Starting binding for file: /home/kuggix/pyright/packages/pyright/dist/typeshed-fallback/stdlib/_collections_abc.pyi ***
+[ImportResolver] Attempting to resolve import: 'typing' from file: /home/kuggix/pyright/packages/pyright/your_python_file.py
+[ImportResolver] Attempting to resolve import: 'typing' from file: /home/kuggix/pyright/packages/pyright/your_python_file.py
+[ImportResolver] Attempting to resolve import: 'string,templatelib' from file: /home/kuggix/pyright/packages/pyright/your_python_file.py
+[Copilot Debug] ImportResolver.resolveImportInternal: Failed to resolve 'string.templatelib'
+[ImportResolver] Attempting to resolve import: '_typeshed' from file: /home/kuggix/pyright/packages/pyright/your_python_file.py
+[Copilot Debug] Program._parseFile: Parsing file:///home/kuggix/pyright/packages/pyright/dist/typeshed-fallback/stdlib/concurrent/futures/__init__.pyi
+[SourceFile.parse] --- Preparing to parse content for file: /home/kuggix/pyright/packages/pyright/dist/typeshed-fallback/stdlib/concurrent/futures/__init__.pyi ---
+[Program._parseFile] === Attempting to process file: /home/kuggix/pyright/packages/pyright/dist/typeshed-fallback/stdlib/concurrent/futures/__init__.pyi ===
+[ImportResolver] Attempting to resolve import: 'builtins' from file: /home/kuggix/pyright/packages/pyright/dist/typeshed-fallback/stdlib/concurrent/futures/__init__.pyi
+[ImportResolver] Attempting to resolve import: '_typeshed,_type_checker_internals' from file: /home/kuggix/pyright/packages/pyright/dist/typeshed-fallback/stdlib/concurrent/futures/__init__.pyi
+[ImportResolver] Attempting to resolve import: 'sys' from file: /home/kuggix/pyright/packages/pyright/dist/typeshed-fallback/stdlib/concurrent/futures/__init__.pyi
+[ImportResolver] Attempting to resolve import: '_base' from file: /home/kuggix/pyright/packages/pyright/dist/typeshed-fallback/stdlib/concurrent/futures/__init__.pyi
+[ImportResolver] Attempting to resolve import: 'process' from file: /home/kuggix/pyright/packages/pyright/dist/typeshed-fallback/stdlib/concurrent/futures/__init__.pyi
+[ImportResolver] Attempting to resolve import: 'thread' from file: /home/kuggix/pyright/packages/pyright/dist/typeshed-fallback/stdlib/concurrent/futures/__init__.pyi
+[ImportResolver] Attempting to resolve import: 'interpreter' from file: /home/kuggix/pyright/packages/pyright/dist/typeshed-fallback/stdlib/concurrent/futures/__init__.pyi
+[SourceFile.bind] *** Starting binding for file: /home/kuggix/pyright/packages/pyright/dist/typeshed-fallback/stdlib/concurrent/futures/__init__.pyi ***
+[Copilot Debug] Program._parseFile: Parsing file:///home/kuggix/pyright/packages/pyright/dist/typeshed-fallback/stdlib/concurrent/futures/thread.pyi
+[SourceFile.parse] --- Preparing to parse content for file: /home/kuggix/pyright/packages/pyright/dist/typeshed-fallback/stdlib/concurrent/futures/thread.pyi ---
+[Program._parseFile] === Attempting to process file: /home/kuggix/pyright/packages/pyright/dist/typeshed-fallback/stdlib/concurrent/futures/thread.pyi ===
+[ImportResolver] Attempting to resolve import: 'builtins' from file: /home/kuggix/pyright/packages/pyright/dist/typeshed-fallback/stdlib/concurrent/futures/thread.pyi
+[ImportResolver] Attempting to resolve import: '_typeshed,_type_checker_internals' from file: /home/kuggix/pyright/packages/pyright/dist/typeshed-fallback/stdlib/concurrent/futures/thread.pyi
+[ImportResolver] Attempting to resolve import: 'queue' from file: /home/kuggix/pyright/packages/pyright/dist/typeshed-fallback/stdlib/concurrent/futures/thread.pyi
+[ImportResolver] Attempting to resolve import: 'sys' from file: /home/kuggix/pyright/packages/pyright/dist/typeshed-fallback/stdlib/concurrent/futures/thread.pyi
+[ImportResolver] Attempting to resolve import: 'collections,abc' from file: /home/kuggix/pyright/packages/pyright/dist/typeshed-fallback/stdlib/concurrent/futures/thread.pyi
+[ImportResolver] Attempting to resolve import: 'threading' from file: /home/kuggix/pyright/packages/pyright/dist/typeshed-fallback/stdlib/concurrent/futures/thread.pyi
+[ImportResolver] Attempting to resolve import: 'types' from file: /home/kuggix/pyright/packages/pyright/dist/typeshed-fallback/stdlib/concurrent/futures/thread.pyi
+[ImportResolver] Attempting to resolve import: 'typing' from file: /home/kuggix/pyright/packages/pyright/dist/typeshed-fallback/stdlib/concurrent/futures/thread.pyi
+[ImportResolver] Attempting to resolve import: 'typing_extensions' from file: /home/kuggix/pyright/packages/pyright/dist/typeshed-fallback/stdlib/concurrent/futures/thread.pyi
+[ImportResolver] Attempting to resolve import: 'weakref' from file: /home/kuggix/pyright/packages/pyright/dist/typeshed-fallback/stdlib/concurrent/futures/thread.pyi
+[ImportResolver] Attempting to resolve import: '_base' from file: /home/kuggix/pyright/packages/pyright/dist/typeshed-fallback/stdlib/concurrent/futures/thread.pyi
+[SourceFile.bind] *** Starting binding for file: /home/kuggix/pyright/packages/pyright/dist/typeshed-fallback/stdlib/concurrent/futures/thread.pyi ***
+[Copilot Debug] Program._parseFile: Parsing file:///home/kuggix/pyright/packages/pyright/dist/typeshed-fallback/stdlib/concurrent/futures/_base.pyi
+[SourceFile.parse] --- Preparing to parse content for file: /home/kuggix/pyright/packages/pyright/dist/typeshed-fallback/stdlib/concurrent/futures/_base.pyi ---
+[Program._parseFile] === Attempting to process file: /home/kuggix/pyright/packages/pyright/dist/typeshed-fallback/stdlib/concurrent/futures/_base.pyi ===
+[ImportResolver] Attempting to resolve import: 'builtins' from file: /home/kuggix/pyright/packages/pyright/dist/typeshed-fallback/stdlib/concurrent/futures/_base.pyi
+[ImportResolver] Attempting to resolve import: '_typeshed,_type_checker_internals' from file: /home/kuggix/pyright/packages/pyright/dist/typeshed-fallback/stdlib/concurrent/futures/_base.pyi
+[ImportResolver] Attempting to resolve import: 'sys' from file: /home/kuggix/pyright/packages/pyright/dist/typeshed-fallback/stdlib/concurrent/futures/_base.pyi
+[ImportResolver] Attempting to resolve import: 'threading' from file: /home/kuggix/pyright/packages/pyright/dist/typeshed-fallback/stdlib/concurrent/futures/_base.pyi
+[ImportResolver] Attempting to resolve import: '_typeshed' from file: /home/kuggix/pyright/packages/pyright/dist/typeshed-fallback/stdlib/concurrent/futures/_base.pyi
+[ImportResolver] Attempting to resolve import: 'collections,abc' from file: /home/kuggix/pyright/packages/pyright/dist/typeshed-fallback/stdlib/concurrent/futures/_base.pyi
+[ImportResolver] Attempting to resolve import: 'logging' from file: /home/kuggix/pyright/packages/pyright/dist/typeshed-fallback/stdlib/concurrent/futures/_base.pyi
+[ImportResolver] Attempting to resolve import: 'types' from file: /home/kuggix/pyright/packages/pyright/dist/typeshed-fallback/stdlib/concurrent/futures/_base.pyi
+[ImportResolver] Attempting to resolve import: 'typing' from file: /home/kuggix/pyright/packages/pyright/dist/typeshed-fallback/stdlib/concurrent/futures/_base.pyi
+[ImportResolver] Attempting to resolve import: 'typing_extensions' from file: /home/kuggix/pyright/packages/pyright/dist/typeshed-fallback/stdlib/concurrent/futures/_base.pyi
+[ImportResolver] Attempting to resolve import: 'builtins' from file: /home/kuggix/pyright/packages/pyright/dist/typeshed-fallback/stdlib/concurrent/futures/_base.pyi
+[SourceFile.bind] *** Starting binding for file: /home/kuggix/pyright/packages/pyright/dist/typeshed-fallback/stdlib/concurrent/futures/_base.pyi ***
+[Copilot Debug] Program._parseFile: Parsing file:///home/kuggix/pyright/packages/pyright/dist/typeshed-fallback/stdlib/typing_extensions.pyi
+[SourceFile.parse] --- Preparing to parse content for file: /home/kuggix/pyright/packages/pyright/dist/typeshed-fallback/stdlib/typing_extensions.pyi ---
+[Program._parseFile] === Attempting to process file: /home/kuggix/pyright/packages/pyright/dist/typeshed-fallback/stdlib/typing_extensions.pyi ===
+[ImportResolver] Attempting to resolve import: 'builtins' from file: /home/kuggix/pyright/packages/pyright/dist/typeshed-fallback/stdlib/typing_extensions.pyi
+[ImportResolver] Attempting to resolve import: '_typeshed,_type_checker_internals' from file: /home/kuggix/pyright/packages/pyright/dist/typeshed-fallback/stdlib/typing_extensions.pyi
+[ImportResolver] Attempting to resolve import: 'abc' from file: /home/kuggix/pyright/packages/pyright/dist/typeshed-fallback/stdlib/typing_extensions.pyi
+[ImportResolver] Attempting to resolve import: 'enum' from file: /home/kuggix/pyright/packages/pyright/dist/typeshed-fallback/stdlib/typing_extensions.pyi
+[ImportResolver] Attempting to resolve import: 'sys' from file: /home/kuggix/pyright/packages/pyright/dist/typeshed-fallback/stdlib/typing_extensions.pyi
+[ImportResolver] Attempting to resolve import: '_collections_abc' from file: /home/kuggix/pyright/packages/pyright/dist/typeshed-fallback/stdlib/typing_extensions.pyi
+[ImportResolver] Attempting to resolve import: '_typeshed' from file: /home/kuggix/pyright/packages/pyright/dist/typeshed-fallback/stdlib/typing_extensions.pyi
+[ImportResolver] Attempting to resolve import: 'collections,abc' from file: /home/kuggix/pyright/packages/pyright/dist/typeshed-fallback/stdlib/typing_extensions.pyi
+[ImportResolver] Attempting to resolve import: 'contextlib' from file: /home/kuggix/pyright/packages/pyright/dist/typeshed-fallback/stdlib/typing_extensions.pyi
+[ImportResolver] Attempting to resolve import: 're' from file: /home/kuggix/pyright/packages/pyright/dist/typeshed-fallback/stdlib/typing_extensions.pyi
+[ImportResolver] Attempting to resolve import: 'types' from file: /home/kuggix/pyright/packages/pyright/dist/typeshed-fallback/stdlib/typing_extensions.pyi
+[ImportResolver] Attempting to resolve import: 'typing' from file: /home/kuggix/pyright/packages/pyright/dist/typeshed-fallback/stdlib/typing_extensions.pyi
+[ImportResolver] Attempting to resolve import: 'types' from file: /home/kuggix/pyright/packages/pyright/dist/typeshed-fallback/stdlib/typing_extensions.pyi
+[ImportResolver] Attempting to resolve import: 'typing' from file: /home/kuggix/pyright/packages/pyright/dist/typeshed-fallback/stdlib/typing_extensions.pyi
+[ImportResolver] Attempting to resolve import: 'typing' from file: /home/kuggix/pyright/packages/pyright/dist/typeshed-fallback/stdlib/typing_extensions.pyi
+[ImportResolver] Attempting to resolve import: 'typing' from file: /home/kuggix/pyright/packages/pyright/dist/typeshed-fallback/stdlib/typing_extensions.pyi
+[ImportResolver] Attempting to resolve import: 'collections,abc' from file: /home/kuggix/pyright/packages/pyright/dist/typeshed-fallback/stdlib/typing_extensions.pyi
+[ImportResolver] Attempting to resolve import: 'types' from file: /home/kuggix/pyright/packages/pyright/dist/typeshed-fallback/stdlib/typing_extensions.pyi
+[ImportResolver] Attempting to resolve import: 'typing' from file: /home/kuggix/pyright/packages/pyright/dist/typeshed-fallback/stdlib/typing_extensions.pyi
+[ImportResolver] Attempting to resolve import: 'io' from file: /home/kuggix/pyright/packages/pyright/dist/typeshed-fallback/stdlib/typing_extensions.pyi
+[ImportResolver] Attempting to resolve import: 'types' from file: /home/kuggix/pyright/packages/pyright/dist/typeshed-fallback/stdlib/typing_extensions.pyi
+[ImportResolver] Attempting to resolve import: 'typing' from file: /home/kuggix/pyright/packages/pyright/dist/typeshed-fallback/stdlib/typing_extensions.pyi
+[ImportResolver] Attempting to resolve import: 'warnings' from file: /home/kuggix/pyright/packages/pyright/dist/typeshed-fallback/stdlib/typing_extensions.pyi
+[ImportResolver] Attempting to resolve import: 'typing' from file: /home/kuggix/pyright/packages/pyright/dist/typeshed-fallback/stdlib/typing_extensions.pyi
+[ImportResolver] Attempting to resolve import: 'typing' from file: /home/kuggix/pyright/packages/pyright/dist/typeshed-fallback/stdlib/typing_extensions.pyi
+[ImportResolver] Attempting to resolve import: 'annotationlib' from file: /home/kuggix/pyright/packages/pyright/dist/typeshed-fallback/stdlib/typing_extensions.pyi
+[SourceFile.bind] *** Starting binding for file: /home/kuggix/pyright/packages/pyright/dist/typeshed-fallback/stdlib/typing_extensions.pyi ***
+[Copilot Debug] Program._parseFile: Parsing file:///home/kuggix/pyright/packages/pyright/dist/typeshed-fallback/stdlib/threading.pyi
+[SourceFile.parse] --- Preparing to parse content for file: /home/kuggix/pyright/packages/pyright/dist/typeshed-fallback/stdlib/threading.pyi ---
+[Program._parseFile] === Attempting to process file: /home/kuggix/pyright/packages/pyright/dist/typeshed-fallback/stdlib/threading.pyi ===
+[ImportResolver] Attempting to resolve import: 'builtins' from file: /home/kuggix/pyright/packages/pyright/dist/typeshed-fallback/stdlib/threading.pyi
+[ImportResolver] Attempting to resolve import: '_typeshed,_type_checker_internals' from file: /home/kuggix/pyright/packages/pyright/dist/typeshed-fallback/stdlib/threading.pyi
+[ImportResolver] Attempting to resolve import: '_thread' from file: /home/kuggix/pyright/packages/pyright/dist/typeshed-fallback/stdlib/threading.pyi
+[ImportResolver] Attempting to resolve import: 'sys' from file: /home/kuggix/pyright/packages/pyright/dist/typeshed-fallback/stdlib/threading.pyi
+[ImportResolver] Attempting to resolve import: '_thread' from file: /home/kuggix/pyright/packages/pyright/dist/typeshed-fallback/stdlib/threading.pyi
+[ImportResolver] Attempting to resolve import: '_typeshed' from file: /home/kuggix/pyright/packages/pyright/dist/typeshed-fallback/stdlib/threading.pyi
+[ImportResolver] Attempting to resolve import: 'collections,abc' from file: /home/kuggix/pyright/packages/pyright/dist/typeshed-fallback/stdlib/threading.pyi
+[ImportResolver] Attempting to resolve import: 'contextvars' from file: /home/kuggix/pyright/packages/pyright/dist/typeshed-fallback/stdlib/threading.pyi
+[ImportResolver] Attempting to resolve import: 'types' from file: /home/kuggix/pyright/packages/pyright/dist/typeshed-fallback/stdlib/threading.pyi
+[ImportResolver] Attempting to resolve import: 'typing' from file: /home/kuggix/pyright/packages/pyright/dist/typeshed-fallback/stdlib/threading.pyi
+[ImportResolver] Attempting to resolve import: 'typing_extensions' from file: /home/kuggix/pyright/packages/pyright/dist/typeshed-fallback/stdlib/threading.pyi
+[SourceFile.bind] *** Starting binding for file: /home/kuggix/pyright/packages/pyright/dist/typeshed-fallback/stdlib/threading.pyi ***
+pyright 1.1.402
+/home/kuggix/pyright/packages/pyright/your_python_file.py
+  /home/kuggix/pyright/packages/pyright/your_python_file.py:68:13 - error: Type of "append" is partially unknown
+    Type of "append" is "(object: Unknown, /) -> None" (reportUnknownMemberType)
+  /home/kuggix/pyright/packages/pyright/your_python_file.py:69:12 - error: Return type, "list[Unknown]", is partially unknown (reportUnknownVariableType)
+2 errors, 0 warnings, 0 informations 
+Completed in 0.365sec

--- a/packages/pyright/jdebug_pyright.md
+++ b/packages/pyright/jdebug_pyright.md
@@ -1,0 +1,113 @@
+# Building and Running Pyright From Source
+
+This guide outlines the steps to build the Pyright CLI from its source code, test it with a sample Python file, configure stricter type checking, and add a custom debug print statement.
+
+## Prerequisites
+
+1.  **Node.js and npm:** Ensure you have Node.js version 16.x or newer and npm (which typically comes with Node.js) installed.
+    *   You can check your versions with `node -v` and `npm -v`.
+2.  **Pyright Repository:** You should have the Pyright repository cloned to your local machine. All commands assume you are operating within this repository.
+
+## 1. Install Project Dependencies
+
+From the root directory of the `pyright` repository, install dependencies for all sub-packages.
+
+```bash
+# Navigate to the root of the pyright repository if you aren't already there
+# cd /path/to/pyright
+
+npm run install:all
+```
+
+This command is defined in the root package.json and will ensure all necessary modules for Pyright and its internal packages are downloaded.
+
+## 2. Build the Pyright CLI
+
+Navigate to the CLI package directory and run its build script. This compiles the TypeScript source code into runnable JavaScript.
+```bash
+cd packages/pyright
+npm run build
+```
+The compiled JavaScript output is typically placed in a dist subdirectory within packages/pyright.
+
+## 3. Prepare Test File and Configuration
+
+### a. Create a Python File for Testing
+Create a Python file that Pyright can analyze. This example includes a deliberate type error.
+File: pyright/packages/pyright/your_python_file.py
+```bash
+// filepath: pyright/packages/pyright/your_python_file.py
+# file to check type check
+
+import os
+
+
+a: int = 1
+a = os.getcwd()  # Pyright will now report an error here: Expression of type "str" cannot be assigned to declared type "int"
+
+
+print(a)
+```
+### b. (Optional) Create a Pyright Configuration File
+
+For stricter type checking, you can add a pyrightconfig.json file.
+File: pyright/packages/pyright/pyrightconfig.json
+```bash
+// filepath: /pyright/packages/pyright/pyrightconfig.json
+{
+  "typeCheckingMode": "strict"
+}
+```
+Place this file in the pyright/packages/pyright/ directory. Pyright will automatically detect and use it when run from this directory.
+
+
+### 4. Run the Pyright CLI from Source
+
+After the build is complete, you can run the CLI from the pyright/packages/pyright/ directory using Node.js.
+
+```bash
+# Ensure you are in the packages/pyright directory
+# cd /path/to/pyright/packages/pyright
+
+node index.js your_python_file.py
+```
+
+
+### 5. Adding Debug Prints
+
+#### a. Modify the Source Code
+
+For example, to add a debug print in Program._parseFile:
+File: pyright/packages/pyright-internal/src/analyzer/program.ts
+```ts
+// ...existing code...
+private _parseFile(fileToParse: SourceFileInfo, content?: string, skipFileNeededCheck?: boolean) {
+    if (!this._isFileNeeded(fileToParse, skipFileNeededCheck) || !fileToParse.sourceFile.isParseRequired()) {
+        return;
+    }
+
+    this._console.info(`[Copilot Debug] Program._parseFile: Parsing ${fileToParse.uri.toString()}`); // <--- ADD THIS LINE
+
+    // SourceFile.parse should only be called here in the program, as calling it
+// ...existing code...
+}
+// ...existing code...
+```
+
+#### b. Rebuild the Pyright CLI
+
+After modifying any TypeScript files (especially in pyright-internal which pyright depends on), you need to rebuild the CLI package.
+
+```bash
+# Ensure you are in the packages/pyright directory
+# cd /path/to/pyright/packages/pyright
+
+npm run build
+```
+
+#### c. Run Pyright with Debug Output
+Run the CLI again. You can use the --verbose flag to see more output, including your custom info logs.
+```bash
+# Ensure you are in the packages/pyright directory
+node index.js --verbose your_python_file.py
+```

--- a/packages/pyright/jtypecheck_plan.md
+++ b/packages/pyright/jtypecheck_plan.md
@@ -1,0 +1,13 @@
+## Demand-driven (or lazy) parsing and analysis.
+ key optimization strategy that type checkers like Pyright use
+
+#### The Core Principle: Analyze Only What's Necessary
+
+lets start with an example secnaio of our file `your_file.py`
+```python
+import os 
+
+an_integer: int = 1
+
+an_integer = os.getcwd()
+```

--- a/packages/pyright/pyrightconfig.json
+++ b/packages/pyright/pyrightconfig.json
@@ -1,0 +1,3 @@
+{
+  "typeCheckingMode": "strict"
+}

--- a/packages/pyright/your_python_file.py
+++ b/packages/pyright/your_python_file.py
@@ -1,0 +1,161 @@
+# Test file for Pyright debugging
+# import os
+# # import sys
+
+# # Variable with an explicit type annotation
+# an_integer: int = 1
+
+# an_integer = '2'
+# an_integer = os.getcwd()
+
+# # Using another library
+# python_version = sys.version
+
+# print(f"Current working directory: {an_integer}")
+# print(f"Python version: {python_version}")
+
+# joined_path = os.path.join("example", "dir")
+# print(f"Joined path: {joined_path}")
+
+
+
+# import random 
+
+# p = random.randint(1, 10)
+# p = '90'
+
+
+# from icecream import ic
+
+# x = 10
+# x = ic(x)
+
+
+# from ros2cli import command
+
+
+# @command('circle')
+# def circle_command(args: list[str]) -> int:
+#     """
+#     A command that prints a message indicating it is part of a circle.
+#     """
+#     print("This is a command in a circular dependency example.")
+#     return 0
+
+
+# use concurrent library to demonstrate a simple example
+
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from typing import List, Callable
+def square(n: int) -> int:
+    """Function to compute the square of a number."""
+    return n * n
+def compute_squares(numbers: List[int], worker: Callable[[int], int]) -> List[int]:
+    """
+    Function to compute squares of a list of numbers using a worker function.
+    
+    Args:
+        numbers: List of integers to compute squares for.
+        worker: Function that computes the square of a number.
+        
+    Returns:
+        List of squared integers.
+    """
+    results = []
+    with ThreadPoolExecutor() as executor:
+        futures = {executor.submit(worker, n): n for n in numbers}
+        for future in as_completed(futures):
+            results.append(future.result())
+    return results
+
+
+
+
+
+
+
+"""
+this is the seond file
+"""
+# """
+# This module demonstrates a simple circle class and a function to calculate the area of a circle.
+# (Module docstrings are optional but good practice in python)
+# # """
+
+# from abc import ABC, abstractmethod
+# from enum import Enum
+# import math
+# import unittest
+
+# # Module-level global var
+# RAD = 5
+
+
+# def calculate_area(radius: float) -> float:
+#     """Function to calculate the area of a circle."""
+#     return math.pi * radius * radius
+
+
+# # Multiline comments in python feels like a hack
+# """
+# Above we have the demonstration of a function to calculate the area of a circle.
+# Below we have the demonstration of a class to calculate the area of a circle.
+# """
+
+
+# class ShapeType(Enum):
+#     """Enum for shape types"""
+
+#     CIRCLE = "Circle"
+#     UNKNOWN = "Unknown"
+
+
+# class Shape(ABC):
+#     """Base class for a shape."""
+
+#     def __init__(self, shape_type: ShapeType):
+#         self.shape_type = shape_type
+
+#     @abstractmethod
+#     def area(self) -> float:
+#         """Abstract method to calculate the area of a shape."""
+#         pass
+
+
+# class Circle(Shape):
+#     """Circle class inherits from Shape."""
+
+#     def __init__(self, radius: float):
+#         super().__init__(ShapeType.CIRCLE)
+#         self.radius = radius
+
+#     def area(self) -> float:
+#         """Overridden method to calculate the area of the circle."""
+#         return math.pi * self.radius * self.radius
+
+
+# c = Circle(RAD)
+
+# if __name__ == "__main__":
+#     # To run the program functionality
+#     print(f"Area of a circle with radius {RAD} using function: {calculate_area(RAD)}")
+#     print(f"Area of a {c.shape_type.value} with radius {RAD} using class: {c.area()}")
+
+#     # Uncomment the next line if you want to run the unit tests
+#     # run_tests()
+
+
+# # Unit Tests!
+# class TestShapesFunctions(unittest.TestCase):
+#     def test_calculate_area(self) -> None:
+#         expected_area = 78.53981633974483
+#         self.assertAlmostEqual(calculate_area(RAD), expected_area)
+
+#     def test_circle_area(self) -> None:
+#         c = Circle(RAD)
+#         expected_area = 78.53981633974483
+#         self.assertAlmostEqual(c.area(), expected_area)
+
+#     def test_circle_type(self) -> None:
+#         c = Circle(RAD)
+#         self.assertEqual(c.shape_type, ShapeType.CIRCLE)


### PR DESCRIPTION
- Created a guide for building and running Pyright from source in jdebug_pyright.md.
- Added a new jtypecheck_plan.md file explaining demand-driven parsing and analysis.
- Introduced a strict type checking configuration in pyrightconfig.json.
- Added a comprehensive test file (your_python_file.py) demonstrating various Python features and type checking scenarios.