### PR TITLE
Fix false-positive reportOverlappingOverload for self-annotated overloads

### DIFF
--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -26711,6 +26711,36 @@ export function createTypeEvaluator(
                 continue;
             }
 
+            // When checking overload overlap for explicitly annotated self/cls
+            // parameters, force invariant comparison if the self type contains
+            // auto-variance TypeVars (i.e. TypeVars whose variance is inferred
+            // from usage rather than explicitly declared). Inferred variance can
+            // be unstable — for example, changing based on whether a backing
+            // attribute is named with a private underscore prefix or not — which
+            // causes spurious reportOverlappingOverload false positives.
+            //
+            // Explicitly declared covariant/contravariant TypeVars are left
+            // unchanged so that genuine subtype-based overlaps are still detected.
+            const isOverloadSelfClsParamComparison =
+                (flags & AssignTypeFlags.OverloadOverlap) !== 0 &&
+                paramIndex === 0 &&
+                destType.shared.methodClass !== undefined &&
+                srcType.shared.methodClass !== undefined &&
+                (FunctionType.isInstanceMethod(destType) || FunctionType.isClassMethod(destType)) &&
+                (FunctionType.isInstanceMethod(srcType) || FunctionType.isClassMethod(srcType));
+
+            const hasExplicitSelfClsTypeAnnotations =
+                FunctionParam.isTypeDeclared(destParam.param) && FunctionParam.isTypeDeclared(srcParam.param);
+
+            const destSelfClsUsesAutoVariance =
+                isClassInstance(destParamType) &&
+                ClassType.getTypeParams(destParamType).some((p) => p.shared.declaredVariance === Variance.Auto);
+
+            const enforceInvariantSelfClsForOverlap =
+                isOverloadSelfClsParamComparison && hasExplicitSelfClsTypeAnnotations && destSelfClsUsesAutoVariance;
+
+            const paramAssignFlags = enforceInvariantSelfClsForOverlap ? flags | AssignTypeFlags.Invariant : flags;
+
             if (isUnpacked(srcParamType)) {
                 canAssign = false;
             } else if (
@@ -26720,7 +26750,7 @@ export function createTypeEvaluator(
                     paramIndex,
                     diag?.createAddendum(),
                     constraints,
-                    flags,
+                    paramAssignFlags,
                     recursionCount
                 )
             ) {

--- a/packages/pyright-internal/src/tests/samples/overloadOverlap2.py
+++ b/packages/pyright-internal/src/tests/samples/overloadOverlap2.py
@@ -1,0 +1,52 @@
+# This sample tests that overlapping-overload diagnostics for explicit self
+# annotations are stable regardless of whether a related subclass stores its
+# backing attribute under a public or a private name.
+#
+# Previously, private names (_f) caused variance to be inferred as covariant
+# instead of invariant, which produced false-positive reportOverlappingOverload
+# errors even though the overloads were semantically non-overlapping.
+#
+# The PEP 695 [T] syntax is required to trigger the bug because those TypeVars
+# use auto-variance inference, unlike old-style TypeVar("T") which is always
+# treated as invariant.
+
+from __future__ import annotations
+
+from typing import Any, Callable, overload
+
+
+class Mixin[T]:
+    @property
+    def value(self) -> T: ...
+
+    @overload
+    def __abs__(self: "Mixin[complex]") -> "Mixin[float]": ...
+
+    @overload
+    def __abs__(self: "Mixin[bool]") -> "Mixin[int]": ...
+
+    @overload
+    def __abs__(self) -> "Mixin[T]": ...
+
+    def __abs__(self) -> Any: ...
+
+
+# Public backing attribute: variance of T is inferred as invariant (always worked).
+class Public[T](Mixin[T]):
+    def __init__(self, f: Callable[[], T]) -> None:
+        self.f = f
+
+    @property
+    def value(self) -> T:
+        return self.f()
+
+
+# Private backing attribute: previously caused variance to be inferred as
+# covariant, which triggered false-positive reportOverlappingOverload errors.
+class Private[T](Mixin[T]):
+    def __init__(self, f: Callable[[], T]) -> None:
+        self._f = f
+
+    @property
+    def value(self) -> T:
+        return self._f()

--- a/packages/pyright-internal/src/tests/typeEvaluator6.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator6.test.ts
@@ -115,6 +115,15 @@ test('OverloadOverlap1', () => {
     TestUtils.validateResults(analysisResults, 16);
 });
 
+test('OverloadOverlap2', () => {
+    const configOptions = new ConfigOptions(Uri.empty());
+    configOptions.defaultPythonVersion = pythonVersion3_12;
+    configOptions.diagnosticRuleSet.reportOverlappingOverload = 'error';
+
+    const analysisResults = TestUtils.typeAnalyzeSampleFiles(['overloadOverlap2.py'], configOptions);
+    TestUtils.validateResults(analysisResults, 0);
+});
+
 test('TypeGuard1', () => {
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['typeGuard1.py']);
 


### PR DESCRIPTION
## Summary

This fixes a false-positive `reportOverlappingOverload` for overloads with explicitly annotated `self`/`cls` in PEP 695 generics.

## Problem

For PEP 695 (`class C[T]: ...`), Pyright infers variance for `T`.  
In this path, overload-overlap checks can become sensitive to implementation details and report overlap when signatures are semantically non-overlapping.

In particular, changing a subclass attribute from `f` to `_f` can change inferred variance and trigger a spurious overlap error.

This does not affect old-style `TypeVar("T")` cases, which are invariant by default.

## Example

Below are four combinations of two classes interacting.

Case | Syntax    | Attribute               | Before fix  | After fix
-----|-----------|-------------------------|-------------|----------
A    | PEP 695   | f  (public attribute)   | 0 errors    | 0 errors
B    | PEP 695   | _f (private attribute)  | 1 error *   | 0 errors
C    | old-style | f  (public attribute)   | 0 errors    | 0 errors
D    | old-style | _f (private attribute)  | 0 errors    | 0 errors

The only case that triggers an error is B. With PEP 695 [T] syntax, TypeVars use auto-variance inference. Surprisingly, whether the downstream class names their attribute `f` or `_f` determines whether or not a `reportOverlappingOverload` error occurs.

```py
from __future__ import annotations

from typing import Any, Callable, Generic, TypeVar, overload


class Mixin695[T]:
    """Used by cases A and B"""
    @property
    def value(self) -> T: ...

    @overload
    def __abs__(self: "Mixin695[complex]") -> "Mixin695[float]": ...
    @overload
    def __abs__(self: "Mixin695[bool]") -> "Mixin695[int]": ...
    @overload
    def __abs__(self) -> "Mixin695[T]": ...
    def __abs__(self) -> Any: ...


# Case A: PEP 695 + public attribute — T inferred invariant, no errors.
class PublicPEP695[T](Mixin695[T]):
    def __init__(self, f: Callable[[], T]) -> None:
        self.f = f  # public: mutable from outside → T invariant

    @property
    def value(self) -> T:
        return self.f()


# Case B: PEP 695 + private attribute — T previously inferred covariant
#         (private attr exempt from invariance check), causing false-positive
class PrivatePEP695[T](Mixin695[T]):
    def __init__(self, f: Callable[[], T]) -> None:
        self._f = f  # private: exempt from invariance → T covariant (bug)

    @property
    def value(self) -> T:
        return self._f()


T = TypeVar("T")


class MixinTypeVar(Generic[T]):
    """Used by cases C and D"""

    @property
    def value(self) -> T: ...

    @overload
    def __abs__(self: "MixinTypeVar[complex]") -> "MixinTypeVar[float]": ...
    @overload
    def __abs__(self: "MixinTypeVar[bool]") -> "MixinTypeVar[int]": ...
    @overload
    def __abs__(self) -> "MixinTypeVar[T]": ...
    def __abs__(self) -> Any: ...


# Case C: old-style TypeVar + public attribute — always clean.
class PublicTypeVar(MixinTypeVar[T]):
    def __init__(self, f: Callable[[], T]) -> None:
        self.f = f

    @property
    def value(self) -> T:
        return self.f()


# Case D: old-style TypeVar + private attribute — always clean.
#         TypeVar("T") defaults to invariant; no variance inference runs.
class PrivateTypeVar(MixinTypeVar[T]):
    def __init__(self, f: Callable[[], T]) -> None:
        self._f = f

    @property
    def value(self) -> T:
        return self._f()
```

I found this behavior when changing a variable from public to private in my reactive programming library, https://github.com/dougmercer/signified

## Fix

During overload-overlap checks, for the first parameter (`self`/`cls`) with explicit annotations, force invariant comparison when the `self`/`cls` type contains auto-variance type parameters.

This is intentionally narrow:
- Applies only to overlap checking.
- Applies only to annotated `self`/`cls`.
- Leaves explicitly declared covariance/contravariance unchanged.