### PR TITLE
Fix __class__ binding in class-body lambdas

### DIFF
--- a/packages/pyright-internal/src/analyzer/binder.ts
+++ b/packages/pyright-internal/src/analyzer/binder.ts
@@ -703,6 +703,12 @@ export class Binder extends ParseTreeWalker {
             () => {
                 AnalyzerNodeInfo.setScope(node, this._currentScope);
 
+                const enclosingClass = ParseTreeUtils.getEnclosingClass(node);
+                if (enclosingClass) {
+                    // Lambdas create the same implicit __class__ closure as named functions.
+                    this._addImplicitSymbolToCurrentScope('__class__', node, '__class__');
+                }
+
                 this._deferBinding(() => {
                     // Create a start node for the lambda.
                     this._currentFlowNode = this._createStartFlowNode();
@@ -3752,7 +3758,7 @@ export class Binder extends ParseTreeWalker {
 
     private _addImplicitSymbolToCurrentScope(
         nameValue: string,
-        node: ModuleNode | ClassNode | FunctionNode,
+        node: ModuleNode | ClassNode | FunctionNode | LambdaNode,
         type: IntrinsicType,
         isClassMember = true
     ) {

--- a/packages/pyright-internal/src/analyzer/declaration.ts
+++ b/packages/pyright-internal/src/analyzer/declaration.ts
@@ -18,6 +18,7 @@ import {
     ImportAsNode,
     ImportFromAsNode,
     ImportFromNode,
+    LambdaNode,
     ModuleNode,
     NameNode,
     ParameterNode,
@@ -87,7 +88,7 @@ export interface DeclarationBase {
 export interface IntrinsicDeclaration extends DeclarationBase {
     type: DeclarationType.Intrinsic;
     name: string;
-    node: ModuleNode | FunctionNode | ClassNode;
+    node: ModuleNode | FunctionNode | LambdaNode | ClassNode;
     intrinsicType: IntrinsicType;
 }
 

--- a/packages/pyright-internal/src/tests/samples/lambda16.py
+++ b/packages/pyright-internal/src/tests/samples/lambda16.py
@@ -1,0 +1,15 @@
+# This sample tests the implicit __class__ closure in a lambda defined in a
+# class body.
+
+# pyright: strict, reportUnknownLambdaType=false
+
+from typing import Callable
+
+
+class A:
+    get_class = lambda: __class__
+
+
+# This should not create an implicit __class__ binding because the lambda is
+# defined outside of a class body.
+get_class: Callable[[], type] = lambda: __class__

--- a/packages/pyright-internal/src/tests/typeEvaluator1.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator1.test.ts
@@ -795,6 +795,12 @@ test('Lambda15', () => {
     TestUtils.validateResults(analysisResults, 0);
 });
 
+test('Lambda16', () => {
+    const analysisResults = TestUtils.typeAnalyzeSampleFiles(['lambda16.py']);
+
+    TestUtils.validateResults(analysisResults, 1);
+});
+
 test('Call1', () => {
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['call1.py']);
 


### PR DESCRIPTION
## Summary
- bind the implicit PEP 3135 `__class__` symbol in lambda scopes enclosed by a class
- allow lambda nodes to back intrinsic declarations
- add a regression sample for `class A: get_class = lambda: __class__`

## Testing
- targeted regression test
- complete `typeEvaluator1.test.ts` (159 passed)
- complete `pyright-internal` suite (62 suites, 2541 tests passed)
- build, ESLint, Prettier, typecheck

Fixes #11511
