### PR TITLE
Fix generic class pattern match widening solved type args to bound (#11526)

### DIFF
--- a/packages/pyright-internal/src/analyzer/patternMatching.ts
+++ b/packages/pyright-internal/src/analyzer/patternMatching.ts
@@ -766,10 +766,14 @@ function specializeBoundedMatchTypeParams(
     const typeArgs = matchType.shared.typeParams.map((param, index) => {
         const specializedArg = solvedTypeArgs?.[index];
 
-        // Keep an argument unless it is genuinely Unknown. A bare in-scope TypeVar
-        // (e.g. a subject `Thing[S]` from a generic function `def f[S: bool]`) is a
-        // legitimately narrowed argument and must not be widened to the bound.
-        if (specializedArg && !containsAnyOrUnknown(specializedArg, /* recurse */ true)) {
+        // Keep an argument unless it is the unsolved sentinel (a bare top-level
+        // Unknown left by the constraint solver when the subject carried no type
+        // arguments). A concrete argument that is merely implicitly parameterized -
+        // e.g. bare `list` (`list[Unknown]`) or `dict` (`dict[Unknown, Unknown]`) - is
+        // a real, solved type and must be preserved rather than widened to the bound.
+        // A bare in-scope TypeVar (e.g. a subject `Thing[S]` from a generic function
+        // `def f[S: bool]`) is likewise a legitimately narrowed argument.
+        if (specializedArg && !isUnknown(specializedArg)) {
             return specializedArg;
         }
 

--- a/packages/pyright-internal/src/tests/samples/matchNamedTupleGeneric1.py
+++ b/packages/pyright-internal/src/tests/samples/matchNamedTupleGeneric1.py
@@ -1,6 +1,6 @@
 # This sample tests generic NamedTuple class pattern matching.
 
-from typing import NamedTuple
+from typing import Any, NamedTuple
 
 
 class Thing[T: bool](NamedTuple):
@@ -90,3 +90,53 @@ def test_generic_supertype(value: GenericBase[int]) -> None:
     match value:
         case BoundedDerived():
             reveal_type(value.foo, expected_text="bool")
+
+
+# The following cases guard against regression #11526: a subject that already
+# carries a concretely-solved type argument must keep that argument after a class
+# pattern match rather than being widened to the type parameter's bound. This is
+# true even when the solved argument is implicitly parameterized (bare `list` is
+# `list[Unknown]`, `dict` is `dict[Unknown, Unknown]`, etc.).
+
+
+class Wrapper[A: str | list]:
+    data: A
+
+
+def test_solved_bare_list(obj: Wrapper[list]) -> list:
+    match obj:
+        case Wrapper(data=data):
+            reveal_type(data, expected_text="list[Unknown]")
+            return data
+
+
+def test_solved_bare_list_instance(obj: Wrapper[list]) -> list:
+    match obj:
+        case Wrapper():
+            reveal_type(obj.data, expected_text="list[Unknown]")
+            return obj.data
+
+
+def test_solved_list_any(obj: Wrapper[list[Any]]) -> list:
+    match obj:
+        case Wrapper(data=data):
+            reveal_type(data, expected_text="list[Any]")
+            return data
+
+
+def test_solved_list_int(obj: Wrapper[list[int]]) -> list[int]:
+    match obj:
+        case Wrapper(data=data):
+            reveal_type(data, expected_text="list[int]")
+            return data
+
+
+class MultiWrapper[A: str | dict]:
+    data: A
+
+
+def test_solved_bare_dict(obj: MultiWrapper[dict]) -> dict:
+    match obj:
+        case MultiWrapper(data=data):
+            reveal_type(data, expected_text="dict[Unknown, Unknown]")
+            return data


### PR DESCRIPTION
## Summary

Fixes #11526, a regression introduced in 1.1.411 by #11489 where a `match` against a generic class pattern loses an already-solved type argument and widens it to the type parameter's bound.

## Problem

```python
class Wrapper[A: str | list]:
    data: A

def failing_match_unpack(obj: Wrapper[list]) -> list:
    match obj:
        case Wrapper(data=data):
            return data  # error: "str | list[Unknown]" is not assignable to "list[Unknown]"
```

`obj` has a concrete type argument (`list`), but after the class pattern match `data` is narrowed to the full bound `str | list` instead of `list`.

## Root cause

#11489 added `specializeBoundedMatchTypeParams`, which falls back to a bounded type parameter's bound when the parameter is left unsolved by the constraint solver. The guard that decides whether an argument was solved used:

```ts
if (specializedArg && !containsAnyOrUnknown(specializedArg, /* recurse */ true)) {
    return specializedArg;
}
```

With `recurse: true`, `containsAnyOrUnknown` descends into type arguments. So a concrete-but-implicitly-parameterized argument — bare `list` is `list[Unknown]`, `dict` is `dict[Unknown, Unknown]`, or explicit `list[Any]` — was treated as "unsolved" and replaced by the parameter's bound.

This matches every observation in the issue:
- `int` (no params) and `list[int]` (no nested Unknown) → kept → works
- bare `list`, `dict`, `set`, `list[Any]` → nested `Unknown`/`Any` found → widened to bound → fails

The genuine "unsolved" sentinel is a bare top-level `Unknown` (the case #11489 targeted, where the subject carries no type arguments). A solved `list[Unknown]` is a real `list` class and must be preserved.

## Fix

Only treat a bare top-level `Unknown` as the unsolved sentinel:

```ts
if (specializedArg && !isUnknown(specializedArg)) {
    return specializedArg;
}
```

This matches the original intent ("keep an argument unless it is genuinely Unknown") while preserving concrete arguments.

## Testing

- Extended `matchNamedTupleGeneric1.py` with regression cases for `Wrapper[list]`, `Wrapper[list[Any]]`, `Wrapper[list[int]]`, and `MultiWrapper[dict]`; the existing `NamedTuple12` test continues to assert 0 errors.
- All original #11489 cases still pass (subject narrowed against `object` still falls back to the bound, in-scope TypeVar arguments preserved, generic-supertype case, etc.).
- Full `pyright-internal` suite passes (the only failing suite is `languageServer.test.ts`, which requires the prebuilt test server bundle and is unrelated).
