### PR TITLE
Fix #11450: [FR]: `struct.unpack` type inference

### DIFF
--- a/packages/pyright-internal/src/analyzer/functionTransform.ts
+++ b/packages/pyright-internal/src/analyzer/functionTransform.ts
@@ -250,8 +250,12 @@ function parseStructFormat(format: string): StructElementType[] | undefined {
     const elements: StructElementType[] = [];
     let index = 0;
 
-    // An optional leading byte-order/size/alignment character.
+    // An optional leading byte-order/size/alignment character. The 'n', 'N',
+    // and 'P' codes are only valid in native mode (no prefix or '@'); under an
+    // explicit byte-order prefix ('=', '<', '>', '!') they raise struct.error.
+    let isNativeMode = true;
     if (index < format.length && '@=<>!'.includes(format[index])) {
+        isNativeMode = format[index] === '@';
         index++;
     }
 
@@ -290,7 +294,7 @@ function parseStructFormat(format: string): StructElementType[] | undefined {
         const code = format[index];
         index++;
 
-        const elementKind = getStructElementType(code);
+        const elementKind = getStructElementType(code, isNativeMode);
         if (elementKind === undefined) {
             return undefined;
         }
@@ -318,7 +322,7 @@ function parseStructFormat(format: string): StructElementType[] | undefined {
     return elements;
 }
 
-function getStructElementType(code: string): StructElementType | 'pad' | undefined {
+function getStructElementType(code: string, isNativeMode: boolean): StructElementType | 'pad' | undefined {
     switch (code) {
         case 'x':
             return 'pad';
@@ -338,10 +342,15 @@ function getStructElementType(code: string): StructElementType | 'pad' | undefin
         case 'L':
         case 'q':
         case 'Q':
+            return 'int';
+
         case 'n':
         case 'N':
         case 'P':
-            return 'int';
+            // These codes are only available in native mode (no prefix or '@').
+            // Under an explicit byte-order prefix they are invalid, so fall back
+            // to the declared return type rather than synthesizing 'int'.
+            return isNativeMode ? 'int' : undefined;
 
         case '?':
             return 'bool';

--- a/packages/pyright-internal/src/analyzer/functionTransform.ts
+++ b/packages/pyright-internal/src/analyzer/functionTransform.ts
@@ -148,8 +148,12 @@ function applyTotalOrderingTransform(
 // Distinguishes between the `struct` functions whose return type can be
 // synthesized from a literal format string. `unpack` and `unpack_from`
 // return a tuple; `iter_unpack` returns an iterator of tuples.
-type StructUnpackKind = 'tuple' | 'iterator';
-
+//
+// Only the module-level `_struct.*` free functions are handled here. The
+// reused-format API (`struct.Struct(fmt).unpack()` / `.unpack_from()` /
+// `.iter_unpack()`) is out of scope: it would require threading the
+// constructor's literal format through to the method calls, so those still
+// infer the declared `tuple[Any, ...]`.
 function getStructUnpackKind(fullName: string): StructUnpackKind | undefined {
     switch (fullName) {
         case '_struct.unpack':
@@ -163,9 +167,6 @@ function getStructUnpackKind(fullName: string): StructUnpackKind | undefined {
             return undefined;
     }
 }
-
-// The synthesized element type produced by a single struct format code.
-type StructElementType = 'int' | 'float' | 'bool' | 'bytes';
 
 // To avoid performance issues with very large repeat counts, fall back to
 // the declared return type (a homogeneous `Any` tuple) above this many elements.
@@ -364,3 +365,10 @@ function getStructElementType(code: string, isNativeMode: boolean): StructElemen
             return undefined;
     }
 }
+
+// The kind of return type synthesized for a dispatched `struct` function:
+// a tuple (`unpack`/`unpack_from`) or an iterator of tuples (`iter_unpack`).
+type StructUnpackKind = 'tuple' | 'iterator';
+
+// The synthesized element type produced by a single struct format code.
+type StructElementType = 'int' | 'float' | 'bool' | 'bytes';

--- a/packages/pyright-internal/src/analyzer/functionTransform.ts
+++ b/packages/pyright-internal/src/analyzer/functionTransform.ts
@@ -208,8 +208,7 @@ function applyStructUnpackTransform(
     const getElementType = (elementKind: StructElementType): Type | undefined => {
         let elementType = elementTypeCache.get(elementKind);
         if (!elementType) {
-            const builtInName = elementKind === 'bytes' ? 'bytes' : elementKind;
-            const builtInType = evaluator.getBuiltInObject(errorNode, builtInName);
+            const builtInType = evaluator.getBuiltInObject(errorNode, elementKind);
             if (!isClassInstance(builtInType)) {
                 return undefined;
             }
@@ -273,8 +272,11 @@ function parseStructFormat(format: string): StructElementType[] | undefined {
                 count = count * 10 + (format.charCodeAt(index) - 0x30);
                 index++;
 
-                // Guard against pathologically large counts.
-                if (count > maxStructUnpackElementCount) {
+                // Guard against pathologically large counts. This bounds the
+                // accumulator itself; the produced element count is bounded
+                // separately below so byte-length codes ('s'/'p') aren't
+                // rejected for large counts.
+                if (count > Number.MAX_SAFE_INTEGER) {
                     return undefined;
                 }
             }
@@ -295,7 +297,7 @@ function parseStructFormat(format: string): StructElementType[] | undefined {
 
         if (code === 's' || code === 'p') {
             // For 's' and 'p', the count is the byte length of a single value,
-            // so it always produces exactly one element.
+            // so it always produces exactly one element regardless of count.
             elements.push('bytes');
         } else if (elementKind === 'pad') {
             // Pad bytes ('x') produce no elements.
@@ -303,6 +305,12 @@ function parseStructFormat(format: string): StructElementType[] | undefined {
             const repeat = count < 0 ? 1 : count;
             for (let i = 0; i < repeat; i++) {
                 elements.push(elementKind);
+
+                // Bound the produced element count to avoid performance issues
+                // with very large repeat counts.
+                if (elements.length > maxStructUnpackElementCount) {
+                    return undefined;
+                }
             }
         }
     }

--- a/packages/pyright-internal/src/analyzer/functionTransform.ts
+++ b/packages/pyright-internal/src/analyzer/functionTransform.ts
@@ -12,6 +12,7 @@ import { DiagnosticRule } from '../common/diagnosticRules';
 import { LocMessage } from '../localization/localize';
 import { ExpressionNode, ParamCategory } from '../parser/parseNodes';
 import { Symbol, SymbolFlags } from './symbol';
+import { makeTupleObject } from './tuples';
 import { Arg, FunctionResult, TypeEvaluator } from './typeEvaluatorTypes';
 import {
     ClassType,
@@ -22,6 +23,7 @@ import {
     isFunction,
     isInstantiableClass,
     OverloadedType,
+    TupleTypeArg,
     Type,
 } from './types';
 import { ClassMember, lookUpObjectMember, MemberAccessFlags, synthesizeTypeVarForSelfCls } from './typeUtils';
@@ -36,6 +38,11 @@ export function applyFunctionTransform(
     if (isFunction(functionType)) {
         if (functionType.shared.fullName === 'functools.total_ordering') {
             return applyTotalOrderingTransform(evaluator, errorNode, argList, result);
+        }
+
+        const structUnpackKind = getStructUnpackKind(functionType.shared.fullName);
+        if (structUnpackKind !== undefined) {
+            return applyStructUnpackTransform(evaluator, errorNode, argList, result, structUnpackKind);
         }
     }
 
@@ -136,4 +143,207 @@ function applyTotalOrderingTransform(
     });
 
     return result;
+}
+
+// Distinguishes between the `struct` functions whose return type can be
+// synthesized from a literal format string. `unpack` and `unpack_from`
+// return a tuple; `iter_unpack` returns an iterator of tuples.
+type StructUnpackKind = 'tuple' | 'iterator';
+
+function getStructUnpackKind(fullName: string): StructUnpackKind | undefined {
+    switch (fullName) {
+        case '_struct.unpack':
+        case '_struct.unpack_from':
+            return 'tuple';
+
+        case '_struct.iter_unpack':
+            return 'iterator';
+
+        default:
+            return undefined;
+    }
+}
+
+// The synthesized element type produced by a single struct format code.
+type StructElementType = 'int' | 'float' | 'bool' | 'bytes';
+
+// To avoid performance issues with very large repeat counts, fall back to
+// the declared return type (a homogeneous `Any` tuple) above this many elements.
+const maxStructUnpackElementCount = 256;
+
+function applyStructUnpackTransform(
+    evaluator: TypeEvaluator,
+    errorNode: ExpressionNode,
+    argList: Arg[],
+    result: FunctionResult,
+    kind: StructUnpackKind
+): FunctionResult {
+    // The format string is always the first positional argument.
+    if (argList.length === 0) {
+        return result;
+    }
+
+    const formatType = evaluator.getTypeOfArg(argList[0], /* inferenceContext */ undefined).type;
+    if (!isClassInstance(formatType)) {
+        return result;
+    }
+
+    // The format must be a `str` or `bytes` literal. Both store their value
+    // as a string in `literalValue`.
+    if (!ClassType.isBuiltIn(formatType, ['str', 'bytes'])) {
+        return result;
+    }
+
+    const formatValue = formatType.priv.literalValue;
+    if (typeof formatValue !== 'string') {
+        return result;
+    }
+
+    const elementKinds = parseStructFormat(formatValue);
+    if (!elementKinds || elementKinds.length > maxStructUnpackElementCount) {
+        return result;
+    }
+
+    const elementTypeCache = new Map<StructElementType, Type>();
+    const getElementType = (elementKind: StructElementType): Type | undefined => {
+        let elementType = elementTypeCache.get(elementKind);
+        if (!elementType) {
+            const builtInName = elementKind === 'bytes' ? 'bytes' : elementKind;
+            const builtInType = evaluator.getBuiltInObject(errorNode, builtInName);
+            if (!isClassInstance(builtInType)) {
+                return undefined;
+            }
+            elementType = builtInType;
+            elementTypeCache.set(elementKind, elementType);
+        }
+        return elementType;
+    };
+
+    const tupleArgs: TupleTypeArg[] = [];
+    for (const elementKind of elementKinds) {
+        const elementType = getElementType(elementKind);
+        if (!elementType) {
+            return result;
+        }
+        tupleArgs.push({ type: elementType, isUnbounded: false });
+    }
+
+    const tupleType = makeTupleObject(evaluator, tupleArgs);
+
+    if (kind === 'tuple') {
+        return { ...result, returnType: tupleType };
+    }
+
+    // iter_unpack returns an Iterator of the synthesized tuple type.
+    const iteratorType = evaluator.getTypingType(errorNode, 'Iterator');
+    if (!iteratorType || !isInstantiableClass(iteratorType)) {
+        return result;
+    }
+
+    const iteratorInstance = ClassType.cloneAsInstance(ClassType.specialize(iteratorType, [tupleType]));
+    return { ...result, returnType: iteratorInstance };
+}
+
+// Parses a struct format string (https://docs.python.org/3/library/struct.html)
+// into the sequence of element types produced by `struct.unpack`. Returns
+// undefined if the format string contains an unrecognized format code.
+function parseStructFormat(format: string): StructElementType[] | undefined {
+    const elements: StructElementType[] = [];
+    let index = 0;
+
+    // An optional leading byte-order/size/alignment character.
+    if (index < format.length && '@=<>!'.includes(format[index])) {
+        index++;
+    }
+
+    while (index < format.length) {
+        const ch = format[index];
+
+        // Whitespace between format codes is ignored.
+        if (ch === ' ' || ch === '\t' || ch === '\n' || ch === '\r' || ch === '\f' || ch === '\v') {
+            index++;
+            continue;
+        }
+
+        // An optional repeat count precedes the format code.
+        let count = -1;
+        if (ch >= '0' && ch <= '9') {
+            count = 0;
+            while (index < format.length && format[index] >= '0' && format[index] <= '9') {
+                count = count * 10 + (format.charCodeAt(index) - 0x30);
+                index++;
+
+                // Guard against pathologically large counts.
+                if (count > maxStructUnpackElementCount) {
+                    return undefined;
+                }
+            }
+
+            // A count must be followed by a format code.
+            if (index >= format.length) {
+                return undefined;
+            }
+        }
+
+        const code = format[index];
+        index++;
+
+        const elementKind = getStructElementType(code);
+        if (elementKind === undefined) {
+            return undefined;
+        }
+
+        if (code === 's' || code === 'p') {
+            // For 's' and 'p', the count is the byte length of a single value,
+            // so it always produces exactly one element.
+            elements.push('bytes');
+        } else if (elementKind === 'pad') {
+            // Pad bytes ('x') produce no elements.
+        } else {
+            const repeat = count < 0 ? 1 : count;
+            for (let i = 0; i < repeat; i++) {
+                elements.push(elementKind);
+            }
+        }
+    }
+
+    return elements;
+}
+
+function getStructElementType(code: string): StructElementType | 'pad' | undefined {
+    switch (code) {
+        case 'x':
+            return 'pad';
+
+        case 'c':
+        case 's':
+        case 'p':
+            return 'bytes';
+
+        case 'b':
+        case 'B':
+        case 'h':
+        case 'H':
+        case 'i':
+        case 'I':
+        case 'l':
+        case 'L':
+        case 'q':
+        case 'Q':
+        case 'n':
+        case 'N':
+        case 'P':
+            return 'int';
+
+        case '?':
+            return 'bool';
+
+        case 'e':
+        case 'f':
+        case 'd':
+            return 'float';
+
+        default:
+            return undefined;
+    }
 }

--- a/packages/pyright-internal/src/tests/samples/structUnpack1.py
+++ b/packages/pyright-internal/src/tests/samples/structUnpack1.py
@@ -20,6 +20,14 @@ assert_type(struct.unpack("2i3f", buffer), tuple[int, int, float, float, float])
 # A 's' code consumes its count as a single bytes value.
 assert_type(struct.unpack("<3s", buffer), tuple[bytes])
 
+# A large byte-length count for 's' still collapses to a single bytes value
+# and must not be rejected by the element-count guard.
+assert_type(struct.unpack("1024s", buffer), tuple[bytes])
+assert_type(struct.unpack("<512s", buffer), tuple[bytes])
+
+# 'p' (Pascal string) behaves the same as 's' for a large byte length.
+assert_type(struct.unpack("300p", buffer), tuple[bytes])
+
 # Pad bytes ('x') produce no elements.
 assert_type(struct.unpack("<ix", buffer), tuple[int])
 

--- a/packages/pyright-internal/src/tests/samples/structUnpack1.py
+++ b/packages/pyright-internal/src/tests/samples/structUnpack1.py
@@ -1,0 +1,55 @@
+# This sample tests the synthesized return type of `struct.unpack`,
+# `struct.unpack_from` and `struct.iter_unpack` when the format string
+# is a literal.
+
+import struct
+from typing import Any, Iterator, assert_type
+
+buffer = b"\x00" * 64
+
+
+# Basic numeric format codes with a repeat count.
+assert_type(struct.unpack("<2i", buffer), tuple[int, int])
+
+# A mix of element kinds.
+assert_type(struct.unpack("<if?", buffer), tuple[int, float, bool])
+
+# Repeat counts apply per code.
+assert_type(struct.unpack("2i3f", buffer), tuple[int, int, float, float, float])
+
+# A 's' code consumes its count as a single bytes value.
+assert_type(struct.unpack("<3s", buffer), tuple[bytes])
+
+# Pad bytes ('x') produce no elements.
+assert_type(struct.unpack("<ix", buffer), tuple[int])
+
+# 'c' produces one bytes value per repeat.
+assert_type(struct.unpack("3c", buffer), tuple[bytes, bytes, bytes])
+
+# A bytes literal format string works the same way.
+assert_type(struct.unpack(b"<2i", buffer), tuple[int, int])
+
+# An empty format string produces an empty tuple.
+assert_type(struct.unpack("", buffer), tuple[()])
+
+# unpack_from behaves the same as unpack.
+assert_type(struct.unpack_from("<2i", buffer), tuple[int, int])
+assert_type(struct.unpack_from("<2i", buffer, 4), tuple[int, int])
+
+# iter_unpack returns an iterator of the synthesized tuple type.
+assert_type(struct.iter_unpack("<2i", buffer), Iterator[tuple[int, int]])
+
+# Whitespace between format codes is ignored.
+assert_type(struct.unpack("i i", buffer), tuple[int, int])
+
+# A format string consisting only of a byte-order character is an empty tuple.
+assert_type(struct.unpack("@", buffer), tuple[()])
+
+
+# An unrecognized format code falls back to the declared return type.
+assert_type(struct.unpack("<2z", buffer), tuple[Any, ...])
+
+
+# A non-literal format string falls back to the declared return type.
+def func1(fmt: str) -> None:
+    assert_type(struct.unpack(fmt, buffer), tuple[Any, ...])

--- a/packages/pyright-internal/src/tests/samples/structUnpack1.py
+++ b/packages/pyright-internal/src/tests/samples/structUnpack1.py
@@ -53,6 +53,24 @@ assert_type(struct.unpack("i i", buffer), tuple[int, int])
 # A format string consisting only of a byte-order character is an empty tuple.
 assert_type(struct.unpack("@", buffer), tuple[()])
 
+# A zero repeat count produces no elements.
+assert_type(struct.unpack("0i", buffer), tuple[()])
+
+# 'n', 'N' and 'P' are valid only in native mode (no prefix or '@').
+assert_type(struct.unpack("nNP", buffer), tuple[int, int, int])
+assert_type(struct.unpack("@nNP", buffer), tuple[int, int, int])
+
+
+# A repeat count just above `maxStructUnpackElementCount` (256) falls back to
+# the declared return type.
+assert_type(struct.unpack("257i", buffer), tuple[Any, ...])
+
+# 'n', 'N' and 'P' under an explicit byte-order prefix are invalid at runtime,
+# so they fall back to the declared return type.
+assert_type(struct.unpack("<n", buffer), tuple[Any, ...])
+assert_type(struct.unpack("=N", buffer), tuple[Any, ...])
+assert_type(struct.unpack(">P", buffer), tuple[Any, ...])
+
 
 # An unrecognized format code falls back to the declared return type.
 assert_type(struct.unpack("<2z", buffer), tuple[Any, ...])

--- a/packages/pyright-internal/src/tests/samples/structUnpack1.py
+++ b/packages/pyright-internal/src/tests/samples/structUnpack1.py
@@ -34,6 +34,24 @@ assert_type(struct.unpack("<ix", buffer), tuple[int])
 # 'c' produces one bytes value per repeat.
 assert_type(struct.unpack("3c", buffer), tuple[bytes, bytes, bytes])
 
+# A mixed line exercises the full numeric code mapping in one place, guarding
+# against a future typo (e.g. 'e' accidentally mapped to int). 'b'/'h'/'l'/'q'
+# are int; 'e'/'f'/'d' are float.
+assert_type(
+    struct.unpack("bhlqefd", buffer),
+    tuple[int, int, int, int, float, float, float],
+)
+
+# The uppercase (unsigned) numeric codes map to the same element types.
+assert_type(struct.unpack("BHILQ", buffer), tuple[int, int, int, int, int])
+
+# Without a count, 's'/'p' still collapse to a single bytes value.
+assert_type(struct.unpack("s", buffer), tuple[bytes])
+assert_type(struct.unpack("p", buffer), tuple[bytes])
+
+# A zero repeat count on 'c' produces no elements.
+assert_type(struct.unpack("0c", buffer), tuple[()])
+
 # A bytes literal format string works the same way.
 assert_type(struct.unpack(b"<2i", buffer), tuple[int, int])
 

--- a/packages/pyright-internal/src/tests/typeEvaluator8.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator8.test.ts
@@ -821,6 +821,12 @@ test('TotalOrdering1', () => {
     TestUtils.validateResults(analysisResults, 5);
 });
 
+test('StructUnpack1', () => {
+    const analysisResults = TestUtils.typeAnalyzeSampleFiles(['structUnpack1.py']);
+
+    TestUtils.validateResults(analysisResults, 0);
+});
+
 test('TupleUnpack1', () => {
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['tupleUnpack1.py']);
 


### PR DESCRIPTION
## Description

Synthesizes a precise return type for `struct.unpack`, `struct.unpack_from`, and `struct.iter_unpack` when the format string is a literal. Instead of the declared `tuple[Any, ...]`, callers now get an exact tuple type (e.g. `tuple[int, int]`) derived from the format codes, so element types and arity are checked and propagated.

## How you figured out what to do

`struct.unpack` returns `tuple[Any, ...]` in typeshed, losing all element information even when the format string is a known literal. Pyright already applies function-result transforms for special-cased callables (e.g. `functools.total_ordering`) in `functionTransform.ts`, which is the natural hook for synthesizing a more specific return type without touching the wire protocol or typeshed.

## Implementation

In `applyFunctionTransform`, dispatch the `_struct.unpack` / `unpack_from` / `iter_unpack` callables to a new `applyStructUnpackTransform`:

-   Reads the first positional argument and only proceeds when it is a `str`/`bytes` **literal**.
-   `parseStructFormat` walks the format string, honoring the optional byte-order character, whitespace, repeat counts, and per-code element kinds (`int`/`float`/`bool`/`bytes`), with `x` producing no element and `s`/`p` collapsing their count into a single `bytes`. The native-only codes `n`/`N`/`P` are only treated as `int` in native mode (no prefix or `@`); under an explicit byte-order prefix they fall back to the declared type, matching the runtime `struct.error`.
-   Builds an exact tuple via `makeTupleObject`; `iter_unpack` wraps it in `Iterator[...]`.
-   Falls back to the declared type for non-literals, unknown codes, or counts above `maxStructUnpackElementCount` (256) to bound performance.

## Testing

Added `structUnpack1.py` with `assert_type` checks covering numeric codes, repeat counts, mixed kinds, `s`/`c`/`x`, bytes-literal formats, empty/byte-order-only formats, whitespace, `unpack_from`, `iter_unpack`, the zero repeat count (`"0i"` → `tuple[()]`), the element-count cap fallback (`"257i"` → `tuple[Any, ...]`), native-mode `n`/`N`/`P` vs. their invalid prefixed forms, and fallback for unknown codes and non-literal formats. Wired up via `StructUnpack1` in `typeEvaluator8.test.ts` (expects 0 errors).

## Addresses

Addresses https://github.com/microsoft/pylance-release/issues/11450

---
*Generated by fix_all_my_issues pipeline*