### PR TITLE
Report duplicate KW_ONLY separators in dataclasses

### DIFF
--- a/packages/pyright-internal/src/analyzer/dataClasses.ts
+++ b/packages/pyright-internal/src/analyzer/dataClasses.ts
@@ -381,6 +381,18 @@ export function synthesizeDataClassMethods(
                         const annotatedType = variableTypeEvaluator();
 
                         if (isClassInstance(annotatedType) && ClassType.isBuiltIn(annotatedType, 'KW_ONLY')) {
+                            // CPython raises a TypeError if more than one KW_ONLY
+                            // separator appears within a single dataclass.
+                            if (sawKeywordOnlySeparator) {
+                                evaluator.addDiagnostic(
+                                    DiagnosticRule.reportGeneralTypeIssues,
+                                    LocMessage.dataClassDuplicateKwOnly().format({
+                                        name: variableNameNode.d.value,
+                                    }),
+                                    variableNameNode
+                                );
+                            }
+
                             sawKeywordOnlySeparator = true;
                             variableNameNode = undefined;
                             typeAnnotationNode = undefined;

--- a/packages/pyright-internal/src/localization/localize.ts
+++ b/packages/pyright-internal/src/localization/localize.ts
@@ -375,6 +375,8 @@ export namespace Localizer {
             new ParameterizedString<{ funcName: string; fieldType: string; fieldName: string }>(
                 getRawString('Diagnostic.dataClassConverterOverloads')
             );
+        export const dataClassDuplicateKwOnly = () =>
+            new ParameterizedString<{ name: string }>(getRawString('Diagnostic.dataClassDuplicateKwOnly'));
         export const dataClassFieldInheritedDefault = () =>
             new ParameterizedString<{ fieldName: string }>(getRawString('Diagnostic.dataClassFieldInheritedDefault'));
         export const dataClassFieldWithDefault = () => getRawString('Diagnostic.dataClassFieldWithDefault');

--- a/packages/pyright-internal/src/localization/package.nls.en-us.json
+++ b/packages/pyright-internal/src/localization/package.nls.en-us.json
@@ -233,6 +233,7 @@
         "dataClassBaseClassNotFrozen": "A frozen class cannot inherit from a class that is not frozen",
         "dataClassConverterFunction": "Argument of type \"{argType}\" is not a valid converter for field \"{fieldName}\" of type \"{fieldType}\"",
         "dataClassConverterOverloads": "No overloads of \"{funcName}\" are valid converters for field \"{fieldName}\" of type \"{fieldType}\"",
+        "dataClassDuplicateKwOnly": "\"{name}\" is a duplicate KW_ONLY separator; only one is allowed within a dataclass",
         "dataClassFieldInheritedDefault": "\"{fieldName}\" overrides a field of the same name but is missing a default value",
         "dataClassFieldWithDefault": "Fields without default values cannot appear after fields with default values",
         "dataClassFieldWithPrivateName": "Dataclass field cannot use private name",

--- a/packages/pyright-internal/src/tests/samples/dataclassKwOnly1.py
+++ b/packages/pyright-internal/src/tests/samples/dataclassKwOnly1.py
@@ -56,3 +56,35 @@ class DC4(DC3):
 
 DC4("", 0.2, b=3)
 DC4(a="", b=3, c=0.2)
+
+
+# This tests that the KW_ONLY separator is recognized even when it
+# is assigned to a name other than "_".
+@dataclass
+class DC5:
+    a: str
+    __: KW_ONLY
+    b: int = 0
+
+
+DC5("hi")
+DC5(a="hi", b=1)
+DC5("hi", b=1)
+
+# This should generate an error because "b" is keyword-only.
+DC5("hi", 1)
+
+
+# This tests that a duplicate KW_ONLY separator is flagged. CPython raises a
+# TypeError at runtime if more than one KW_ONLY separator appears.
+@dataclass
+class DC6:
+    a: str
+    _: KW_ONLY
+    b: int = 0
+    # This should generate an error because only one KW_ONLY separator is allowed.
+    __: KW_ONLY
+    c: int = 0
+
+
+DC6("hi", b=1, c=2)

--- a/packages/pyright-internal/src/tests/typeEvaluator4.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator4.test.ts
@@ -426,7 +426,7 @@ test('DataClassKwOnly1', () => {
     configOptions.defaultPythonVersion = pythonVersion3_10;
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['dataclassKwOnly1.py'], configOptions);
 
-    TestUtils.validateResults(analysisResults, 3);
+    TestUtils.validateResults(analysisResults, 5);
 });
 
 test('DataClassKwOnly2', () => {


### PR DESCRIPTION
## Description

Pyright recognized the dataclass `KW_ONLY` sentinel only when it was assigned to a field named `_`. At runtime, the `dataclasses` module treats **any** field annotated as `KW_ONLY` as the keyword-only separator regardless of name. That core name-guard removal (the original #11451 fix) has since landed on `main` via #11486, so this PR is rebased on top of it and contributes the remaining test coverage plus a related correctness diagnostic.

## Changes

After rebasing onto current `main` (which already contains the #11486 name-guard removal), this PR adds:

1. **New diagnostic — duplicate `KW_ONLY` separators.** CPython raises `TypeError: '<name>' is KW_ONLY, but KW_ONLY has already been specified` when more than one `KW_ONLY` separator appears in a single dataclass. Pyright previously accepted this silently. `dataClasses.ts` now checks `sawKeywordOnlySeparator` before setting it and reports a `reportGeneralTypeIssues` diagnostic on the second separator.
   - New NLS key `Diagnostic.dataClassDuplicateKwOnly` (`localize.ts` + `package.nls.en-us.json`). The key is inserted as its own entry without modifying the adjacent `dataClassFieldInheritedDefault` line, so there is no Prettier/JSON whitespace change.
2. **Test coverage** in `dataclassKwOnly1.py`:
   - `DC5` — `KW_ONLY` separator bound to a non-`_` name (`__`), exercising the #11486 behavior (positive calls plus a keyword-only enforcement error).
   - `DC6` — two `KW_ONLY` separators, expecting the new duplicate diagnostic.
   - Expected error count updated `3 → 5` in `typeEvaluator4.test.ts`.

## Testing

- `npx jest typeEvaluator4 -t "DataClassKwOnly1"` passes.
- `prettier -c` and `eslint` pass on the changed files.

## Addresses

Relates to https://github.com/microsoft/pylance-release/issues/11451 (the core recognition fix landed separately in #11486).
