### PR TITLE
Fixed bug that results in incorrect behavior when `partial` is applie…

### DIFF
--- a/packages/pyright-internal/src/analyzer/constructorTransform.ts
+++ b/packages/pyright-internal/src/analyzer/constructorTransform.ts
@@ -278,9 +278,10 @@ function applyPartialTransformToFunction(
                     argumentErrors = true;
                 }
             } else {
-                const paramType = FunctionType.getParamType(origFunctionType, argIndex);
+                const paramInfo = paramListDetails.params[argIndex];
+                const paramType = paramInfo.type;
                 const diag = new DiagnosticAddendum();
-                const paramName = paramListDetails.params[argIndex].param.name ?? '';
+                const paramName = paramInfo.param.name ?? '';
 
                 const argTypeResult = evaluator.getTypeOfExpression(
                     arg.valueExpression,

--- a/packages/pyright-internal/src/tests/samples/partial8.py
+++ b/packages/pyright-internal/src/tests/samples/partial8.py
@@ -1,0 +1,17 @@
+# This sample tests the case where functools.partial is applied to
+# a function that includes a positional-only parameter separator.
+
+from functools import partial
+
+
+def func1(s: int, /, a: int, b: str) -> int: ...
+
+
+func1_partial = partial(func1, 1, 0, "")
+reveal_type(func1_partial(), expected_text="int")
+
+func1_partial_missing = partial(func1, 1)
+reveal_type(func1_partial_missing(0, ""), expected_text="int")
+
+# This should generate an error.
+partial(func1, s=1)

--- a/packages/pyright-internal/src/tests/typeEvaluator8.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator8.test.ts
@@ -791,6 +791,12 @@ test('Partial7', () => {
     TestUtils.validateResults(analysisResults, 1);
 });
 
+test('Partial8', () => {
+    const analysisResults = TestUtils.typeAnalyzeSampleFiles(['partial8.py']);
+
+    TestUtils.validateResults(analysisResults, 1);
+});
+
 test('TotalOrdering1', () => {
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['totalOrdering1.py']);
 


### PR DESCRIPTION
…d to a function with a positional-only parameter separator. This addresses #10954.