### PR TITLE
fix: Generic definition

### DIFF
--- a/packages/pyright-internal/typeshed-fallback/stdlib/typing.pyi
+++ b/packages/pyright-internal/typeshed-fallback/stdlib/typing.pyi
@@ -235,7 +235,6 @@ class _SpecialForm(_Final):
         def __ror__(self, other: Any) -> _SpecialForm: ...
 
 Union: _SpecialForm
-Generic: _SpecialForm
 Protocol: _SpecialForm
 Callable: _SpecialForm
 Type: _SpecialForm
@@ -439,6 +438,10 @@ Annotated: _SpecialForm
 
 # Predefined type variables.
 AnyStr = TypeVar("AnyStr", str, bytes)  # noqa: Y001
+
+class Generic:
+    @classmethod
+    def __class_getitem__(cls, args: TypeVar | ParamSpec | tuple[TypeVar | ParamSpec, ...]) -> _Final: ...
 
 class _ProtocolMeta(ABCMeta):
     if sys.version_info >= (3, 12):

--- a/packages/pyright-internal/typeshed-fallback/stdlib/typing.pyi
+++ b/packages/pyright-internal/typeshed-fallback/stdlib/typing.pyi
@@ -439,9 +439,13 @@ Annotated: _SpecialForm
 # Predefined type variables.
 AnyStr = TypeVar("AnyStr", str, bytes)  # noqa: Y001
 
-class Generic:
-    @classmethod
-    def __class_getitem__(cls, args: TypeVar | ParamSpec | tuple[TypeVar | ParamSpec, ...]) -> _Final: ...
+if sys.version_info >= (3, 12):
+    class Generic:
+        @classmethod
+        def __class_getitem__(cls, args: TypeVar | ParamSpec | tuple[TypeVar | ParamSpec, ...]) -> _Final: ...
+else:
+    # Dummy case; true definition accessible in typing
+    Generic: _SpecialForm
 
 class _ProtocolMeta(ABCMeta):
     if sys.version_info >= (3, 12):


### PR DESCRIPTION
Proposing a slightly more refined way to define `Generic`:
* From **Python 3.12**, it is [internal](https://github.com/python/cpython/blob/3663b2ad54c9e15775a605facf69da8f5ee8d335/Lib/typing.py#L40) so we often fall back to the definition here - better to have something more accurate
* Instances of `_SpecialForm`/`_Final` semantically [prohibit subclassing](https://github.com/python/cpython/blob/3663b2ad54c9e15775a605facf69da8f5ee8d335/Lib/typing.py#L1516) whereas `Generic[...]` can be subclassed
* This benefits other types too (e.g., `Protocol` if in the future its definition is also updated from `_SpecialForm`)

Based on [cpython spec](https://github.com/python/cpython/blob/3663b2ad54c9e15775a605facf69da8f5ee8d335/Objects/typevarobject.c#L2288), `Generic` has a custom `__class_getitem__` that should be in the class template:

```bash
>>> set(dir(Generic)) - set(dir(object))
{'__module__', '__class_getitem__'}
```