### PR TITLE
Fix percent-encoded drive letter colon (%3A) in Windows file URIs

### DIFF
--- a/packages/pyright-internal/src/common/uri/uri.ts
+++ b/packages/pyright-internal/src/common/uri/uri.ts
@@ -31,7 +31,7 @@ export type SerializedType = [UriKinds, ...any[]];
 import type { Uri as UriInterface } from './uriInterface';
 export interface Uri extends UriInterface {}
 
-const _dosPathRegex = /^\/[a-zA-Z]:\//;
+const _dosPathRegex = /^\/[a-zA-Z](?::|%3[aA])\//;
 const _win32NormalizationRegex = /\//g;
 
 // Returns just the fsPath path portion of a vscode URI.
@@ -49,9 +49,11 @@ function getFilePath(uri: URI): string {
     }
 
     // If this is a DOS-style path with a drive letter, remove
-    // the leading slash.
+    // the leading slash and decode percent-encoded colons.
     if (filePath.match(_dosPathRegex)) {
         filePath = filePath.slice(1);
+        // Decode %3A/%3a back to ':' for Windows drive letters
+        filePath = filePath.replace(/^([a-zA-Z])%3[aA]/, '$1:');
     }
 
     // vscode.URI normalizes the path to use the correct path separators.


### PR DESCRIPTION
## Summary

Some LSP clients send file URIs with the drive letter colon percent-encoded as `%3A` (e.g., `file:///c%3A/Users/...`). The existing `_dosPathRegex` in `getFilePath()` only matches literal colons, causing it to fail to strip the leading slash and decode the path correctly on Windows.

This results in invalid file paths that break path resolution, particularly when using `--threads` for parallel type checking (where URIs are serialized between worker threads).

## Changes

- Updated `_dosPathRegex` to also match `%3A`/`%3a` after the drive letter: `/^\/[a-zA-Z](?::|%3[aA])\//`
- Added decode step to convert `%3A`/`%3a` back to `:` after stripping the leading slash

## Test

Before fix:
- `file:///c%3A/Users/project/file.py` → `/c%3A/Users/project/file.py` (broken path)

After fix:
- `file:///c%3A/Users/project/file.py` → `c:/Users/project/file.py` (correct path)

Verified with `pyright --threads auto` on a real Windows project — paths resolve correctly.