### PR TITLE
Fixed a bug that results in false positive errors when using `object`…

### DIFF
--- a/packages/pyright-internal/src/analyzer/sentinel.ts
+++ b/packages/pyright-internal/src/analyzer/sentinel.ts
@@ -14,6 +14,7 @@ import { getFileInfo } from './analyzerNodeInfo';
 import { getClassFullName, getTypeSourceId } from './parseTreeUtils';
 import { Arg, TypeEvaluator } from './typeEvaluatorTypes';
 import { ClassType, ClassTypeFlags, SentinelLiteral, Type, TypeBase } from './types';
+import { computeMroLinearization } from './typeUtils';
 
 export function createSentinelType(
     evaluator: TypeEvaluator,
@@ -71,6 +72,8 @@ export function createSentinelType(
         evaluator.getTypeClassType()
     );
 
+    classType.shared.baseClasses.push(evaluator.getObjectType());
+    computeMroLinearization(classType);
     classType = ClassType.cloneWithLiteral(classType, new SentinelLiteral(fullClassName, className));
 
     let instanceType = ClassType.cloneAsInstance(classType);


### PR DESCRIPTION
… methods (like `__eq__`) on a `Sentinel` instance. This addresses #10773.