### PR TITLE
Microoptimize time measurements

### DIFF
--- a/packages/pyright-internal/src/common/timing.ts
+++ b/packages/pyright-internal/src/common/timing.ts
@@ -40,9 +40,9 @@ export class TimingStat {
             return callback(...args);
         } else {
             this.isTiming = true;
-            const duration = new Duration();
+            const startTime = Date.now();
             const result = callback(...args);
-            this.totalTime += duration.getDurationInMilliseconds();
+            this.totalTime += Date.now() - startTime;
             this.isTiming = false;
 
             return result;
@@ -52,9 +52,9 @@ export class TimingStat {
     subtractFromTime(callback: () => void) {
         if (this.isTiming) {
             this.isTiming = false;
-            const duration = new Duration();
+            const startTime = Date.now();
             callback();
-            this.totalTime -= duration.getDurationInMilliseconds();
+            this.totalTime -= Date.now() - startTime;
             this.isTiming = true;
         } else {
             callback();


### PR DESCRIPTION
Removes Duration object allocations in TimingStat by switching to Date.now() deltas; same semantics, less GC churn.

This does not meaningfully improve performance, but seems just right to do.