### PR TITLE
Clarify assignment-expression diagnostic in comprehension iterables

### DIFF
--- a/packages/pyright-internal/src/localization/localize.ts
+++ b/packages/pyright-internal/src/localization/localize.ts
@@ -1234,6 +1234,7 @@ export namespace Localizer {
         export const variadicTypeParamTooManyClass = () =>
             new ParameterizedString<{ names: string }>(getRawString('Diagnostic.variadicTypeParamTooManyClass'));
         export const walrusIllegal = () => getRawString('Diagnostic.walrusIllegal');
+        export const walrusInComprehensionIterable = () => getRawString('Diagnostic.walrusInComprehensionIterable');
         export const walrusNotAllowed = () => getRawString('Diagnostic.walrusNotAllowed');
         export const wildcardInFunction = () => getRawString('Diagnostic.wildcardInFunction');
         export const wildcardPatternTypeUnknown = () => getRawString('Diagnostic.wildcardPatternTypeUnknown');

--- a/packages/pyright-internal/src/localization/package.nls.en-us.json
+++ b/packages/pyright-internal/src/localization/package.nls.en-us.json
@@ -1763,6 +1763,7 @@
             "comment": ["{Locked='TypeVarTuple'}", "A generic type is a parameterized type, for example a container where the generic type parameter specifies the type of elements in the container"]
         },
         "walrusIllegal": "Operator \":=\" requires Python 3.8 or newer",
+        "walrusInComprehensionIterable": "Assignment expression cannot be used in a comprehension iterable expression",
         "walrusNotAllowed": "Operator \":=\" is not allowed in this context without surrounding parentheses",
         "wildcardInFunction": {
             "message": "Wildcard import not allowed within a class or function",

--- a/packages/pyright-internal/src/parser/parser.ts
+++ b/packages/pyright-internal/src/parser/parser.ts
@@ -251,6 +251,7 @@ export class Parser {
     private _importedModules: ModuleImport[] = [];
     private _containsWildcardImport = false;
     private _assignmentExpressionsAllowed = true;
+    private _assignmentExpressionErrorMessage: string | undefined;
     private _typingImportAliases: string[] = [];
     private _typingSymbolAliases: Map<string, string> = new Map<string, string>();
     private _maxChildDepthMap = new Map<number, number>();
@@ -1835,7 +1836,7 @@ export class Parser {
         } else {
             this._disallowAssignmentExpression(() => {
                 seqExpr = this._parseOrTest();
-            });
+            }, LocMessage.walrusInComprehensionIterable());
         }
 
         const compForNode = ComprehensionForNode.create(asyncToken || forToken, targetExpr, seqExpr!);
@@ -3381,7 +3382,7 @@ export class Parser {
         }
 
         if (!this._assignmentExpressionsAllowed || disallowAssignmentExpression) {
-            this._addSyntaxError(LocMessage.walrusNotAllowed(), walrusToken);
+            this._addSyntaxError(this._assignmentExpressionErrorMessage || LocMessage.walrusNotAllowed(), walrusToken);
         }
 
         if (PythonVersion.isLessThan(this._getLanguageVersion(), pythonVersion3_8)) {
@@ -5306,13 +5307,16 @@ export class Parser {
         return false;
     }
 
-    private _disallowAssignmentExpression(callback: () => void) {
+    private _disallowAssignmentExpression(callback: () => void, errorMessage?: string) {
         const wasAllowed = this._assignmentExpressionsAllowed;
+        const previousErrorMessage = this._assignmentExpressionErrorMessage;
         this._assignmentExpressionsAllowed = false;
+        this._assignmentExpressionErrorMessage = errorMessage;
 
         callback();
 
         this._assignmentExpressionsAllowed = wasAllowed;
+        this._assignmentExpressionErrorMessage = previousErrorMessage;
     }
 
     private _getNextToken(): Token {

--- a/packages/pyright-internal/src/tests/parser.test.ts
+++ b/packages/pyright-internal/src/tests/parser.test.ts
@@ -200,6 +200,18 @@ test('TrailingBackslashCRAtEOF', () => {
     assert.ok(errors.some((e) => e.message.includes('Unexpected EOF')));
 });
 
+test('AssignmentExpressionInComprehensionIterable', () => {
+    const diagSink = new DiagnosticSink();
+    TestUtils.parseText('[x for x in [y for y in range(10) if (z := y)]]', diagSink);
+
+    const errors = diagSink.getErrors();
+    assert.strictEqual(errors.length, 1);
+    assert.strictEqual(
+        errors[0].message,
+        'Assignment expression cannot be used in a comprehension iterable expression'
+    );
+});
+
 test('LazyImport - Python 3.15', () => {
     const diagSink = new DiagnosticSink();
     const parseOptions = new ParseOptions();


### PR DESCRIPTION
Fixes #11514.

Use the grammar-specific diagnostic when an assignment expression appears in a comprehension iterable, where adding parentheses cannot make it valid.

Tests: `npm run build`; `npm run test:norebuild -- --runInBand parser.test.ts`.