### PR TITLE
Fixed a bug that results in a false positive error when a `break` or …

### DIFF
--- a/packages/pyright-internal/src/parser/parser.ts
+++ b/packages/pyright-internal/src/parser/parser.ts
@@ -1478,6 +1478,8 @@ export class Parser {
 
     private _parseLoopSuite(): SuiteNode {
         const wasInLoop = this._isInLoop;
+        const wasInExceptionGroup = this._isInExceptionGroup;
+        this._isInExceptionGroup = false;
         this._isInLoop = true;
 
         // Record the fact that we are no longer in a finally block
@@ -1496,6 +1498,7 @@ export class Parser {
 
         this._isInLoop = wasInLoop;
         this._isInFinallyLoop = wasInFinallyLoop;
+        this._isInExceptionGroup = wasInExceptionGroup;
 
         if (typeComment) {
             suite.d.typeComment = typeComment;

--- a/packages/pyright-internal/src/tests/samples/exceptionGroup1.py
+++ b/packages/pyright-internal/src/tests/samples/exceptionGroup1.py
@@ -101,6 +101,10 @@ def func7():
                 # continue is not allowed in an except* block.
                 continue
 
+            while 1 < 2:
+                # This is allowed because it's within a nested loop.
+                break
+
             # This should generate an error because
             # return is not allowed in an except* block.
             return


### PR DESCRIPTION
…`continue` statement is used within a `while` or `for` loop within an exception group block. This addresses #10766.