### PR TITLE
Fix callable positional count diagnostics

### DIFF
--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -26924,9 +26924,9 @@ export function createTypeEvaluator(
                 ).length;
 
                 diag?.createAddendum().addMessage(
-                    LocAddendum.functionTooFewParams().format({
-                        expected: nonDefaultSrcParamCount,
-                        received: destPositionalCount,
+                    LocAddendum.functionTooManyParams().format({
+                        expected: destPositionalCount,
+                        received: nonDefaultSrcParamCount,
                     })
                 );
                 canAssign = false;
@@ -26997,9 +26997,9 @@ export function createTypeEvaluator(
 
                 if (srcPositionalCount < adjDestPositionalCount) {
                     diag?.addMessage(
-                        LocAddendum.functionTooManyParams().format({
-                            expected: srcPositionalCount,
-                            received: destPositionalCount,
+                        LocAddendum.functionTooFewParams().format({
+                            expected: adjDestPositionalCount,
+                            received: srcPositionalCount,
                         })
                     );
                     canAssign = false;

--- a/packages/pyright-internal/src/tests/diagnostics.test.ts
+++ b/packages/pyright-internal/src/tests/diagnostics.test.ts
@@ -39,3 +39,44 @@ test('pyright ignore unused import', async () => {
         marker: { category: 'none', message: '' },
     });
 });
+
+test('callable assignment positional parameter count', async () => {
+    const code = `
+// @filename: test.py
+//// from typing import Callable
+////
+//// def decorator(func: Callable[[int], int]) -> Callable[[int], int]:
+////     return func
+////
+//// def decorator0(func: Callable[[], int]) -> Callable[[], int]:
+////     return func
+////
+//// @[|/*marker*/decorator|]
+//// def foo() -> int:
+////     return 1
+////
+//// @[|/*marker2*/decorator0|]
+//// def bar(value: int, /) -> int:
+////     return value
+    `;
+
+    const state = parseAndGetTestState(code).state;
+
+    state.verifyDiagnostics({
+        marker: {
+            category: 'error',
+            message:
+                'Argument of type "() -> int" cannot be assigned to parameter "func" of type "(int) -> int" in function "decorator"\n' +
+                '  Type "() -> int" is not assignable to type "(int) -> int"\n' +
+                '    Function accepts too few positional parameters; expected 1 but received 0',
+        },
+        marker2: {
+            category: 'error',
+            message:
+                'Argument of type "(value: int, /) -> int" cannot be assigned to parameter "func" of type "() -> int" in function "decorator0"\n' +
+                '  Type "(value: int, /) -> int" is not assignable to type "() -> int"\n' +
+                '    Position-only parameter mismatch; expected 1 but received 0\n' +
+                '    Function accepts too many positional parameters; expected 0 but received 1',
+        },
+    });
+});


### PR DESCRIPTION
## Summary
Fixes microsoft/pyright#11464 by reporting callable positional parameter count mismatches from the source function's perspective.

## Reproduction
```python
from typing import Callable

def decorator(func: Callable[[int], int]) -> Callable[[int], int]:
    return func

@decorator
def foo() -> int:
    return 1
```

Before this change, Pyright reported:

```text
Function accepts too many positional parameters; expected 0 but received 1
```

For `foo`, the clearer diagnostic is:

```text
Function accepts too few positional parameters; expected 1 but received 0
```

## Root cause
When callable parameter counts differed, `typeEvaluator.ts` selected the `tooFew`/`tooMany` addendum and populated the expected/received values from the destination callable perspective. For diagnostics shown on the source callable being assigned, this inverted the user-facing message.

## Changes
- Swap the positional-count diagnostic addendum direction for callable assignability failures.
- Report expected/received counts from the callable being assigned.
- Add a fourslash diagnostic regression test that checks both too-few and too-many positional count messages.

## Tests
- `npm install`
- `npm run build` from `packages/pyright-internal`
- `node --max-old-space-size=8192 --expose-gc ./node_modules/jest/bin/jest --runTestsByPath src/tests/diagnostics.test.ts --runInBand --forceExit` from `packages/pyright-internal`
- `npx prettier -c packages/pyright-internal/src/analyzer/typeEvaluator.ts packages/pyright-internal/src/tests/diagnostics.test.ts`
- `git diff --check`

## Screenshots/Logs
Not applicable; diagnostic text is covered by the regression test.
