### PR TITLE
Fixed bug that results in false positive "reportPossiblyUnboundVariab…

### DIFF
--- a/packages/pyright-internal/src/analyzer/checker.ts
+++ b/packages/pyright-internal/src/analyzer/checker.ts
@@ -4417,6 +4417,11 @@ export class Checker extends ParseTreeWalker {
             return;
         }
 
+        // Skip this for keyword argument names.
+        if (node.parent?.nodeType === ParseNodeType.Argument && node.parent.d.name === node) {
+            return;
+        }
+
         if (!AnalyzerNodeInfo.isCodeUnreachable(node)) {
             const type = this._evaluator.getType(node);
 


### PR DESCRIPTION
…le" error on keyword argument names. This addresses #10811.