### PR TITLE
Fix wrong symbol range in `callHierarchy/incomingCalls` response

### DIFF
--- a/packages/pyright-internal/src/languageService/callHierarchyProvider.ts
+++ b/packages/pyright-internal/src/languageService/callHierarchyProvider.ts
@@ -589,6 +589,12 @@ class FindIncomingCallTreeWalker extends ParseTreeWalker {
             };
         } else {
             const functionRange = convertOffsetsToRange(
+                executionNode.start,
+                executionNode.start + executionNode.length,
+                this._parseResults.tokenizerOutput.lines
+            );
+
+            const functionSelectionRange = convertOffsetsToRange(
                 executionNode.d.name.start,
                 executionNode.d.name.start + executionNode.d.name.length,
                 this._parseResults.tokenizerOutput.lines
@@ -599,7 +605,7 @@ class FindIncomingCallTreeWalker extends ParseTreeWalker {
                 kind: SymbolKind.Function,
                 uri: convertUriToLspUriString(this._program.fileSystem, this._fileUri),
                 range: functionRange,
-                selectionRange: functionRange,
+                selectionRange: functionSelectionRange,
             };
         }
 

--- a/packages/pyright-internal/src/languageService/referencesProvider.ts
+++ b/packages/pyright-internal/src/languageService/referencesProvider.ts
@@ -402,6 +402,10 @@ export class ReferencesProvider {
         if (node.nodeType === ParseNodeType.Name) {
             return this.getDeclarationForNode(program, fileUri, node, reporter, useCase, token);
         }
+        
+        if (node.nodeType === ParseNodeType.Function) {
+            return this.getDeclarationForNode(program, fileUri, node.d.name, reporter, useCase, token);
+        }
 
         // For other node types, there are no references to be found.
         return undefined;


### PR DESCRIPTION
### Context
This fixes #11443 

Return the range that encloses the function node instead of just the function name.