### PR TITLE
Fix #11481: 1.1.410 detects type as module

### DIFF
--- a/packages/pyright-internal/src/analyzer/binder.ts
+++ b/packages/pyright-internal/src/analyzer/binder.ts
@@ -4362,6 +4362,20 @@ export class Binder extends ParseTreeWalker {
             return false;
         }
 
+        // The imported symbol may be both an implicitly-imported submodule and a
+        // class/function/variable of the same name (e.g. a package that re-exports
+        // a class whose name matches a submodule). In that case the non-module
+        // declaration appears later in the declaration list and "wins" when the
+        // symbol is resolved. Only treat this wildcard re-export as a pure submodule
+        // re-export when the module alias is the symbol's effective (last)
+        // declaration; otherwise fall through so a normal alias declaration is
+        // created that resolves to the winning symbol.
+        // See https://github.com/microsoft/pyright/issues/11481.
+        const importedDecls = importedSymbol.getDeclarations();
+        if (importedDecls[importedDecls.length - 1] !== importedModuleAliasDecl) {
+            return false;
+        }
+
         const existingModuleAliasDecl = this._getMultipartModuleAliasDeclaration(
             localSymbol,
             importedModuleAliasDecl.moduleName,

--- a/packages/pyright-internal/src/analyzer/binder.ts
+++ b/packages/pyright-internal/src/analyzer/binder.ts
@@ -4367,10 +4367,20 @@ export class Binder extends ParseTreeWalker {
         // a class whose name matches a submodule). In that case the non-module
         // declaration appears later in the declaration list and "wins" when the
         // symbol is resolved. Only treat this wildcard re-export as a pure submodule
-        // re-export when the module alias is the symbol's effective (last)
-        // declaration; otherwise fall through so a normal alias declaration is
-        // created that resolves to the winning symbol.
-        // See https://github.com/microsoft/pyright/issues/11481.
+        // re-export when the module alias is the symbol's last declaration;
+        // otherwise fall through so a normal alias declaration is created that
+        // resolves to the winning symbol.
+        //
+        // We compare against the raw last declaration (not getLastTypedDeclarationForSymbol)
+        // on purpose: a module alias is a DeclarationType.Alias, which hasTypeForDeclaration
+        // treats as untyped, so it never appears among a symbol's typed declarations.
+        // The evaluator resolves alias symbols (like this one, whose declarations are all
+        // imports) by declaration order, so the last declaration is the relevant "winner"
+        // here. When this guard falls through, the alias created by the caller resolves to
+        // the winning (e.g. class) declaration and intentionally has no submoduleFallback:
+        // the class shadows the submodule, so submodule member access through the
+        // re-exported name is no longer offered. The genuine-submodule case (where the
+        // module alias is the last declaration) keeps its module/submodule behavior.
         const importedDecls = importedSymbol.getDeclarations();
         if (importedDecls[importedDecls.length - 1] !== importedModuleAliasDecl) {
             return false;

--- a/packages/pyright-internal/src/tests/fourslash/import.multipartModuleClassShadow.fourslash.ts
+++ b/packages/pyright-internal/src/tests/fourslash/import.multipartModuleClassShadow.fourslash.ts
@@ -3,7 +3,6 @@
 // This verifies that when a package re-exports (via wildcard) a name that is
 // both an implicitly-imported submodule and a class/symbol of the same name,
 // the class/symbol "wins" rather than being shadowed by the submodule.
-// See https://github.com/microsoft/pyright/issues/11481.
 
 // @filename: pkg/__init__.py
 //// from .sub import *
@@ -22,5 +21,27 @@
 //// # used as a type annotation and called.
 //// view: ImageView = ImageView()
 //// reveal_type(ImageView, expected_text="type[ImageView]")
+
+// Companion case: a pure submodule re-export (no shadowing class) must still
+// resolve as a module so that submodule member access remains available. This
+// locks in that the multipart-alias behavior didn't regress.
+
+// @filename: pkg2/__init__.py
+//// from .sub2 import *
+
+// @filename: pkg2/sub2/__init__.py
+//// from . import mod
+
+// @filename: pkg2/sub2/mod.py
+//// def mod_func() -> None:
+////     pass
+
+// @filename: test2.py
+//// import pkg2
+////
+//// # mod has only a submodule alias declaration, so it stays a module and its
+//// # members remain accessible through the re-exported name.
+//// pkg2.mod.mod_func()
+//// reveal_type(pkg2.mod, expected_text='Module("..mod")')
 
 helper.verifyDiagnostics();

--- a/packages/pyright-internal/src/tests/fourslash/import.multipartModuleClassShadow.fourslash.ts
+++ b/packages/pyright-internal/src/tests/fourslash/import.multipartModuleClassShadow.fourslash.ts
@@ -1,0 +1,26 @@
+/// <reference path="typings/fourslash.d.ts" />
+
+// This verifies that when a package re-exports (via wildcard) a name that is
+// both an implicitly-imported submodule and a class/symbol of the same name,
+// the class/symbol "wins" rather than being shadowed by the submodule.
+// See https://github.com/microsoft/pyright/issues/11481.
+
+// @filename: pkg/__init__.py
+//// from .sub import *
+
+// @filename: pkg/sub/__init__.py
+//// from .ImageView import ImageView
+
+// @filename: pkg/sub/ImageView.py
+//// class ImageView:
+////     pass
+
+// @filename: test.py
+//// from pkg import ImageView
+////
+//// # ImageView should resolve to the class, not the submodule, so it can be
+//// # used as a type annotation and called.
+//// view: ImageView = ImageView()
+//// reveal_type(ImageView, expected_text="type[ImageView]")
+
+helper.verifyDiagnostics();


### PR DESCRIPTION
## Description

When a package re-exports (via a wildcard `from .sub import *`) a name that is both an implicitly-imported submodule **and** a class of the same name, Pylance 1.1.410 incorrectly resolved the name to the submodule instead of the class. This broke using the name as a type annotation or calling it.

## How you figured out what to do

Reproduced the issue with a package whose submodule (`ImageView.py`) defines a class (`ImageView`) re-exported through wildcard imports. The symbol ended up with multiple declarations: an implicit submodule alias and the class. The binder's multipart module-alias handling treated the wildcard re-export as a pure submodule re-export, shadowing the class even though the non-module declaration is the symbol's effective (last) declaration.

## Implementation

In `binder.ts`, the wildcard re-export is now only treated as a pure submodule re-export when the module alias is the symbol's **effective (last)** declaration. When a later non-module declaration (the class) wins, the binder falls through to create a normal alias declaration that resolves to the winning symbol.

```ts
const importedDecls = importedSymbol.getDeclarations();
if (importedDecls[importedDecls.length - 1] !== importedModuleAliasDecl) {
    return false;
}
```

## Testing

Added a fourslash regression test (`import.multipartModuleClassShadow.fourslash.ts`) that sets up a package re-exporting a class whose name matches a submodule. It verifies the name resolves to `type[ImageView]`, can be used as a type annotation and called, with no diagnostics.

Run with:

```
cd packages/pyright/packages/pyright-internal
node node_modules\jest\bin\jest fourSlashRunner.test.ts --runInBand -t import.multipartModuleClassShadow.fourslash
```

## Addresses

Fixes https://github.com/microsoft/pylance-release/issues/11481

---
*Generated by fix_all_my_issues pipeline*