### PR TITLE
Fix completions for unpacking TypeDicts with missing fields

### DIFF
--- a/packages/pyright-internal/src/tests/completions.test.ts
+++ b/packages/pyright-internal/src/tests/completions.test.ts
@@ -1480,3 +1480,116 @@ test('overloaded Literal[...] suggestions in call arguments', async () => {
         },
     });
 });
+
+test('nested TypedDict completion with Unpack - without other fields', async () => {
+    const code = `
+// @filename: test.py
+//// from typing import Unpack, TypedDict
+//// 
+//// class InnerDict(TypedDict):
+////     a: int
+////     b: str
+//// 
+//// class OuterDict(TypedDict):
+////     inner: InnerDict
+////     field_1: str
+//// 
+//// def test_inner_dict(**kwargs: Unpack[OuterDict]):
+////     pass
+//// 
+//// test_inner_dict(inner={[|/*marker*/|]})
+    `;
+
+    const state = parseAndGetTestState(code).state;
+
+    await state.verifyCompletion('included', 'markdown', {
+        marker: {
+            completions: [
+                {
+                    kind: CompletionItemKind.Constant,
+                    label: "'a'",
+                    textEdit: { range: state.getPositionRange('marker'), newText: "'a'" },
+                },
+                {
+                    kind: CompletionItemKind.Constant,
+                    label: "'b'",
+                    textEdit: { range: state.getPositionRange('marker'), newText: "'b'" },
+                },
+            ],
+        },
+    });
+});
+
+test('nested TypedDict completion with Unpack - with other fields', async () => {
+    const code = `
+// @filename: test.py
+//// from typing import Unpack, TypedDict
+//// 
+//// class InnerDict(TypedDict):
+////     a: int
+////     b: str
+//// 
+//// class OuterDict(TypedDict):
+////     inner: InnerDict
+////     field_1: str
+//// 
+//// def test_inner_dict(**kwargs: Unpack[OuterDict]):
+////     pass
+//// 
+//// test_inner_dict(field_1="test", inner={[|/*marker*/|]})
+    `;
+
+    const state = parseAndGetTestState(code).state;
+
+    await state.verifyCompletion('included', 'markdown', {
+        marker: {
+            completions: [
+                {
+                    kind: CompletionItemKind.Constant,
+                    label: '"a"',
+                    textEdit: { range: state.getPositionRange('marker'), newText: '"a"' },
+                },
+                {
+                    kind: CompletionItemKind.Constant,
+                    label: '"b"',
+                    textEdit: { range: state.getPositionRange('marker'), newText: '"b"' },
+                },
+            ],
+        },
+    });
+});
+
+test('simple nested TypedDict completion - no Unpack', async () => {
+    const code = `
+// @filename: test.py
+//// from typing import TypedDict
+//// 
+//// class InnerDict(TypedDict):
+////     a: int
+////     b: str
+//// 
+//// def test_func(inner: InnerDict):
+////     pass
+//// 
+//// test_func(inner={[|/*marker*/|]})
+    `;
+
+    const state = parseAndGetTestState(code).state;
+
+    await state.verifyCompletion('included', 'markdown', {
+        marker: {
+            completions: [
+                {
+                    kind: CompletionItemKind.Constant,
+                    label: "'a'",
+                    textEdit: { range: state.getPositionRange('marker'), newText: "'a'" },
+                },
+                {
+                    kind: CompletionItemKind.Constant,
+                    label: "'b'",
+                    textEdit: { range: state.getPositionRange('marker'), newText: "'b'" },
+                },
+            ],
+        },
+    });
+});


### PR DESCRIPTION
Pylance has a bug that I thought I'd look into: https://github.com/microsoft/pylance-release/issues/6732

In error cases, completions don't come up. 

```
from typing import Unpack, TypedDict

class InnerDict(TypedDict):
    a: int
    b: str

class OuterDict(TypedDict):
    inner: InnerDict
    field_1: str

def test(**kwargs: Unpack[OuterDict]):
    pass

#  Completions for "a", "b" inside {} don't show up because field_1 is not present
test(inner={})

# Completions do work when field_1 is present
test(field_1="x", inner={})
```

The fix here was to include the inference context when validating arguments. 