### PR TITLE
Fix NewType identity comparisons with base literals

### DIFF
--- a/packages/pyright-internal/src/analyzer/typeGuards.ts
+++ b/packages/pyright-internal/src/analyzer/typeGuards.ts
@@ -1081,10 +1081,21 @@ function narrowTupleTypeForIsNone(evaluator: TypeEvaluator, type: Type, isPositi
     });
 }
 
+// Walks a chain of NewType instances down to the innermost non-NewType base
+// instance (e.g. NewType("Y", NewType("X", bool)) -> an instance of bool).
+// Returns undefined if `subtype` is not a NewType instance or its base cannot
+// be resolved to a class.
 function getInnermostNewTypeBaseInstance(subtype: Type): Type | undefined {
-    let currentType = subtype;
+    if (!isClassInstance(subtype) || !ClassType.isNewTypeClass(subtype)) {
+        return undefined;
+    }
 
-    while (isClassInstance(currentType) && ClassType.isNewTypeClass(currentType) && currentType.shared.baseClasses.length > 0) {
+    let currentType: Type = subtype;
+    while (isClassInstance(currentType) && ClassType.isNewTypeClass(currentType)) {
+        if (currentType.shared.baseClasses.length === 0) {
+            return undefined;
+        }
+
         const baseClass = currentType.shared.baseClasses[0];
         if (!isClass(baseClass)) {
             return undefined;
@@ -1094,20 +1105,6 @@ function getInnermostNewTypeBaseInstance(subtype: Type): Type | undefined {
     }
 
     return currentType;
-}
-
-function isNewTypeWithSingletonBase(
-    evaluator: TypeEvaluator,
-    subtype: Type,
-    targetType: Type,
-    isExactMatch: (type: Type) => boolean
-) {
-    const baseInstance = getInnermostNewTypeBaseInstance(subtype);
-    if (!baseInstance || baseInstance === subtype) {
-        return false;
-    }
-
-    return isExactMatch(baseInstance) || evaluator.assignType(baseInstance, targetType);
 }
 
 // Handle type narrowing for expressions of the form "x is None" and "x is not None".
@@ -1157,8 +1154,14 @@ function narrowTypeForIsNone(evaluator: TypeEvaluator, type: Type, isPositiveTes
 
             const adjustedSubtype = useExpandedSubtype ? subtype : unexpandedSubtype;
 
-            // NewType instances can be identity-compared with their underlying base type.
-            if (isNewTypeWithSingletonBase(evaluator, adjustedSubtype, evaluator.getNoneType(), isNoneInstance)) {
+            // A NewType whose innermost base is exactly None (e.g. NewType("Apple", NoneType))
+            // can be identity-compared with None: keep the NewType identity on the positive
+            // branch and eliminate it on the negative branch. A NewType whose base is merely
+            // None-compatible (e.g. NewType("Obj", object)) is intentionally not handled here;
+            // it falls through to the generic checks below so that "is not None" does not
+            // incorrectly collapse to Never.
+            const newTypeBaseInstance = getInnermostNewTypeBaseInstance(adjustedSubtype);
+            if (newTypeBaseInstance && isNoneInstance(newTypeBaseInstance)) {
                 resultIncludesNoneSubtype = true;
                 return isPositiveTest ? adjustedSubtype : undefined;
             }
@@ -1186,10 +1189,8 @@ function narrowTypeForIsNone(evaluator: TypeEvaluator, type: Type, isPositiveTes
     // of the subtypes are None types with conditions, retain those.
     if (isPositiveTest && resultIncludesNoneSubtype) {
         return mapSubtypes(result, (subtype) => {
-            return isNoneInstance(subtype) ||
-                isNewTypeWithSingletonBase(evaluator, subtype, evaluator.getNoneType(), isNoneInstance)
-                ? subtype
-                : undefined;
+            const baseInstance = getInnermostNewTypeBaseInstance(subtype);
+            return isNoneInstance(subtype) || (baseInstance && isNoneInstance(baseInstance)) ? subtype : undefined;
         });
     }
 
@@ -1231,7 +1232,11 @@ function narrowTypeForIsEllipsis(evaluator: TypeEvaluator, node: ExpressionNode,
                     ? unexpandedSubtype
                     : subtype;
 
-            if (isNewTypeWithSingletonBase(evaluator, adjustedSubtype, ellipsisType, isEllipsisInstance)) {
+            // Only a NewType whose innermost base is exactly the ellipsis type is treated
+            // as the singleton (see narrowTypeForIsNone for the rationale); a merely
+            // ellipsis-compatible base falls through so "is not ..." does not collapse to Never.
+            const newTypeBaseInstance = getInnermostNewTypeBaseInstance(adjustedSubtype);
+            if (newTypeBaseInstance && isEllipsisInstance(newTypeBaseInstance)) {
                 resultIncludesEllipsisSubtype = true;
                 return isPositiveTest ? adjustedSubtype : undefined;
             }
@@ -1257,8 +1262,8 @@ function narrowTypeForIsEllipsis(evaluator: TypeEvaluator, node: ExpressionNode,
     // of the subtypes are ellipsis types with conditions, retain those.
     if (isPositiveTest && resultIncludesEllipsisSubtype) {
         return mapSubtypes(result, (subtype) => {
-            return isEllipsisInstance(subtype) ||
-                isNewTypeWithSingletonBase(evaluator, subtype, ellipsisType, isEllipsisInstance)
+            const baseInstance = getInnermostNewTypeBaseInstance(subtype);
+            return isEllipsisInstance(subtype) || (baseInstance && isEllipsisInstance(baseInstance))
                 ? subtype
                 : undefined;
         });

--- a/packages/pyright-internal/src/analyzer/typeGuards.ts
+++ b/packages/pyright-internal/src/analyzer/typeGuards.ts
@@ -1081,6 +1081,25 @@ function narrowTupleTypeForIsNone(evaluator: TypeEvaluator, type: Type, isPositi
     });
 }
 
+function isNewTypeWithSingletonBase(
+    evaluator: TypeEvaluator,
+    subtype: Type,
+    targetType: Type,
+    isExactMatch: (type: Type) => boolean
+) {
+    if (!isClassInstance(subtype) || !ClassType.isNewTypeClass(subtype) || subtype.shared.baseClasses.length === 0) {
+        return false;
+    }
+
+    const baseClass = subtype.shared.baseClasses[0];
+    if (!isClass(baseClass)) {
+        return false;
+    }
+
+    const baseInstance = ClassType.cloneAsInstance(baseClass);
+    return isExactMatch(baseInstance) || evaluator.assignType(baseInstance, targetType);
+}
+
 // Handle type narrowing for expressions of the form "x is None" and "x is not None".
 function narrowTypeForIsNone(evaluator: TypeEvaluator, type: Type, isPositiveTest: boolean) {
     const expandedType = mapSubtypes(type, (subtype) => {
@@ -1129,22 +1148,9 @@ function narrowTypeForIsNone(evaluator: TypeEvaluator, type: Type, isPositiveTes
             const adjustedSubtype = useExpandedSubtype ? subtype : unexpandedSubtype;
 
             // NewType instances can be identity-compared with their underlying base type.
-            if (isClassInstance(adjustedSubtype) && ClassType.isNewTypeClass(adjustedSubtype) && adjustedSubtype.shared.baseClasses.length > 0) {
-                const baseClass = adjustedSubtype.shared.baseClasses[0];
-                if (isClass(baseClass)) {
-                    const baseInstance = ClassType.cloneAsInstance(baseClass);
-                    if (isNoneInstance(baseInstance)) {
-                        resultIncludesNoneSubtype = true;
-                        return isPositiveTest ? adjustedSubtype : undefined;
-                    }
-
-                    if (evaluator.assignType(baseInstance, evaluator.getNoneType())) {
-                        resultIncludesNoneSubtype = true;
-                        return isPositiveTest
-                            ? addConditionToType(evaluator.getNoneType(), subtype.props?.condition)
-                            : adjustedSubtype;
-                    }
-                }
+            if (isNewTypeWithSingletonBase(evaluator, adjustedSubtype, evaluator.getNoneType(), isNoneInstance)) {
+                resultIncludesNoneSubtype = true;
+                return isPositiveTest ? adjustedSubtype : undefined;
             }
 
             // Is it an exact match for None?
@@ -1170,7 +1176,10 @@ function narrowTypeForIsNone(evaluator: TypeEvaluator, type: Type, isPositiveTes
     // of the subtypes are None types with conditions, retain those.
     if (isPositiveTest && resultIncludesNoneSubtype) {
         return mapSubtypes(result, (subtype) => {
-            return isNoneInstance(subtype) ? subtype : undefined;
+            return isNoneInstance(subtype) ||
+                isNewTypeWithSingletonBase(evaluator, subtype, evaluator.getNoneType(), isNoneInstance)
+                ? subtype
+                : undefined;
         });
     }
 
@@ -1212,6 +1221,11 @@ function narrowTypeForIsEllipsis(evaluator: TypeEvaluator, node: ExpressionNode,
                     ? unexpandedSubtype
                     : subtype;
 
+            if (isNewTypeWithSingletonBase(evaluator, adjustedSubtype, ellipsisType, isEllipsisInstance)) {
+                resultIncludesEllipsisSubtype = true;
+                return isPositiveTest ? adjustedSubtype : undefined;
+            }
+
             // Is it an exact match for ellipsis?
             if (isEllipsisInstance(subtype)) {
                 resultIncludesEllipsisSubtype = true;
@@ -1233,7 +1247,10 @@ function narrowTypeForIsEllipsis(evaluator: TypeEvaluator, node: ExpressionNode,
     // of the subtypes are ellipsis types with conditions, retain those.
     if (isPositiveTest && resultIncludesEllipsisSubtype) {
         return mapSubtypes(result, (subtype) => {
-            return isEllipsisInstance(subtype) ? subtype : undefined;
+            return isEllipsisInstance(subtype) ||
+                isNewTypeWithSingletonBase(evaluator, subtype, ellipsisType, isEllipsisInstance)
+                ? subtype
+                : undefined;
         });
     }
 

--- a/packages/pyright-internal/src/analyzer/typeGuards.ts
+++ b/packages/pyright-internal/src/analyzer/typeGuards.ts
@@ -1081,22 +1081,32 @@ function narrowTupleTypeForIsNone(evaluator: TypeEvaluator, type: Type, isPositi
     });
 }
 
+function getInnermostNewTypeBaseInstance(subtype: Type): Type | undefined {
+    let currentType = subtype;
+
+    while (isClassInstance(currentType) && ClassType.isNewTypeClass(currentType) && currentType.shared.baseClasses.length > 0) {
+        const baseClass = currentType.shared.baseClasses[0];
+        if (!isClass(baseClass)) {
+            return undefined;
+        }
+
+        currentType = ClassType.cloneAsInstance(baseClass);
+    }
+
+    return currentType;
+}
+
 function isNewTypeWithSingletonBase(
     evaluator: TypeEvaluator,
     subtype: Type,
     targetType: Type,
     isExactMatch: (type: Type) => boolean
 ) {
-    if (!isClassInstance(subtype) || !ClassType.isNewTypeClass(subtype) || subtype.shared.baseClasses.length === 0) {
+    const baseInstance = getInnermostNewTypeBaseInstance(subtype);
+    if (!baseInstance || baseInstance === subtype) {
         return false;
     }
 
-    const baseClass = subtype.shared.baseClasses[0];
-    if (!isClass(baseClass)) {
-        return false;
-    }
-
-    const baseInstance = ClassType.cloneAsInstance(baseClass);
     return isExactMatch(baseInstance) || evaluator.assignType(baseInstance, targetType);
 }
 
@@ -2777,13 +2787,7 @@ function narrowTypeForLiteralComparison(
             }
 
             if (isIsOperator || isNoneInstance(subtype)) {
-                let compareType: Type = subtype;
-                if (isClassInstance(subtype) && ClassType.isNewTypeClass(subtype) && subtype.shared.baseClasses.length > 0) {
-                    const baseClass = subtype.shared.baseClasses[0];
-                    if (isClass(baseClass)) {
-                        compareType = ClassType.cloneAsInstance(baseClass);
-                    }
-                }
+                const compareType = getInnermostNewTypeBaseInstance(subtype) ?? subtype;
 
                 const isSubtype = evaluator.assignType(compareType, literalType);
                 if (isSubtype) {

--- a/packages/pyright-internal/src/analyzer/typeGuards.ts
+++ b/packages/pyright-internal/src/analyzer/typeGuards.ts
@@ -1128,6 +1128,25 @@ function narrowTypeForIsNone(evaluator: TypeEvaluator, type: Type, isPositiveTes
 
             const adjustedSubtype = useExpandedSubtype ? subtype : unexpandedSubtype;
 
+            // NewType instances can be identity-compared with their underlying base type.
+            if (isClassInstance(adjustedSubtype) && ClassType.isNewTypeClass(adjustedSubtype) && adjustedSubtype.shared.baseClasses.length > 0) {
+                const baseClass = adjustedSubtype.shared.baseClasses[0];
+                if (isClass(baseClass)) {
+                    const baseInstance = ClassType.cloneAsInstance(baseClass);
+                    if (isNoneInstance(baseInstance)) {
+                        resultIncludesNoneSubtype = true;
+                        return isPositiveTest ? adjustedSubtype : undefined;
+                    }
+
+                    if (evaluator.assignType(baseInstance, evaluator.getNoneType())) {
+                        resultIncludesNoneSubtype = true;
+                        return isPositiveTest
+                            ? addConditionToType(evaluator.getNoneType(), subtype.props?.condition)
+                            : adjustedSubtype;
+                    }
+                }
+            }
+
             // Is it an exact match for None?
             if (isNoneInstance(subtype)) {
                 resultIncludesNoneSubtype = true;
@@ -2741,8 +2760,19 @@ function narrowTypeForLiteralComparison(
             }
 
             if (isIsOperator || isNoneInstance(subtype)) {
-                const isSubtype = evaluator.assignType(subtype, literalType);
-                return isSubtype ? literalType : undefined;
+                let compareType: Type = subtype;
+                if (isClassInstance(subtype) && ClassType.isNewTypeClass(subtype) && subtype.shared.baseClasses.length > 0) {
+                    const baseClass = subtype.shared.baseClasses[0];
+                    if (isClass(baseClass)) {
+                        compareType = ClassType.cloneAsInstance(baseClass);
+                    }
+                }
+
+                const isSubtype = evaluator.assignType(compareType, literalType);
+                if (isSubtype) {
+                    return isClassInstance(subtype) && ClassType.isNewTypeClass(subtype) ? subtype : literalType;
+                }
+                return undefined;
             }
         }
 

--- a/packages/pyright-internal/src/tests/samples/newTypeIsLiteral1.py
+++ b/packages/pyright-internal/src/tests/samples/newTypeIsLiteral1.py
@@ -1,14 +1,15 @@
 # This sample tests `is` comparisons involving NewType instances.
 
-from types import NoneType
+from types import EllipsisType, NoneType
 from typing import NewType, reveal_type
 
 Apple = NewType("Apple", NoneType)
 Banana = NewType("Banana", bool)
 Cherry = NewType("Cherry", int)
+Dragonfruit = NewType("Dragonfruit", EllipsisType)
 
 
-def f(a: Apple, b: Banana, c: Cherry) -> None:
+def f(a: Apple, b: Banana, c: Cherry, d: Dragonfruit) -> None:
     if a is None:
         reveal_type(a, expected_text="Apple")
 
@@ -18,5 +19,8 @@ def f(a: Apple, b: Banana, c: Cherry) -> None:
     if c is False:
         reveal_type(c, expected_text="Cherry")
 
+    if d is ...:
+        reveal_type(d, expected_text="Dragonfruit")
 
-f(Apple(None), Banana(True), Cherry(False))
+
+f(Apple(None), Banana(True), Cherry(False), Dragonfruit(...))

--- a/packages/pyright-internal/src/tests/samples/newTypeIsLiteral1.py
+++ b/packages/pyright-internal/src/tests/samples/newTypeIsLiteral1.py
@@ -1,0 +1,22 @@
+# This sample tests `is` comparisons involving NewType instances.
+
+from types import NoneType
+from typing import NewType, reveal_type
+
+Apple = NewType("Apple", NoneType)
+Banana = NewType("Banana", bool)
+Cherry = NewType("Cherry", int)
+
+
+def f(a: Apple, b: Banana, c: Cherry) -> None:
+    if a is None:
+        reveal_type(a, expected_text="Apple")
+
+    if b is True:
+        reveal_type(b, expected_text="Banana")
+
+    if c is False:
+        reveal_type(c, expected_text="Cherry")
+
+
+f(Apple(None), Banana(True), Cherry(False))

--- a/packages/pyright-internal/src/tests/samples/newTypeIsLiteral1.py
+++ b/packages/pyright-internal/src/tests/samples/newTypeIsLiteral1.py
@@ -11,6 +11,12 @@ Cherry = NewType("Cherry", int)
 Dragonfruit = NewType("Dragonfruit", EllipsisType)
 Elderberry = NewType("Elderberry", Dragonfruit)
 
+# NewTypes over a non-singleton base that is merely compatible with the
+# singleton (object accepts both None and ...). The negative branch must stay
+# reachable rather than collapsing to Never.
+Fig = NewType("Fig", object)
+Guava = NewType("Guava", object)
+
 
 def f(a: Apple, aa: Apricot, b: Banana, bb: Plantain, c: Cherry, d: Dragonfruit, dd: Elderberry) -> None:
     if a is None:
@@ -34,6 +40,18 @@ def f(a: Apple, aa: Apricot, b: Banana, bb: Plantain, c: Cherry, d: Dragonfruit,
     if dd is ...:
         reveal_type(dd, expected_text="Elderberry")
 
+
+def g(o: Fig, e: Guava) -> None:
+    # A NewType over a non-singleton base (object) is not identity-equal to the
+    # singleton, so the negative branch must keep the NewType and stay reachable
+    # rather than collapsing to Never (a regression caught under reportUnreachable).
+    if o is not None:
+        reveal_type(o, expected_text="Fig")
+
+    if e is not ...:
+        reveal_type(e, expected_text="Guava")
+
+
 f(
     Apple(None),
     Apricot(Apple(None)),
@@ -43,3 +61,5 @@ f(
     Dragonfruit(...),
     Elderberry(Dragonfruit(...)),
 )
+
+g(Fig(object()), Guava(object()))

--- a/packages/pyright-internal/src/tests/samples/newTypeIsLiteral1.py
+++ b/packages/pyright-internal/src/tests/samples/newTypeIsLiteral1.py
@@ -4,17 +4,26 @@ from types import EllipsisType, NoneType
 from typing import NewType, reveal_type
 
 Apple = NewType("Apple", NoneType)
+Apricot = NewType("Apricot", Apple)
 Banana = NewType("Banana", bool)
+Plantain = NewType("Plantain", Banana)
 Cherry = NewType("Cherry", int)
 Dragonfruit = NewType("Dragonfruit", EllipsisType)
+Elderberry = NewType("Elderberry", Dragonfruit)
 
 
-def f(a: Apple, b: Banana, c: Cherry, d: Dragonfruit) -> None:
+def f(a: Apple, aa: Apricot, b: Banana, bb: Plantain, c: Cherry, d: Dragonfruit, dd: Elderberry) -> None:
     if a is None:
         reveal_type(a, expected_text="Apple")
 
+    if aa is None:
+        reveal_type(aa, expected_text="Apricot")
+
     if b is True:
         reveal_type(b, expected_text="Banana")
+
+    if bb is True:
+        reveal_type(bb, expected_text="Plantain")
 
     if c is False:
         reveal_type(c, expected_text="Cherry")
@@ -22,5 +31,15 @@ def f(a: Apple, b: Banana, c: Cherry, d: Dragonfruit) -> None:
     if d is ...:
         reveal_type(d, expected_text="Dragonfruit")
 
+    if dd is ...:
+        reveal_type(dd, expected_text="Elderberry")
 
-f(Apple(None), Banana(True), Cherry(False), Dragonfruit(...))
+f(
+    Apple(None),
+    Apricot(Apple(None)),
+    Banana(True),
+    Plantain(Banana(True)),
+    Cherry(False),
+    Dragonfruit(...),
+    Elderberry(Dragonfruit(...)),
+)

--- a/packages/pyright-internal/src/tests/typeEvaluator2.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator2.test.ts
@@ -305,6 +305,12 @@ test('NewType7', () => {
     TestUtils.validateResults(analysisResults, 2);
 });
 
+test('NewType8', () => {
+    const analysisResults = TestUtils.typeAnalyzeSampleFiles(['newTypeIsLiteral1.py']);
+
+    TestUtils.validateResults(analysisResults, 0);
+});
+
 test('isInstance1', () => {
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['isinstance1.py']);
 

--- a/packages/pyright-internal/src/tests/typeEvaluator2.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator2.test.ts
@@ -306,7 +306,9 @@ test('NewType7', () => {
 });
 
 test('NewType8', () => {
-    const analysisResults = TestUtils.typeAnalyzeSampleFiles(['newTypeIsLiteral1.py']);
+    const configOptions = new ConfigOptions(Uri.empty());
+    configOptions.diagnosticRuleSet.reportUnreachable = 'error';
+    const analysisResults = TestUtils.typeAnalyzeSampleFiles(['newTypeIsLiteral1.py'], configOptions);
 
     TestUtils.validateResults(analysisResults, 0);
 });


### PR DESCRIPTION
## Summary

Fixes pyright treating valid `is` comparisons between `NewType` instances and their underlying base literals as unreachable.

## Problem

```python
Banana = NewType("Banana", bool)

def f(b: Banana) -> None:
    if b is True:  # incorrectly marked unreachable
        reveal_type(b)
```

## Fix

Compare `NewType` instances against their underlying base types when evaluating `is` narrowing for literals and `None`.

## Testing

- Added `newTypeIsLiteral1.py` + `NewType8` test (0 errors expected)

Fixes #11463