### PR TITLE
Make PEP 661 (sentinel) support non-experimental

### DIFF
--- a/packages/pyright-internal/src/analyzer/sentinel.ts
+++ b/packages/pyright-internal/src/analyzer/sentinel.ts
@@ -78,10 +78,7 @@ export function createSentinelType(
 
     let instanceType = ClassType.cloneAsInstance(classType);
 
-    // Is TypeForm supported?
-    if (fileInfo.diagnosticRuleSet.enableExperimentalFeatures) {
-        instanceType = TypeBase.cloneWithTypeForm(instanceType, instanceType);
-    }
+    instanceType = TypeBase.cloneWithTypeForm(instanceType, instanceType);
 
     return instanceType;
 }

--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -10591,11 +10591,13 @@ export function createTypeEvaluator(
                 return { returnType: createNewType(errorNode, argList) };
             }
 
-            // Handle the Sentinel call specially.
-            if (className === 'Sentinel') {
-                if (AnalyzerNodeInfo.getFileInfo(errorNode).diagnosticRuleSet.enableExperimentalFeatures) {
-                    return { returnType: createSentinelType(evaluatorInterface, errorNode, argList) };
-                }
+            // Handle sentinel calls specially.
+            if (
+                expandedCallType.shared.fullName === 'builtins.sentinel' ||
+                expandedCallType.shared.fullName === 'typing_extensions.sentinel' ||
+                expandedCallType.shared.fullName === 'typing_extensions.Sentinel'
+            ) {
+                return { returnType: createSentinelType(evaluatorInterface, errorNode, argList) };
             }
 
             if (ClassType.isSpecialFormClass(expandedCallType)) {

--- a/packages/pyright-internal/src/common/pythonVersion.ts
+++ b/packages/pyright-internal/src/common/pythonVersion.ts
@@ -215,5 +215,6 @@ export const pythonVersion3_11 = PythonVersion.create(3, 11);
 export const pythonVersion3_12 = PythonVersion.create(3, 12);
 export const pythonVersion3_13 = PythonVersion.create(3, 13);
 export const pythonVersion3_14 = PythonVersion.create(3, 14);
+export const pythonVersion3_15 = PythonVersion.create(3, 15);
 
 export const latestStablePythonVersion = pythonVersion3_14;

--- a/packages/pyright-internal/src/tests/samples/sentinel1.py
+++ b/packages/pyright-internal/src/tests/samples/sentinel1.py
@@ -1,7 +1,7 @@
 # This sample tests the handling of Sentinel as described in PEP 661.
 
 from typing import Literal, TypeAlias
-from typing_extensions import Sentinel, TypeForm  # pyright: ignore[reportMissingModuleSource]
+from typing_extensions import Sentinel, TypeForm, sentinel  # pyright: ignore[reportMissingModuleSource]
 
 # This should generate an error because the names don't match.
 BAD_NAME1 = Sentinel("OTHER")
@@ -15,14 +15,22 @@ BAD_CALL2 = Sentinel("BAD_CALL2", 1)
 # This should generate an error because the arg type is wrong.
 BAD_CALL3 = Sentinel(1)
 
+# This should generate an error because the arg count is wrong.
+BAD_CALL4 = sentinel()
+
+# This should generate an error because the arg type is wrong.
+BAD_CALL5 = sentinel(1)
 
 MISSING = Sentinel("MISSING")
+NOT_GIVEN = sentinel("NOT_GIVEN")
 
 type TA1 = int | MISSING
 
 TA2: TypeAlias = int | MISSING
 
 TA3 = int | MISSING
+
+TA4: TypeAlias = int | NOT_GIVEN
 
 # This should generate an error because Literal isn't appropriate here.
 x: Literal[MISSING]
@@ -57,3 +65,10 @@ def func3(x: Literal[0, 3, "hi"] | MISSING) -> None:
 
 t1 = type(MISSING)
 reveal_type(t1, expected_text="type[MISSING]")
+
+
+def func4(value: str | NOT_GIVEN) -> None:
+    if value is NOT_GIVEN:
+        reveal_type(value, expected_text="NOT_GIVEN")
+    else:
+        reveal_type(value, expected_text="str")

--- a/packages/pyright-internal/src/tests/samples/sentinel2.py
+++ b/packages/pyright-internal/src/tests/samples/sentinel2.py
@@ -1,0 +1,32 @@
+# This sample tests the handling of the sentinel builtin added in Python 3.15.
+
+from typing import Literal, TypeAlias
+
+# This should generate an error because the names don't match.
+BAD_NAME1 = sentinel("OTHER")
+
+# This should generate an error because the arg count is wrong.
+BAD_CALL1 = sentinel()
+
+# This should generate an error because the arg count is wrong.
+BAD_CALL2 = sentinel("BAD_CALL2", 1)
+
+# This should generate an error because the arg type is wrong.
+BAD_CALL3 = sentinel(1)
+
+
+MISSING = sentinel("MISSING")
+
+type TA1 = int | MISSING
+
+TA2: TypeAlias = int | MISSING
+
+# This should generate an error because Literal isn't appropriate here.
+x: Literal[MISSING]
+
+
+def func1(value: int | MISSING) -> None:
+    if value is MISSING:
+        reveal_type(value, expected_text="MISSING")
+    else:
+        reveal_type(value, expected_text="int")

--- a/packages/pyright-internal/src/tests/typeEvaluator2.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator2.test.ts
@@ -9,7 +9,7 @@
  */
 
 import { ConfigOptions } from '../common/configOptions';
-import { pythonVersion3_10, pythonVersion3_13, pythonVersion3_9 } from '../common/pythonVersion';
+import { pythonVersion3_10, pythonVersion3_13, pythonVersion3_15, pythonVersion3_9 } from '../common/pythonVersion';
 import { Uri } from '../common/uri/uri';
 import * as TestUtils from './testUtils';
 
@@ -995,9 +995,13 @@ test('SolverUnknown1', () => {
 });
 
 test('Sentinel1', () => {
-    const configOptions = new ConfigOptions(Uri.empty());
+    const analysisResults = TestUtils.typeAnalyzeSampleFiles(['sentinel1.py']);
+    TestUtils.validateResults(analysisResults, 7);
+});
 
-    configOptions.diagnosticRuleSet.enableExperimentalFeatures = true;
-    const analysisResults = TestUtils.typeAnalyzeSampleFiles(['sentinel1.py'], configOptions);
+test('Sentinel2', () => {
+    const configOptions = new ConfigOptions(Uri.empty());
+    configOptions.defaultPythonVersion = pythonVersion3_15;
+    const analysisResults = TestUtils.typeAnalyzeSampleFiles(['sentinel2.py'], configOptions);
     TestUtils.validateResults(analysisResults, 5);
 });

--- a/packages/pyright-internal/typeshed-fallback/stdlib/builtins.pyi
+++ b/packages/pyright-internal/typeshed-fallback/stdlib/builtins.pyi
@@ -1556,6 +1556,15 @@ def iter(object: Callable[[], _T | None], sentinel: None, /) -> Iterator[_T]: ..
 @overload
 def iter(object: Callable[[], _T], sentinel: object, /) -> Iterator[_T]: ...
 
+if sys.version_info >= (3, 15):
+    @final
+    class sentinel:
+        __name__: str
+        __module__: str
+        def __init__(self, name: str, /) -> None: ...
+        def __or__(self, other: Any) -> types.UnionType: ...
+        def __ror__(self, other: Any) -> types.UnionType: ...
+
 if sys.version_info >= (3, 10):
     _ClassInfo: TypeAlias = type | types.UnionType | tuple[_ClassInfo, ...]
 else:

--- a/packages/pyright-internal/typeshed-fallback/stdlib/typing_extensions.pyi
+++ b/packages/pyright-internal/typeshed-fallback/stdlib/typing_extensions.pyi
@@ -141,6 +141,7 @@ __all__ = [
     "override",
     "Protocol",
     "Sentinel",
+    "sentinel",
     "reveal_type",
     "runtime",
     "runtime_checkable",
@@ -700,8 +701,23 @@ else:
     def type_repr(value: object) -> str: ...
 
 # PEP 661
+@final
+class sentinel:
+    __name__: str
+    __module__: str
+    def __init__(self, name: str, /) -> None: ...
+    if sys.version_info >= (3, 14):
+        def __or__(self, other: Any) -> UnionType: ...  # other can be any type form legal for unions
+        def __ror__(self, other: Any) -> UnionType: ...  # other can be any type form legal for unions
+    elif sys.version_info >= (3, 10):
+        def __or__(self, other: Any) -> _SpecialForm: ...  # other can be any type form legal for unions
+        def __ror__(self, other: Any) -> _SpecialForm: ...  # other can be any type form legal for unions
+
+@final
 class Sentinel:
-    def __init__(self, name: str, repr: str | None = None) -> None: ...
+    __name__: str
+    __module__: str
+    def __init__(self, name: str, /) -> None: ...
     if sys.version_info >= (3, 14):
         def __or__(self, other: Any) -> UnionType: ...  # other can be any type form legal for unions
         def __ror__(self, other: Any) -> UnionType: ...  # other can be any type form legal for unions


### PR DESCRIPTION
PEP 661 was accepted and is going to be in Python 3.15, so pyright
support no longer needs to be experimental.
