### PR TITLE
Fix ParamSpec freshening in self-application scenarios

### DIFF
--- a/packages/pyright-internal/src/analyzer/typeUtils.ts
+++ b/packages/pyright-internal/src/analyzer/typeUtils.ts
@@ -4035,16 +4035,15 @@ class UniqueFunctionSignatureTransformer extends TypeVarTransformer {
                 const solution = new ConstraintSolution();
 
                 // Create new type variables with the same scope but with
-                // different (unique) names.
+                // different (unique) names. We need to handle all type parameters
+                // to fix ParamSpec self-application issues like id(id).
                 sourceType.shared.typeParams.forEach((typeParam) => {
-                    if (typeParam.priv.scopeType === TypeVarScopeType.Function) {
-                        const replacement: Type = TypeVarType.cloneForNewName(
-                            typeParam,
-                            `${typeParam.shared.name}(${offsetIndex})`
-                        );
+                    const replacement: Type = TypeVarType.cloneForNewName(
+                        typeParam,
+                        `${typeParam.shared.name}(${offsetIndex})`
+                    );
 
-                        solution.setType(typeParam, replacement);
-                    }
+                    solution.setType(typeParam, replacement);
                 });
 
                 updatedSourceType = applySolvedTypeVars(sourceType, solution);


### PR DESCRIPTION
Fixes type inference bug where `id(id)` with ParamSpec returns partially unknown types instead of proper generic function type.

#10271 fix