### PR TITLE
Fix false positive reportUnnecessaryComparison for bytes-like types

### DIFF
--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -26059,6 +26059,32 @@ export function createTypeEvaluator(
         );
     }
 
+    // The "bytes" entry of "typePromotions" (see below) groups together the
+    // "bytes-like" types that support cross-type content comparisons via
+    // "==" and "!=", even though they're otherwise unrelated (non-overlapping)
+    // types. Unlike the numeric promotions ("int" -> "float" -> "complex"),
+    // where two disjoint literal subtypes (e.g. "Literal[1]" and "Literal[2]")
+    // must still be treated as non-comparable, every pairing within this
+    // group is mutually comparable, so it's safe to treat fullName membership
+    // in this specific set as sufficient without consulting literal values.
+    const bytesLikeTypeNames = new Set(['builtins.bytes', ...(typePromotions.get('builtins.bytes') ?? [])]);
+
+    function isBytesLikeType(type: ClassType) {
+        return type.shared.mro.some((mroClass) => isClass(mroClass) && bytesLikeTypeNames.has(mroClass.shared.fullName));
+    }
+
+    // Determines whether the two types are both members of the "bytes-like"
+    // group of types ("bytes", "bytearray" and "memoryview"). Pyright models
+    // this relationship as a "type promotion" (used elsewhere for
+    // assignability), but that grouping is also useful for determining
+    // whether two otherwise-disjoint built-in types can be compared with
+    // "==" or "!=", since these types share compatible "__eq__" semantics
+    // regardless of whether the "disableBytesTypePromotions" setting allows
+    // the assignment.
+    function isTypePromotionRelated(leftType: ClassType, rightType: ClassType) {
+        return isBytesLikeType(leftType) && isBytesLikeType(rightType);
+    }
+
     // Determines whether the two types are potentially comparable -- i.e.
     // their types overlap in such a way that it makes sense for them to
     // be compared with an == or != operator. The functional also supports
@@ -26165,6 +26191,17 @@ export function createTypeEvaluator(
                         }
 
                         return boolVal === (intVal === 1);
+                    }
+
+                    // Types like "bytes", "bytearray" and "memoryview" are otherwise
+                    // disjoint but are still comparable with "==" and "!=" because
+                    // their "__eq__" methods support cross-type content comparisons.
+                    // Pyright models this relationship as a "type promotion" (used
+                    // elsewhere for assignability), so reuse that same list here
+                    // regardless of the "disableBytesTypePromotions" setting, since
+                    // comparability isn't affected by that assignability toggle.
+                    if (isTypePromotionRelated(leftType, rightType)) {
+                        return true;
                     }
 
                     return false;

--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -27497,6 +27497,32 @@ export function createTypeEvaluator(
         );
     }
 
+    // The "bytes" entry of "typePromotions" (see below) groups together the
+    // "bytes-like" types that support cross-type content comparisons via
+    // "==" and "!=", even though they're otherwise unrelated (non-overlapping)
+    // types. Unlike the numeric promotions ("int" -> "float" -> "complex"),
+    // where two disjoint literal subtypes (e.g. "Literal[1]" and "Literal[2]")
+    // must still be treated as non-comparable, every pairing within this
+    // group is mutually comparable, so it's safe to treat fullName membership
+    // in this specific set as sufficient without consulting literal values.
+    const bytesLikeTypeNames = new Set(['builtins.bytes', ...(typePromotions.get('builtins.bytes') ?? [])]);
+
+    function isBytesLikeType(type: ClassType) {
+        return type.shared.mro.some((mroClass) => isClass(mroClass) && bytesLikeTypeNames.has(mroClass.shared.fullName));
+    }
+
+    // Determines whether the two types are both members of the "bytes-like"
+    // group of types ("bytes", "bytearray" and "memoryview"). Pyright models
+    // this relationship as a "type promotion" (used elsewhere for
+    // assignability), but that grouping is also useful for determining
+    // whether two otherwise-disjoint built-in types can be compared with
+    // "==" or "!=", since these types share compatible "__eq__" semantics
+    // regardless of whether the "disableBytesTypePromotions" setting allows
+    // the assignment.
+    function isTypePromotionRelated(leftType: ClassType, rightType: ClassType) {
+        return isBytesLikeType(leftType) && isBytesLikeType(rightType);
+    }
+
     // Determines whether the two types are potentially comparable -- i.e.
     // their types overlap in such a way that it makes sense for them to
     // be compared with an == or != operator. The functional also supports
@@ -27603,6 +27629,17 @@ export function createTypeEvaluator(
                         }
 
                         return boolVal === (intVal === 1);
+                    }
+
+                    // Types like "bytes", "bytearray" and "memoryview" are otherwise
+                    // disjoint but are still comparable with "==" and "!=" because
+                    // their "__eq__" methods support cross-type content comparisons.
+                    // Pyright models this relationship as a "type promotion" (used
+                    // elsewhere for assignability), so reuse that same list here
+                    // regardless of the "disableBytesTypePromotions" setting, since
+                    // comparability isn't affected by that assignability toggle.
+                    if (isTypePromotionRelated(leftType, rightType)) {
+                        return true;
                     }
 
                     return false;

--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -27497,18 +27497,16 @@ export function createTypeEvaluator(
         );
     }
 
-    // The "bytes" entry of "typePromotions" (see below) groups together the
-    // "bytes-like" types that support cross-type content comparisons via
-    // "==" and "!=", even though they're otherwise unrelated (non-overlapping)
-    // types. Unlike the numeric promotions ("int" -> "float" -> "complex"),
-    // where two disjoint literal subtypes (e.g. "Literal[1]" and "Literal[2]")
-    // must still be treated as non-comparable, every pairing within this
-    // group is mutually comparable, so it's safe to treat fullName membership
-    // in this specific set as sufficient without consulting literal values.
-    const bytesLikeTypeNames = new Set(['builtins.bytes', ...(typePromotions.get('builtins.bytes') ?? [])]);
-
+    // Types like "bytes", "bytearray" and "memoryview" support cross-type
+    // content comparisons via "==" and "!=", even though they're otherwise
+    // unrelated (non-overlapping) types. Use derivesFromStdlibClass to check
+    // membership in this group across the MRO.
     function isBytesLikeType(type: ClassType) {
-        return type.shared.mro.some((mroClass) => isClass(mroClass) && bytesLikeTypeNames.has(mroClass.shared.fullName));
+        return (
+            derivesFromStdlibClass(type, 'bytes') ||
+            derivesFromStdlibClass(type, 'bytearray') ||
+            derivesFromStdlibClass(type, 'memoryview')
+        );
     }
 
     // Determines whether the two types are both members of the "bytes-like"
@@ -27638,7 +27636,7 @@ export function createTypeEvaluator(
                     // elsewhere for assignability), so reuse that same list here
                     // regardless of the "disableBytesTypePromotions" setting, since
                     // comparability isn't affected by that assignability toggle.
-                    if (isTypePromotionRelated(leftType, rightType)) {
+                    if (!assumeIsOperator && isTypePromotionRelated(leftType, rightType)) {
                         return true;
                     }
 

--- a/packages/pyright-internal/src/tests/samples/comparison1.py
+++ b/packages/pyright-internal/src/tests/samples/comparison1.py
@@ -75,3 +75,39 @@ def func4(val: str | None):
     # This should generate an error because there is no overlap in types.
     if val == 42:
         ...
+
+
+def func5(data1: bytearray, data2: bytes):
+    # "bytearray" and "bytes" are disjoint types, but they should still be
+    # considered comparable because their "__eq__" methods support
+    # cross-type content comparisons.
+    if data1 == data2:
+        ...
+
+    if data1 == b"\x00\x00\x00\x00":
+        ...
+
+
+def func6(x: int, y: str):
+    # This should generate an error because there is no overlap in types.
+    if x == y:
+        ...
+
+
+def func7(x: list[int], y: dict[str, int]):
+    # This should generate an error because there is no overlap in types.
+    if x == y:
+        ...
+
+
+def func8(a: memoryview, b: bytes, c: bytearray):
+    # "memoryview", "bytes" and "bytearray" are all mutually comparable
+    # for the same reason as func5, above.
+    if a == b:
+        ...
+
+    if a == c:
+        ...
+
+    if b == c:
+        ...

--- a/packages/pyright-internal/src/tests/samples/comparison1.py
+++ b/packages/pyright-internal/src/tests/samples/comparison1.py
@@ -111,3 +111,17 @@ def func8(a: memoryview, b: bytes, c: bytearray):
 
     if b == c:
         ...
+
+
+def func9(a: memoryview, b: bytes, c: bytearray):
+    # Distinct bytes-like types are never identical, so identity comparisons
+    # ("is" and "is not") should generate an unnecessary comparison error.
+    if a is b:
+        ...
+
+    if a is not c:
+        ...
+
+    if b is c:
+        ...
+

--- a/packages/pyright-internal/src/tests/samples/typeNarrowingIn1.py
+++ b/packages/pyright-internal/src/tests/samples/typeNarrowingIn1.py
@@ -224,3 +224,14 @@ def func23[T: LiteralString](x: str, y: tuple[T, ...]) -> T:
     if x in y:
         return x
     raise ValueError(f"Invalid value {x!r}")
+
+
+def func24(a: bytes | int, b: list[bytearray], c: bytearray | str, d: list[memoryview]):
+    # bytes-like types (bytes, bytearray, memoryview) are mutually comparable,
+    # so container narrowing does not eliminate them against each other.
+    if a in b:
+        reveal_type(a, expected_text="bytes")
+
+    if c in d:
+        reveal_type(c, expected_text="bytearray")
+

--- a/packages/pyright-internal/src/tests/typeEvaluator6.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator6.test.ts
@@ -652,7 +652,7 @@ test('Comparison1', () => {
 
     configOptions.diagnosticRuleSet.reportUnnecessaryComparison = 'error';
     const analysisResults2 = TestUtils.typeAnalyzeSampleFiles(['comparison1.py'], configOptions);
-    TestUtils.validateResults(analysisResults2, 7);
+    TestUtils.validateResults(analysisResults2, 9);
 });
 
 test('Comparison2', () => {

--- a/packages/pyright-internal/src/tests/typeEvaluator6.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator6.test.ts
@@ -682,7 +682,7 @@ test('Comparison1', () => {
 
     configOptions.diagnosticRuleSet.reportUnnecessaryComparison = 'error';
     const analysisResults2 = TestUtils.typeAnalyzeSampleFiles(['comparison1.py'], configOptions);
-    TestUtils.validateResults(analysisResults2, 7);
+    TestUtils.validateResults(analysisResults2, 9);
 });
 
 test('Comparison2', () => {

--- a/packages/pyright-internal/src/tests/typeEvaluator6.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator6.test.ts
@@ -682,7 +682,7 @@ test('Comparison1', () => {
 
     configOptions.diagnosticRuleSet.reportUnnecessaryComparison = 'error';
     const analysisResults2 = TestUtils.typeAnalyzeSampleFiles(['comparison1.py'], configOptions);
-    TestUtils.validateResults(analysisResults2, 9);
+    TestUtils.validateResults(analysisResults2, 12);
 });
 
 test('Comparison2', () => {


### PR DESCRIPTION
Fixes #11433

`reportUnnecessaryComparison` treats two disjoint built-in class instances as never comparable with `==`/`!=`. That's a reasonable default, but it doesn't hold for `bytes`, `bytearray` and `memoryview`: they're unrelated for assignability purposes, yet their `__eq__` implementations do support cross-type content comparisons (`bytearray(4) == bytes(4)` is `True` at runtime).

This adds a narrow carve-out in `isTypeComparable` for this specific group of types, reusing the existing `typePromotions` table that already models the relationship elsewhere (it's the same list consulted for the `bytes`/`bytearray`/`memoryview` assignability promotion). Comparability isn't gated behind `disableBytesTypePromotions`, since that setting is about assignment compatibility, not about whether `__eq__` can return `True`.

Added test cases to `comparison1.py` covering `bytearray`/`bytes`, a `bytearray`-vs-literal-bytes comparison, and all pairings of `bytes`/`bytearray`/`memoryview`, alongside a couple of genuinely-disjoint builtin cases (`int`/`str`, `list`/`dict`) to confirm the general diagnostic still fires where it should.