### PR TITLE
Update NODE_VERSION to '22.x' for consistency

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,7 +1,7 @@
 name: 'Build'
 
 env:
-  NODE_VERSION: '22' # Shipped with VS Code.
+  NODE_VERSION: '22.x' # Shipped with VS Code.
   ARTIFACT_NAME_VSIX: vsix
   VSIX_NAME: vscode-pyright.vsix
 

--- a/.github/workflows/mypy_primer_pr.yaml
+++ b/.github/workflows/mypy_primer_pr.yaml
@@ -16,7 +16,7 @@
 name: Run mypy_primer on PR
 
 env:
-  NODE_VERSION: '22.12.0' # Pin to a Node 22 release supported by @rspack/core.
+  NODE_VERSION: '22.x' # Shipped with VS Code.
 
 on:
   # Run on the creation or update of a PR.

--- a/.github/workflows/mypy_primer_push.yaml
+++ b/.github/workflows/mypy_primer_push.yaml
@@ -5,7 +5,7 @@
 name: Run mypy_primer on push
 
 env:
-  NODE_VERSION: '22.12.x' # Shipped with VS Code.
+  NODE_VERSION: '22.x' # Shipped with VS Code.
 
 on:
   # Run on all pushes to main.

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -1,7 +1,7 @@
 name: 'Validation'
 
 env:
-  NODE_VERSION: '22' # Shipped with VS Code.
+  NODE_VERSION: '22.x' # Shipped with VS Code.
   PYTHON_VERSION: 3.11
 
 on:

--- a/build/azuredevops/azure-pipelines.yml
+++ b/build/azuredevops/azure-pipelines.yml
@@ -41,9 +41,9 @@ extends:
                 fetchTags: true
                 persistCredentials: True
               - task: NodeTool@0
-                displayName: Use Node 18.x
+                displayName: Use Node 22.x
                 inputs:
-                  versionSpec: 18.x
+                  versionSpec: 22.x
               - task: CmdLine@2
                 displayName: npm install
                 inputs:


### PR DESCRIPTION
Standardize the NODE_VERSION across workflow files to '22.x' to align with the version used in VS Code. This change enhances consistency and clarity in the build environment.