### PR TITLE
Allow Callable class attributes to be overridden by instance methods

### DIFF
--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -27819,19 +27819,32 @@ export function createTypeEvaluator(
                     }
                 }
             } else if (overrideParamDetails.positionParamCount > baseParamDetails.positionParamCount) {
-                // Verify that all of the override parameters that extend the
-                // signature are either *args, **kwargs or parameters with
-                // default values.
+                const isCallableAttrOverriddenByInstanceMethod =
+                    baseParamDetails.positionParamCount === 0 &&
+                    overrideParamDetails.positionParamCount === 1 &&
+                    FunctionType.isInstanceMethod(overrideMethod) &&
+                    !FunctionType.isStaticMethod(baseMethod) &&
+                    !FunctionType.isClassMethod(baseMethod);
 
-                for (let i = baseParamDetails.positionParamCount; i < overrideParamDetails.positionParamCount; i++) {
-                    const overrideParam = overrideParamDetails.params[i].param;
+                if (!isCallableAttrOverriddenByInstanceMethod) {
+                    // Verify that all of the override parameters that extend the
+                    // signature are either *args, **kwargs or parameters with
+                    // default values.
 
-                    if (
-                        overrideParam.category === ParamCategory.Simple &&
-                        overrideParam.name &&
-                        !overrideParamDetails.params[i].defaultType
+                    for (
+                        let i = baseParamDetails.positionParamCount;
+                        i < overrideParamDetails.positionParamCount;
+                        i++
                     ) {
-                        foundParamCountMismatch = true;
+                        const overrideParam = overrideParamDetails.params[i].param;
+
+                        if (
+                            overrideParam.category === ParamCategory.Simple &&
+                            overrideParam.name &&
+                            !overrideParamDetails.params[i].defaultType
+                        ) {
+                            foundParamCountMismatch = true;
+                        }
                     }
                 }
             }

--- a/packages/pyright-internal/src/tests/samples/methodOverrideCallable1.py
+++ b/packages/pyright-internal/src/tests/samples/methodOverrideCallable1.py
@@ -1,0 +1,18 @@
+# This sample tests overriding a Callable class attribute with an instance method.
+
+from collections.abc import Callable
+from typing import override
+
+
+class A:
+    hello: Callable[[], None] = lambda: print("hello")
+
+
+class B(A):
+    @override
+    def hello(self) -> None:
+        print("hi")
+
+
+b = B()
+b.hello()

--- a/packages/pyright-internal/src/tests/typeEvaluator3.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator3.test.ts
@@ -958,6 +958,13 @@ test('MethodOverride1', () => {
     TestUtils.validateResults(analysisResults, 43);
 });
 
+test('MethodOverrideCallable1', () => {
+    const configOptions = new ConfigOptions(Uri.empty());
+    configOptions.diagnosticRuleSet.reportIncompatibleMethodOverride = 'error';
+    const analysisResults = TestUtils.typeAnalyzeSampleFiles(['methodOverrideCallable1.py'], configOptions);
+    TestUtils.validateResults(analysisResults, 0);
+});
+
 test('MethodOverride2', () => {
     const configOptions = new ConfigOptions(Uri.empty());
 


### PR DESCRIPTION
## Summary

Fixes incompatible method override diagnostics when a base class declares a `Callable`-typed attribute and a subclass overrides it with an instance method.

## Problem

```python
class A:
    hello: Callable[[], None] = lambda: print("hello")

class B(A):
    @override
    def hello(self) -> None:
        print("hi")
```

Pyright reported a positional parameter count mismatch (0 vs 1). mypy and ty accept this.

## Fix

Treat a zero-parameter Callable class attribute overridden by a one-parameter instance method as compatible.

## Testing

- Added `methodOverrideCallable1.py` + `MethodOverrideCallable1` test (0 errors expected)

Fixes #11475