### PR TITLE
fix(dataClasses): recognize `KW_ONLY` separator for any variable name

### DIFF
--- a/packages/pyright-internal/src/analyzer/dataClasses.ts
+++ b/packages/pyright-internal/src/analyzer/dataClasses.ts
@@ -376,7 +376,8 @@ export function synthesizeDataClassMethods(
                         });
 
                     // Is this a KW_ONLY separator introduced in Python 3.10?
-                    if (!isNamedTuple && statement.d.valueExpr.d.value === '_') {
+                    // Per the Python docs, the variable name is ignored — any name works.
+                    if (!isNamedTuple) {
                         const annotatedType = variableTypeEvaluator();
 
                         if (isClassInstance(annotatedType) && ClassType.isBuiltIn(annotatedType, 'KW_ONLY')) {

--- a/packages/pyright-internal/src/tests/samples/dataclassKwOnly2.py
+++ b/packages/pyright-internal/src/tests/samples/dataclassKwOnly2.py
@@ -1,0 +1,47 @@
+# This sample tests that KW_ONLY can be assigned to any variable name,
+# not just `_`. Python docs state the name is ignored at runtime.
+# See: https://docs.python.org/3/library/dataclasses.html#dataclasses.KW_ONLY
+
+from dataclasses import KW_ONLY, dataclass
+
+
+@dataclass
+class DC1:
+    a: int
+    __: KW_ONLY
+    b: str
+
+
+DC1(1, b="hi")
+DC1(a=1, b="hi")
+
+# This should generate an error because "b" is keyword-only.
+DC1(1, "hi")
+
+
+@dataclass
+class DC2:
+    a: int = 0
+    __: KW_ONLY
+    b: str = "hi"
+
+
+DC2(a=0, b="hi")
+DC2(b="hi")
+
+# This should generate an error because "b" is keyword-only.
+DC2(0, "hi")
+
+
+@dataclass
+class DC3:
+    a: int = 0
+    kw_sep: KW_ONLY
+    b: str = "hi"
+
+
+DC3(a=0, b="hi")
+DC3(b="hi")
+
+# This should generate an error because "b" is keyword-only.
+DC3(0, "hi")

--- a/packages/pyright-internal/src/tests/typeEvaluator4.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator4.test.ts
@@ -429,6 +429,14 @@ test('DataClassKwOnly1', () => {
     TestUtils.validateResults(analysisResults, 3);
 });
 
+test('DataClassKwOnly2', () => {
+    const configOptions = new ConfigOptions(Uri.empty());
+    configOptions.defaultPythonVersion = pythonVersion3_10;
+    const analysisResults = TestUtils.typeAnalyzeSampleFiles(['dataclassKwOnly2.py'], configOptions);
+
+    TestUtils.validateResults(analysisResults, 3);
+});
+
 test('DataClassSlots1', () => {
     const configOptions = new ConfigOptions(Uri.empty());
     configOptions.defaultPythonVersion = pythonVersion3_10;


### PR DESCRIPTION
Closes #11451

---

`dataclasses.KW_ONLY` marks a separator field: every parameter declared after it in the class body becomes keyword-only. The [Python docs](https://docs.python.org/3/library/dataclasses.html#dataclasses.KW_ONLY) explicitly state that *the variable name is ignored* — `_` is merely a convention, and any identifier works equally well at runtime.

Before this change, Pyright checked for `=== '_'` before evaluating the annotation type, so non-`_` names like `__` or `kw_sep` were treated as ordinary fields instead of separators. This caused two classes of false-positive diagnostics:

1. **`reportGeneralTypeIssues`** — "Fields without default values cannot appear after fields with default values" — when a `KW_ONLY` separator with no default appeared after a field that did have one.
2. Downstream constructor-call errors, because the keyword-only fields were incorrectly treated as positional.

**Fix:** Remove the `=== '_'` guard so any `TypeAnnotation` whose RHS resolves to `KW_ONLY` is treated as a separator.

A new test sample (`dataclassKwOnly2.py`) exercises the three common patterns: `__: KW_ONLY`, `__: KW_ONLY` after a field with a default, and an arbitrary name (`kw_sep: KW_ONLY`).

> Note: This fix was developed with AI-agent assistance.