### PR TITLE
Fix #11475: Cannot override a class's callable variable with a method

### DIFF
--- a/packages/pyright-internal/src/analyzer/checker.ts
+++ b/packages/pyright-internal/src/analyzer/checker.ts
@@ -5862,7 +5862,11 @@ export class Checker extends ParseTreeWalker {
                 // If one base defines the member as a plain callable variable and a
                 // sibling base overrides it with a real method, bind the method's "self"
                 // so the two are compared as plain callables (mirrors the single-base
-                // override handling in `_validateBaseClassOverride`).
+                // override handling in `_validateBaseClassOverride`). This is
+                // load-bearing for parametered callables (e.g. `Callable[[int], None]`
+                // vs `def cb(self, value: int)`): without binding, the method's extra
+                // "self" causes a spurious arity mismatch. See the `DiamondParam*`
+                // samples in methodOverride7.py.
                 const childClassSelf = ClassType.cloneAsInstance(
                     selfSpecializeClass(childClassType, { useBoundTypeVars: true })
                 );
@@ -6631,24 +6635,48 @@ export class Checker extends ParseTreeWalker {
             childClassType
         );
 
-        if (boundOverrideType && isFunction(baseType) && isFunction(boundOverrideType)) {
+        if (!boundOverrideType) {
+            return { baseType, overrideType };
+        }
+
+        // Mark both the base callable and the bound override as static so the
+        // override comparison does not skip the first parameter as an unbound
+        // "self" (see the `i === 0` self/cls skip in typeEvaluator's
+        // `validateOverrideMethodInternal`). Without this, the bound override
+        // keeps its instance-method flag and its first real parameter would be
+        // silently dropped during the comparison.
+        const staticBaseType = isFunction(baseType) ? this._markFunctionStatic(baseType) : baseType;
+
+        if (isFunction(boundOverrideType)) {
             return {
-                baseType: FunctionType.cloneWithNewFlags(
-                    baseType,
-                    baseType.shared.flags | FunctionTypeFlags.StaticMethod
-                ),
-                overrideType: FunctionType.cloneWithNewFlags(
-                    boundOverrideType,
-                    boundOverrideType.shared.flags | FunctionTypeFlags.StaticMethod
-                ),
+                baseType: staticBaseType,
+                overrideType: this._markFunctionStatic(boundOverrideType),
             };
         }
 
-        if (boundOverrideType) {
-            return { baseType, overrideType: boundOverrideType };
+        if (isOverloaded(boundOverrideType)) {
+            // An overloaded method binds to an overloaded callable. Apply the
+            // same static normalization to every overload (and the
+            // implementation, if present) so an incompatible first parameter in
+            // an overloaded override is still caught rather than skipped as
+            // "self".
+            const staticOverloads = OverloadedType.getOverloads(boundOverrideType).map((overload) =>
+                this._markFunctionStatic(overload)
+            );
+            const impl = OverloadedType.getImplementation(boundOverrideType);
+            const staticImpl = impl && isFunction(impl) ? this._markFunctionStatic(impl) : impl;
+
+            return {
+                baseType: staticBaseType,
+                overrideType: OverloadedType.create(staticOverloads, staticImpl),
+            };
         }
 
-        return { baseType, overrideType };
+        return { baseType, overrideType: boundOverrideType };
+    }
+
+    private _markFunctionStatic(functionType: FunctionType): FunctionType {
+        return FunctionType.cloneWithNewFlags(functionType, functionType.shared.flags | FunctionTypeFlags.StaticMethod);
     }
 
     private _validateBaseClassOverride(

--- a/packages/pyright-internal/src/analyzer/checker.ts
+++ b/packages/pyright-internal/src/analyzer/checker.ts
@@ -6600,6 +6600,12 @@ export class Checker extends ParseTreeWalker {
     // not skip the first parameter as an unbound "self". All other cases are returned
     // unchanged. This matches the behavior of other type checkers, which allow overriding
     // a callable attribute with a method.
+    //
+    // Note: this validates only the read direction (the bound override is compatible with
+    // the base callable). A method is effectively read-only, so this intentionally does not
+    // attempt to preserve assignability of the mutable callable attribute; that asymmetry
+    // matches other type checkers and does not trigger `reportIncompatibleVariableOverride`
+    // because the override is a function, not a variable.
     private _getCallableVariableOverrideComparison(
         baseSymbol: Symbol,
         overrideSymbol: Symbol,

--- a/packages/pyright-internal/src/analyzer/checker.ts
+++ b/packages/pyright-internal/src/analyzer/checker.ts
@@ -6656,6 +6656,19 @@ export class Checker extends ParseTreeWalker {
         if (isFunctionOrOverloaded(baseType)) {
             const diagAddendum = new DiagnosticAddendum();
 
+            // Determine whether the base class member is a plain callable variable
+            // (e.g. `x: Callable[..., None]`) rather than an actual method. In that
+            // case, accessing the override method on an instance binds its "self"
+            // parameter, so we bind it here before comparing signatures. This matches
+            // the behavior of other type checkers, which allow overriding a callable
+            // attribute with a method.
+            const baseDecls = baseClassAndSymbol.symbol.getDeclarations();
+            const baseIsCallableVariable =
+                baseDecls.length > 0 && baseDecls.every((decl) => decl.type === DeclarationType.Variable);
+            const overrideIsMethod = overrideSymbol
+                .getDeclarations()
+                .some((decl) => decl.type === DeclarationType.Function);
+
             // Don't check certain magic functions or private symbols.
             // Also, skip this check if the class is a TypedDict. The methods for a TypedDict
             // are synthesized, and they can result in many overloads. We assume they
@@ -6674,10 +6687,22 @@ export class Checker extends ParseTreeWalker {
                 // false positives.
                 const enforceParamNameMatch = !SymbolNameUtils.isDunderName(memberName);
 
+                let overrideTypeForComparison: FunctionType | OverloadedType = overrideType;
+                if (baseIsCallableVariable && overrideIsMethod) {
+                    const boundOverrideType = this._evaluator.bindFunctionToClassOrObject(
+                        childClassSelf,
+                        overrideType,
+                        childClassType
+                    );
+                    if (boundOverrideType) {
+                        overrideTypeForComparison = boundOverrideType;
+                    }
+                }
+
                 if (
                     this._evaluator.validateOverrideMethod(
                         baseType,
-                        overrideType,
+                        overrideTypeForComparison,
                         childClassType,
                         diagAddendum,
                         enforceParamNameMatch

--- a/packages/pyright-internal/src/analyzer/checker.ts
+++ b/packages/pyright-internal/src/analyzer/checker.ts
@@ -140,6 +140,7 @@ import {
     EnumLiteral,
     FunctionParam,
     FunctionType,
+    FunctionTypeFlags,
     ModuleType,
     OverloadedType,
     Type,
@@ -5858,10 +5859,27 @@ export class Checker extends ParseTreeWalker {
             const diagAddendum = new DiagnosticAddendum();
 
             if (isFunctionOrOverloaded(overrideType)) {
-                if (
-                    !this._evaluator.validateOverrideMethod(
+                // If one base defines the member as a plain callable variable and a
+                // sibling base overrides it with a real method, bind the method's "self"
+                // so the two are compared as plain callables (mirrors the single-base
+                // override handling in `_validateBaseClassOverride`).
+                const childClassSelf = ClassType.cloneAsInstance(
+                    selfSpecializeClass(childClassType, { useBoundTypeVars: true })
+                );
+                const { baseType: overriddenTypeForComparison, overrideType: overrideTypeForComparison } =
+                    this._getCallableVariableOverrideComparison(
+                        overriddenClassAndSymbol.symbol,
+                        overrideClassAndSymbol.symbol,
                         overriddenType,
                         overrideType,
+                        childClassType,
+                        childClassSelf
+                    );
+
+                if (
+                    !this._evaluator.validateOverrideMethod(
+                        overriddenTypeForComparison,
+                        overrideTypeForComparison,
                         /* baseClass */ undefined,
                         diagAddendum,
                         /* enforceParamNameMatch */ true
@@ -6574,6 +6592,59 @@ export class Checker extends ParseTreeWalker {
         );
     }
 
+    // If a base class member is a plain callable variable (e.g. `x: Callable[..., None]`)
+    // and the override is a real method, accessing the override on an instance binds its
+    // "self" parameter, leaving a signature that should be compared against the base
+    // callable. This helper detects that asymmetry and returns adjusted types: the bound
+    // override and the base callable, both marked static so the override comparison does
+    // not skip the first parameter as an unbound "self". All other cases are returned
+    // unchanged. This matches the behavior of other type checkers, which allow overriding
+    // a callable attribute with a method.
+    private _getCallableVariableOverrideComparison(
+        baseSymbol: Symbol,
+        overrideSymbol: Symbol,
+        baseType: Type,
+        overrideType: FunctionType | OverloadedType,
+        childClassType: ClassType,
+        childClassSelf: ClassType
+    ): { baseType: Type; overrideType: FunctionType | OverloadedType } {
+        const baseDecls = baseSymbol.getDeclarations();
+        const baseIsCallableVariable =
+            baseDecls.length > 0 && baseDecls.every((decl) => decl.type === DeclarationType.Variable);
+        const overrideIsMethod = overrideSymbol
+            .getDeclarations()
+            .some((decl) => decl.type === DeclarationType.Function);
+
+        if (!baseIsCallableVariable || !overrideIsMethod) {
+            return { baseType, overrideType };
+        }
+
+        const boundOverrideType = this._evaluator.bindFunctionToClassOrObject(
+            childClassSelf,
+            overrideType,
+            childClassType
+        );
+
+        if (boundOverrideType && isFunction(baseType) && isFunction(boundOverrideType)) {
+            return {
+                baseType: FunctionType.cloneWithNewFlags(
+                    baseType,
+                    baseType.shared.flags | FunctionTypeFlags.StaticMethod
+                ),
+                overrideType: FunctionType.cloneWithNewFlags(
+                    boundOverrideType,
+                    boundOverrideType.shared.flags | FunctionTypeFlags.StaticMethod
+                ),
+            };
+        }
+
+        if (boundOverrideType) {
+            return { baseType, overrideType: boundOverrideType };
+        }
+
+        return { baseType, overrideType };
+    }
+
     private _validateBaseClassOverride(
         baseClassAndSymbol: ClassMember,
         overrideSymbol: Symbol,
@@ -6656,19 +6727,6 @@ export class Checker extends ParseTreeWalker {
         if (isFunctionOrOverloaded(baseType)) {
             const diagAddendum = new DiagnosticAddendum();
 
-            // Determine whether the base class member is a plain callable variable
-            // (e.g. `x: Callable[..., None]`) rather than an actual method. In that
-            // case, accessing the override method on an instance binds its "self"
-            // parameter, so we bind it here before comparing signatures. This matches
-            // the behavior of other type checkers, which allow overriding a callable
-            // attribute with a method.
-            const baseDecls = baseClassAndSymbol.symbol.getDeclarations();
-            const baseIsCallableVariable =
-                baseDecls.length > 0 && baseDecls.every((decl) => decl.type === DeclarationType.Variable);
-            const overrideIsMethod = overrideSymbol
-                .getDeclarations()
-                .some((decl) => decl.type === DeclarationType.Function);
-
             // Don't check certain magic functions or private symbols.
             // Also, skip this check if the class is a TypedDict. The methods for a TypedDict
             // are synthesized, and they can result in many overloads. We assume they
@@ -6687,21 +6745,26 @@ export class Checker extends ParseTreeWalker {
                 // false positives.
                 const enforceParamNameMatch = !SymbolNameUtils.isDunderName(memberName);
 
-                let overrideTypeForComparison: FunctionType | OverloadedType = overrideType;
-                if (baseIsCallableVariable && overrideIsMethod) {
-                    const boundOverrideType = this._evaluator.bindFunctionToClassOrObject(
-                        childClassSelf,
+                // If the base class member is a plain callable variable
+                // (e.g. `x: Callable[..., None]`) rather than an actual method,
+                // bind the override method's "self" so the two are compared as
+                // plain callables. The declaration scans needed to detect this
+                // are computed inside this helper, so the common method-vs-method
+                // path and the exempt/private/TypedDict early-returns above pay
+                // nothing extra.
+                const { baseType: baseTypeForComparison, overrideType: overrideTypeForComparison } =
+                    this._getCallableVariableOverrideComparison(
+                        baseClassAndSymbol.symbol,
+                        overrideSymbol,
+                        baseType,
                         overrideType,
-                        childClassType
+                        childClassType,
+                        childClassSelf
                     );
-                    if (boundOverrideType) {
-                        overrideTypeForComparison = boundOverrideType;
-                    }
-                }
 
                 if (
                     this._evaluator.validateOverrideMethod(
-                        baseType,
+                        baseTypeForComparison,
                         overrideTypeForComparison,
                         childClassType,
                         diagAddendum,

--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -27855,6 +27855,12 @@ export function createTypeEvaluator(
                 // If the first parameter is a "self" or "cls" parameter, skip the
                 // test because these are allowed to violate the Liskov substitution
                 // principle.
+                //
+                // Note: the checker deliberately defeats this skip for the
+                // "callable variable overridden by a method" case by marking both
+                // sides static before calling this routine (see
+                // `_getCallableVariableOverrideComparison` in checker.ts). Keep the
+                // two in sync if this skip logic changes.
                 if (i === 0) {
                     if (
                         FunctionType.isInstanceMethod(overrideMethod) ||

--- a/packages/pyright-internal/src/tests/samples/methodOverride7.py
+++ b/packages/pyright-internal/src/tests/samples/methodOverride7.py
@@ -55,6 +55,24 @@ class E(A):
         return ""
 
 
+from typing import overload
+
+
+class F(A):
+    # This should generate an error because the bound override is an
+    # overloaded method whose first real parameter type (str) is incompatible
+    # with the base callable's parameter type (int). The static normalization
+    # of each bound overload ensures the first parameter is not skipped as
+    # "self".
+    @overload
+    def cb(self, value: str) -> None: ...
+    @overload
+    def cb(self, value: str, extra: int) -> None: ...
+    @override
+    def cb(self, value: str, extra: int = 0) -> None:
+        print(value)
+
+
 # The following classes verify that inheriting a callable variable and a
 # real method with the same name from two different base classes (a "diamond"
 # of sorts) does not produce a spurious reportIncompatibleMethodOverride. Both
@@ -70,4 +88,29 @@ class DiamondAB(A, Mixin):
 
 
 class DiamondBA(Mixin, A):
+    pass
+
+
+# Parametered diamond: one base supplies a callable variable with a parameter
+# and a sibling base supplies a method with a matching parameter. This is the
+# load-bearing case for the multiple-inheritance bind-before-compare handling:
+# without binding the method's "self", the comparison would see an extra
+# positional parameter and emit a spurious error. Both inheritance orders are
+# exercised and should produce no error.
+
+
+class CallableVarBase:
+    cb: Callable[[int], None] = lambda x: print(x)
+
+
+class MethodBase:
+    def cb(self, value: int) -> None:
+        print(value)
+
+
+class DiamondParamVM(CallableVarBase, MethodBase):
+    pass
+
+
+class DiamondParamMV(MethodBase, CallableVarBase):
     pass

--- a/packages/pyright-internal/src/tests/samples/methodOverride7.py
+++ b/packages/pyright-internal/src/tests/samples/methodOverride7.py
@@ -2,7 +2,7 @@
 # (which is not a method) with a method in a subclass is allowed. When
 # the base member is a plain callable attribute rather than a method,
 # the override method's "self" parameter is bound when accessed on an
-# instance, so the signatures are compatible.
+# instance, so the signatures are compared as plain (bound) callables.
 
 from collections.abc import Callable
 from typing import override
@@ -12,6 +12,8 @@ class A:
     hello: Callable[[], None] = lambda: print("hello")
 
     cb: Callable[[int], None] = lambda x: print(x)
+
+    ret: Callable[[], int] = lambda: 0
 
 
 class B(A):
@@ -23,10 +25,49 @@ class B(A):
     def cb(self, value: int) -> None:
         print(value)
 
+    @override
+    def ret(self) -> int:
+        return 0
+
 
 class C(A):
-    # This should generate an error because the bound override signature
-    # is incompatible with the base callable variable.
+    # This should generate an error because the bound override adds a
+    # required positional parameter (arity mismatch).
     @override
     def hello(self, extra: int) -> None:
         print("hi")
+
+
+class D(A):
+    # This should generate an error because the bound override's first
+    # real parameter type (str) is incompatible with the base callable's
+    # parameter type (int).
+    @override
+    def cb(self, value: str) -> None:
+        print(value)
+
+
+class E(A):
+    # This should generate an error because the bound override's return
+    # type (str) is incompatible with the base callable's return type (int).
+    @override
+    def ret(self) -> str:
+        return ""
+
+
+# The following classes verify that inheriting a callable variable and a
+# real method with the same name from two different base classes (a "diamond"
+# of sorts) does not produce a spurious reportIncompatibleMethodOverride. Both
+# inheritance orders are exercised.
+
+
+class Mixin:
+    def hello(self) -> None: ...
+
+
+class DiamondAB(A, Mixin):
+    pass
+
+
+class DiamondBA(Mixin, A):
+    pass

--- a/packages/pyright-internal/src/tests/samples/methodOverride7.py
+++ b/packages/pyright-internal/src/tests/samples/methodOverride7.py
@@ -1,0 +1,32 @@
+# This sample tests that overriding a class-level callable variable
+# (which is not a method) with a method in a subclass is allowed. When
+# the base member is a plain callable attribute rather than a method,
+# the override method's "self" parameter is bound when accessed on an
+# instance, so the signatures are compatible.
+
+from collections.abc import Callable
+from typing import override
+
+
+class A:
+    hello: Callable[[], None] = lambda: print("hello")
+
+    cb: Callable[[int], None] = lambda x: print(x)
+
+
+class B(A):
+    @override
+    def hello(self) -> None:
+        print("hi")
+
+    @override
+    def cb(self, value: int) -> None:
+        print(value)
+
+
+class C(A):
+    # This should generate an error because the bound override signature
+    # is incompatible with the base callable variable.
+    @override
+    def hello(self, extra: int) -> None:
+        print("hi")

--- a/packages/pyright-internal/src/tests/typeEvaluator3.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator3.test.ts
@@ -1012,7 +1012,7 @@ test('MethodOverride7', () => {
 
     configOptions.diagnosticRuleSet.reportIncompatibleMethodOverride = 'error';
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['methodOverride7.py'], configOptions);
-    TestUtils.validateResults(analysisResults, 3);
+    TestUtils.validateResults(analysisResults, 4);
 });
 
 test('Enum1', () => {

--- a/packages/pyright-internal/src/tests/typeEvaluator3.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator3.test.ts
@@ -1007,6 +1007,14 @@ test('MethodOverride6', () => {
     TestUtils.validateResults(analysisResults2, 3);
 });
 
+test('MethodOverride7', () => {
+    const configOptions = new ConfigOptions(Uri.empty());
+
+    configOptions.diagnosticRuleSet.reportIncompatibleMethodOverride = 'error';
+    const analysisResults = TestUtils.typeAnalyzeSampleFiles(['methodOverride7.py'], configOptions);
+    TestUtils.validateResults(analysisResults, 1);
+});
+
 test('Enum1', () => {
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['enum1.py']);
 

--- a/packages/pyright-internal/src/tests/typeEvaluator3.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator3.test.ts
@@ -1012,7 +1012,7 @@ test('MethodOverride7', () => {
 
     configOptions.diagnosticRuleSet.reportIncompatibleMethodOverride = 'error';
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['methodOverride7.py'], configOptions);
-    TestUtils.validateResults(analysisResults, 1);
+    TestUtils.validateResults(analysisResults, 3);
 });
 
 test('Enum1', () => {


### PR DESCRIPTION
## Description

Pylance/Pyright incorrectly flagged an error when a subclass overrode a base class's callable **variable** (e.g. `x: Callable[[], None]`) with a real **method**. Other type checkers allow this, because when you access the override method on an instance, its `self` parameter is bound, leaving a signature that matches the base callable attribute.

## How you figured out what to do

The base-class member here is a plain `Callable` attribute, not a method, so it has no implicit `self`. The override, being a method, *does* declare `self`. The override check compared the unbound method signature (which still has `self`) against the base callable, producing a spurious `reportIncompatibleMethodOverride` error. The fix is to bind the override method to the class before comparing, but only when the base member is actually a callable variable.

## Implementation

In `checker.ts`, within the override-validation path for function-typed members:

- Detect when the base member is a **callable variable** (all declarations are `DeclarationType.Variable`) and the override is a **method** (`DeclarationType.Function`).
- In that case, bind the override method's `self` via `bindFunctionToClassOrObject` and use the bound type for `validateOverrideMethod`.
- All other cases are unchanged, so normal method-vs-method override checking still applies.

## Testing

Added `methodOverride7.py` sample plus a `MethodOverride7` test in `typeEvaluator3.test.ts` (with `reportIncompatibleMethodOverride = 'error'`):

- `class B(A)` overrides callable attributes `hello` / `cb` with compatible methods — no error.
- `class C(A)` overrides `hello` with an incompatible signature (extra required parameter) — still produces exactly **1** error, confirming the bound comparison continues to catch genuine mismatches.

Ran the targeted Pyright type-evaluator tests to confirm the new case passes and the negative case still errors.

## Addresses

Fixes https://github.com/microsoft/pylance-release/issues/11475

---
*Generated by fix_all_my_issues pipeline*