### PR TITLE
Avoid unnecessary workspace configuration request

### DIFF
--- a/packages/pyright-internal/src/server.ts
+++ b/packages/pyright-internal/src/server.ts
@@ -125,7 +125,7 @@ export class PyrightServer extends LanguageServerBase {
                 }
             }
 
-            const pythonAnalysisSection = await this.getConfiguration(workspace.rootUri, 'python.analysis');
+            const pythonAnalysisSection = pythonSection?.analysis;
             if (pythonAnalysisSection) {
                 const typeshedPaths = pythonAnalysisSection.typeshedPaths;
                 if (typeshedPaths && Array.isArray(typeshedPaths) && typeshedPaths.length > 0) {

--- a/packages/pyright-internal/src/tests/lsp/languageServerTestUtils.ts
+++ b/packages/pyright-internal/src/tests/lsp/languageServerTestUtils.ts
@@ -712,7 +712,6 @@ export async function runPyrightServer(
                         finalConfiguration = configuration;
                     }
                 }
-
                 result.push(finalConfiguration);
             }
 

--- a/packages/pyright-internal/src/tests/lsp/languageServerTestUtils.ts
+++ b/packages/pyright-internal/src/tests/lsp/languageServerTestUtils.ts
@@ -268,7 +268,7 @@ function isPlainObject(value: unknown): boolean {
  * Returns true if the update was applied, false otherwise.
  */
 function updateConfigurationSection(
-    configuration: any,
+    configuration: Record<string, any>,
     requestedSection: string | undefined,
     targetSection: string | undefined,
     targetValue: any,
@@ -283,7 +283,11 @@ function updateConfigurationSection(
     // Path relative to the object we actually hold.
     const relativeParts = targetSectionParts.slice(requestedSectionParts.length);
     if (relativeParts.length === 0) {
-        return false; // target == the section itself; nothing to set
+        // target == the section itself
+        for (const [key, value] of Object.entries(targetValue)) {
+            configuration[key] = value;
+        }
+        return true;
     }
 
     // Walk to the parent, creating missing intermediate objects along the way.

--- a/packages/pyright-internal/src/tests/lsp/languageServerTestUtils.ts
+++ b/packages/pyright-internal/src/tests/lsp/languageServerTestUtils.ts
@@ -701,17 +701,18 @@ export async function runPyrightServer(
             const result = [];
             const mappedSettings = settingsMap.get(info) || [];
             for (const item of p.items) {
-                const setting = mappedSettings.find(
+                const matchingSettings = mappedSettings.filter(
                     (s) =>
                         (s.item.scopeUri === item.scopeUri || s.item.scopeUri === undefined) &&
                         (isRequestedConfigurationSectionIncludesTargetSection(item.section, s.item.section))
                 );
-                let finalConfiguration = undefined;
-                if (setting) {
+                if (matchingSettings.length) {
                     // Indicate we queried at least one setting.
                     info.queriedConfigSettings.resolve();
-
-                    const configuration = {};
+                }
+                let finalConfiguration = undefined;
+                for (const setting of matchingSettings) {
+                    const configuration: Record<string, any> = finalConfiguration ?? {};
                     if (updateConfigurationSection(configuration, item.section, setting.item.section, setting.value)) {
                         finalConfiguration = configuration;
                     }

--- a/packages/pyright-internal/src/tests/lsp/languageServerTestUtils.ts
+++ b/packages/pyright-internal/src/tests/lsp/languageServerTestUtils.ts
@@ -281,9 +281,7 @@ function updateConfigurationSection(
     const relativeParts = targetSectionParts.slice(requestedSectionParts.length);
     if (relativeParts.length === 0) {
         // target == the section itself
-        for (const [key, value] of Object.entries(targetValue)) {
-            configuration[key] = value;
-        }
+        Object.assign(configuration, targetValue);
         return true;
     }
 

--- a/packages/pyright-internal/src/tests/lsp/languageServerTestUtils.ts
+++ b/packages/pyright-internal/src/tests/lsp/languageServerTestUtils.ts
@@ -243,14 +243,11 @@ export function createFileSystem(projectRoot: string, testData: FourSlashData, o
 
 const settingsMap = new Map<PyrightServerInfo, { item: ConfigurationItem; value: any }[]>();
 
-function isRequestedConfigurationSectionIncludesTargetSection(
-    requestedSection: string | undefined,
-    targetSection: string | undefined
-) {
-    const requestedSectionParts = requestedSection ? requestedSection.split('.') : [];
-    const targetSectionParts = targetSection ? targetSection.split('.') : [];
-    for (const [i, requestedSectionPart] of requestedSectionParts.entries()) {
-        if (targetSectionParts[i] !== requestedSectionPart) {
+function isDotPathPrefix(prefix: string | undefined, path: string | undefined) {
+    const prefixParts = prefix ? prefix.split('.') : [];
+    const pathParts = path ? path.split('.') : [];
+    for (const [i, requestedSectionPart] of prefixParts.entries()) {
+        if (pathParts[i] !== requestedSectionPart) {
             return false;
         }
     }
@@ -273,7 +270,7 @@ function updateConfigurationSection(
     targetSection: string | undefined,
     targetValue: any
 ): boolean {
-    if (!isRequestedConfigurationSectionIncludesTargetSection(requestedSection, targetSection)) {
+    if (!isDotPathPrefix(requestedSection, targetSection)) {
         return false;
     }
 
@@ -704,7 +701,7 @@ export async function runPyrightServer(
                 const matchingSettings = mappedSettings.filter(
                     (s) =>
                         (s.item.scopeUri === item.scopeUri || s.item.scopeUri === undefined) &&
-                        isRequestedConfigurationSectionIncludesTargetSection(item.section, s.item.section)
+                        isDotPathPrefix(item.section, s.item.section)
                 );
                 if (matchingSettings.length) {
                     // Indicate we queried at least one setting.

--- a/packages/pyright-internal/src/tests/lsp/languageServerTestUtils.ts
+++ b/packages/pyright-internal/src/tests/lsp/languageServerTestUtils.ts
@@ -258,7 +258,7 @@ function isRequestedConfigurationSectionIncludesTargetSection(
 }
 
 function isPlainObject(value: unknown): boolean {
-    return typeof value === "object" && value !== null && !Array.isArray(value);
+    return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
 
 /**
@@ -271,14 +271,14 @@ function updateConfigurationSection(
     configuration: Record<string, any>,
     requestedSection: string | undefined,
     targetSection: string | undefined,
-    targetValue: any,
+    targetValue: any
 ): boolean {
     if (!isRequestedConfigurationSectionIncludesTargetSection(requestedSection, targetSection)) {
         return false;
     }
 
-    const requestedSectionParts = requestedSection ? requestedSection.split(".") : [];
-    const targetSectionParts = targetSection ? targetSection.split(".") : [];
+    const requestedSectionParts = requestedSection ? requestedSection.split('.') : [];
+    const targetSectionParts = targetSection ? targetSection.split('.') : [];
 
     // Path relative to the object we actually hold.
     const relativeParts = targetSectionParts.slice(requestedSectionParts.length);
@@ -704,7 +704,7 @@ export async function runPyrightServer(
                 const matchingSettings = mappedSettings.filter(
                     (s) =>
                         (s.item.scopeUri === item.scopeUri || s.item.scopeUri === undefined) &&
-                        (isRequestedConfigurationSectionIncludesTargetSection(item.section, s.item.section))
+                        isRequestedConfigurationSectionIncludesTargetSection(item.section, s.item.section)
                 );
                 if (matchingSettings.length) {
                     // Indicate we queried at least one setting.

--- a/packages/pyright-internal/src/tests/lsp/languageServerTestUtils.ts
+++ b/packages/pyright-internal/src/tests/lsp/languageServerTestUtils.ts
@@ -243,17 +243,67 @@ export function createFileSystem(projectRoot: string, testData: FourSlashData, o
 
 const settingsMap = new Map<PyrightServerInfo, { item: ConfigurationItem; value: any }[]>();
 
-export function updateSettingsMap(info: PyrightServerInfo, settings: { item: ConfigurationItem; value: any }[]) {
-    const ignoreCase = toBoolean(info.testData.globalOptions[GlobalMetadataOptionNames.ignoreCase]);
-    // Normalize the URIs for all of the settings.
-    settings.forEach((s) => {
-        if (s.item.scopeUri) {
-            s.item.scopeUri = UriEx.parse(s.item.scopeUri, !ignoreCase).toString();
+function isRequestedConfigurationSectionIncludesTargetSection(
+    requestedSection: string | undefined,
+    targetSection: string | undefined
+) {
+    const requestedSectionParts = requestedSection ? requestedSection.split('.') : [];
+    const targetSectionParts = targetSection ? targetSection.split('.') : [];
+    for (const [i, requestedSectionPart] of requestedSectionParts.entries()) {
+        if (targetSectionParts[i] !== requestedSectionPart) {
+            return false;
         }
-    });
+    }
+    return true;
+}
 
-    const current = settingsMap.get(info) || [];
-    settingsMap.set(info, [...settings, ...current]);
+function isPlainObject(value: unknown): boolean {
+    return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Update `targetSection` to `targetValue` inside `configuration`, where `configuration` is the object that
+ * was returned for `requestedSection` (dot notation). Missing intermediate objects are created as needed.
+ *
+ * Returns true if the update was applied, false otherwise.
+ */
+function updateConfigurationSection(
+    configuration: any,
+    requestedSection: string | undefined,
+    targetSection: string | undefined,
+    targetValue: any,
+): boolean {
+    if (!isRequestedConfigurationSectionIncludesTargetSection(requestedSection, targetSection)) {
+        return false;
+    }
+
+    const requestedSectionParts = requestedSection ? requestedSection.split(".") : [];
+    const targetSectionParts = targetSection ? targetSection.split(".") : [];
+
+    // Path relative to the object we actually hold.
+    const relativeParts = targetSectionParts.slice(requestedSectionParts.length);
+    if (relativeParts.length === 0) {
+        return false; // target == the section itself; nothing to set
+    }
+
+    // Walk to the parent, creating missing intermediate objects along the way.
+    let node = configuration;
+    for (const part of relativeParts.slice(0, -1)) {
+        if (!isPlainObject(node)) {
+            return false; // an existing value blocks the path (e.g. a string)
+        }
+        if (!isPlainObject(node[part])) {
+            node[part] = {};
+        }
+        node = node[part];
+    }
+
+    const last = relativeParts[relativeParts.length - 1];
+    if (!isPlainObject(node)) {
+        return false; // parent isn't an object, can't set a key on it
+    }
+    node[last] = targetValue;
+    return true;
 }
 
 export function getParseResults(fileContents: string, isStubFile = false, useNotebookMode = false) {
@@ -650,13 +700,20 @@ export async function runPyrightServer(
                 const setting = mappedSettings.find(
                     (s) =>
                         (s.item.scopeUri === item.scopeUri || s.item.scopeUri === undefined) &&
-                        s.item.section === item.section
+                        (isRequestedConfigurationSectionIncludesTargetSection(item.section, s.item.section))
                 );
+                let finalConfiguration = undefined;
                 if (setting) {
                     // Indicate we queried at least one setting.
                     info.queriedConfigSettings.resolve();
+
+                    const configuration = {};
+                    if (updateConfigurationSection(configuration, item.section, setting.item.section, setting.value)) {
+                        finalConfiguration = configuration;
+                    }
                 }
-                result.push(setting?.value);
+
+                result.push(finalConfiguration);
             }
 
             return result;


### PR DESCRIPTION
The code requested the python section first and, right after that, the `python.analysis` section. Each triggered a `workspace/configuration` request (for clients that support the "configuration" capability). The `python.analysis` request is unnecessary because it's a subset of the already-requested `python` section, so avoiding it prevents a redundant request.