### PR TITLE
Fixed bug in type narrowing for literal patterns. The runtime uses eq…

### DIFF
--- a/packages/pyright-internal/src/tests/samples/matchLiteral1.py
+++ b/packages/pyright-internal/src/tests/samples/matchLiteral1.py
@@ -8,9 +8,9 @@ from typing import Literal, TypeVar
 def test_unknown(value_to_match):
     match value_to_match:
         case 3 as a1, -3 as a2:
-            reveal_type(a1, expected_text="Literal[3]")
-            reveal_type(a2, expected_text="Literal[-3]")
-            reveal_type(value_to_match, expected_text="Sequence[int]")
+            reveal_type(a1, expected_text="Unknown")
+            reveal_type(a2, expected_text="Unknown")
+            reveal_type(value_to_match, expected_text="Sequence[Unknown]")
 
         case 3j as b1, -3 + 5j as b2:
             reveal_type(b1, expected_text="complex")
@@ -18,44 +18,62 @@ def test_unknown(value_to_match):
             reveal_type(value_to_match, expected_text="Sequence[complex]")
 
         case "hi" as c1, None as c2:
-            reveal_type(c1, expected_text="Literal['hi']")
+            reveal_type(c1, expected_text="Unknown")
             reveal_type(c2, expected_text="None")
-            reveal_type(value_to_match, expected_text="Sequence[str | None]")
+            reveal_type(value_to_match, expected_text="Sequence[Unknown]")
 
         case True as d1, False as d2:
-            reveal_type(d1, expected_text="Literal[True]")
-            reveal_type(d2, expected_text="Literal[False]")
-            reveal_type(value_to_match, expected_text="Sequence[bool]")
+            reveal_type(d1, expected_text="Unknown")
+            reveal_type(d2, expected_text="Unknown")
+            reveal_type(value_to_match, expected_text="Sequence[Unknown]")
 
 
 def test_tuple(value_to_match: tuple[int | float | str | complex, ...]):
     match value_to_match:
         case (3, -3) as a1:
-            reveal_type(a1, expected_text="tuple[Literal[3], Literal[-3]]")
-            reveal_type(value_to_match, expected_text="tuple[Literal[3], Literal[-3]]")
+            reveal_type(
+                a1,
+                expected_text="tuple[float | complex | Literal[3], float | complex | Literal[-3]]",
+            )
+            reveal_type(
+                value_to_match,
+                expected_text="tuple[float | complex | Literal[3], float | complex | Literal[-3]]",
+            )
 
         case (3j, -3 + 5j) as b1:
-            reveal_type(b1, expected_text="tuple[complex, complex]")
-            reveal_type(value_to_match, expected_text="tuple[complex, complex]")
+            reveal_type(
+                b1, expected_text="tuple[int | float | complex, int | float | complex]"
+            )
+            reveal_type(
+                value_to_match,
+                expected_text="tuple[int | float | complex, int | float | complex]",
+            )
 
 
 def test_union(value_to_match: int | float | str | complex | bool | None):
     match value_to_match:
         case (3 | -3j) as a1:
-            reveal_type(a1, expected_text="bool | complex | Literal[3]")
-            reveal_type(value_to_match, expected_text="bool | complex | Literal[3]")
+            reveal_type(a1, expected_text="float | complex | bool | int")
+            reveal_type(value_to_match, expected_text="float | complex | bool | int")
 
         case (True | False | 3.4 | -3 + 3j | None) as b1:
-            reveal_type(b1, expected_text="float | complex | bool | None")
-            reveal_type(value_to_match, expected_text="float | complex | bool | None")
+            reveal_type(b1, expected_text="int | float | complex | bool | None")
+            reveal_type(
+                value_to_match, expected_text="int | float | complex | bool | None"
+            )
 
         case ("hi" | 3.4) as c1:
-            reveal_type(c1, expected_text="float | Literal['hi']")
-            reveal_type(value_to_match, expected_text="float | Literal['hi']")
+            reveal_type(c1, expected_text="int | float | Literal['hi']")
+            reveal_type(value_to_match, expected_text="int | float | Literal['hi']")
 
         case ((True | "True") as d1) | ((False | "False") as d1):
-            reveal_type(d1, expected_text="bool | Literal['True', 'False']")
-            reveal_type(value_to_match, expected_text="bool | Literal['True', 'False']")
+            reveal_type(
+                d1, expected_text="int | float | complex | Literal['True', 'False']"
+            )
+            reveal_type(
+                value_to_match,
+                expected_text="int | float | complex | Literal['True', 'False']",
+            )
 
 
 def test_none(value_to_match: int | None):
@@ -70,12 +88,24 @@ def test_none(value_to_match: int | None):
 class A(str): ...
 
 
-def test_subclass(a: A):
+def test_subclass1(a: A):
     match a:
         case "TEST" as m:
             reveal_type(m, expected_text="A")
         case x:
             reveal_type(x, expected_text="A")
+
+
+def test_subclass2(subj: int):
+    match subj:
+        case 1.0e4:
+            reveal_type(subj, expected_text="int")
+
+
+def test_subclass3(subj: Literal[1]):
+    match subj:
+        case 1.0:
+            reveal_type(subj, expected_text="Literal[1]")
 
 
 T1 = TypeVar("T1", Literal["A"], Literal["B"])

--- a/packages/pyright-internal/src/tests/samples/matchMapping1.py
+++ b/packages/pyright-internal/src/tests/samples/matchMapping1.py
@@ -34,7 +34,7 @@ def test_dict(value_to_match: dict[str | int, str | int]):
             reveal_type(b3, expected_text="dict[str | int, str | int]")
             reveal_type(value_to_match, expected_text="dict[str | int, str | int]")
 
-        case {3j: c1}:
+        case {None: c1}:
             reveal_type(c1, expected_text="Never")
             reveal_type(value_to_match, expected_text="Never")
 

--- a/packages/pyright-internal/src/tests/samples/matchSequence1.py
+++ b/packages/pyright-internal/src/tests/samples/matchSequence1.py
@@ -258,7 +258,7 @@ def test_union(
             reveal_type(e1, expected_text="complex | float | Any")
             reveal_type(
                 value_to_match,
-                expected_text="tuple[Literal[3], complex] | tuple[Literal[3], float] | Sequence[Any]",
+                expected_text="tuple[complex, complex] | tuple[float, float] | Sequence[Any]",
             )
 
         case "hi", *f1:
@@ -267,11 +267,12 @@ def test_union(
 
         case *g1, 3j:
             reveal_type(
-                g1, expected_text="list[complex] | list[int | str | float] | list[Any]"
+                g1,
+                expected_text="list[complex] | list[int | str | float] | list[float] | list[Any]",
             )
             reveal_type(
                 value_to_match,
-                expected_text="tuple[complex, complex] | Tuple[int, str, float, complex] | Sequence[Any]",
+                expected_text="tuple[complex, complex] | Tuple[int, str, float, complex] | Tuple[float, ...] | Sequence[Any]",
             )
 
         case *h1, "hi":
@@ -369,8 +370,8 @@ def test_object1(seq: object):
             reveal_type(seq, expected_text="Sequence[Unknown]")
 
         case [1, "hi", True] as h1:
-            reveal_type(h1, expected_text="Sequence[int | str | bool]")
-            reveal_type(seq, expected_text="Sequence[int | str | bool]")
+            reveal_type(h1, expected_text="Sequence[Unknown]")
+            reveal_type(seq, expected_text="Sequence[Unknown]")
 
         case [1, i1] as i2:
             reveal_type(i1, expected_text="Unknown")


### PR DESCRIPTION
…uality checks, so matching against the pattern `3` cannot necessarily narrow the type to `Literal[3]`. This addresses #11026.