### PR TITLE
Optimize findClosestMatch complexity

### DIFF
--- a/packages/pyright-internal/src/readonlyAugmentedFileSystem.ts
+++ b/packages/pyright-internal/src/readonlyAugmentedFileSystem.ts
@@ -215,20 +215,19 @@ export class ReadOnlyAugmentedFileSystem implements FileSystem {
     private _findClosestMatch(uri: Uri, map: UriMap<MappedEntry>): MappedEntry | undefined {
         // Search through the map of directories to find the closest match. The
         // closest match is the longest path that is a parent of the uri.
-        let entry = map.get(uri);
-        if (!entry) {
-            let foundKey = undefined;
-            for (const [key, value] of map.entries()) {
-                if (uri.isChild(key)) {
-                    // Update the found key if it is a better match.
-                    if (!foundKey || foundKey.getPathLength() < key.getPathLength()) {
-                        foundKey = key;
-                        entry = value;
-                    }
-                }
+        while (true) {
+            const entry = map.get(uri);
+            if (entry) {
+                return entry;
             }
+
+            const parent = uri.getDirectory();
+            if (parent.equals(uri)) {
+                return undefined;
+            }
+
+            uri = parent;
         }
-        return entry;
     }
 
     private _getOriginalEntry(uri: Uri): MappedEntry | undefined {


### PR DESCRIPTION
This change improved the performance on openstreetmap-ng codebase by about 6%.

14.5s → 13.6s (-6.6% ± 0.6%)

- Old algorithm: O(n) per query (n = map.size), even though only a handful of ancestors could possibly match.
- New algorithm: O(depth) map lookups (depth = number of path segments, usually small), and returns as soon as the best match is found.

The correctness is preserved because “best match” is defined purely in terms of ancestor relationship + maximum path length, and walking ancestors from deepest to root returns the same maximum-length ancestor when present.