### PR TITLE
Adapt stubPath special-casing to latest changes

### DIFF
--- a/packages/vscode-pyright/src/extension.ts
+++ b/packages/vscode-pyright/src/extension.ts
@@ -126,7 +126,7 @@ export async function activate(context: ExtensionContext) {
                     }
 
                     for (const [i, item] of params.items.entries()) {
-                        if (item.section === 'python.analysis') {
+                        if (item.section === 'python') {
                             const analysisConfig = workspace.getConfiguration(
                                 item.section,
                                 item.scopeUri ? Uri.parse(item.scopeUri) : undefined

--- a/packages/vscode-pyright/src/extension.ts
+++ b/packages/vscode-pyright/src/extension.ts
@@ -127,7 +127,7 @@ export async function activate(context: ExtensionContext) {
 
                     for (const [i, item] of params.items.entries()) {
                         if (item.section === 'python') {
-                            const analysisConfig = workspace.getConfiguration(
+                            const pythonConfig = workspace.getConfiguration(
                                 item.section,
                                 item.scopeUri ? Uri.parse(item.scopeUri) : undefined
                             );
@@ -135,8 +135,8 @@ export async function activate(context: ExtensionContext) {
                             // If stubPath is not set, remove it rather than sending default value.
                             // This lets the server know that it's unset rather than explicitly
                             // set to the default value (typings) so it can behave differently.
-                            if (!isConfigSettingSetByUser(analysisConfig, 'stubPath')) {
-                                delete (result[i] as any).stubPath;
+                            if (!isConfigSettingSetByUser(pythonConfig, 'analysis.stubPath')) {
+                                delete (result[i] as any).analysis.stubPath;
                             }
                         }
                     }

--- a/packages/vscode-pyright/src/extension.ts
+++ b/packages/vscode-pyright/src/extension.ts
@@ -136,7 +136,7 @@ export async function activate(context: ExtensionContext) {
                             // This lets the server know that it's unset rather than explicitly
                             // set to the default value (typings) so it can behave differently.
                             if (!isConfigSettingSetByUser(pythonConfig, 'analysis.stubPath')) {
-                                delete (result[i] as any).analysis.stubPath;
+                                delete (result[i] as any).analysis?.stubPath;
                             }
                         }
                     }


### PR DESCRIPTION
In https://github.com/microsoft/pyright/pull/11480 I've removed redundant `workspace/configuration` requests but I've missed this special-case logic in vscode extension that removes `stubPath` property if it's at default value.

Without this change, the server would receive the default `typings` value and complain that the path is not correct (in logs only, I believe).