### PR TITLE
Fixed regression that resulted in a false positive error when using `…

### DIFF
--- a/packages/pyright-internal/src/tests/checker.test.ts
+++ b/packages/pyright-internal/src/tests/checker.test.ts
@@ -528,6 +528,11 @@ test('UninitializedVariable2', () => {
     TestUtils.validateResults(analysisResults, 3);
 });
 
+test('UninitializedVariable3', () => {
+    const analysisResults = TestUtils.typeAnalyzeSampleFiles(['uninitializedVariable3.py']);
+    TestUtils.validateResults(analysisResults, 0);
+});
+
 test('DeprecatedAlias1', () => {
     const configOptions = new ConfigOptions(Uri.empty());
 

--- a/packages/pyright-internal/src/tests/samples/uninitializedVariable3.py
+++ b/packages/pyright-internal/src/tests/samples/uninitializedVariable3.py
@@ -1,0 +1,13 @@
+# This sample tests a special case for the reportUninitializedInstanceVariable
+# test involving NamedTuple classes.
+
+# pyright: reportUninitializedInstanceVariable=true
+
+from typing import final, NamedTuple
+
+
+@final
+class A(NamedTuple):
+    x: int
+    y: float
+


### PR DESCRIPTION
…reportUninitializedInstanceVariable` with a `NamedTuple` class. This addresses #10490.