### PR TITLE
reportPrivateUsage: honor __all__ for module-level _name in non-py.typed source

### DIFF
--- a/packages/pyright-internal/src/analyzer/binder.ts
+++ b/packages/pyright-internal/src/analyzer/binder.ts
@@ -3550,12 +3550,8 @@ export class Binder extends ParseTreeWalker {
                             // Don't include private-named symbols in the builtin scope.
                             symbol.setIsExternallyHidden();
                         } else {
-                            // Defer the private/protected decision until __all__ has
-                            // been processed so an explicit __all__ entry can mark
-                            // the symbol public. Previously this path called
-                            // setIsPrivateMember() directly for non-stub,
-                            // non-py.typed source files, which meant __all__ was
-                            // honored only for stubs and py.typed packages.
+                            // Defer the private/protected decision until __all__ is processed
+                            // so an explicit __all__ entry can promote the symbol to public.
                             this._potentialPrivateSymbols.set(name, symbol);
                         }
                     }

--- a/packages/pyright-internal/src/analyzer/binder.ts
+++ b/packages/pyright-internal/src/analyzer/binder.ts
@@ -3546,15 +3546,17 @@ export class Binder extends ParseTreeWalker {
                             } else {
                                 this._potentialPrivateSymbols.set(name, symbol);
                             }
-                        } else if (this._fileInfo.isStubFile || this._fileInfo.isInPyTypedPackage) {
-                            if (this._currentScope.type === ScopeType.Builtin) {
-                                // Don't include private-named symbols in the builtin scope.
-                                symbol.setIsExternallyHidden();
-                            } else {
-                                this._potentialPrivateSymbols.set(name, symbol);
-                            }
+                        } else if (this._currentScope.type === ScopeType.Builtin) {
+                            // Don't include private-named symbols in the builtin scope.
+                            symbol.setIsExternallyHidden();
                         } else {
-                            symbol.setIsPrivateMember();
+                            // Defer the private/protected decision until __all__ has
+                            // been processed so an explicit __all__ entry can mark
+                            // the symbol public. Previously this path called
+                            // setIsPrivateMember() directly for non-stub,
+                            // non-py.typed source files, which meant __all__ was
+                            // honored only for stubs and py.typed packages.
+                            this._potentialPrivateSymbols.set(name, symbol);
                         }
                     }
                 }

--- a/packages/pyright-internal/src/tests/checker.test.ts
+++ b/packages/pyright-internal/src/tests/checker.test.ts
@@ -47,6 +47,13 @@ test('Private1', () => {
     TestUtils.validateResults(analysisResults, 4);
 });
 
+test('Private2', () => {
+    const configOptions = new ConfigOptions(Uri.empty());
+    configOptions.diagnosticRuleSet.reportPrivateUsage = 'error';
+    const analysisResults = TestUtils.typeAnalyzeSampleFiles(['private4.py'], configOptions);
+    TestUtils.validateResults(analysisResults, 1);
+});
+
 test('Constant1', () => {
     const configOptions = new ConfigOptions(Uri.empty());
 

--- a/packages/pyright-internal/src/tests/checker.test.ts
+++ b/packages/pyright-internal/src/tests/checker.test.ts
@@ -54,6 +54,13 @@ test('Private2', () => {
     TestUtils.validateResults(analysisResults, 1);
 });
 
+test('Private3', () => {
+    const configOptions = new ConfigOptions(Uri.empty());
+    configOptions.diagnosticRuleSet.reportPrivateUsage = 'error';
+    const analysisResults = TestUtils.typeAnalyzeSampleFiles(['private6.py'], configOptions);
+    TestUtils.validateResults(analysisResults, 1);
+});
+
 test('Constant1', () => {
     const configOptions = new ConfigOptions(Uri.empty());
 

--- a/packages/pyright-internal/src/tests/samples/private3.py
+++ b/packages/pyright-internal/src/tests/samples/private3.py
@@ -1,0 +1,16 @@
+# This sample tests that __all__ membership suppresses reportPrivateUsage
+# for module-level single-underscore names.
+
+__all__ = ["_exported_via_all", "Public"]
+
+
+def _exported_via_all() -> int:
+    return 1
+
+
+def _not_exported() -> int:
+    return 2
+
+
+class Public:
+    pass

--- a/packages/pyright-internal/src/tests/samples/private4.py
+++ b/packages/pyright-internal/src/tests/samples/private4.py
@@ -1,0 +1,12 @@
+# This sample tests that __all__ membership suppresses reportPrivateUsage
+# for module-level single-underscore names.
+
+from .private3 import _exported_via_all, _not_exported
+
+# This should NOT generate an error: _exported_via_all is listed in
+# private3.__all__, so it is part of the module's public interface despite
+# the leading underscore.
+a = _exported_via_all()
+
+# This should generate an error: _not_exported is not in __all__.
+b = _not_exported()

--- a/packages/pyright-internal/src/tests/samples/private5.py
+++ b/packages/pyright-internal/src/tests/samples/private5.py
@@ -1,0 +1,15 @@
+# This sample tests that single-underscore names remain private when __all__
+# uses an unsupported (computed) form. The binder cannot determine the
+# contents of __all__ here, so deferred resolution should still mark _name
+# as private.
+
+_base: list[str] = []
+__all__ = _base + ["public"]
+
+
+def _name() -> int:
+    return 1
+
+
+def public() -> int:
+    return 2

--- a/packages/pyright-internal/src/tests/samples/private6.py
+++ b/packages/pyright-internal/src/tests/samples/private6.py
@@ -1,0 +1,10 @@
+# This sample tests that single-underscore names remain private when the
+# defining module's __all__ uses an unsupported (computed) form.
+
+from .private5 import _name, public
+
+# This should generate an error: private5.__all__ is computed, so _name
+# stays private.
+a = _name()
+
+b = public()


### PR DESCRIPTION
`reportPrivateUsage` consults `__all__` for module-level single-underscore names only when the declaring file is bound as a stub or a py.typed package. For plain source files, `_bindNameValueToScope` calls `setIsPrivateMember()` directly, so an explicit `__all__` entry does not suppress the diagnostic.

This means the same symbol is reported or not depending on whether its file is in `include`:

```python
# pkg/__init__.py
__all__ = ["_exported"]
def _exported() -> int: return 1
```
```python
# app.py
from pkg import _exported  # reportPrivateUsage fires iff pkg is in include
```

This PR routes the non-stub, non-py.typed path through `_potentialPrivateSymbols` as well, so `__all__` is honored consistently.

The new `private3.py`/`private4.py` sample test fails before the change (2 errors) and passes after (1 error - only the name not in `__all__`).