### PR TITLE
Fix regression in symlinked files

### DIFF
--- a/packages/pyright-internal/src/analyzer/importResolver.ts
+++ b/packages/pyright-internal/src/analyzer/importResolver.ts
@@ -531,8 +531,12 @@ export class ImportResolver {
             const entries = this.fileSystem.readdirEntriesSync(uri);
             entries.forEach((entry) => {
                 newCachedDir.entries.set(entry.name, entry);
-                const isFile = entry.isFile() || (entry.isSymbolicLink() && tryStat(this.fileSystem, uri.combinePaths(entry.name))?.isFile());
-                const isDirectory = entry.isDirectory() || (entry.isSymbolicLink() && tryStat(this.fileSystem, uri.combinePaths(entry.name))?.isDirectory());
+                const isFile =
+                    entry.isFile() ||
+                    (entry.isSymbolicLink() && tryStat(this.fileSystem, uri.combinePaths(entry.name))?.isFile());
+                const isDirectory =
+                    entry.isDirectory() ||
+                    (entry.isSymbolicLink() && tryStat(this.fileSystem, uri.combinePaths(entry.name))?.isDirectory());
                 const resolvableName = isFile
                     ? stripFileExtension(entry.name, /* multiDotExtension */ true)
                     : entry.name;

--- a/packages/pyright-internal/src/analyzer/importResolver.ts
+++ b/packages/pyright-internal/src/analyzer/importResolver.ts
@@ -531,14 +531,13 @@ export class ImportResolver {
             const entries = this.fileSystem.readdirEntriesSync(uri);
             entries.forEach((entry) => {
                 newCachedDir.entries.set(entry.name, entry);
-                const isFile =
-                    entry.isFile() ||
-                    (entry.isSymbolicLink() && tryStat(this.fileSystem, uri.combinePaths(entry.name))?.isFile());
-                const isDirectory =
-                    !isFile &&
-                    (entry.isDirectory() ||
-                        (entry.isSymbolicLink() &&
-                            tryStat(this.fileSystem, uri.combinePaths(entry.name))?.isDirectory()));
+                let isFile = entry.isFile();
+                let isDirectory = entry.isDirectory();
+                if ((!isFile || !isDirectory) && entry.isSymbolicLink()) {
+                    const stat = tryStat(this.fileSystem, uri.combinePaths(entry.name));
+                    isFile = isFile || stat?.isFile() === true;
+                    isDirectory = isDirectory || stat?.isDirectory() === true;
+                }
                 const resolvableName = isFile
                     ? stripFileExtension(entry.name, /* multiDotExtension */ true)
                     : entry.name;

--- a/packages/pyright-internal/src/analyzer/importResolver.ts
+++ b/packages/pyright-internal/src/analyzer/importResolver.ts
@@ -533,10 +533,10 @@ export class ImportResolver {
                 newCachedDir.entries.set(entry.name, entry);
                 let isFile = entry.isFile();
                 let isDirectory = entry.isDirectory();
-                if ((!isFile || !isDirectory) && entry.isSymbolicLink()) {
+                if (entry.isSymbolicLink()) {
                     const stat = tryStat(this.fileSystem, uri.combinePaths(entry.name));
-                    isFile = isFile || stat?.isFile() === true;
-                    isDirectory = isDirectory || stat?.isDirectory() === true;
+                    isFile = !!stat?.isFile();
+                    isDirectory = !!stat?.isDirectory();
                 }
                 const resolvableName = isFile
                     ? stripFileExtension(entry.name, /* multiDotExtension */ true)

--- a/packages/pyright-internal/src/analyzer/importResolver.ts
+++ b/packages/pyright-internal/src/analyzer/importResolver.ts
@@ -531,12 +531,14 @@ export class ImportResolver {
             const entries = this.fileSystem.readdirEntriesSync(uri);
             entries.forEach((entry) => {
                 newCachedDir.entries.set(entry.name, entry);
-                const resolvableName = entry.isFile() || (entry.isSymbolicLink() && tryStat(this.fileSystem, uri.combinePaths(entry.name))?.isFile())
+                const isFile = entry.isFile() || (entry.isSymbolicLink() && tryStat(this.fileSystem, uri.combinePaths(entry.name))?.isFile());
+                const isDirectory = entry.isDirectory() || (entry.isSymbolicLink() && tryStat(this.fileSystem, uri.combinePaths(entry.name))?.isDirectory());
+                const resolvableName = isFile
                     ? stripFileExtension(entry.name, /* multiDotExtension */ true)
                     : entry.name;
                 newCachedDir.resolvableNames.add(resolvableName);
 
-                if (entry.isDirectory() && entry.name.endsWith(stubsSuffix)) {
+                if (isDirectory && entry.name.endsWith(stubsSuffix)) {
                     newCachedDir.resolvableNames.add(
                         resolvableName.substring(0, resolvableName.length - stubsSuffix.length)
                     );

--- a/packages/pyright-internal/src/analyzer/importResolver.ts
+++ b/packages/pyright-internal/src/analyzer/importResolver.ts
@@ -531,7 +531,7 @@ export class ImportResolver {
             const entries = this.fileSystem.readdirEntriesSync(uri);
             entries.forEach((entry) => {
                 newCachedDir.entries.set(entry.name, entry);
-                const resolvableName = entry.isFile()
+                const resolvableName = entry.isFile() || (entry.isSymbolicLink() && tryStat(this.fileSystem, uri.combinePaths(entry.name))?.isFile())
                     ? stripFileExtension(entry.name, /* multiDotExtension */ true)
                     : entry.name;
                 newCachedDir.resolvableNames.add(resolvableName);

--- a/packages/pyright-internal/src/analyzer/importResolver.ts
+++ b/packages/pyright-internal/src/analyzer/importResolver.ts
@@ -535,8 +535,10 @@ export class ImportResolver {
                     entry.isFile() ||
                     (entry.isSymbolicLink() && tryStat(this.fileSystem, uri.combinePaths(entry.name))?.isFile());
                 const isDirectory =
-                    !isFile && (entry.isDirectory() ||
-                    (entry.isSymbolicLink() && tryStat(this.fileSystem, uri.combinePaths(entry.name))?.isDirectory()));
+                    !isFile &&
+                    (entry.isDirectory() ||
+                        (entry.isSymbolicLink() &&
+                            tryStat(this.fileSystem, uri.combinePaths(entry.name))?.isDirectory()));
                 const resolvableName = isFile
                     ? stripFileExtension(entry.name, /* multiDotExtension */ true)
                     : entry.name;

--- a/packages/pyright-internal/src/analyzer/importResolver.ts
+++ b/packages/pyright-internal/src/analyzer/importResolver.ts
@@ -535,8 +535,8 @@ export class ImportResolver {
                     entry.isFile() ||
                     (entry.isSymbolicLink() && tryStat(this.fileSystem, uri.combinePaths(entry.name))?.isFile());
                 const isDirectory =
-                    entry.isDirectory() ||
-                    (entry.isSymbolicLink() && tryStat(this.fileSystem, uri.combinePaths(entry.name))?.isDirectory());
+                    !isFile && (entry.isDirectory() ||
+                    (entry.isSymbolicLink() && tryStat(this.fileSystem, uri.combinePaths(entry.name))?.isDirectory()));
                 const resolvableName = isFile
                     ? stripFileExtension(entry.name, /* multiDotExtension */ true)
                     : entry.name;

--- a/packages/pyright-internal/src/tests/importResolver.test.ts
+++ b/packages/pyright-internal/src/tests/importResolver.test.ts
@@ -345,7 +345,6 @@ describe('Import tests with fake venv', () => {
 
             assert(result.isImportFound);
         });
-
     }
 
     describe('Import tests that can run with or without a true venv', () => {
@@ -800,7 +799,6 @@ describe('Import tests with fake venv', () => {
             assert(!moduleImportInfo.isThirdPartyPyTypedPresent);
             assert(!moduleImportInfo.isLocalTypingsFile);
         });
-
     });
 
     if (usingTrueVenv()) {

--- a/packages/pyright-internal/src/tests/importResolver.test.ts
+++ b/packages/pyright-internal/src/tests/importResolver.test.ts
@@ -780,20 +780,22 @@ describe('Import tests with fake venv', () => {
                 },
             ];
 
-            const result = getImportResult(files, ["file2"], (c) => {
-                c.defaultExtraPaths = [
-                    UriEx.file(combinePaths('/', 'external_symlinked')),
-                ];
-
-            }, (importResolver, uri, configOptions) => {
-                const fs = importResolver.serviceProvider.fs() as PyrightFileSystem;
-                const testFs = (fs as any).realFS as TestFileSystem;
-                testFs.mkdirSync(UriEx.file(combinePaths('/', 'external_symlinked')));
-                testFs.symlinkSync(
-                    combinePaths('/', 'external', 'file2.py'),
-                    combinePaths('/', 'external_symlinked', 'file2.py')
-                );
-            });
+            const result = getImportResult(
+                files,
+                ['file2'],
+                (c) => {
+                    c.defaultExtraPaths = [UriEx.file(combinePaths('/', 'external_symlinked'))];
+                },
+                (importResolver, uri, configOptions) => {
+                    const fs = importResolver.serviceProvider.fs() as PyrightFileSystem;
+                    const testFs = (fs as any).realFS as TestFileSystem;
+                    testFs.mkdirSync(UriEx.file(combinePaths('/', 'external_symlinked')));
+                    testFs.symlinkSync(
+                        combinePaths('/', 'external', 'file2.py'),
+                        combinePaths('/', 'external_symlinked', 'file2.py')
+                    );
+                }
+            );
 
             assert(result.isImportFound);
         });


### PR DESCRIPTION
As explained in https://github.com/microsoft/pyright/issues/10906, 1.1.405 introduced a regression for symlinked file import lookup.

The root cause was the 'resolvableNames' shortcut to skip looking for imports. Symlinked files were not taken into account when resolving the name of a directory entry.

I tested this using the example in the associated pylance issue and wrote an automated test.
https://github.com/microsoft/pylance-release/issues/7564