### PR TITLE
Fixed bug that omit `**kwargs` parameter with an unpacked TypedDict with extra items.

### DIFF
--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -2738,7 +2738,7 @@ export function createTypeEvaluator(
                     ParamCategory.KwargsDict,
                     extraItemsType,
                     FunctionParamFlags.TypeDeclared,
-                    'kwargs',
+                    'kwargs'
                 )
             );
         }

--- a/packages/pyright-internal/src/analyzer/typePrinter.ts
+++ b/packages/pyright-internal/src/analyzer/typePrinter.ts
@@ -1163,6 +1163,20 @@ function printFunctionPartsInternal(
                 );
                 paramTypeStrings.push(`${k}: ${valueTypeString}`);
             });
+
+            const extraItemsType = paramType.shared.typedDictEntries?.extraItems?.valueType;
+            if (extraItemsType && !isNever(extraItemsType)) {
+                const valueTypeString = printTypeInternal(
+                    extraItemsType,
+                    printTypeFlags,
+                    returnTypeCallback,
+                    uniqueNameMap,
+                    recursionTypes,
+                    recursionCount
+                );
+                paramTypeStrings.push(`**kwargs: ${valueTypeString}`);
+            }
+
             return;
         }
 

--- a/packages/pyright-internal/src/tests/fourslash/signature.complicated.fourslash.ts
+++ b/packages/pyright-internal/src/tests/fourslash/signature.complicated.fourslash.ts
@@ -3,7 +3,7 @@
 // @filename: complicated.py
 //// from typing import Any, Optional, Type, Union, TypedDict, Unpack, NotRequired
 ////
-//// class Movie(TypedDict, extra_items: int):
+//// class Movie(TypedDict, extra_items=int):
 ////     key1: str
 ////     key2: NotRequired[int]
 ////


### PR DESCRIPTION
This addresses #10996. I assume this should fix it?