### PR TITLE
Fixed false negative when a keyword parameter in a child class method…

### DIFF
--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -27885,6 +27885,28 @@ export function createTypeEvaluator(
                             );
                             canOverride = false;
                         }
+                    } else {
+                        // Base has a **kwargs; ensure the added keyword-only parameter's
+                        // type is compatible with the base's **kwargs value type.
+                        const baseKwargsType = baseParamDetails.params[baseParamDetails.kwargsIndex].type;
+                        if (
+                            !assignType(
+                                paramInfo.type,
+                                baseKwargsType,
+                                diag?.createAddendum(),
+                                constraints,
+                                AssignTypeFlags.Default
+                            )
+                        ) {
+                            diag?.addMessage(
+                                LocAddendum.overrideParamKeywordType().format({
+                                    name: paramInfo.param.name ?? '?',
+                                    baseType: printType(baseKwargsType),
+                                    overrideType: printType(paramInfo.type),
+                                })
+                            );
+                            canOverride = false;
+                        }
                     }
                 }
             });

--- a/packages/pyright-internal/src/tests/samples/methodOverride1.py
+++ b/packages/pyright-internal/src/tests/samples/methodOverride1.py
@@ -146,6 +146,8 @@ class ParentClass:
 
     def __my_method47__(self, x: int) -> None: ...
 
+    def my_method48(self, /, **kwargs: object) -> None: ...
+
 
 T_ChildClass = TypeVar("T_ChildClass", bound="ChildClass")
 
@@ -310,6 +312,10 @@ class ChildClass(ParentClass):
 
     # This should generate an error because of a type mismatch.
     def __my_method47__(self, y: str) -> None: ...
+
+    # This should generate an error because the keyword-only parameter "x: int"
+    # is not compatible with the base method's "**kwargs: object".
+    def my_method48(self, /, *, x: int = 3, **kwargs: object) -> None: ...
 
 
 class A:

--- a/packages/pyright-internal/src/tests/typeEvaluator3.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator3.test.ts
@@ -946,7 +946,7 @@ test('MethodOverride1', () => {
 
     configOptions.diagnosticRuleSet.reportIncompatibleMethodOverride = 'error';
     analysisResults = TestUtils.typeAnalyzeSampleFiles(['methodOverride1.py'], configOptions);
-    TestUtils.validateResults(analysisResults, 42);
+    TestUtils.validateResults(analysisResults, 43);
 });
 
 test('MethodOverride2', () => {


### PR DESCRIPTION
… overrides a method with a `**kwargs` in the parent and the type is incompatible. This addresses #10815.