### PR TITLE
Evaluate truthiness of literals in static boolean expressions

### DIFF
--- a/packages/pyright-internal/src/analyzer/staticExpressions.ts
+++ b/packages/pyright-internal/src/analyzer/staticExpressions.ts
@@ -84,12 +84,13 @@ function _evaluateStaticBoolOrBoolLikeExpression(
 
     if (node.nodeType === ParseNodeType.UnaryOperation) {
         if (node.d.operator === OperatorType.Not) {
-            const value = evaluateStaticBoolLikeExpression(
+            const value = _evaluateStaticBoolOrBoolLikeExpression(
                 node.d.expr,
                 execEnv,
                 definedConstants,
                 typingImportAliases,
-                sysImportAliases
+                sysImportAliases,
+                evaluateLeafAsBool
             );
             if (value !== undefined) {
                 return !value;

--- a/packages/pyright-internal/src/analyzer/staticExpressions.ts
+++ b/packages/pyright-internal/src/analyzer/staticExpressions.ts
@@ -90,7 +90,9 @@ function _evaluateStaticBoolOrBoolLikeExpression(
                 definedConstants,
                 typingImportAliases,
                 sysImportAliases,
-                evaluateLeafAsBool
+                // `not x` always forces a truthiness context on its operand and yields real `bool`.
+                // So the operand is folded with the bool-like leaf even for strict callers.
+                _evaluateBoolLikeLiteral
             );
             if (value !== undefined) {
                 return !value;

--- a/packages/pyright-internal/src/analyzer/staticExpressions.ts
+++ b/packages/pyright-internal/src/analyzer/staticExpressions.ts
@@ -10,7 +10,16 @@
 
 import { ExecutionEnvironment, PythonPlatform } from '../common/configOptions';
 import { PythonReleaseLevel, PythonVersion } from '../common/pythonVersion';
-import { ArgCategory, ExpressionNode, NameNode, NumberNode, ParseNodeType, TupleNode } from '../parser/parseNodes';
+import {
+    ArgCategory,
+    DictionaryEntryNode,
+    ExpressionNode,
+    NameNode,
+    NumberNode,
+    ParseNodeType,
+    StringListNode,
+    TupleNode,
+} from '../parser/parseNodes';
 import { KeywordType, OperatorType } from '../parser/tokenizerTypes';
 
 // Returns undefined if the expression cannot be evaluated
@@ -22,13 +31,54 @@ export function evaluateStaticBoolExpression(
     typingImportAliases?: string[],
     sysImportAliases?: string[]
 ): boolean | undefined {
+    return _evaluateStaticBoolOrBoolLikeExpression(
+        node,
+        execEnv,
+        definedConstants,
+        typingImportAliases,
+        sysImportAliases,
+        _evaluateBoolConstant
+    );
+}
+
+// Similar to evaluateStaticBoolExpression except that it handles other non-bool
+// values that are statically falsy or truthy (like "None", "...", and
+// numeric/string/container literals).
+export function evaluateStaticBoolLikeExpression(
+    node: ExpressionNode,
+    execEnv: ExecutionEnvironment,
+    definedConstants: Map<string, boolean | string>,
+    typingImportAliases?: string[],
+    sysImportAliases?: string[]
+): boolean | undefined {
+    return _evaluateStaticBoolOrBoolLikeExpression(
+        node,
+        execEnv,
+        definedConstants,
+        typingImportAliases,
+        sysImportAliases,
+        _evaluateBoolLikeLiteral
+    );
+}
+
+// Shared implementation of the two functions above.
+// The "evaluatePrimitive" callback evaluates leaf expressions.
+function _evaluateStaticBoolOrBoolLikeExpression(
+    node: ExpressionNode,
+    execEnv: ExecutionEnvironment,
+    definedConstants: Map<string, boolean | string>,
+    typingImportAliases: string[] | undefined,
+    sysImportAliases: string[] | undefined,
+    evaluateLeafAsBool: (node: ExpressionNode) => boolean | undefined
+): boolean | undefined {
     if (node.nodeType === ParseNodeType.AssignmentExpression) {
-        return evaluateStaticBoolExpression(
+        return _evaluateStaticBoolOrBoolLikeExpression(
             node.d.rightExpr,
             execEnv,
             definedConstants,
             typingImportAliases,
-            sysImportAliases
+            sysImportAliases,
+            evaluateLeafAsBool
         );
     }
 
@@ -48,19 +98,21 @@ export function evaluateStaticBoolExpression(
     } else if (node.nodeType === ParseNodeType.BinaryOperation) {
         // Is it an OR or AND expression?
         if (node.d.operator === OperatorType.Or || node.d.operator === OperatorType.And) {
-            const leftValue = evaluateStaticBoolExpression(
+            const leftValue = _evaluateStaticBoolOrBoolLikeExpression(
                 node.d.leftExpr,
                 execEnv,
                 definedConstants,
                 typingImportAliases,
-                sysImportAliases
+                sysImportAliases,
+                evaluateLeafAsBool
             );
-            const rightValue = evaluateStaticBoolExpression(
+            const rightValue = _evaluateStaticBoolOrBoolLikeExpression(
                 node.d.rightExpr,
                 execEnv,
                 definedConstants,
                 typingImportAliases,
-                sysImportAliases
+                sysImportAliases,
+                evaluateLeafAsBool
             );
 
             if (leftValue === undefined || rightValue === undefined) {
@@ -139,12 +191,6 @@ export function evaluateStaticBoolExpression(
                 }
             }
         }
-    } else if (node.nodeType === ParseNodeType.Constant) {
-        if (node.d.constType === KeywordType.True) {
-            return true;
-        } else if (node.d.constType === KeywordType.False) {
-            return false;
-        }
     } else if (node.nodeType === ParseNodeType.Name) {
         if (node.d.value === 'TYPE_CHECKING') {
             return true;
@@ -170,26 +216,102 @@ export function evaluateStaticBoolExpression(
         }
     }
 
-    return undefined;
+    return evaluateLeafAsBool(node);
 }
 
-// Similar to evaluateStaticBoolExpression except that it handles
-// other non-bool values that are statically falsy or truthy
-// (like "None").
-export function evaluateStaticBoolLikeExpression(
-    node: ExpressionNode,
-    execEnv: ExecutionEnvironment,
-    definedConstants: Map<string, boolean | string>,
-    typingImportAliases?: string[],
-    sysImportAliases?: string[]
-): boolean | undefined {
+function _evaluateBoolConstant(node: ExpressionNode): boolean | undefined {
     if (node.nodeType === ParseNodeType.Constant) {
-        if (node.d.constType === KeywordType.None) {
+        if (node.d.constType === KeywordType.True) {
+            return true;
+        }
+        if (node.d.constType === KeywordType.False) {
             return false;
         }
     }
 
-    return evaluateStaticBoolExpression(node, execEnv, definedConstants, typingImportAliases, sysImportAliases);
+    return undefined;
+}
+
+function _evaluateBoolLikeLiteral(node: ExpressionNode): boolean | undefined {
+    switch (node.nodeType) {
+        case ParseNodeType.Constant:
+            if (node.d.constType === KeywordType.True) {
+                return true;
+            }
+            if (node.d.constType === KeywordType.False || node.d.constType === KeywordType.None) {
+                return false;
+            }
+            return undefined;
+
+        case ParseNodeType.Ellipsis:
+            return true;
+
+        case ParseNodeType.Number:
+            return _evaluateNumberTruthiness(node);
+
+        case ParseNodeType.StringList:
+            return _evaluateStringListTruthiness(node);
+
+        case ParseNodeType.List:
+        case ParseNodeType.Set:
+        case ParseNodeType.Tuple:
+            return _evaluateSequenceTruthiness(node.d.items);
+
+        case ParseNodeType.Dictionary:
+            return _evaluateDictTruthiness(node.d.items);
+
+        default:
+            return undefined;
+    }
+}
+
+function _evaluateNumberTruthiness(node: NumberNode): boolean {
+    // bool(v) is False iff v == 0:
+    // - zero (0, 0.0, 0j) is falsy;
+    // - everything else is truthy, including infinity and NaN.
+    if (typeof node.d.value === 'bigint') {
+        return node.d.value !== BigInt(0);
+    }
+    return node.d.value !== 0;
+}
+
+function _evaluateStringListTruthiness(node: StringListNode): boolean | undefined {
+    // If any segment is an f-string, the concatenated value is runtime-dependent
+    // (e.g. f"{x}" may be empty or not).
+    if (node.d.strings.some((str) => str.nodeType === ParseNodeType.FormatString)) {
+        return undefined;
+    }
+
+    // Truthy iff any segment is non-empty.
+    return node.d.strings.some((str) => str.d.value.length > 0);
+}
+
+function _evaluateSequenceTruthiness(items: ExpressionNode[]): boolean | undefined {
+    if (items.length === 0) {
+        return false;
+    }
+
+    // A concrete element (not an unpack "*x" or a comprehension) guarantees the sequence is non-empty.
+    if (items.some((item) => item.nodeType !== ParseNodeType.Unpack && item.nodeType !== ParseNodeType.Comprehension)) {
+        return true;
+    }
+
+    // Only unpacks/comprehensions remain (e.g. "[*x]", "[i for i in y]").
+    return undefined;
+}
+
+function _evaluateDictTruthiness(items: DictionaryEntryNode[]): boolean | undefined {
+    if (items.length === 0) {
+        return false;
+    }
+
+    // A concrete key/value entry guarantees the dict is non-empty.
+    if (items.some((item) => item.nodeType === ParseNodeType.DictionaryKeyEntry)) {
+        return true;
+    }
+
+    // Only "**" expansions or comprehensions remain.
+    return undefined;
 }
 
 function _convertTupleToVersion(node: TupleNode): PythonVersion | undefined {

--- a/packages/pyright-internal/src/analyzer/staticExpressions.ts
+++ b/packages/pyright-internal/src/analyzer/staticExpressions.ts
@@ -62,7 +62,7 @@ export function evaluateStaticBoolLikeExpression(
 }
 
 // Shared implementation of the two functions above.
-// The "evaluatePrimitive" callback evaluates leaf expressions.
+// The `evaluateLeafAsBool` callback evaluates leaf expressions.
 function _evaluateStaticBoolOrBoolLikeExpression(
     node: ExpressionNode,
     execEnv: ExecutionEnvironment,

--- a/packages/pyright-internal/src/tests/samples/optional1.py
+++ b/packages/pyright-internal/src/tests/samples/optional1.py
@@ -3,6 +3,10 @@
 from typing import Any, Optional
 
 
+# An opaque condition to make variables Optional after `if`.
+def cond() -> bool: ...
+
+
 class Foo:
     def __init__(self):
         self.value = 3
@@ -23,7 +27,7 @@ class Foo:
 
 
 a = None
-if 1:
+if cond():
     a = Foo()
 
 # If "reportOptionalMemberAccess" is enabled,
@@ -36,7 +40,7 @@ def foo():
 
 
 b = None
-if 1:
+if cond():
     b = foo
 
 # If "reportOptionalCall" is enabled,
@@ -45,7 +49,7 @@ b()
 
 
 c = None
-if 1:
+if cond():
     c = [3, 4, 5]
 
 # If "reportOptionalSubscript" is enabled,
@@ -61,13 +65,13 @@ for val in c:
 # If "reportOptionalContextManager" is enabled,
 # this should generate an error.
 cm = None
-if 1:
+if cond():
     cm = Foo()
 with cm as val:
     pass
 
 e = None
-if 1:
+if cond():
     e = 4
 
 # If "reportOptionalOperand" is enabled,

--- a/packages/pyright-internal/src/tests/samples/staticExpressionLiteral1.py
+++ b/packages/pyright-internal/src/tests/samples/staticExpressionLiteral1.py
@@ -1,5 +1,7 @@
 # This sample tests the static evaluation of literal truthiness
 
+from typing import Literal, assert_type
+
 
 # The literal condition is statically known
 def positive() -> None:
@@ -128,3 +130,21 @@ def negative(items: list[int], text: str, mapping: dict[str, int]) -> None:
         v = "error"
     else:
         v = 1
+
+
+# `not` always forces a truthiness context
+def strict_not_folding() -> None:
+    a = not None
+    assert_type(a, Literal[True])
+
+    b = not 0
+    assert_type(b, Literal[True])
+
+    c = not 1
+    assert_type(c, Literal[False])
+
+    d = not []
+    assert_type(d, Literal[True])
+
+    e = not not None
+    assert_type(e, Literal[False])

--- a/packages/pyright-internal/src/tests/samples/staticExpressionLiteral1.py
+++ b/packages/pyright-internal/src/tests/samples/staticExpressionLiteral1.py
@@ -1,0 +1,130 @@
+# This sample tests the static evaluation of literal truthiness
+
+
+# The literal condition is statically known
+def positive() -> None:
+    x: int
+
+    while not 1:
+        x = "unreachable"
+
+    # Falsy literals
+    if 0:
+        x = "unreachable"
+
+    if 0.0:
+        x = "unreachable"
+
+    if 0j:
+        x = "unreachable"
+
+    if "":
+        x = "unreachable"
+
+    if b"":
+        x = "unreachable"
+
+    if ():
+        x = "unreachable"
+
+    if []:
+        x = "unreachable"
+
+    if {}:
+        x = "unreachable"
+
+    if None:
+        x = "unreachable"
+
+    # Truthy literals
+    if 1:
+        x = 1
+    else:
+        x = "unreachable"
+
+    if "x":
+        x = 1
+    else:
+        x = "unreachable"
+
+    if b"ad":
+        x = 1
+    else:
+        x = "unreachable"
+
+    if (1,):
+        x = 1
+    else:
+        x = "unreachable"
+
+    if [1]:
+        x = 1
+    else:
+        x = "unreachable"
+
+    if {1}:
+        x = 1
+    else:
+        x = "unreachable"
+
+    if {1: 2}:
+        x = 1
+    else:
+        x = "unreachable"
+
+    if ...:
+        x = 1
+    else:
+        x = "unreachable"
+
+    # Boolean operators applied to literal operands
+    if 1 and 0:
+        x = "unreachable"
+
+    if 0 or "x":
+        x = 1
+    else:
+        x = "unreachable"
+
+    if not 1:
+        x = "unreachable"
+
+    if not []:
+        x = 1
+    else:
+        x = "unreachable"
+
+    if not not 1:
+        x = 1
+    else:
+        x = "unreachable"
+
+
+# The literal truthiness is not statically determinable
+# Both branches are analyzed and the incompatible assignment is reported as an error
+def negative(items: list[int], text: str, mapping: dict[str, int]) -> None:
+    v: int
+
+    # An unpacked element may expand to nothing, so `[*items]` may be empty
+    if [*items]:
+        v = "error"
+    else:
+        v = 1
+
+    # The value of an f-string with a field depends on a runtime value
+    if f"{text}":
+        v = "error"
+    else:
+        v = 1
+
+    # A comprehension may yield nothing
+    if [i for i in items]:
+        v = "error"
+    else:
+        v = 1
+
+    # A dict built only from "**" expansion may be empty
+    if {**mapping}:
+        v = "error"
+    else:
+        v = 1

--- a/packages/pyright-internal/src/tests/samples/staticExpressionLiteral1.py
+++ b/packages/pyright-internal/src/tests/samples/staticExpressionLiteral1.py
@@ -136,15 +136,19 @@ def negative(items: list[int], text: str, mapping: dict[str, int]) -> None:
 def strict_not_folding() -> None:
     a = not None
     assert_type(a, Literal[True])
-
     b = not 0
     assert_type(b, Literal[True])
-
     c = not 1
     assert_type(c, Literal[False])
-
     d = not []
     assert_type(d, Literal[True])
-
     e = not not None
     assert_type(e, Literal[False])
+    f = not {}
+    assert_type(f, Literal[True])
+    g = not {1, 2}
+    assert_type(g, Literal[False])
+    h = not [1]
+    assert_type(h, Literal[False])
+    i = not {1: 2}
+    assert_type(i, Literal[False])

--- a/packages/pyright-internal/src/tests/typeEvaluator8.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator8.test.ts
@@ -963,6 +963,12 @@ test('StaticExpression2', () => {
     TestUtils.validateResults(analysisResults, 0);
 });
 
+test('StaticExpressionLiteral1', () => {
+    const analysisResults = TestUtils.typeAnalyzeSampleFiles(['staticExpressionLiteral1.py']);
+
+    TestUtils.validateResults(analysisResults, 4);
+});
+
 test('SpecialForm1', () => {
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['specialForm1.py']);
 


### PR DESCRIPTION
## Summary

Currently, `bool`-like expressions evaluator supports only `None` as a falsy literal.
So that, this code does not report `print(x)` as unreachable:

```python
while 1:
    x = 1
print(x)
```

This PR adds support of other literal types listed below

| Expression form | Examples | Static result |
| --- | --- | --- |
| Bool keywords | `True`, `False` | `true` / `false` |
| `None` | `None` | `false` |
| Ellipsis | `...` | `true` |
| Numbers | `0`, `0.0`, `0j` / `1`, `3.14`, `1j` | `false` / `true` |
| Strings & bytes | `""`, `b""` / `"x"`, `b"x"` | `false` / `true` |
| List / set / tuple / dict | `[]`, `()`, `{}` / `[1]`, `(1,)`, `{1}`, `{1: 2}` | `false` / `true` |
| `not` of a foldable operand | `not 1`, `not []`, `not not 1` | negated |
| `and` / `or` of foldable operands | `1 and 0`, `0 or "x"` | combined truthiness |
| Container with a concrete element | `[1, *x]`, `{**d, "k": 1}` | `true` (definitely non-empty) |
| f-strings | `f"{x}"` | `undefined` (runtime-dependent) |
| Spread/comprehension-only containers | `[*x]`, `[i for i in y]`, `{**d}` | `undefined` (length unknown) |
| Negative or non-literal operands | `-1`, `x`, `f()`, `Decimal(0)`, `set()` | `undefined` (a negative number isn't a single node)|


## Tests

Added `staticExpressionLiteral1.py` with positive and negative cases.
One of the tests is updated because `if 1` is determined now.

Fixes #11505