### PR TITLE
Refactor import resolver infrastructure and enhance file system interactions

### DIFF
--- a/packages/pyright-internal/src/analyzer/importResolverFileSystem.ts
+++ b/packages/pyright-internal/src/analyzer/importResolverFileSystem.ts
@@ -1,0 +1,202 @@
+/*
+ * importResolverFileSystem.ts
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT license.
+ */
+
+import type { FileSystem, Stats } from '../common/fileSystem';
+import { stubsSuffix } from '../common/pathConsts';
+import { stripFileExtension } from '../common/pathUtils';
+import { Uri } from '../common/uri/uri';
+import { isDirectory, isFile, tryRealpath, tryStat } from '../common/uri/uriUtils';
+
+import { ImportResolverFileSystem } from './importResolverTypes';
+
+type Dirent = ReturnType<FileSystem['readdirEntriesSync']>[number];
+
+interface CachedDir {
+    entriesByName: ReadonlyMap<string, Dirent>;
+    entriesArray: Dirent[];
+    resolvableNames: ReadonlySet<string>;
+}
+
+export function createImportResolverFileSystem(fileSystem: FileSystem): ImportResolverFileSystem {
+    return new ImportResolverFileSystemImpl(fileSystem);
+}
+
+class ImportResolverFileSystemImpl implements ImportResolverFileSystem {
+    private readonly _cachedDirInfoForPath = new Map<string, CachedDir>();
+    private readonly _cachedFilesForPath = new Map<string, Uri[]>();
+    private readonly _cachedDirExistenceForRoot = new Map<string, boolean>();
+
+    constructor(private readonly _fileSystem: FileSystem) {}
+
+    invalidateCache(): void {
+        this._cachedDirInfoForPath.clear();
+        this._cachedFilesForPath.clear();
+        this._cachedDirExistenceForRoot.clear();
+    }
+
+    readdirEntriesSync(uri: Uri): Dirent[] {
+        return this._getCachedDir(uri).entriesArray;
+    }
+
+    getResolvableNamesInDirectory(dirPath: Uri): ReadonlySet<string> {
+        return this._getCachedDir(dirPath).resolvableNames;
+    }
+
+    fileExists(uri: Uri): boolean {
+        const directory = uri.getDirectory();
+        if (directory.equals(uri)) {
+            // Started at root, so this can't be a file.
+            return false;
+        }
+
+        const cachedDir = this._getCachedDir(directory);
+        const entry = cachedDir.entriesByName.get(uri.fileName);
+        if (entry?.isFile()) {
+            return true;
+        }
+
+        if (entry?.isSymbolicLink()) {
+            const realPath = tryRealpath(this._fileSystem, uri);
+            if (realPath && this._fileSystem.existsSync(realPath) && isFile(this._fileSystem, realPath)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    dirExists(uri: Uri): boolean {
+        const parent = uri.getDirectory();
+        if (parent.equals(uri)) {
+            // Started at root. No entries to read, so have to check ourselves.
+            const cachedExistence = this._cachedDirExistenceForRoot.get(uri.key);
+            if (cachedExistence !== undefined) {
+                return cachedExistence;
+            }
+
+            const exists = tryStat(this._fileSystem, uri)?.isDirectory() ?? false;
+            this._cachedDirExistenceForRoot.set(uri.key, exists);
+            return exists;
+        }
+
+        const cachedDir = this._getCachedDir(parent);
+        const entry = cachedDir.entriesByName.get(uri.fileName);
+        if (entry?.isDirectory()) {
+            return true;
+        }
+
+        if (entry?.isSymbolicLink()) {
+            const realPath = tryRealpath(this._fileSystem, uri);
+            if (realPath && this._fileSystem.existsSync(realPath) && isDirectory(this._fileSystem, realPath)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    getFilesInDirectory(dirPath: Uri): readonly Uri[] {
+        const cachedValue = this._cachedFilesForPath.get(dirPath.key);
+        if (cachedValue) {
+            return cachedValue;
+        }
+
+        let newCacheValue: Uri[] = [];
+        try {
+            const entriesInDir = this._getCachedDir(dirPath);
+            const filesInDir: Dirent[] = [];
+
+            // Add any files or symbolic links that point to files.
+            entriesInDir.entriesArray.forEach((entry) => {
+                if (entry.isFile()) {
+                    filesInDir.push(entry);
+                } else if (
+                    entry.isSymbolicLink() &&
+                    tryStat(this._fileSystem, dirPath.combinePaths(entry.name))?.isFile()
+                ) {
+                    filesInDir.push(entry);
+                }
+            });
+
+            newCacheValue = filesInDir.map((f) => dirPath.combinePaths(f.name));
+        } catch {
+            newCacheValue = [];
+        }
+
+        this._cachedFilesForPath.set(dirPath.key, newCacheValue);
+        return newCacheValue;
+    }
+
+    existsSync(uri: Uri): boolean {
+        return this._fileSystem.existsSync(uri);
+    }
+
+    readFileSync(uri: Uri, encoding?: null): Buffer;
+    readFileSync(uri: Uri, encoding: BufferEncoding): string;
+    readFileSync(uri: Uri, encoding?: BufferEncoding | null): string | Buffer {
+        return this._fileSystem.readFileSync(uri, encoding as BufferEncoding | null);
+    }
+
+    statSync(uri: Uri): Stats {
+        return this._fileSystem.statSync(uri);
+    }
+
+    realCasePath(uri: Uri): Uri {
+        return this._fileSystem.realCasePath(uri);
+    }
+
+    getModulePath(): Uri {
+        return this._fileSystem.getModulePath();
+    }
+
+    private _getCachedDir(dirPath: Uri): CachedDir {
+        const cachedValue = this._cachedDirInfoForPath.get(dirPath.key);
+        if (cachedValue) {
+            return cachedValue;
+        }
+
+        const entriesByName = new Map<string, Dirent>();
+        const resolvableNames = new Set<string>();
+        let entriesArray: Dirent[] = [];
+
+        try {
+            const entries = this._fileSystem.readdirEntriesSync(dirPath);
+            entriesArray = entries;
+
+            entries.forEach((entry) => {
+                entriesByName.set(entry.name, entry);
+
+                let isFile = entry.isFile();
+                let isDirectory = entry.isDirectory();
+                if (entry.isSymbolicLink()) {
+                    const stat = tryStat(this._fileSystem, dirPath.combinePaths(entry.name));
+                    isFile = !!stat?.isFile();
+                    isDirectory = !!stat?.isDirectory();
+                }
+
+                const resolvableName = isFile
+                    ? stripFileExtension(entry.name, /* multiDotExtension */ true)
+                    : entry.name;
+                resolvableNames.add(resolvableName);
+
+                if (isDirectory && entry.name.endsWith(stubsSuffix)) {
+                    resolvableNames.add(resolvableName.substring(0, resolvableName.length - stubsSuffix.length));
+                }
+            });
+        } catch {
+            // Swallow error.
+        }
+
+        const frozen: CachedDir = {
+            entriesByName,
+            entriesArray,
+            resolvableNames,
+        };
+
+        this._cachedDirInfoForPath.set(dirPath.key, frozen);
+        return frozen;
+    }
+}

--- a/packages/pyright-internal/src/analyzer/importResolverTypes.ts
+++ b/packages/pyright-internal/src/analyzer/importResolverTypes.ts
@@ -1,0 +1,61 @@
+/*
+ * importResolverTypes.ts
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT license.
+ */
+
+import type { FileSystem } from '../common/fileSystem';
+import type { PythonVersion } from '../common/pythonVersion';
+import type { Uri } from '../common/uri/uri';
+import type { ImportLogger } from './importLogger';
+
+export interface SupportedVersionInfo {
+    min: PythonVersion;
+    max?: PythonVersion | undefined;
+    unsupportedPlatforms?: string[];
+    supportedPlatforms?: string[];
+}
+
+export type TypeshedThirdPartyPackageMapResult = readonly [ReadonlyMap<string, readonly Uri[]>, readonly Uri[]];
+
+// Optional hook used to override how typeshed-derived information is computed and cached.
+//
+// ImportResolver will consult this service (if registered) before falling back to a default
+// implementation. Tests can use this to provide a memoized implementation so expensive
+// typeshed scanning/reading work is performed once and reused across many ImportResolver instances.
+export interface TypeshedInfoProvider {
+    getTypeshedRoot(customTypeshedPath: Uri | undefined, importLogger?: ImportLogger): Uri | undefined;
+
+    getTypeshedSubdirectory(
+        isStdLib: boolean,
+        customTypeshedPath: Uri | undefined,
+        importLogger?: ImportLogger
+    ): Uri | undefined;
+
+    getThirdPartyPackageMap(
+        customTypeshedPath: Uri | undefined,
+        importLogger?: ImportLogger
+    ): TypeshedThirdPartyPackageMapResult;
+
+    getStdLibModuleVersionInfo(
+        customTypeshedPath: Uri | undefined,
+        importLogger?: ImportLogger
+    ): ReadonlyMap<string, SupportedVersionInfo>;
+}
+
+// Minimal cached filesystem facade used by ImportResolver.
+//
+// It caches directory enumeration and a few existence/file-list lookups to avoid repeated IO.
+// The API is intentionally small and tailored to ImportResolver's needs.
+export interface ImportResolverFileSystem
+    extends Pick<
+        FileSystem,
+        'existsSync' | 'realCasePath' | 'getModulePath' | 'readdirEntriesSync' | 'readFileSync' | 'statSync'
+    > {
+    // ImportResolver-specific helper.
+    fileExists(uri: Uri): boolean;
+    dirExists(uri: Uri): boolean;
+    getFilesInDirectory(dirPath: Uri): readonly Uri[];
+    getResolvableNamesInDirectory(dirPath: Uri): ReadonlySet<string>;
+    invalidateCache(): void;
+}

--- a/packages/pyright-internal/src/analyzer/pythonPathUtils.ts
+++ b/packages/pyright-internal/src/analyzer/pythonPathUtils.ts
@@ -25,7 +25,7 @@ export interface PythonPathResult {
 export const stdLibFolderName = 'stdlib';
 export const thirdPartyFolderName = 'stubs';
 
-export function getTypeShedFallbackPath(fs: FileSystem) {
+export function getTypeShedFallbackPath(fs: Pick<FileSystem, 'getModulePath' | 'existsSync' | 'realCasePath'>) {
     const moduleDirectory = fs.getModulePath();
     if (!moduleDirectory || moduleDirectory.isEmpty()) {
         return undefined;

--- a/packages/pyright-internal/src/analyzer/typeshedInfoProvider.ts
+++ b/packages/pyright-internal/src/analyzer/typeshedInfoProvider.ts
@@ -1,0 +1,252 @@
+/*
+ * typeshedInfoProvider.ts
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT license.
+ */
+
+import { stripFileExtension } from '../common/pathUtils';
+import { pythonVersion3_0, PythonVersion } from '../common/pythonVersion';
+import { Uri } from '../common/uri/uri';
+
+import type { ImportLogger } from './importLogger';
+import {
+    ImportResolverFileSystem,
+    SupportedVersionInfo,
+    TypeshedInfoProvider,
+    TypeshedThirdPartyPackageMapResult,
+} from './importResolverTypes';
+import * as PythonPathUtils from './pythonPathUtils';
+
+export function createDefaultTypeshedInfoProvider(fileSystem: ImportResolverFileSystem): TypeshedInfoProvider {
+    return new DefaultTypeshedInfoProvider(fileSystem);
+}
+
+class DefaultTypeshedInfoProvider implements TypeshedInfoProvider {
+    private readonly _typeshedRootCache = new Map<string, Uri | undefined>();
+    private readonly _typeshedSubdirectoryCache = new Map<string, Uri | undefined>();
+    private readonly _thirdPartyPackageMapCache = new Map<string, TypeshedThirdPartyPackageMapResult>();
+    private readonly _stdlibVersionInfoCache = new Map<string, ReadonlyMap<string, SupportedVersionInfo>>();
+
+    constructor(private readonly _fileSystem: ImportResolverFileSystem) {
+        // Empty
+    }
+
+    getTypeshedRoot(customTypeshedPath: Uri | undefined, _importLogger?: ImportLogger): Uri | undefined {
+        const key = customTypeshedPath?.key ?? '';
+        const cached = this._typeshedRootCache.get(key);
+        if (cached !== undefined) {
+            return cached;
+        }
+
+        const root = this._computeTypeshedRoot(customTypeshedPath);
+        this._typeshedRootCache.set(key, root);
+        return root;
+    }
+
+    getTypeshedSubdirectory(
+        isStdLib: boolean,
+        customTypeshedPath: Uri | undefined,
+        importLogger?: ImportLogger
+    ): Uri | undefined {
+        const key = `${isStdLib ? 'stdlib' : 'thirdParty'}:${customTypeshedPath?.key ?? ''}`;
+        const cached = this._typeshedSubdirectoryCache.get(key);
+        if (cached !== undefined) {
+            return cached;
+        }
+
+        const typeshedRoot = this.getTypeshedRoot(customTypeshedPath, importLogger);
+        if (!typeshedRoot) {
+            this._typeshedSubdirectoryCache.set(key, undefined);
+            return undefined;
+        }
+
+        const subdir = PythonPathUtils.getTypeshedSubdirectory(typeshedRoot, isStdLib);
+        if (!this._fileSystem.dirExists(subdir)) {
+            this._typeshedSubdirectoryCache.set(key, undefined);
+            return undefined;
+        }
+
+        this._typeshedSubdirectoryCache.set(key, subdir);
+        return subdir;
+    }
+
+    getThirdPartyPackageMap(
+        customTypeshedPath: Uri | undefined,
+        importLogger?: ImportLogger
+    ): TypeshedThirdPartyPackageMapResult {
+        const key = customTypeshedPath?.key ?? '';
+        const cached = this._thirdPartyPackageMapCache.get(key);
+        if (cached) {
+            return cached;
+        }
+
+        const thirdPartyDir = this.getTypeshedSubdirectory(/* isStdLib */ false, customTypeshedPath, importLogger);
+        const typeshedThirdPartyPackagePaths = new Map<string, Uri[]>();
+
+        if (thirdPartyDir) {
+            // `readdirEntriesSync` is cached by ImportResolverFileSystem, so repeated calls across
+            // ImportResolvers will share the same cached directory enumerations.
+            for (const outerEntry of this._fileSystem.readdirEntriesSync(thirdPartyDir)) {
+                if (!outerEntry.isDirectory()) {
+                    continue;
+                }
+
+                const innerDirPath = thirdPartyDir.combinePaths(outerEntry.name);
+
+                for (const innerEntry of this._fileSystem.readdirEntriesSync(innerDirPath)) {
+                    if (innerEntry.name === '@python2') {
+                        continue;
+                    }
+
+                    if (innerEntry.isDirectory()) {
+                        const pathList = typeshedThirdPartyPackagePaths.get(innerEntry.name);
+                        if (pathList) {
+                            pathList.push(innerDirPath);
+                        } else {
+                            typeshedThirdPartyPackagePaths.set(innerEntry.name, [innerDirPath]);
+                        }
+                    } else if (innerEntry.isFile()) {
+                        if (innerEntry.name.endsWith('.pyi')) {
+                            const strippedFileName = stripFileExtension(innerEntry.name);
+                            const pathList = typeshedThirdPartyPackagePaths.get(strippedFileName);
+                            if (pathList) {
+                                pathList.push(innerDirPath);
+                            } else {
+                                typeshedThirdPartyPackagePaths.set(strippedFileName, [innerDirPath]);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        const flattenPaths = Array.from(typeshedThirdPartyPackagePaths.values()).flatMap((v) => v);
+        const result: TypeshedThirdPartyPackageMapResult = [
+            typeshedThirdPartyPackagePaths,
+            Array.from(new Set(flattenPaths)).sort(),
+        ];
+
+        this._thirdPartyPackageMapCache.set(key, result);
+        return result;
+    }
+
+    getStdLibModuleVersionInfo(
+        customTypeshedPath: Uri | undefined,
+        importLogger?: ImportLogger
+    ): ReadonlyMap<string, SupportedVersionInfo> {
+        const key = customTypeshedPath?.key ?? '';
+        const cached = this._stdlibVersionInfoCache.get(key);
+        if (cached) {
+            return cached;
+        }
+
+        const versionRangeMap = new Map<string, SupportedVersionInfo>();
+
+        // Read the VERSIONS file from typeshed.
+        const typeshedStdLibPath = this.getTypeshedSubdirectory(/* isStdLib */ true, customTypeshedPath, importLogger);
+        if (typeshedStdLibPath) {
+            const versionsFilePath = typeshedStdLibPath.combinePaths('VERSIONS');
+            try {
+                const fileStats = this._fileSystem.statSync(versionsFilePath);
+                if (fileStats.size > 0 && fileStats.size < 256 * 1024) {
+                    const fileContents = this._fileSystem.readFileSync(versionsFilePath, 'utf8');
+                    fileContents.split(/\r?\n/).forEach((line) => {
+                        const commentSplit = line.split('#');
+
+                        // Platform-specific information can be specified after a semicolon.
+                        const semicolonSplit = commentSplit[0].split(';').map((s) => s.trim());
+
+                        // Version information is found after a colon.
+                        const colonSplit = semicolonSplit[0].split(':');
+                        if (colonSplit.length !== 2) {
+                            return;
+                        }
+
+                        const versionSplit = colonSplit[1].split('-');
+                        if (versionSplit.length > 2) {
+                            return;
+                        }
+
+                        const moduleName = colonSplit[0].trim();
+                        if (!moduleName) {
+                            return;
+                        }
+
+                        let minVersionString = versionSplit[0].trim();
+                        if (minVersionString.endsWith('+')) {
+                            // If the version ends in "+", strip it off.
+                            minVersionString = minVersionString.substr(0, minVersionString.length - 1);
+                        }
+
+                        let minVersion = PythonVersion.fromString(minVersionString);
+                        if (!minVersion) {
+                            minVersion = pythonVersion3_0;
+                        }
+
+                        let maxVersion: PythonVersion | undefined;
+                        if (versionSplit.length > 1) {
+                            maxVersion = PythonVersion.fromString(versionSplit[1].trim());
+                        }
+
+                        // A semicolon can be followed by a semicolon-delimited list of other
+                        // exclusions. The "platform" exclusion is a comma delimited list platforms
+                        // that are supported or not supported.
+                        let supportedPlatforms: string[] | undefined;
+                        let unsupportedPlatforms: string[] | undefined;
+                        const platformsHeader = 'platforms=';
+                        let platformExclusions = semicolonSplit.slice(1).find((s) => s.startsWith(platformsHeader));
+
+                        if (platformExclusions) {
+                            platformExclusions = platformExclusions.trim().substring(platformsHeader.length);
+                            const commaSplit = platformExclusions.split(',');
+                            for (let platform of commaSplit) {
+                                platform = platform.trim();
+                                let isUnsupported = false;
+
+                                // Remove the '!' from the start if it's an exclusion.
+                                if (platform.startsWith('!')) {
+                                    isUnsupported = true;
+                                    platform = platform.substring(1);
+                                }
+
+                                if (isUnsupported) {
+                                    unsupportedPlatforms = unsupportedPlatforms ?? [];
+                                    unsupportedPlatforms.push(platform);
+                                } else {
+                                    supportedPlatforms = supportedPlatforms ?? [];
+                                    supportedPlatforms.push(platform);
+                                }
+                            }
+                        }
+
+                        versionRangeMap.set(moduleName, {
+                            min: minVersion,
+                            max: maxVersion,
+                            supportedPlatforms,
+                            unsupportedPlatforms,
+                        });
+                    });
+                } else {
+                    importLogger?.log(`Typeshed stdlib VERSIONS file is unexpectedly large`);
+                }
+            } catch (e: any) {
+                importLogger?.log(`Could not read typeshed stdlib VERSIONS file: '${JSON.stringify(e)}'`);
+            }
+        }
+
+        this._stdlibVersionInfoCache.set(key, versionRangeMap);
+        return versionRangeMap;
+    }
+
+    private _computeTypeshedRoot(customTypeshedPath: Uri | undefined): Uri | undefined {
+        // Did the user specify a typeshed path? If not, use the fallback.
+        if (customTypeshedPath) {
+            if (this._fileSystem.dirExists(customTypeshedPath)) {
+                return customTypeshedPath;
+            }
+        }
+
+        const fallback = PythonPathUtils.getTypeShedFallbackPath(this._fileSystem) ?? Uri.empty();
+        return fallback.isEmpty() ? undefined : fallback;
+    }
+}

--- a/packages/pyright-internal/src/common/collectionUtils.ts
+++ b/packages/pyright-internal/src/common/collectionUtils.ts
@@ -62,7 +62,7 @@ export function append<T>(to: T[] | undefined, value: T | undefined): T[] | unde
  * same as receiver.push(...elementsToPush) except that it doesn't risk overflowing
  * the stack if elementsToPush is very large.
  */
-export function appendArray<T>(to: T[], elementsToPush: T[]) {
+export function appendArray<T>(to: T[], elementsToPush: readonly T[]) {
     if (elementsToPush.length < 256) {
         to.push(...elementsToPush);
         return;
@@ -307,7 +307,7 @@ export function binarySearchKey<T, U>(
  *
  * @param array The array to flatten.
  */
-export function flatten<T>(array: (NonNullable<T>[] | NonNullable<T>)[]): T[] {
+export function flatten<T>(array: (readonly NonNullable<T>[] | NonNullable<T>)[]): T[] {
     const result: T[] = [];
     for (const v of array) {
         if (v) {
@@ -383,7 +383,7 @@ export function addIfUnique<T>(arr: T[], t: T, equalityComparer: EqualityCompare
     return arr;
 }
 
-export function getMapValues<K, V>(m: Map<K, V>, predicate: (k: K, v: V) => boolean): V[] {
+export function getMapValues<K, V>(m: ReadonlyMap<K, V>, predicate: (k: K, v: V) => boolean): V[] {
     const values: V[] = [];
     m.forEach((v, k) => {
         if (predicate(k, v)) {

--- a/packages/pyright-internal/src/common/core.ts
+++ b/packages/pyright-internal/src/common/core.ts
@@ -72,7 +72,7 @@ export function compareValues(a: number | undefined, b: number | undefined): Com
 /**
  * Tests whether a value is an array.
  */
-export function isArray<T extends any[]>(value: any): value is T {
+export function isArray<T extends any[] | readonly any[]>(value: any): value is T {
     return Array.isArray ? Array.isArray(value) : value instanceof Array;
 }
 

--- a/packages/pyright-internal/src/common/pathUtils.ts
+++ b/packages/pyright-internal/src/common/pathUtils.ts
@@ -61,7 +61,10 @@ export namespace FileSpec {
 }
 
 export interface FileSystemEntries {
-    files: string[];
+    files: {
+        name: string;
+        size: number;
+    }[];
     directories: string[];
 }
 

--- a/packages/pyright-internal/src/common/serviceKeys.ts
+++ b/packages/pyright-internal/src/common/serviceKeys.ts
@@ -8,6 +8,7 @@
 
 import { CacheManager } from '../analyzer/cacheManager';
 import { ISourceFileFactory } from '../analyzer/programTypes';
+import { ImportResolverFileSystem, TypeshedInfoProvider } from '../analyzer/importResolverTypes';
 import { SupportPartialStubs } from '../partialStubService';
 import { CancellationProvider } from './cancellationUtils';
 import { CaseSensitivityDetector } from './caseSensitivityDetector';
@@ -41,4 +42,6 @@ export namespace ServiceKeys {
     export const windowService = new ServiceKey<WindowService>('WindowService');
     export const commandService = new ServiceKey<CommandService>('CommandService');
     export const cancellationProvider = new ServiceKey<CancellationProvider>('CancellationProvider');
+    export const importResolverFileSystem = new ServiceKey<ImportResolverFileSystem>('ImportResolverFileSystem');
+    export const typeshedInfoProvider = new ServiceKey<TypeshedInfoProvider>('TypeshedInfoProvider');
 }

--- a/packages/pyright-internal/src/common/serviceProviderExtensions.ts
+++ b/packages/pyright-internal/src/common/serviceProviderExtensions.ts
@@ -8,7 +8,7 @@
 import { CacheManager } from '../analyzer/cacheManager';
 import { ISourceFileFactory } from '../analyzer/programTypes';
 import { IPythonMode, SourceFile, SourceFileEditMode } from '../analyzer/sourceFile';
-import { PartialStubService, SupportPartialStubs } from '../partialStubService';
+import { NoOpPartialStubs, SupportPartialStubs } from '../partialStubService';
 import { CancellationProvider, DefaultCancellationProvider } from './cancellationUtils';
 import { CaseSensitivityDetector } from './caseSensitivityDetector';
 import { ConsoleInterface, NullConsole } from './console';
@@ -86,13 +86,15 @@ ServiceProvider.prototype.console = function () {
     }
     return this.get(ServiceKeys.console);
 };
+
 ServiceProvider.prototype.partialStubs = function () {
     const result = this.tryGet(ServiceKeys.partialStubs);
     if (!result) {
-        this.add(ServiceKeys.partialStubs, new PartialStubService(this.fs()));
+        this.add(ServiceKeys.partialStubs, new NoOpPartialStubs());
     }
     return this.get(ServiceKeys.partialStubs);
 };
+
 ServiceProvider.prototype.tmp = function () {
     return this.tryGet(ServiceKeys.tempFile);
 };

--- a/packages/pyright-internal/src/partialStubService.ts
+++ b/packages/pyright-internal/src/partialStubService.ts
@@ -44,7 +44,9 @@ export class PartialStubService implements SupportPartialStubs {
     // Disposables to cleanup moved directories
     private _movedDirectories: Disposable[] = [];
 
-    constructor(private _realFs: FileSystem) {}
+    constructor(private _realFs: FileSystem) {
+        // Empty
+    }
 
     isPartialStubPackagesScanned(execEnv: ExecutionEnvironment): boolean {
         return execEnv.root ? this.isPathScanned(execEnv.root) : false;
@@ -150,5 +152,29 @@ export class PartialStubService implements SupportPartialStubs {
         // If partial stub we found is from bundled stub and library installed is marked as py.typed
         // allow moving only if the package is marked as partially typed.
         return !packagePyTyped || packagePyTyped.isPartiallyTyped;
+    }
+}
+
+/**
+ * A no-op implementation of SupportPartialStubs for testing scenarios that don't require
+ * partial stub package resolution. This avoids the expensive file system scanning overhead
+ * of PartialStubService.processPartialStubPackages.
+ */
+export class NoOpPartialStubs implements SupportPartialStubs {
+    isPartialStubPackagesScanned(_execEnv: ExecutionEnvironment): boolean {
+        // Always report as already scanned to prevent actual scanning.
+        return true;
+    }
+
+    isPathScanned(_path: Uri): boolean {
+        return true;
+    }
+
+    processPartialStubPackages(_paths: Uri[], _roots: Uri[], _bundledStubPath?: Uri): void {
+        // No-op: skip all file system operations.
+    }
+
+    clearPartialStubs(): void {
+        // No-op.
     }
 }

--- a/packages/pyright-internal/src/tests/fourSlashRunner.test.ts
+++ b/packages/pyright-internal/src/tests/fourSlashRunner.test.ts
@@ -29,7 +29,7 @@ describe('fourslash tests', () => {
 
             // TODO: make these to use promise/async rather than callback token
             it('fourslash test ' + justName + ' run', (cb) => {
-                runFourSlashTest(MODULE_PATH, fn, cb);
+                runFourSlashTest(MODULE_PATH, fn, cb, { enablePartialStub: true });
             });
         });
     });

--- a/packages/pyright-internal/src/tests/harness/fourslash/runner.ts
+++ b/packages/pyright-internal/src/tests/harness/fourslash/runner.ts
@@ -12,15 +12,10 @@ import { combinePaths } from '../../../common/pathUtils';
 import * as host from '../testHost';
 import { parseTestData } from './fourSlashParser';
 import { FourSlashData } from './fourSlashTypes';
-import { HostSpecificFeatures, TestState } from './testState';
+import { TestState, TestStateOptions } from './testState';
 import { Consts } from './testState.Consts';
 
-export type TestStateFactory = (
-    basePath: string,
-    testData: FourSlashData,
-    mountPaths?: Map<string, string>,
-    hostSpecificFeatures?: HostSpecificFeatures
-) => TestState;
+export type TestStateFactory = (basePath: string, testData: FourSlashData, options?: TestStateOptions) => TestState;
 
 /**
  * run given fourslash test file
@@ -32,12 +27,11 @@ export function runFourSlashTest(
     basePath: string,
     fileName: string,
     cb?: jest.DoneCallback,
-    mountPaths?: Map<string, string>,
-    hostSpecificFeatures?: HostSpecificFeatures,
+    stateOptions?: TestStateOptions,
     testStateFactory?: TestStateFactory
 ) {
     const content = host.HOST.readFile(fileName)!;
-    runFourSlashTestContent(basePath, fileName, content, cb, mountPaths, hostSpecificFeatures, testStateFactory);
+    runFourSlashTestContent(basePath, fileName, content, cb, stateOptions, testStateFactory);
 }
 
 /**
@@ -53,8 +47,7 @@ export function runFourSlashTestContent(
     fileName: string,
     content: string,
     cb?: jest.DoneCallback,
-    mountPaths?: Map<string, string>,
-    hostSpecificFeatures?: HostSpecificFeatures,
+    stateOptions?: TestStateOptions,
     testStateFactory?: TestStateFactory
 ) {
     // give file paths an absolute path for the virtual file system
@@ -65,8 +58,8 @@ export function runFourSlashTestContent(
     const testData = parseTestData(absoluteBasePath, content, absoluteFileName);
     const state =
         testStateFactory !== undefined
-            ? testStateFactory(absoluteBasePath, testData, mountPaths, hostSpecificFeatures)
-            : new TestState(absoluteBasePath, testData, mountPaths, hostSpecificFeatures);
+            ? testStateFactory(absoluteBasePath, testData, stateOptions)
+            : new TestState(absoluteBasePath, testData, stateOptions);
     const output = ts.transpileModule(content, {
         reportDiagnostics: true,
         compilerOptions: { target: ts.ScriptTarget.ES2019 },

--- a/packages/pyright-internal/src/tests/harness/vfs/factory.ts
+++ b/packages/pyright-internal/src/tests/harness/vfs/factory.ts
@@ -188,9 +188,12 @@ function canReuseCache(host: TestHost, mountPaths: Map<string, string>): boolean
 
 function createResolver(host: TestHost): FileSystemResolver {
     return {
-        readdirSync(path: string): string[] {
+        readdirSync(path: string) {
             const { files, directories } = host.getAccessibleFileSystemEntries(path);
-            return directories.concat(files);
+            return [
+                ...directories.map((name) => ({ name, kind: 'directory' as const })),
+                ...files.map((entry) => ({ name: entry.name, kind: 'file' as const, size: entry.size })),
+            ];
         },
         statSync(path: string): { mode: number; size: number } {
             if (host.directoryExists(path)) {

--- a/packages/pyright-internal/src/tests/importResolverSupport.test.ts
+++ b/packages/pyright-internal/src/tests/importResolverSupport.test.ts
@@ -1,0 +1,434 @@
+/*
+ * importResolverInfrastructure.test.ts
+ *
+ * Unit tests for the extracted ImportResolver infrastructure helpers.
+ */
+
+import assert from 'assert';
+
+import { createImportResolverFileSystem } from '../analyzer/importResolverFileSystem';
+import { ImportLogger } from '../analyzer/importLogger';
+import { createDefaultTypeshedInfoProvider } from '../analyzer/typeshedInfoProvider';
+import { typeshedFallback } from '../common/pathConsts';
+import { normalizeSlashes } from '../common/pathUtils';
+import { PythonVersion } from '../common/pythonVersion';
+import { Uri } from '../common/uri/uri';
+import { TestFileSystem } from './harness/vfs/filesystem';
+
+function normalizedPath(uri: Uri): string {
+    return normalizeSlashes(uri.getFilePath(), '/');
+}
+
+describe('ImportResolverFileSystem', () => {
+    test('readdirEntriesSync caches per-directory and is cleared by invalidateCache', () => {
+        const fs = new TestFileSystem(/* ignoreCase */ false, { cwd: '/' });
+        fs.mkdirpSync('/dir');
+        fs.writeFileSync(Uri.file('/dir/a.py', fs), '');
+
+        const spy = jest.spyOn(fs, 'readdirEntriesSync');
+
+        const cache = createImportResolverFileSystem(fs);
+        cache.readdirEntriesSync(Uri.file('/dir', fs));
+        cache.readdirEntriesSync(Uri.file('/dir', fs));
+        assert.strictEqual(spy.mock.calls.length, 1);
+
+        cache.invalidateCache();
+        cache.readdirEntriesSync(Uri.file('/dir', fs));
+        assert.strictEqual(spy.mock.calls.length, 2);
+
+        spy.mockRestore();
+    });
+
+    test('fileExists/dirExists follow symlinks via realpath (parity with pre-refactor behavior)', () => {
+        const fs = new TestFileSystem(/* ignoreCase */ false, { cwd: '/' });
+        fs.mkdirpSync('/realDir');
+        fs.writeFileSync(Uri.file('/realFile.txt', fs), 'x');
+        fs.mkdirpSync('/links');
+        fs.symlinkSync('/realFile.txt', '/links/fileLink.txt');
+        fs.symlinkSync('/realDir', '/links/dirLink');
+
+        const cache = createImportResolverFileSystem(fs);
+
+        assert.strictEqual(cache.fileExists(Uri.file('/links/fileLink.txt', fs)), true);
+        assert.strictEqual(cache.fileExists(Uri.file('/links/dirLink', fs)), false);
+
+        assert.strictEqual(cache.dirExists(Uri.file('/links/dirLink', fs)), true);
+        assert.strictEqual(cache.dirExists(Uri.file('/links/fileLink.txt', fs)), false);
+    });
+
+    test('fileExists/dirExists return false for missing paths and broken symlinks', () => {
+        const fs = new TestFileSystem(/* ignoreCase */ false, { cwd: '/' });
+        fs.mkdirpSync('/links');
+        fs.symlinkSync('/doesNotExist', '/links/brokenLink');
+
+        const cache = createImportResolverFileSystem(fs);
+
+        assert.strictEqual(cache.fileExists(Uri.file('/missingFile', fs)), false);
+        assert.strictEqual(cache.dirExists(Uri.file('/missingDir', fs)), false);
+
+        assert.strictEqual(cache.fileExists(Uri.file('/links/brokenLink', fs)), false);
+        assert.strictEqual(cache.dirExists(Uri.file('/links/brokenLink', fs)), false);
+    });
+
+    test('dirExists caches existence checks for root', () => {
+        const fs = new TestFileSystem(/* ignoreCase */ false, { cwd: '/' });
+        const statSpy = jest.spyOn(fs, 'statSync');
+
+        const cache = createImportResolverFileSystem(fs);
+        const root = Uri.file('/', fs);
+
+        assert.strictEqual(cache.dirExists(root), true);
+        assert.strictEqual(cache.dirExists(root), true);
+
+        // For the root path we should consult the filesystem once and then cache the result.
+        assert.strictEqual(statSpy.mock.calls.length, 1);
+        statSpy.mockRestore();
+    });
+
+    test('getFilesInDirectory returns files and symlinks-to-files and caches results', () => {
+        const fs = new TestFileSystem(/* ignoreCase */ false, { cwd: '/' });
+        fs.mkdirpSync('/dir');
+        fs.writeFileSync(Uri.file('/dir/a.py', fs), '');
+        fs.writeFileSync(Uri.file('/realFile.txt', fs), 'x');
+        fs.symlinkSync('/realFile.txt', '/dir/fileLink.txt');
+
+        const readdirSpy = jest.spyOn(fs, 'readdirEntriesSync');
+
+        const cache = createImportResolverFileSystem(fs);
+        const dir = Uri.file('/dir', fs);
+
+        const files1 = cache.getFilesInDirectory(dir);
+        assert(files1.some((u) => normalizedPath(u) === '/dir/a.py'));
+        assert(files1.some((u) => normalizedPath(u) === '/dir/fileLink.txt'));
+
+        const callsAfterFirst = readdirSpy.mock.calls.length;
+
+        const files2 = cache.getFilesInDirectory(dir);
+        assert.deepStrictEqual(
+            files2.map((u) => normalizedPath(u)).sort(),
+            files1.map((u) => normalizedPath(u)).sort()
+        );
+
+        // Second call should be served from cache.
+        assert.strictEqual(readdirSpy.mock.calls.length, callsAfterFirst);
+
+        readdirSpy.mockRestore();
+    });
+
+    test('getFilesInDirectory is stale until invalidateCache', () => {
+        const fs = new TestFileSystem(/* ignoreCase */ false, { cwd: '/' });
+        fs.mkdirpSync('/dir');
+        fs.writeFileSync(Uri.file('/dir/a.py', fs), '');
+
+        const cache = createImportResolverFileSystem(fs);
+        const dir = Uri.file('/dir', fs);
+
+        const files1 = cache
+            .getFilesInDirectory(dir)
+            .map((u) => normalizedPath(u))
+            .sort();
+        assert.deepStrictEqual(files1, ['/dir/a.py']);
+
+        fs.writeFileSync(Uri.file('/dir/b.py', fs), '');
+
+        // Served from cache, so it won't include newly-added files.
+        const files2 = cache
+            .getFilesInDirectory(dir)
+            .map((u) => normalizedPath(u))
+            .sort();
+        assert.deepStrictEqual(files2, ['/dir/a.py']);
+
+        cache.invalidateCache();
+        const files3 = cache
+            .getFilesInDirectory(dir)
+            .map((u) => normalizedPath(u))
+            .sort();
+        assert.deepStrictEqual(files3, ['/dir/a.py', '/dir/b.py']);
+    });
+
+    test('getResolvableNamesInDirectory includes extensionless file names and -stubs suffix stripping', () => {
+        const fs = new TestFileSystem(/* ignoreCase */ false, { cwd: '/' });
+        fs.mkdirpSync('/dir');
+        fs.mkdirpSync('/dir/pkg-stubs');
+        fs.writeFileSync(Uri.file('/dir/foo.cpython-311-x86_64-linux-gnu.so', fs), '');
+
+        const cache = createImportResolverFileSystem(fs);
+        const names = cache.getResolvableNamesInDirectory(Uri.file('/dir', fs));
+
+        assert(names.has('pkg-stubs'));
+        assert(names.has('pkg'));
+        assert(names.has('foo'));
+    });
+
+    test('getResolvableNamesInDirectory strips extensions (including multi-dot) and follows symlinks for file-ness', () => {
+        const fs = new TestFileSystem(/* ignoreCase */ false, { cwd: '/' });
+        fs.mkdirpSync('/dir');
+
+        fs.writeFileSync(Uri.file('/dir/a.py', fs), '');
+        fs.writeFileSync(Uri.file('/dir/b.pyi', fs), '');
+        fs.writeFileSync(Uri.file('/dir/c.pyc', fs), '');
+        fs.writeFileSync(Uri.file('/dir/foo.cpython-311-x86_64-linux-gnu.so', fs), '');
+
+        fs.writeFileSync(Uri.file('/real.pyi', fs), 'x');
+        fs.symlinkSync('/real.pyi', '/dir/link.pyi');
+
+        const cache = createImportResolverFileSystem(fs);
+        const names = cache.getResolvableNamesInDirectory(Uri.file('/dir', fs));
+
+        assert(names.has('a'));
+        assert(names.has('b'));
+        assert(names.has('c'));
+        assert(names.has('foo'));
+        assert(names.has('link'));
+    });
+
+    test('readdirEntriesSync failures are swallowed and cached until invalidateCache', () => {
+        const fs = new TestFileSystem(/* ignoreCase */ false, { cwd: '/' });
+        fs.mkdirpSync('/boom');
+
+        const original = fs.readdirEntriesSync.bind(fs);
+        const readdirSpy = jest.spyOn(fs, 'readdirEntriesSync').mockImplementation((uri) => {
+            if (normalizedPath(uri) === '/boom') {
+                throw new Error('boom');
+            }
+            return original(uri);
+        });
+
+        const cache = createImportResolverFileSystem(fs);
+
+        assert.deepStrictEqual(cache.readdirEntriesSync(Uri.file('/boom', fs)), []);
+        assert.deepStrictEqual(cache.readdirEntriesSync(Uri.file('/boom', fs)), []);
+
+        // Only one underlying call, and then we serve the cached empty value.
+        assert.strictEqual(readdirSpy.mock.calls.length, 1);
+
+        cache.invalidateCache();
+        assert.deepStrictEqual(cache.readdirEntriesSync(Uri.file('/boom', fs)), []);
+        assert.strictEqual(readdirSpy.mock.calls.length, 2);
+
+        readdirSpy.mockRestore();
+    });
+});
+
+describe('TypeshedInfoProvider (default)', () => {
+    function createFsWithTypeshedLayout() {
+        const fs = new TestFileSystem(/* ignoreCase */ false, { cwd: '/' });
+
+        const typeshedRoot = `/${typeshedFallback}`;
+        fs.mkdirpSync(typeshedRoot);
+        fs.mkdirpSync(`${typeshedRoot}/stdlib`);
+        fs.mkdirpSync(`${typeshedRoot}/stubs`);
+
+        const cache = createImportResolverFileSystem(fs);
+        const provider = createDefaultTypeshedInfoProvider(cache);
+
+        return { fs, cache, provider, typeshedRoot };
+    }
+
+    test('getTypeshedRoot prefers custom path when present, otherwise falls back', () => {
+        const { fs, provider, typeshedRoot } = createFsWithTypeshedLayout();
+
+        fs.mkdirpSync('/customTypeshed');
+
+        const custom = Uri.file('/customTypeshed', fs);
+        const resolvedCustom = provider.getTypeshedRoot(custom);
+        assert(resolvedCustom);
+        assert.strictEqual(normalizedPath(resolvedCustom), '/customTypeshed');
+
+        const resolvedFallback = provider.getTypeshedRoot(undefined);
+        assert(resolvedFallback);
+        assert.strictEqual(normalizedPath(resolvedFallback), typeshedRoot);
+    });
+
+    test('getTypeshedRoot ignores a custom typeshed path that is not a directory', () => {
+        const { fs, provider, typeshedRoot } = createFsWithTypeshedLayout();
+
+        const customPath = Uri.file('/customTypeshed', fs);
+        fs.writeFileSync(customPath, 'not a directory');
+
+        const resolved = provider.getTypeshedRoot(customPath);
+        assert(resolved);
+        assert.strictEqual(normalizedPath(resolved), typeshedRoot);
+    });
+
+    test('getTypeshedSubdirectory returns undefined when the expected subdirectory does not exist', () => {
+        const fs = new TestFileSystem(/* ignoreCase */ false, { cwd: '/' });
+
+        const typeshedRoot = `/${typeshedFallback}`;
+        fs.mkdirpSync(typeshedRoot);
+        fs.mkdirpSync(`${typeshedRoot}/stdlib`);
+        // Intentionally omit `${typeshedRoot}/stubs`.
+
+        const cache = createImportResolverFileSystem(fs);
+        const provider = createDefaultTypeshedInfoProvider(cache);
+
+        assert.strictEqual(
+            provider.getTypeshedSubdirectory(/* isStdLib */ false, /* customTypeshedPath */ undefined),
+            undefined
+        );
+    });
+
+    test('getThirdPartyPackageMap builds expected map and is memoized (independent of filesystem cache)', () => {
+        const { fs, cache, provider, typeshedRoot } = createFsWithTypeshedLayout();
+
+        // Build a minimal stubs layout:
+        //   stubs/a/foo/
+        //   stubs/a/bar.pyi
+        //   stubs/a/@python2/   (ignored)
+        //   stubs/b/foo/
+        fs.mkdirpSync(`${typeshedRoot}/stubs/a/foo`);
+        fs.mkdirpSync(`${typeshedRoot}/stubs/a/@python2`);
+        fs.writeFileSync(Uri.file(`${typeshedRoot}/stubs/a/bar.pyi`, fs), '');
+        fs.writeFileSync(Uri.file(`${typeshedRoot}/stubs/a/readme.txt`, fs), '');
+        fs.mkdirpSync(`${typeshedRoot}/stubs/b/foo`);
+        fs.writeFileSync(Uri.file(`${typeshedRoot}/stubs/outerFile.txt`, fs), '');
+
+        const readdirSpy = jest.spyOn(fs, 'readdirEntriesSync');
+
+        const [packageMap, roots] = provider.getThirdPartyPackageMap(undefined);
+        assert.deepStrictEqual(
+            roots.map((u) => normalizedPath(u)).sort(),
+            [`${typeshedRoot}/stubs/a`, `${typeshedRoot}/stubs/b`].sort()
+        );
+
+        const fooPaths = packageMap.get('foo');
+        assert(fooPaths);
+        assert.deepStrictEqual(
+            fooPaths.map((u) => normalizedPath(u)).sort(),
+            [`${typeshedRoot}/stubs/a`, `${typeshedRoot}/stubs/b`].sort()
+        );
+
+        const barPaths = packageMap.get('bar');
+        assert(barPaths);
+        assert.deepStrictEqual(
+            barPaths.map((u) => normalizedPath(u)),
+            [`${typeshedRoot}/stubs/a`]
+        );
+
+        assert(!packageMap.has('@python2'));
+        assert(!packageMap.has('readme'));
+
+        const callsAfterFirst = readdirSpy.mock.calls.length;
+
+        // Clear the ImportResolverFileSystem cache to ensure TypeshedInfoProvider memoization is effective.
+        cache.invalidateCache();
+
+        const [packageMap2, roots2] = provider.getThirdPartyPackageMap(undefined);
+        assert.strictEqual(packageMap2, packageMap);
+        assert.strictEqual(roots2, roots);
+
+        // Should not have re-enumerated directories.
+        assert.strictEqual(readdirSpy.mock.calls.length, callsAfterFirst);
+        readdirSpy.mockRestore();
+    });
+
+    test('getStdLibModuleVersionInfo parses VERSIONS and is memoized (independent of filesystem cache)', () => {
+        const { fs, cache, provider, typeshedRoot } = createFsWithTypeshedLayout();
+
+        const versionsUri = Uri.file(`${typeshedRoot}/stdlib/VERSIONS`, fs);
+        fs.writeFileSync(
+            versionsUri,
+            [
+                'asyncio: 3.4-',
+                'distutils: 3.0-3.10 ; platforms=win32, !linux',
+                'bar: -3.8',
+                'email: 3.6+  # plus suffix is allowed',
+                'this is not valid',
+                ': 3.7-  # missing module name',
+            ].join('\n'),
+            'utf8'
+        );
+
+        const statSpy = jest.spyOn(fs, 'statSync');
+        const readSpy = jest.spyOn(fs, 'readFileSync');
+
+        const versionInfo = provider.getStdLibModuleVersionInfo(undefined);
+
+        const asyncio = versionInfo.get('asyncio');
+        assert(asyncio);
+        assert(PythonVersion.isEqualTo(asyncio.min, PythonVersion.fromString('3.4')!));
+        assert.strictEqual(asyncio.max, undefined);
+
+        const distutils = versionInfo.get('distutils');
+        assert(distutils);
+        assert(PythonVersion.isEqualTo(distutils.min, PythonVersion.fromString('3.0')!));
+        assert(PythonVersion.isEqualTo(distutils.max!, PythonVersion.fromString('3.10')!));
+        assert.deepStrictEqual(distutils.supportedPlatforms, ['win32']);
+        assert.deepStrictEqual(distutils.unsupportedPlatforms, ['linux']);
+
+        const bar = versionInfo.get('bar');
+        assert(bar);
+        // Empty min version defaults to 3.0.
+        assert(PythonVersion.isEqualTo(bar.min, PythonVersion.fromString('3.0')!));
+        assert(PythonVersion.isEqualTo(bar.max!, PythonVersion.fromString('3.8')!));
+
+        const email = versionInfo.get('email');
+        assert(email);
+        assert(PythonVersion.isEqualTo(email.min, PythonVersion.fromString('3.6')!));
+
+        const statCallsAfterFirst = statSpy.mock.calls.length;
+        const readCallsAfterFirst = readSpy.mock.calls.length;
+
+        // Clear the ImportResolverFileSystem cache to ensure TypeshedInfoProvider memoization is effective.
+        cache.invalidateCache();
+
+        const versionInfo2 = provider.getStdLibModuleVersionInfo(undefined);
+        assert.strictEqual(versionInfo2, versionInfo);
+
+        assert.strictEqual(statSpy.mock.calls.length, statCallsAfterFirst);
+        assert.strictEqual(readSpy.mock.calls.length, readCallsAfterFirst);
+
+        statSpy.mockRestore();
+        readSpy.mockRestore();
+    });
+
+    test('getStdLibModuleVersionInfo memoizes an empty result when VERSIONS is missing', () => {
+        const { fs, provider, typeshedRoot } = createFsWithTypeshedLayout();
+
+        // No VERSIONS file.
+        const versionInfo1 = provider.getStdLibModuleVersionInfo(undefined);
+        assert.strictEqual(versionInfo1.size, 0);
+
+        // Create it later; memoization should keep returning the originally computed value.
+        fs.writeFileSync(Uri.file(`${typeshedRoot}/stdlib/VERSIONS`, fs), 'asyncio: 3.4-', 'utf8');
+        const versionInfo2 = provider.getStdLibModuleVersionInfo(undefined);
+        assert.strictEqual(versionInfo2, versionInfo1);
+        assert.strictEqual(versionInfo2.size, 0);
+    });
+
+    test('getStdLibModuleVersionInfo logs and skips reading when VERSIONS is too large', () => {
+        const { fs, provider, typeshedRoot } = createFsWithTypeshedLayout();
+
+        const versionsUri = Uri.file(`${typeshedRoot}/stdlib/VERSIONS`, fs);
+        fs.writeFileSync(versionsUri, 'a'.repeat(256 * 1024), 'utf8');
+
+        const importLogger = new ImportLogger();
+        const readSpy = jest.spyOn(fs, 'readFileSync');
+
+        const versionInfo = provider.getStdLibModuleVersionInfo(undefined, importLogger);
+        assert.strictEqual(versionInfo.size, 0);
+        assert.strictEqual(readSpy.mock.calls.length, 0);
+
+        assert(importLogger.getLogs().some((l) => l.includes('unexpectedly large')));
+
+        readSpy.mockRestore();
+    });
+
+    test('getStdLibModuleVersionInfo logs and returns empty when reading VERSIONS throws', () => {
+        const { fs, provider, typeshedRoot } = createFsWithTypeshedLayout();
+
+        const versionsUri = Uri.file(`${typeshedRoot}/stdlib/VERSIONS`, fs);
+        fs.writeFileSync(versionsUri, 'asyncio: 3.4-', 'utf8');
+
+        const importLogger = new ImportLogger();
+        const readSpy = jest.spyOn(fs, 'readFileSync').mockImplementation(() => {
+            throw new Error('read failed');
+        });
+
+        const versionInfo = provider.getStdLibModuleVersionInfo(undefined, importLogger);
+        assert.strictEqual(versionInfo.size, 0);
+        assert(importLogger.getLogs().some((l) => l.includes('Could not read typeshed stdlib VERSIONS file')));
+
+        readSpy.mockRestore();
+    });
+});


### PR DESCRIPTION
This PR is `to gather feedback` before we make these changes in Pylance and push them to Pyright. `It is not intended to be checked into Pyright directly`.

The main purpose of this PR is to improve Jest test performance and provide knobs to control performance in tests.

This change mainly includes two updates.

Improvements to `TestFileSystem` around mounting real folders to our test virtual file system. It now provides related data at once rather than gathering information one by one through separate calls, and mounts more lazily by supporting mounting a file rather than an entire folder.

Extracting caches in the import resolver as services so they can be mocked or use different implementations in tests. Usually, we create a new import resolver for each test, and most of those tests share the same typeshed, site-packages, etc., but we rebuild them (stdlib version map, typestub root maps, etc.) repeatedly. Each build is cheap (10–100 milliseconds), but doing this a few thousand times is expensive. `The actual implementation of the services is a 1:1 match with the previous implementation`, and in Pyright it always uses the default implementation, which is the same as before.

- Here is the list of changes:

Updated `FileSystemResolver` to return detailed directory entries, including kind and size.
Improved `TestFileSystem` to lazily populate links for mounted directories, optimizing path traversal.
Introduced `ImportResolverFileSystem` to cache directory enumeration and file existence checks, reducing IO operations.
Implemented `TypeshedInfoProvider` to manage typeshed paths and version information, with caching for efficiency.

Added comprehensive unit tests for the new import resolver infrastructure, ensuring correct behavior and cache management.

...

`TestFileSystem` changes made each jest test to be up to a few seconds faster (depends on how many tests are in the jest file)
`ImportResolver` changes made the target language server tests that enabled the mocked service a few seconds faster. combined with TestFileSystem improvement, ~10 seconds faster.

* it also has a test knob for `partial stubs` but pyright doesn't have bundled `partial stub` so it shouldn't matter for pyright's test.