### PR TITLE
Avoid double fileContents hashing and fix lastFileContentHash=0 bug

### DIFF
--- a/packages/pyright-internal/src/analyzer/sourceFile.ts
+++ b/packages/pyright-internal/src/analyzer/sourceFile.ts
@@ -626,7 +626,7 @@ export class SourceFile {
         const tokenizeContents = this._tokenizeContents.bind(this);
         const parsedFileContents = this._writableData.parsedFileContents;
         const contentHash =
-            this._writableData.lastFileContentHash || StringUtils.hashString(this._writableData.parsedFileContents);
+            this._writableData.lastFileContentHash ?? StringUtils.hashString(this._writableData.parsedFileContents);
         let tokenizerOutput: TokenizerOutput | undefined = this._writableData.tokenizerOutput;
 
         return {
@@ -1510,9 +1510,11 @@ export class SourceFile {
         parseOptions.pythonVersion = execEnvironment.pythonVersion;
         parseOptions.skipFunctionAndClassBody = configOptions.indexGenerationMode ?? false;
 
+        const contentHash = this._writableData.lastFileContentHash ?? StringUtils.hashString(fileContents);
+
         // Parse the token stream, building the abstract syntax tree.
         const parser = new Parser();
-        return parser.parseSourceFile(fileContents, parseOptions, diagSink);
+        return parser.parseSourceFile(fileContents, parseOptions, diagSink, contentHash);
     }
 
     private _tokenizeContents(fileContents: string, contentHash: number): TokenizerOutput {

--- a/packages/pyright-internal/src/parser/parser.ts
+++ b/packages/pyright-internal/src/parser/parser.ts
@@ -253,7 +253,12 @@ export class Parser {
     private _maxChildDepthMap = new Map<number, number>();
     private _hasTypeAnnotations = false;
 
-    parseSourceFile(fileContents: string, parseOptions: ParseOptions, diagSink: DiagnosticSink): ParseFileResults {
+    parseSourceFile(
+        fileContents: string,
+        parseOptions: ParseOptions,
+        diagSink: DiagnosticSink,
+        contentHash = hashString(fileContents)
+    ): ParseFileResults {
         this._hasTypeAnnotations = false;
         timingStats.tokenizeFileTime.timeOperation(() => {
             this._startNewParse(fileContents, 0, fileContents.length, parseOptions, diagSink);
@@ -291,7 +296,7 @@ export class Parser {
         assert(this._tokenizerOutput !== undefined);
         return {
             text: fileContents,
-            contentHash: hashString(fileContents),
+            contentHash,
             parserOutput: {
                 parseTree: moduleNode,
                 importedModules: this._importedModules,


### PR DESCRIPTION
Avoid SourceFile double file hashing on read by passing down the computed hash.

Additionally fix lastFileContentHash=0 comparison bug by replacing || with ??.

This does not meaningfully improve performance, but seems just right to do.