### PR TITLE
Fixed bug that results in spurious errors when a wildcard import targ…

### DIFF
--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -5493,6 +5493,7 @@ export function createTypeEvaluator(
                         match.priv.scopeName,
                         match.priv.scopeType
                     );
+                    type.shared.declaredVariance = match.shared.declaredVariance;
                     return {
                         type,
                         scopeNode,


### PR DESCRIPTION
…ets a traditional `TypeVar` with the same name as a PEP 695 TypeVar. This addresses #10900.