### PR TITLE
Fix reachability for generic context managers with bool __exit__

### DIFF
--- a/packages/pyright-internal/src/analyzer/codeFlowEngine.ts
+++ b/packages/pyright-internal/src/analyzer/codeFlowEngine.ts
@@ -1979,6 +1979,12 @@ export function getCodeFlowEngine(
                         }
                     }
 
+                    // Generic context managers (e.g. ContextManager[bool]) declare __exit__ as returning
+                    // a TypeVar. Specialize using the instance type args before checking for bool.
+                    if (isTypeVar(returnType) && cmType.priv.typeArgs && cmType.priv.typeArgs.length >= 1) {
+                        returnType = cmType.priv.typeArgs[0];
+                    }
+
                     cmSwallowsExceptions = false;
                     if (isClassInstance(returnType) && ClassType.isBuiltIn(returnType, 'bool')) {
                         if (returnType.priv.literalValue === undefined || returnType.priv.literalValue === true) {

--- a/packages/pyright-internal/src/analyzer/codeFlowEngine.ts
+++ b/packages/pyright-internal/src/analyzer/codeFlowEngine.ts
@@ -68,6 +68,8 @@ import {
     UnknownType,
 } from './types';
 import {
+    applySolvedTypeVars,
+    buildSolution,
     cleanIncompleteUnknown,
     derivesFromStdlibClass,
     doForEachSubtype,
@@ -1979,10 +1981,14 @@ export function getCodeFlowEngine(
                         }
                     }
 
-                    // Generic context managers (e.g. ContextManager[bool]) declare __exit__ as returning
-                    // a TypeVar. Specialize using the instance type args before checking for bool.
-                    if (isTypeVar(returnType) && cmType.priv.typeArgs && cmType.priv.typeArgs.length >= 1) {
-                        returnType = cmType.priv.typeArgs[0];
+                    // Generic context managers can declare __exit__ as returning a TypeVar
+                    // that isn't necessarily the first type parameter. Specialize the declared
+                    // return type using the context manager instance's type arguments.
+                    if (cmType.shared.typeParams.length > 0 && cmType.priv.typeArgs) {
+                        returnType = applySolvedTypeVars(
+                            returnType,
+                            buildSolution(cmType.shared.typeParams, cmType.priv.typeArgs)
+                        );
                     }
 
                     cmSwallowsExceptions = false;

--- a/packages/pyright-internal/src/tests/checker.test.ts
+++ b/packages/pyright-internal/src/tests/checker.test.ts
@@ -212,6 +212,12 @@ test('With6', () => {
     TestUtils.validateResults(analysisResults, 0);
 });
 
+test('With7', () => {
+    const analysisResults = TestUtils.typeAnalyzeSampleFiles(['with7.py']);
+
+    TestUtils.validateResults(analysisResults, 0);
+});
+
 test('Mro1', () => {
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['mro1.py']);
 

--- a/packages/pyright-internal/src/tests/samples/with7.py
+++ b/packages/pyright-internal/src/tests/samples/with7.py
@@ -1,0 +1,20 @@
+# Regression test for https://github.com/microsoft/pyright/issues/11483
+# Generic ContextManager[T] should treat __exit__ return type like typing.ContextManager[bool].
+
+from typing import Generic, Self, TypeVar, reveal_type
+
+T = TypeVar("T", bound="bool|None")
+
+
+class ContextManager(Generic[T]):
+    def __enter__(self) -> Self: ...
+
+    def __exit__(self, exc_type, exc_val, exc_tb) -> T: ...
+
+
+def test_generic_bool_context_manager() -> None:
+    foo = "str"
+    with ContextManager[bool]() as ctx:
+        reveal_type(ctx.__exit__(None, None, None), expected_text="bool")
+        foo = 1
+    reveal_type(foo, expected_text="Literal['str', 1]")

--- a/packages/pyright-internal/src/tests/samples/with7.py
+++ b/packages/pyright-internal/src/tests/samples/with7.py
@@ -18,3 +18,21 @@ def test_generic_bool_context_manager() -> None:
         reveal_type(ctx.__exit__(None, None, None), expected_text="bool")
         foo = 1
     reveal_type(foo, expected_text="Literal['str', 1]")
+
+
+TEnter = TypeVar("TEnter")
+TExit = TypeVar("TExit", bound="bool|None")
+
+
+class SplitContextManager(Generic[TEnter, TExit]):
+    def __enter__(self) -> TEnter: ...
+
+    def __exit__(self, exc_type, exc_val, exc_tb) -> TExit: ...
+
+
+def test_multi_typevar_context_manager() -> None:
+    bar = "str"
+    with SplitContextManager[int, bool]() as ctx:
+        reveal_type(ctx, expected_text="int")
+        bar = 1
+    reveal_type(bar, expected_text="Literal['str', 1]")


### PR DESCRIPTION
Fixes #11483

`isExceptionContextManager` only treated `__exit__` as swallowing exceptions when the declared return type was literally `bool`. For `ContextManager[bool]`, the declared return is the TypeVar `T`.

Specialize the return type from the context manager instance type args before the bool check. Added `with7.py` regression sample.