### PR TITLE
Fix symlinked partial stub packages

### DIFF
--- a/packages/pyright-internal/src/readonlyAugmentedFileSystem.ts
+++ b/packages/pyright-internal/src/readonlyAugmentedFileSystem.ts
@@ -13,6 +13,7 @@ import { FileSystem, MkDirOptions, Stats, VirtualDirent } from './common/fileSys
 import { FileWatcher, FileWatcherEventHandler } from './common/fileWatcher';
 import { Uri } from './common/uri/uri';
 import { UriMap } from './common/uri/uriMap';
+import { tryStat } from './common/uri/uriUtils';
 import { Disposable } from 'vscode-jsonrpc';
 
 interface MappedEntry {
@@ -70,12 +71,20 @@ export class ReadOnlyAugmentedFileSystem implements FileSystem {
         const mappedEntry = this._getOriginalEntry(uri);
         if (mappedEntry) {
             const originalUri = this._getInternalOriginalUri(uri);
-            const filteredEntries = this.realFS
-                .readdirEntriesSync(originalUri)
-                .filter((e) => mappedEntry.filter(originalUri.combinePaths(e.name), this.realFS))
-                .map((e) => new VirtualDirent(e.name, e.isFile(), uri.getFilePath()));
-            for (const entry of filteredEntries) {
-                entries.set(entry.name, entry);
+            for (const entry of this.realFS.readdirEntriesSync(originalUri)) {
+                const originalEntryUri = originalUri.combinePaths(entry.name);
+                if (!mappedEntry.filter(originalEntryUri, this.realFS)) {
+                    continue;
+                }
+
+                // Mapped entries are virtual, so resolve types that readdir cannot classify, including symlinks and
+                // DT_UNKNOWN entries.
+                const target = entry.isFile() || entry.isDirectory() ? entry : tryStat(this.realFS, originalEntryUri);
+                if (!target || (!target.isFile() && !target.isDirectory())) {
+                    continue;
+                }
+
+                entries.set(entry.name, new VirtualDirent(entry.name, target.isFile(), uri.getFilePath()));
             }
         }
 

--- a/packages/pyright-internal/src/tests/importResolver.test.ts
+++ b/packages/pyright-internal/src/tests/importResolver.test.ts
@@ -68,6 +68,52 @@ describe('Import tests with fake venv', () => {
                 );
             });
 
+            test('symlinked partial stub file exists', () => {
+                const stubSource = combinePaths(normalizeSlashes('/'), 'wheel', 'partialStub.pyi');
+                const files = [
+                    {
+                        path: stubSource,
+                        content: 'def test(): ...',
+                    },
+                    {
+                        path: combinePaths(libraryRoot, 'myLib-stubs', 'py.typed'),
+                        content: 'partial\n',
+                    },
+                    {
+                        path: combinePaths(libraryRoot, 'myLib', 'partialStub.py'),
+                        content: 'def test(): pass',
+                    },
+                ];
+
+                const testFS = createTestFileSystem(files);
+                testFS.symlinkSync(stubSource, combinePaths(libraryRoot, 'myLib-stubs', 'partialStub.pyi'));
+                const fs = new PyrightFileSystem(testFS);
+                const partialStubService = new PartialStubService(fs);
+                const sp = createServiceProvider(testFS, fs, partialStubService);
+                const configOptions = new ConfigOptions(UriEx.file('/'));
+                const uri = UriEx.file(files[files.length - 1].path);
+                const importResolver = new ImportResolver(
+                    sp,
+                    configOptions,
+                    new TestAccessHost(sp.fs().getModulePath(), [UriEx.file(libraryRoot)])
+                );
+
+                const importResult = importResolver.resolveImport(uri, configOptions.findExecEnvironment(uri), {
+                    leadingDots: 0,
+                    nameParts: ['myLib', 'partialStub'],
+                    importedSymbols: new Set<string>(),
+                });
+
+                assert(importResult.isImportFound);
+                assert(importResult.isStubFile);
+                assert.strictEqual(
+                    1,
+                    importResult.resolvedUris.filter(
+                        (f) => f.getFilePath() === combinePaths(libraryRoot, 'myLib', 'partialStub.pyi')
+                    ).length
+                );
+            });
+
             test('partial stub __init__ exists', () => {
                 const files = [
                     {

--- a/packages/pyright-internal/src/tests/pyrightFileSystem.test.ts
+++ b/packages/pyright-internal/src/tests/pyrightFileSystem.test.ts
@@ -59,6 +59,35 @@ test('virtual file exists', () => {
     assert(!fs.existsSync(libraryRootUri.combinePaths('myLib-stubs')));
 });
 
+test('mapped symlinks reflect their targets', () => {
+    const testFs = new TestFileSystem(/* ignoreCase */ false, { cwd: normalizeSlashes('/') });
+    const stubPackage = combinePaths(libraryRoot, 'myLib-stubs');
+    const stubSource = combinePaths(normalizeSlashes('/'), 'wheel', 'partialStub.pyi');
+    const markerSource = combinePaths(normalizeSlashes('/'), 'wheel', 'py.typed');
+    const missingStub = combinePaths(stubPackage, 'missing.pyi');
+
+    testFs.mkdirpSync(combinePaths(libraryRoot, 'myLib'));
+    testFs.writeFileSync(Uri.file(combinePaths(libraryRoot, 'myLib', 'partialStub.py'), testFs), 'def test(): pass');
+    testFs.mkdirpSync(stubPackage);
+    testFs.mkdirpSync(getDirectoryPath(stubSource));
+    testFs.writeFileSync(Uri.file(stubSource, testFs), 'def test(): ...');
+    testFs.writeFileSync(Uri.file(markerSource, testFs), 'partial\n');
+    testFs.symlinkSync(stubSource, combinePaths(stubPackage, 'partialStub.pyi'));
+    testFs.symlinkSync(markerSource, combinePaths(stubPackage, 'py.typed'));
+    testFs.symlinkSync(combinePaths(normalizeSlashes('/'), 'wheel', 'missing.pyi'), missingStub);
+
+    const fs = new PyrightFileSystem(testFs);
+    const ps = new PartialStubService(fs);
+    ps.processPartialStubPackages([libraryRootUri], [libraryRootUri]);
+
+    const entries = fs.readdirEntriesSync(libraryRootUri.combinePaths('myLib'));
+    assert.strictEqual(2, entries.length);
+    const stubFile = entries.find((entry) => entry.name === 'partialStub.pyi');
+    assert.ok(stubFile, 'Expected partialStub.pyi');
+    assert(stubFile.isFile());
+    assert(!entries.some((entry) => entry.name === 'missing.pyi'));
+});
+
 test('virtual file coexists with real', () => {
     const files = [
         {


### PR DESCRIPTION
Partial stub packages are overlaid onto their runtime packages. When a
file in the stub package is a symbolic link, its directory entry reports
that it is a link rather than a file. `ReadOnlyAugmentedFileSystem`
currently converts that entry to a virtual directory, so import
resolution ignores the `.pyi` and falls back to the runtime `.py`.

Resolve symbolic links before constructing virtual directory entries.
Dangling links and special files are omitted rather than exposed as
directories. This preserves the partial stub overlay for environments
that install wheel files as symbolic links.