### PR TITLE
Fixed bug that results in false negative when a `closed=False` is use…

### DIFF
--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -17720,6 +17720,24 @@ export function createTypeEvaluator(
                                         classType.shared.typedDictExtraItemsExpr
                                     );
                                 }
+                            } else {
+                                // PEP 728: A class that subclasses from a non-open TypedDict
+                                // cannot specify closed=False.
+                                const nonOpenBase = classType.shared.baseClasses.find(
+                                    (base) =>
+                                        isInstantiableClass(base) &&
+                                        ClassType.isTypedDictClass(base) &&
+                                        ClassType.isTypedDictEffectivelyClosed(base)
+                                );
+                                if (nonOpenBase) {
+                                    addDiagnostic(
+                                        DiagnosticRule.reportGeneralTypeIssues,
+                                        LocMessage.typedDictClosedFalseNonOpenBase().format({
+                                            name: (nonOpenBase as ClassType).shared.name,
+                                        }),
+                                        arg.d.valueExpr
+                                    );
+                                }
                             }
 
                             if (sawClosedOrExtraItems) {

--- a/packages/pyright-internal/src/localization/localize.ts
+++ b/packages/pyright-internal/src/localization/localize.ts
@@ -1016,6 +1016,8 @@ export namespace Localizer {
             new ParameterizedString<{ name: string; type: string }>(getRawString('Diagnostic.typedDictClosedExtras'));
         export const typedDictClosedNoExtras = () =>
             new ParameterizedString<{ name: string }>(getRawString('Diagnostic.typedDictClosedNoExtras'));
+        export const typedDictClosedFalseNonOpenBase = () =>
+            new ParameterizedString<{ name: string }>(getRawString('Diagnostic.typedDictClosedFalseNonOpenBase'));
         export const typedDictDelete = () => getRawString('Diagnostic.typedDictDelete');
         export const typedDictEmptyName = () => getRawString('Diagnostic.typedDictEmptyName');
         export const typedDictEntryName = () => getRawString('Diagnostic.typedDictEntryName');

--- a/packages/pyright-internal/src/localization/package.nls.en-us.json
+++ b/packages/pyright-internal/src/localization/package.nls.en-us.json
@@ -1537,6 +1537,10 @@
             "message": "Base class \"{name}\" is a closed TypedDict; extra items are not allowed",
             "comment": "{Locked='closed','TypedDict'}"
         },
+        "typedDictClosedFalseNonOpenBase": {
+            "message": "Base class \"{name}\" is not an open TypedDict; closed=False is not allowed",
+            "comment": "{Locked='TypedDict','closed'}"
+        },
         "typedDictDelete": {
             "message": "Could not delete item in TypedDict",
             "comment": "{Locked='TypedDict'}"

--- a/packages/pyright-internal/src/tests/samples/typedDictClosed3.py
+++ b/packages/pyright-internal/src/tests/samples/typedDictClosed3.py
@@ -120,3 +120,20 @@ class MovieNotRequiredYear(MovieBase):
 
 class MovieWithYear(MovieBase):
     year: NotRequired[int | None]
+
+
+class ParentNonOpen5(TypedDict, closed=True):
+    pass
+
+# This should generate an error because a subclass of
+# a closed TypedDict cannot be open.
+class ChildNotClosed5(ParentNonOpen5, closed=False):
+    pass
+
+class ParentNonOpen6(TypedDict, extra_items=str):
+    pass
+
+# This should generate an error because a subclass of
+# a closed TypedDict cannot be open.
+class ChildNotClosed6(ParentNonOpen6, closed=False):
+    pass

--- a/packages/pyright-internal/src/tests/typeEvaluator5.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator5.test.ts
@@ -360,7 +360,7 @@ test('TypedDictClosed2', () => {
 
 test('TypedDictClosed3', () => {
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['typedDictClosed3.py']);
-    TestUtils.validateResults(analysisResults, 10);
+    TestUtils.validateResults(analysisResults, 12);
 });
 
 test('TypedDictClosed4', () => {


### PR DESCRIPTION
…d in `TypedDict` that subclasses from a non-open `TypedDict` base class. This addresses #10859.