### PR TITLE
Fix #11470: Pyright is incorrectly handling overload functions

### DIFF
--- a/packages/pyright-internal/src/analyzer/checker.ts
+++ b/packages/pyright-internal/src/analyzer/checker.ts
@@ -421,6 +421,15 @@ export class Checker extends ParseTreeWalker {
             const keywordNames = new Set<string>();
             const paramDetails = getParamListDetails(functionTypeResult.functionType);
 
+            // If this function is the implementation of an overloaded function,
+            // its signature is ignored by the type checker (only the @overload
+            // signatures define the function's type). Per the typing spec, the
+            // implementation's parameters are allowed to remain unannotated, so
+            // skip the unknown/missing parameter type checks for it.
+            const isOverloadImplementation =
+                isOverloaded(functionTypeResult.decoratedType) &&
+                !FunctionType.isOverloaded(functionTypeResult.functionType);
+
             // Report any unknown or missing parameter types.
             node.d.params.forEach((param, index) => {
                 if (param.d.name) {
@@ -464,7 +473,10 @@ export class Checker extends ParseTreeWalker {
                         const functionTypeParam = functionTypeResult.functionType.shared.parameters[paramIndex];
                         const paramType = FunctionType.getParamType(functionTypeResult.functionType, paramIndex);
 
-                        if (this._fileInfo.diagnosticRuleSet.reportUnknownParameterType !== 'none') {
+                        if (
+                            !isOverloadImplementation &&
+                            this._fileInfo.diagnosticRuleSet.reportUnknownParameterType !== 'none'
+                        ) {
                             if (
                                 isUnknown(paramType) ||
                                 (isTypeVar(paramType) &&
@@ -504,7 +516,11 @@ export class Checker extends ParseTreeWalker {
                             }
                         }
 
-                        if (!hasAnnotation && this._fileInfo.diagnosticRuleSet.reportMissingParameterType !== 'none') {
+                        if (
+                            !isOverloadImplementation &&
+                            !hasAnnotation &&
+                            this._fileInfo.diagnosticRuleSet.reportMissingParameterType !== 'none'
+                        ) {
                             this._evaluator.addDiagnostic(
                                 DiagnosticRule.reportMissingParameterType,
                                 LocMessage.paramAnnotationMissing().format({ name: param.d.name.d.value }),

--- a/packages/pyright-internal/src/tests/samples/overloadImpl3.py
+++ b/packages/pyright-internal/src/tests/samples/overloadImpl3.py
@@ -1,0 +1,41 @@
+# This sample tests that the parameters of an overload implementation are not
+# subject to the reportUnknownParameterType and reportMissingParameterType
+# checks. The implementation signature is ignored by the type checker, so its
+# parameters are allowed to remain unannotated.
+
+# pyright: strict
+
+from typing import overload
+
+
+class Foo:
+    @overload
+    def foo(self, value: int) -> int: ...
+
+    @overload
+    def foo(self, value: str) -> str: ...
+
+    # The unannotated "value" parameter should not generate errors here.
+    def foo(self, value) -> int | str:
+        return 0
+
+
+@overload
+def func1(value: int) -> int: ...
+
+
+@overload
+def func1(value: str) -> str: ...
+
+
+# The unannotated "value" parameter should not generate errors here.
+def func1(value) -> int | str:
+    return 0
+
+
+# A non-overloaded function with an unannotated parameter should still
+# generate errors.
+def func2(value) -> int:
+    # This should generate an error because "value" has an unknown type and
+    # an error because "value" is missing a type annotation.
+    return 1

--- a/packages/pyright-internal/src/tests/typeEvaluator6.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator6.test.ts
@@ -103,6 +103,11 @@ test('OverloadImpl2', () => {
     TestUtils.validateResults(analysisResults, 2);
 });
 
+test('OverloadImpl3', () => {
+    const analysisResults = TestUtils.typeAnalyzeSampleFiles(['overloadImpl3.py']);
+    TestUtils.validateResults(analysisResults, 2);
+});
+
 test('OverloadOverlap1', () => {
     const configOptions = new ConfigOptions(Uri.empty());
 


### PR DESCRIPTION
## Description

Fixes a false positive where Pyright reported `reportUnknownParameterType` and `reportMissingParameterType` on the **implementation** of an overloaded function. Per the typing spec, only the `@overload` signatures define the function's public type; the implementation signature is ignored by the type checker, so its parameters are permitted to remain unannotated. Pyright was incorrectly flagging unannotated parameters on the implementation under strict mode.

## How you figured out what to do

The unknown/missing parameter type checks in `checker.ts` ran unconditionally for every function definition. Overload implementations were not exempted, even though their signatures carry no type-checking weight. The fix is to detect overload implementations and skip these two specific diagnostics for them.

## Implementation

In `packages/pyright-internal/src/analyzer/checker.ts`, compute whether the current function is an overload implementation:

```ts
const isOverloadImplementation =
    isOverloaded(functionTypeResult.decoratedType) &&
    !FunctionType.isOverloaded(functionTypeResult.functionType);
```

The decorated type is overloaded (the symbol has `@overload` signatures), but the function type itself is not marked overloaded — which uniquely identifies the implementation function. This guard is then added to the `reportUnknownParameterType` and `reportMissingParameterType` checks so they are skipped for the implementation only. All other functions (including non-overloaded ones and the `@overload` signatures themselves) continue to be checked as before.

## Testing

Added `packages/pyright-internal/src/tests/samples/overloadImpl3.py` under `# pyright: strict`, covering:

- An overloaded **method** (`Foo.foo`) with an unannotated `value` parameter on the implementation — should produce **no** errors.
- An overloaded **free function** (`func1`) with an unannotated implementation parameter — should produce **no** errors.
- A regular non-overloaded function (`func2`) with an unannotated parameter — should still produce both the unknown-type and missing-annotation errors (2 expected errors).

Wired up `OverloadImpl3` in `typeEvaluator6.test.ts`, asserting exactly 2 errors so the regression coverage confirms both that the implementation is exempt and that ordinary functions are unaffected.

Run with:

```
cd packages/pyright/packages/pyright-internal
node node_modules\jest\bin\jest typeEvaluator6 --runInBand --detectOpenHandles --forceExit --testTimeout=180000 -t "OverloadImpl3"
```

## Addresses

Fixes https://github.com/microsoft/pylance-release/issues/11470

---
*Generated by fix_all_my_issues pipeline*