### PR TITLE
Warn when `self` or `cls` parameter has a default value

### DIFF
--- a/packages/pyright-internal/src/localization/localize.ts
+++ b/packages/pyright-internal/src/localization/localize.ts
@@ -329,6 +329,8 @@ export namespace Localizer {
             new ParameterizedString<{ name: string; classType: string }>(
                 getRawString('Diagnostic.clsSelfParamTypeMismatch')
             );
+        export const clsSelfParamDefaultNotAllowed = () =>
+            new ParameterizedString<{ name: string }>(getRawString('Diagnostic.clsSelfParamDefaultNotAllowed'));
         export const codeTooComplexToAnalyze = () => getRawString('Diagnostic.codeTooComplexToAnalyze');
         export const collectionAliasInstantiation = () =>
             new ParameterizedString<{ type: string; alias: string }>(

--- a/packages/pyright-internal/src/localization/package.nls.en-us.json
+++ b/packages/pyright-internal/src/localization/package.nls.en-us.json
@@ -173,6 +173,7 @@
             "comment": "{Locked='ClassVar'}"
         },
         "clsSelfParamTypeMismatch": "Type of parameter \"{name}\" must be a supertype of its class \"{classType}\"",
+        "clsSelfParamDefaultNotAllowed": "Parameter \"{name}\" must not have a default value",
         "codeTooComplexToAnalyze": "Code is too complex to analyze; reduce complexity by refactoring into subroutines or reducing conditional code paths",
         "collectionAliasInstantiation": "Type \"{type}\" cannot be instantiated, use \"{alias}\" instead",
         "comparisonAlwaysFalse": {

--- a/packages/pyright-internal/src/localization/package.nls.ru.json
+++ b/packages/pyright-internal/src/localization/package.nls.ru.json
@@ -85,6 +85,7 @@
         "classVarTooManyArgs": "Ожидается только один аргумент типа после \"ClassVar\"",
         "classVarWithTypeVar": "Тип \"ClassVar\" не может включать переменные типа",
         "clsSelfParamTypeMismatch": "Тип параметра \"{name}\" должен быть супертипом своего класса \"{classType}\"",
+        "clsSelfParamDefaultNotAllowed": "Параметр \"{name}\" не может иметь значение по умолчанию",
         "codeTooComplexToAnalyze": "Код слишком сложен для анализа; уменьшите сложность, разбив его на фрагменты (вложенные процедуры) или сократите количество условных конструкций",
         "collectionAliasInstantiation": "Тип \"{type}\" не может быть создан, вместо этого используйте \"{alias}\"",
         "comparisonAlwaysFalse": "Условие всегда будет оцениваться как False, поскольку типы \"{leftType}\" и \"{rightType}\" не перекрываются",

--- a/packages/pyright-internal/src/tests/samples/self12.py
+++ b/packages/pyright-internal/src/tests/samples/self12.py
@@ -1,0 +1,14 @@
+# The `self` or `cls` parameter of a method should not have a default value
+
+class Foo:
+    def instance_method(self=42) -> None:
+        pass
+
+    @classmethod
+    def class_method(cls=42) -> None:
+        pass
+
+    @staticmethod
+    def static_method(something=42) -> None:
+        pass
+

--- a/packages/pyright-internal/src/tests/typeEvaluator8.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator8.test.ts
@@ -719,6 +719,14 @@ test('Self11', () => {
     TestUtils.validateResults(analysisResults, 0);
 });
 
+test('Self12', () => {
+    const [analysisResult] = TestUtils.typeAnalyzeSampleFiles(['self12.py']);
+
+    assert.equal(analysisResult.errors.length, 2);
+    assert.equal(analysisResult.errors[0].message, 'Parameter "self" must not have a default value');
+    assert.equal(analysisResult.errors[1].message, 'Parameter "cls" must not have a default value');
+});
+
 test('UnusedVariable1', () => {
     const configOptions = new ConfigOptions(Uri.empty());
 


### PR DESCRIPTION
Pyright currently does not raise any diagnostics on this:

```py
class Foo:
    def bar(self=42) -> None:  # allowed
        pass

foo = Foo()
foo.bar()  # also allowed
```

Having a default value for the first parameter of a method or classmethod is generally dubious, and is probably a typo from hastily editing the code:
```diff
- def bird(self, ex_parrot=42):
+ def bird(self=42):
```
