### PR TITLE
Fixed a bug that results in spurious errors if a class decorator is a…

### DIFF
--- a/packages/pyright-internal/src/analyzer/typeUtils.ts
+++ b/packages/pyright-internal/src/analyzer/typeUtils.ts
@@ -3745,7 +3745,9 @@ export class TypeVarTransformer {
                 } else {
                     const newTypeArgType = this.apply(typeParams[0], recursionCount);
                     newTupleTypeArgs = [{ type: newTypeArgType, isUnbounded: true }];
-                    specializationNeeded = true;
+                    if (newTypeArgType !== typeParams[0] || !!classType.priv.typeArgs) {
+                        specializationNeeded = true;
+                    }
                     isTypeArgExplicit = false;
                 }
             }

--- a/packages/pyright-internal/src/tests/samples/dataclassConverter2.py
+++ b/packages/pyright-internal/src/tests/samples/dataclassConverter2.py
@@ -1,7 +1,6 @@
 # This sample tests assignment of dataclass fields that use
 # the converter parameter described in PEP 712.
 
-from dataclasses import dataclass, field
 from typing import Any, Callable, dataclass_transform
 
 


### PR DESCRIPTION
…pplied to `builtins.tuple`. This addresses #10836.