### PR TITLE
Bump version to 1.1.411

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -2,7 +2,7 @@
   "packages": [
     "packages/*"
   ],
-  "version": "1.1.410",
+  "version": "1.1.411",
   "command": {
     "version": {
       "push": false,

--- a/packages/pyright-internal/package-lock.json
+++ b/packages/pyright-internal/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "pyright-internal",
-    "version": "1.1.410",
+    "version": "1.1.411",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "pyright-internal",
-            "version": "1.1.410",
+            "version": "1.1.411",
             "license": "MIT",
             "dependencies": {
                 "@yarnpkg/fslib": "2.10.4",

--- a/packages/pyright-internal/package.json
+++ b/packages/pyright-internal/package.json
@@ -2,7 +2,7 @@
     "name": "pyright-internal",
     "displayName": "pyright",
     "description": "Type checker for the Python language",
-    "version": "1.1.410",
+    "version": "1.1.411",
     "license": "MIT",
     "private": true,
     "files": [

--- a/packages/pyright/package-lock.json
+++ b/packages/pyright/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "pyright",
-    "version": "1.1.410",
+    "version": "1.1.411",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "pyright",
-            "version": "1.1.410",
+            "version": "1.1.411",
             "license": "MIT",
             "bin": {
                 "pyright": "index.js",

--- a/packages/pyright/package.json
+++ b/packages/pyright/package.json
@@ -2,7 +2,7 @@
     "name": "pyright",
     "displayName": "Pyright",
     "description": "Type checker for the Python language",
-    "version": "1.1.410",
+    "version": "1.1.411",
     "license": "MIT",
     "author": {
         "name": "Microsoft Corporation"

--- a/packages/vscode-pyright/package-lock.json
+++ b/packages/vscode-pyright/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "vscode-pyright",
-    "version": "1.1.410",
+    "version": "1.1.411",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "vscode-pyright",
-            "version": "1.1.410",
+            "version": "1.1.411",
             "license": "MIT",
             "dependencies": {
                 "vscode-jsonrpc": "^9.0.0-next.8",

--- a/packages/vscode-pyright/package.json
+++ b/packages/vscode-pyright/package.json
@@ -2,7 +2,7 @@
     "name": "vscode-pyright",
     "displayName": "Pyright",
     "description": "VS Code static type checking for Python",
-    "version": "1.1.410",
+    "version": "1.1.411",
     "private": true,
     "license": "MIT",
     "author": {


### PR DESCRIPTION
Bumps the package version from 1.1.410 to 1.1.411 in preparation for the next release.

Updates the version in:
- `lerna.json`
- `packages/pyright/package.json` (+ lockfile)
- `packages/pyright-internal/package.json` (+ lockfile)
- `packages/vscode-pyright/package.json` (+ lockfile)

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>