### PR TITLE
Fix generic NamedTuple match narrowing for bounded type vars

### DIFF
--- a/packages/pyright-internal/src/analyzer/patternMatching.ts
+++ b/packages/pyright-internal/src/analyzer/patternMatching.ts
@@ -754,12 +754,17 @@ function narrowTypeBasedOnLiteralPattern(
 function specializeBoundedMatchTypeParams(
     evaluator: TypeEvaluator,
     matchType: ClassType,
-    subjectTypeArgs: Type[] | undefined,
     solvedTypeArgs: Type[] | undefined,
     condition: ReturnType<typeof getTypeCondition>
 ): Type {
+    // `solvedTypeArgs` is indexed by `matchType`'s own type parameters, so the
+    // caller must align it to the pattern class (e.g. pass `resultType.priv.typeArgs`
+    // where `resultType` is the same generic class). The subject's own type arguments
+    // must not be used here: the subject may be a different generic class (e.g. a
+    // generic supertype), and indexing it by the pattern class's parameters would
+    // misread unrelated arguments.
     const typeArgs = matchType.shared.typeParams.map((param, index) => {
-        const specializedArg = subjectTypeArgs?.[index] ?? solvedTypeArgs?.[index];
+        const specializedArg = solvedTypeArgs?.[index];
 
         // Keep an argument unless it is genuinely Unknown. A bare in-scope TypeVar
         // (e.g. a subject `Thing[S]` from a generic function `def f[S: bool]`) is a
@@ -1075,13 +1080,9 @@ function narrowTypeBasedOnClassPattern(
                                 (param) => isTypeVar(param) && param.shared.boundType
                             )
                         ) {
-                            const subjectTypeArgs = isClassInstance(subjectSubtypeExpanded)
-                                ? subjectSubtypeExpanded.priv.typeArgs
-                                : undefined;
                             resultType = specializeBoundedMatchTypeParams(
                                 evaluator,
                                 unexpandedSubtype,
-                                subjectTypeArgs,
                                 resultType.priv.typeArgs,
                                 getTypeCondition(subjectSubtypeExpanded)
                             );

--- a/packages/pyright-internal/src/analyzer/patternMatching.ts
+++ b/packages/pyright-internal/src/analyzer/patternMatching.ts
@@ -68,7 +68,6 @@ import {
     addConditionToType,
     containsAnyOrUnknown,
     convertToInstance,
-    convertToInstantiable,
     doForEachSubtype,
     getTypeCondition,
     getTypeVarScopeIds,
@@ -86,7 +85,6 @@ import {
     partiallySpecializeType,
     preserveUnknown,
     requiresSpecialization,
-    selfSpecializeClass,
     specializeTupleClass,
     specializeWithUnknownTypeArgs,
     transformPossibleRecursiveTypeAlias,
@@ -748,6 +746,41 @@ function narrowTypeBasedOnLiteralPattern(
     });
 }
 
+// When a class pattern matches a generic class whose type parameters have an
+// upper bound (e.g. `class Thing[T: bool]`), the constraint solver may leave the
+// parameters unsolved (Unknown) because the subject carries no type arguments.
+// Rather than surfacing Unknown, fall back to each parameter's bound while
+// preserving any argument that was concretely solved. The subject's condition is
+// reapplied to the resulting instance.
+function specializeBoundedMatchTypeParams(
+    evaluator: TypeEvaluator,
+    matchType: ClassType,
+    subjectTypeArgs: Type[] | undefined,
+    solvedTypeArgs: Type[] | undefined,
+    condition: ReturnType<typeof getTypeCondition>
+): Type {
+    const typeArgs = matchType.shared.typeParams.map((param, index) => {
+        const specializedArg = subjectTypeArgs?.[index] ?? solvedTypeArgs?.[index];
+
+        // Keep an argument that was solved to a concrete (non-bound, non-Unknown) type.
+        if (
+            specializedArg &&
+            !requiresSpecialization(specializedArg) &&
+            !containsAnyOrUnknown(specializedArg, /* recurse */ true)
+        ) {
+            return specializedArg;
+        }
+
+        if (isTypeVar(param) && param.shared.boundType) {
+            return convertToInstance(param.shared.boundType);
+        }
+
+        return specializedArg ?? getUnknownForTypeVar(param, evaluator.getTupleClassType());
+    });
+
+    return addConditionToType(convertToInstance(ClassType.specialize(matchType, typeArgs)), condition);
+}
+
 function narrowTypeBasedOnClassPattern(
     evaluator: TypeEvaluator,
     type: Type,
@@ -920,10 +953,7 @@ function narrowTypeBasedOnClassPattern(
                 const expandedSubtypeInstance = convertToInstance(expandedSubtype);
                 const isPatternMetaclass = isMetaclassInstance(expandedSubtypeInstance);
 
-                return evaluator.mapSubtypesExpandTypeVars(
-                    type,
-                    /* options */ undefined,
-                    (subjectSubtypeExpanded, subjectSubtypeUnexpanded) => {
+                return evaluator.mapSubtypesExpandTypeVars(type, /* options */ undefined, (subjectSubtypeExpanded) => {
                     if (isAnyOrUnknown(subjectSubtypeExpanded)) {
                         if (isInstantiableClass(expandedSubtype) && ClassType.isBuiltIn(expandedSubtype, 'Callable')) {
                             // Convert to an unknown callable type.
@@ -1027,73 +1057,35 @@ function narrowTypeBasedOnClassPattern(
                                                 },
                                             }
                                         ) as ClassType;
-
-                                        if (
-                                            unexpandedSubtype.shared.typeParams.some(
-                                                (param) => isTypeVar(param) && param.shared.boundType
-                                            )
-                                        ) {
-                                            const subjectTypeArgs = isClassInstance(subjectSubtypeExpanded)
-                                                ? subjectSubtypeExpanded.priv.typeArgs
-                                                : undefined;
-                                            const solvedTypeArgs = isClassInstance(resultType)
-                                                ? resultType.priv.typeArgs
-                                                : undefined;
-                                            const typeArgs = unexpandedSubtype.shared.typeParams.map((param, index) => {
-                                                const specializedArg = subjectTypeArgs?.[index] ?? solvedTypeArgs?.[index];
-                                                if (specializedArg && !requiresSpecialization(specializedArg)) {
-                                                    return specializedArg;
-                                                }
-
-                                                if (isTypeVar(param) && param.shared.boundType) {
-                                                    return convertToInstance(param.shared.boundType);
-                                                }
-
-                                                return specializedArg ?? getUnknownForTypeVar(param, evaluator.getTupleClassType());
-                                            });
-
-                                            resultType = addConditionToType(
-                                                convertToInstance(ClassType.specialize(unexpandedSubtype, typeArgs)),
-                                                getTypeCondition(subjectSubtypeExpanded)
-                                            );
-                                        }
                                     }
-
                                 }
                             }
                         } else {
                             return undefined;
                         }
 
+                        // For a generic class pattern whose type parameters are bounded
+                        // (e.g. `class Thing[T: bool]`), the subject may carry no type arguments,
+                        // leaving the parameters unsolved. Fall back to each parameter's bound -
+                        // but only for the pattern class itself. When the subject narrowed to a
+                        // proper subclass of the pattern class, its own type arguments must be
+                        // preserved rather than rebuilt from the (widened) base.
                         if (
                             isClassInstance(resultType) &&
                             isInstantiableClass(unexpandedSubtype) &&
-                            unexpandedSubtype.shared.typeParams.some((param) => isTypeVar(param) && param.shared.boundType)
+                            ClassType.isSameGenericClass(resultType, ClassType.cloneAsInstance(unexpandedSubtype)) &&
+                            unexpandedSubtype.shared.typeParams.some(
+                                (param) => isTypeVar(param) && param.shared.boundType
+                            )
                         ) {
-                            const genericMatchType = unexpandedSubtype;
-                            const subjectTypeArgs = isClassInstance(subjectSubtypeUnexpanded)
-                                ? subjectSubtypeUnexpanded.priv.typeArgs
+                            const subjectTypeArgs = isClassInstance(subjectSubtypeExpanded)
+                                ? subjectSubtypeExpanded.priv.typeArgs
                                 : undefined;
-                            const solvedTypeArgs = resultType.priv.typeArgs;
-                            const typeArgs = genericMatchType.shared.typeParams.map((param, index) => {
-                                const specializedArg = subjectTypeArgs?.[index] ?? solvedTypeArgs?.[index];
-                                if (
-                                    specializedArg &&
-                                    !requiresSpecialization(specializedArg) &&
-                                    !containsAnyOrUnknown(specializedArg, /* recurse */ true)
-                                ) {
-                                    return specializedArg;
-                                }
-
-                                if (isTypeVar(param) && param.shared.boundType) {
-                                    return convertToInstance(param.shared.boundType);
-                                }
-
-                                return specializedArg ?? getUnknownForTypeVar(param, evaluator.getTupleClassType());
-                            });
-
-                            resultType = addConditionToType(
-                                convertToInstance(ClassType.specialize(genericMatchType, typeArgs)),
+                            resultType = specializeBoundedMatchTypeParams(
+                                evaluator,
+                                unexpandedSubtype,
+                                subjectTypeArgs,
+                                resultType.priv.typeArgs,
                                 getTypeCondition(subjectSubtypeExpanded)
                             );
                         }
@@ -1130,8 +1122,7 @@ function narrowTypeBasedOnClassPattern(
                     }
 
                     return undefined;
-                    }
-                );
+                });
             }
 
             return undefined;

--- a/packages/pyright-internal/src/analyzer/patternMatching.ts
+++ b/packages/pyright-internal/src/analyzer/patternMatching.ts
@@ -58,6 +58,7 @@ import {
     isNever,
     isSameWithoutLiteralValue,
     isTypeSame,
+    isTypeVar,
     isTypeVarTuple,
     isUnknown,
     isUnpackedTypeVar,
@@ -67,9 +68,11 @@ import {
     addConditionToType,
     containsAnyOrUnknown,
     convertToInstance,
+    convertToInstantiable,
     doForEachSubtype,
     getTypeCondition,
     getTypeVarScopeIds,
+    getUnknownForTypeVar,
     getUnknownTypeForCallable,
     isLiteralType,
     isLiteralTypeOrUnion,
@@ -82,6 +85,7 @@ import {
     mapSubtypes,
     partiallySpecializeType,
     preserveUnknown,
+    selfSpecializeClass,
     specializeTupleClass,
     specializeWithUnknownTypeArgs,
     transformPossibleRecursiveTypeAlias,
@@ -755,7 +759,14 @@ function narrowTypeBasedOnClassPattern(
     // specialize it with Unknown type arguments.
     if (isClass(exprType) && !exprType.props?.typeAliasInfo) {
         exprType = ClassType.cloneRemoveTypePromotions(exprType);
-        exprType = specializeWithUnknownTypeArgs(exprType, evaluator.getTupleClassType());
+        if (
+            isInstantiableClass(exprType) &&
+            exprType.shared.typeParams.some((param) => isTypeVar(param) && param.shared.boundType)
+        ) {
+            exprType = selfSpecializeClass(exprType, { useBoundTypeVars: true });
+        } else {
+            exprType = specializeWithUnknownTypeArgs(exprType, evaluator.getTupleClassType());
+        }
     }
 
     // Are there any positional arguments? If so, try to get the mappings for
@@ -1019,6 +1030,32 @@ function narrowTypeBasedOnClassPattern(
                                                 },
                                             }
                                         ) as ClassType;
+                                    }
+
+                                    if (
+                                        isInstantiableClass(unexpandedSubtype) &&
+                                        unexpandedSubtype.shared.typeParams.some(
+                                            (param) => isTypeVar(param) && param.shared.boundType
+                                        )
+                                    ) {
+                                        const boundedTypeArgs = unexpandedSubtype.shared.typeParams.map((param) => {
+                                            if (isTypeVar(param) && param.shared.boundType) {
+                                                return TypeBase.isInstantiable(param)
+                                                    ? convertToInstantiable(param.shared.boundType, /* includeSubclasses */ false)
+                                                    : convertToInstance(param.shared.boundType);
+                                            }
+
+                                            return getUnknownForTypeVar(
+                                                param,
+                                                evaluator.getTupleClassType()
+                                            );
+                                        });
+                                        resultType = addConditionToType(
+                                            convertToInstance(
+                                                ClassType.specialize(unexpandedSubtype, boundedTypeArgs)
+                                            ),
+                                            getTypeCondition(subjectSubtypeExpanded)
+                                        );
                                     }
                                 }
                             }

--- a/packages/pyright-internal/src/analyzer/patternMatching.ts
+++ b/packages/pyright-internal/src/analyzer/patternMatching.ts
@@ -84,7 +84,6 @@ import {
     mapSubtypes,
     partiallySpecializeType,
     preserveUnknown,
-    requiresSpecialization,
     specializeTupleClass,
     specializeWithUnknownTypeArgs,
     transformPossibleRecursiveTypeAlias,
@@ -762,12 +761,10 @@ function specializeBoundedMatchTypeParams(
     const typeArgs = matchType.shared.typeParams.map((param, index) => {
         const specializedArg = subjectTypeArgs?.[index] ?? solvedTypeArgs?.[index];
 
-        // Keep an argument that was solved to a concrete (non-bound, non-Unknown) type.
-        if (
-            specializedArg &&
-            !requiresSpecialization(specializedArg) &&
-            !containsAnyOrUnknown(specializedArg, /* recurse */ true)
-        ) {
+        // Keep an argument unless it is genuinely Unknown. A bare in-scope TypeVar
+        // (e.g. a subject `Thing[S]` from a generic function `def f[S: bool]`) is a
+        // legitimately narrowed argument and must not be widened to the bound.
+        if (specializedArg && !containsAnyOrUnknown(specializedArg, /* recurse */ true)) {
             return specializedArg;
         }
 

--- a/packages/pyright-internal/src/analyzer/patternMatching.ts
+++ b/packages/pyright-internal/src/analyzer/patternMatching.ts
@@ -85,6 +85,7 @@ import {
     mapSubtypes,
     partiallySpecializeType,
     preserveUnknown,
+    requiresSpecialization,
     selfSpecializeClass,
     specializeTupleClass,
     specializeWithUnknownTypeArgs,
@@ -759,14 +760,7 @@ function narrowTypeBasedOnClassPattern(
     // specialize it with Unknown type arguments.
     if (isClass(exprType) && !exprType.props?.typeAliasInfo) {
         exprType = ClassType.cloneRemoveTypePromotions(exprType);
-        if (
-            isInstantiableClass(exprType) &&
-            exprType.shared.typeParams.some((param) => isTypeVar(param) && param.shared.boundType)
-        ) {
-            exprType = selfSpecializeClass(exprType, { useBoundTypeVars: true });
-        } else {
-            exprType = specializeWithUnknownTypeArgs(exprType, evaluator.getTupleClassType());
-        }
+        exprType = specializeWithUnknownTypeArgs(exprType, evaluator.getTupleClassType());
     }
 
     // Are there any positional arguments? If so, try to get the mappings for
@@ -926,7 +920,10 @@ function narrowTypeBasedOnClassPattern(
                 const expandedSubtypeInstance = convertToInstance(expandedSubtype);
                 const isPatternMetaclass = isMetaclassInstance(expandedSubtypeInstance);
 
-                return evaluator.mapSubtypesExpandTypeVars(type, /* options */ undefined, (subjectSubtypeExpanded) => {
+                return evaluator.mapSubtypesExpandTypeVars(
+                    type,
+                    /* options */ undefined,
+                    (subjectSubtypeExpanded, subjectSubtypeUnexpanded) => {
                     if (isAnyOrUnknown(subjectSubtypeExpanded)) {
                         if (isInstantiableClass(expandedSubtype) && ClassType.isBuiltIn(expandedSubtype, 'Callable')) {
                             // Convert to an unknown callable type.
@@ -1030,37 +1027,75 @@ function narrowTypeBasedOnClassPattern(
                                                 },
                                             }
                                         ) as ClassType;
-                                    }
 
-                                    if (
-                                        isInstantiableClass(unexpandedSubtype) &&
-                                        unexpandedSubtype.shared.typeParams.some(
-                                            (param) => isTypeVar(param) && param.shared.boundType
-                                        )
-                                    ) {
-                                        const boundedTypeArgs = unexpandedSubtype.shared.typeParams.map((param) => {
-                                            if (isTypeVar(param) && param.shared.boundType) {
-                                                return TypeBase.isInstantiable(param)
-                                                    ? convertToInstantiable(param.shared.boundType, /* includeSubclasses */ false)
-                                                    : convertToInstance(param.shared.boundType);
-                                            }
+                                        if (
+                                            unexpandedSubtype.shared.typeParams.some(
+                                                (param) => isTypeVar(param) && param.shared.boundType
+                                            )
+                                        ) {
+                                            const subjectTypeArgs = isClassInstance(subjectSubtypeExpanded)
+                                                ? subjectSubtypeExpanded.priv.typeArgs
+                                                : undefined;
+                                            const solvedTypeArgs = isClassInstance(resultType)
+                                                ? resultType.priv.typeArgs
+                                                : undefined;
+                                            const typeArgs = unexpandedSubtype.shared.typeParams.map((param, index) => {
+                                                const specializedArg = subjectTypeArgs?.[index] ?? solvedTypeArgs?.[index];
+                                                if (specializedArg && !requiresSpecialization(specializedArg)) {
+                                                    return specializedArg;
+                                                }
 
-                                            return getUnknownForTypeVar(
-                                                param,
-                                                evaluator.getTupleClassType()
+                                                if (isTypeVar(param) && param.shared.boundType) {
+                                                    return convertToInstance(param.shared.boundType);
+                                                }
+
+                                                return specializedArg ?? getUnknownForTypeVar(param, evaluator.getTupleClassType());
+                                            });
+
+                                            resultType = addConditionToType(
+                                                convertToInstance(ClassType.specialize(unexpandedSubtype, typeArgs)),
+                                                getTypeCondition(subjectSubtypeExpanded)
                                             );
-                                        });
-                                        resultType = addConditionToType(
-                                            convertToInstance(
-                                                ClassType.specialize(unexpandedSubtype, boundedTypeArgs)
-                                            ),
-                                            getTypeCondition(subjectSubtypeExpanded)
-                                        );
+                                        }
                                     }
+
                                 }
                             }
                         } else {
                             return undefined;
+                        }
+
+                        if (
+                            isClassInstance(resultType) &&
+                            isInstantiableClass(unexpandedSubtype) &&
+                            unexpandedSubtype.shared.typeParams.some((param) => isTypeVar(param) && param.shared.boundType)
+                        ) {
+                            const genericMatchType = unexpandedSubtype;
+                            const subjectTypeArgs = isClassInstance(subjectSubtypeUnexpanded)
+                                ? subjectSubtypeUnexpanded.priv.typeArgs
+                                : undefined;
+                            const solvedTypeArgs = resultType.priv.typeArgs;
+                            const typeArgs = genericMatchType.shared.typeParams.map((param, index) => {
+                                const specializedArg = subjectTypeArgs?.[index] ?? solvedTypeArgs?.[index];
+                                if (
+                                    specializedArg &&
+                                    !requiresSpecialization(specializedArg) &&
+                                    !containsAnyOrUnknown(specializedArg, /* recurse */ true)
+                                ) {
+                                    return specializedArg;
+                                }
+
+                                if (isTypeVar(param) && param.shared.boundType) {
+                                    return convertToInstance(param.shared.boundType);
+                                }
+
+                                return specializedArg ?? getUnknownForTypeVar(param, evaluator.getTupleClassType());
+                            });
+
+                            resultType = addConditionToType(
+                                convertToInstance(ClassType.specialize(genericMatchType, typeArgs)),
+                                getTypeCondition(subjectSubtypeExpanded)
+                            );
                         }
 
                         // Are there any positional arguments? If so, try to get the mappings for
@@ -1095,7 +1130,8 @@ function narrowTypeBasedOnClassPattern(
                     }
 
                     return undefined;
-                });
+                    }
+                );
             }
 
             return undefined;

--- a/packages/pyright-internal/src/analyzer/typeUtils.ts
+++ b/packages/pyright-internal/src/analyzer/typeUtils.ts
@@ -4192,15 +4192,6 @@ class ApplySolvedTypeVarsTransformer extends TypeVarTransformer {
 
         let replacement = solutionSet.getType(typeVar);
 
-        if (replacement && isUnknown(replacement) && typeVar.shared.boundType) {
-            return this.apply(
-                TypeBase.isInstantiable(typeVar)
-                    ? convertToInstantiable(typeVar.shared.boundType, /* includeSubclasses */ false)
-                    : convertToInstance(typeVar.shared.boundType),
-                recursionCount
-            );
-        }
-
         if (replacement) {
             // No more processing is needed for ParamSpecs.
             if (isParamSpec(typeVar)) {
@@ -4288,16 +4279,6 @@ class ApplySolvedTypeVarsTransformer extends TypeVarTransformer {
         // Use the default value if there is one.
         if (typeVar.shared.isDefaultExplicit && !this._options.replaceUnsolved?.useUnknown) {
             return this._solveDefaultType(typeVar, recursionCount);
-        }
-
-        // Use the bound type if there is one. This is important for pattern matching
-        // where unsolved type variables with bounds (e.g. T: bool) should retain
-        // their bound rather than being replaced with Unknown.
-        if (typeVar.shared.boundType) {
-            const boundType = TypeBase.isInstantiable(typeVar)
-                ? convertToInstantiable(typeVar.shared.boundType, /* includeSubclasses */ false)
-                : convertToInstance(typeVar.shared.boundType);
-            return this.apply(boundType, recursionCount);
         }
 
         return getUnknownForTypeVar(typeVar, this._options.replaceUnsolved?.tupleClassType);

--- a/packages/pyright-internal/src/analyzer/typeUtils.ts
+++ b/packages/pyright-internal/src/analyzer/typeUtils.ts
@@ -4192,6 +4192,15 @@ class ApplySolvedTypeVarsTransformer extends TypeVarTransformer {
 
         let replacement = solutionSet.getType(typeVar);
 
+        if (replacement && isUnknown(replacement) && typeVar.shared.boundType) {
+            return this.apply(
+                TypeBase.isInstantiable(typeVar)
+                    ? convertToInstantiable(typeVar.shared.boundType, /* includeSubclasses */ false)
+                    : convertToInstance(typeVar.shared.boundType),
+                recursionCount
+            );
+        }
+
         if (replacement) {
             // No more processing is needed for ParamSpecs.
             if (isParamSpec(typeVar)) {
@@ -4279,6 +4288,16 @@ class ApplySolvedTypeVarsTransformer extends TypeVarTransformer {
         // Use the default value if there is one.
         if (typeVar.shared.isDefaultExplicit && !this._options.replaceUnsolved?.useUnknown) {
             return this._solveDefaultType(typeVar, recursionCount);
+        }
+
+        // Use the bound type if there is one. This is important for pattern matching
+        // where unsolved type variables with bounds (e.g. T: bool) should retain
+        // their bound rather than being replaced with Unknown.
+        if (typeVar.shared.boundType) {
+            const boundType = TypeBase.isInstantiable(typeVar)
+                ? convertToInstantiable(typeVar.shared.boundType, /* includeSubclasses */ false)
+                : convertToInstance(typeVar.shared.boundType);
+            return this.apply(boundType, recursionCount);
         }
 
         return getUnknownForTypeVar(typeVar, this._options.replaceUnsolved?.tupleClassType);

--- a/packages/pyright-internal/src/tests/samples/matchNamedTupleGeneric1.py
+++ b/packages/pyright-internal/src/tests/samples/matchNamedTupleGeneric1.py
@@ -73,3 +73,20 @@ def test_positional(value: object) -> None:
     match value:
         case Thing(x):
             reveal_type(x, expected_text="bool")
+
+
+class GenericBase[U]:
+    pass
+
+
+class BoundedDerived[T: bool](GenericBase[int]):
+    foo: T
+
+
+def test_generic_supertype(value: GenericBase[int]) -> None:
+    # `BoundedDerived` has a generic supertype `GenericBase[int]`. The fallback must
+    # read the pattern class's own unsolved bounded parameter (so `T` resolves to its
+    # bound `bool`), not the supertype's unrelated `int` type argument.
+    match value:
+        case BoundedDerived():
+            reveal_type(value.foo, expected_text="bool")

--- a/packages/pyright-internal/src/tests/samples/matchNamedTupleGeneric1.py
+++ b/packages/pyright-internal/src/tests/samples/matchNamedTupleGeneric1.py
@@ -23,3 +23,37 @@ def test_literal(value: Thing[bool] | object) -> str:
             return "thing"
         case _:
             return ""
+
+
+class Animal:
+    pass
+
+
+class Container[T: Animal](NamedTuple):
+    item: T
+
+
+def test_nonfinal_bound(value: object) -> None:
+    # T's bound (Animal) is not final, so falling back to the bound is a real
+    # widening. An unsolved bounded parameter should surface as the bound rather
+    # than Unknown.
+    match value:
+        case Container():
+            reveal_type(value.item, expected_text="Animal")
+
+
+class Base[T: bool]:
+    pass
+
+
+class Sub(Base[bool]):
+    pass
+
+
+def test_subclass(value: Sub) -> None:
+    # The subject is a subclass of the bounded-generic pattern class. Matching
+    # `case Base()` must keep the narrowed subclass type rather than rebuilding
+    # it from the widened base class.
+    match value:
+        case Base():
+            reveal_type(value, expected_text="Sub")

--- a/packages/pyright-internal/src/tests/samples/matchNamedTupleGeneric1.py
+++ b/packages/pyright-internal/src/tests/samples/matchNamedTupleGeneric1.py
@@ -14,3 +14,12 @@ def test(value: object) -> str:
             return "thing" if value.foo else ""
         case _:
             return ""
+
+
+def test_literal(value: Thing[bool] | object) -> str:
+    match value:
+        case Thing(foo=True):
+            reveal_type(value.foo, expected_text="bool")
+            return "thing"
+        case _:
+            return ""

--- a/packages/pyright-internal/src/tests/samples/matchNamedTupleGeneric1.py
+++ b/packages/pyright-internal/src/tests/samples/matchNamedTupleGeneric1.py
@@ -57,3 +57,19 @@ def test_subclass(value: Sub) -> None:
     match value:
         case Base():
             reveal_type(value, expected_text="Sub")
+
+
+def f[S: bool](value: Thing[S]) -> None:
+    # The subject's type argument is an in-scope TypeVar. Matching must preserve
+    # the narrowed `S` rather than widening it to the bound `bool`.
+    match value:
+        case Thing():
+            reveal_type(value.foo, expected_text="S@f")
+
+
+def test_positional(value: object) -> None:
+    # Positional matching binds via __match_args__; confirm it still works for a
+    # generic NamedTuple whose parameter falls back to its bound.
+    match value:
+        case Thing(x):
+            reveal_type(x, expected_text="bool")

--- a/packages/pyright-internal/src/tests/samples/matchNamedTupleGeneric1.py
+++ b/packages/pyright-internal/src/tests/samples/matchNamedTupleGeneric1.py
@@ -1,0 +1,16 @@
+# This sample tests generic NamedTuple class pattern matching.
+
+from typing import NamedTuple
+
+
+class Thing[T: bool](NamedTuple):
+    foo: T
+
+
+def test(value: object) -> str:
+    match value:
+        case Thing():
+            reveal_type(value.foo, expected_text="bool")
+            return "thing" if value.foo else ""
+        case _:
+            return ""

--- a/packages/pyright-internal/src/tests/typeEvaluator8.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator8.test.ts
@@ -11,7 +11,7 @@
 import * as assert from 'assert';
 
 import { ConfigOptions } from '../common/configOptions';
-import { pythonVersion3_10, pythonVersion3_11, pythonVersion3_8 } from '../common/pythonVersion';
+import { pythonVersion3_10, pythonVersion3_11, pythonVersion3_8, pythonVersion3_12 } from '../common/pythonVersion';
 import { Uri } from '../common/uri/uri';
 import * as TestUtils from './testUtils';
 
@@ -627,6 +627,14 @@ test('NamedTuple11', () => {
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['namedTuple11.py']);
 
     TestUtils.validateResults(analysisResults, 3);
+});
+
+test('NamedTuple12', () => {
+    const configOptions = new ConfigOptions(Uri.empty());
+    configOptions.defaultPythonVersion = pythonVersion3_12;
+    const analysisResults = TestUtils.typeAnalyzeSampleFiles(['matchNamedTupleGeneric1.py'], configOptions);
+
+    TestUtils.validateResults(analysisResults, 0);
 });
 
 test('Slots1', () => {


### PR DESCRIPTION
## Summary

Fixes pyright incorrectly reporting `Unknown` for fields on generic `NamedTuple` classes after a successful class pattern match when the type parameter has a bound (e.g. `Thing[T: bool]`).

## Problem

```python
class Thing[T: bool](NamedTuple):
    foo: T

def test(value: object) -> str:
    match value:
        case Thing():
            reveal_type(value.foo)  # was Unknown
```

## Fix

- When preparing class patterns, prefer bound type args over `Unknown` for bounded type params
- When narrowing after a match against `object`, specialize bounded type params to their bounds
- When replacing unsolved type vars during constraint application, fall back to bound types before `Unknown`

## Testing

- Added `matchNamedTupleGeneric1.py` + `NamedTuple12` test
- `npm run test:norebuild -- --testNamePattern=NamedTuple12` passes
- `MatchClass1` regression test passes

Fixes #11487