### PR TITLE
Fix false positive when assigning to an attribute of a union with divergent member types

### DIFF
--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -2832,6 +2832,56 @@ export function createTypeEvaluator(
         return false;
     }
 
+    // Given a member symbol and the context in which it was accessed, computes
+    // the declared type of the member (applying descriptor setter types, partial
+    // specialization, and function binding as appropriate). Returns undefined if
+    // the symbol has no declared type.
+    function resolveDeclaredMemberType(
+        symbol: Symbol,
+        classOrObjectBase: ClassType | undefined,
+        memberAccessClass: Type | undefined,
+        useDescriptorSetterType: boolean,
+        bindFunction: boolean,
+        selfType: ClassType | TypeVarType | undefined
+    ): Type | undefined {
+        let declaredType = getDeclaredTypeOfSymbol(symbol)?.type;
+        if (!declaredType) {
+            return undefined;
+        }
+
+        // If it's a descriptor, we need to get the setter type.
+        if (useDescriptorSetterType && isClassInstance(declaredType)) {
+            const setter = getBoundMagicMethod(declaredType, '__set__');
+            if (setter && isFunction(setter) && setter.shared.parameters.length >= 2) {
+                declaredType = FunctionType.getParamType(setter, 1);
+
+                if (isAnyOrUnknown(declaredType)) {
+                    return undefined;
+                }
+            }
+        }
+
+        if (classOrObjectBase) {
+            if (memberAccessClass && isInstantiableClass(memberAccessClass)) {
+                declaredType = partiallySpecializeType(declaredType, memberAccessClass, getTypeClassType(), selfType);
+            }
+
+            if (isFunctionOrOverloaded(declaredType)) {
+                if (bindFunction) {
+                    declaredType = bindFunctionToClassOrObject(
+                        classOrObjectBase,
+                        declaredType,
+                        /* memberClass */ undefined,
+                        /* treatConstructorAsClassMethod */ undefined,
+                        selfType
+                    );
+                }
+            }
+        }
+
+        return declaredType;
+    }
+
     // Determines whether the specified expression is a symbol with a declared type.
     function getDeclaredTypeForExpression(expression: ExpressionNode, usage?: EvaluatorUsage): Type | undefined {
         let symbol: Symbol | undefined;
@@ -2882,10 +2932,39 @@ export function createTypeEvaluator(
                 const baseTypeConcrete = makeTopLevelTypeVarsConcrete(baseType);
                 const memberName = expression.d.member.d.value;
 
-                // Normally, baseTypeConcrete will not be a composite type (a union),
-                // but this can occur. In this case, it's not clear how to handle this
-                // correctly. For now, we'll just loop through the subtypes and
-                // use one of them. We'll sort the subtypes for determinism.
+                if (isTypeVar(baseType)) {
+                    selfType = baseType;
+                }
+
+                // Normally, baseType will not be a composite type (a union), but
+                // this can occur. In this case, we compute the declared type of the
+                // member for each subtype. If the subtypes declare the member with
+                // the same generic class but different (invariant) type arguments
+                // (e.g. "list[int]" vs. "list[str]"), there is no single declared
+                // type that can serve as the expected type for bidirectional
+                // inference of an assigned value. Committing to one subtype's
+                // declared type produces a false positive when assigning a value
+                // (such as an empty container) that is compatible with every
+                // subtype, so in that case we return undefined and let the value be
+                // evaluated without an expected type. We sort the subtypes for
+                // determinism.
+                //
+                // This is deliberately limited to the "same class, differing type
+                // arguments" case. When the subtypes declare the member with
+                // unrelated types, we retain the previous behavior (use one
+                // subtype's declared type) so that genuine assignment errors are
+                // still reported at the same location and downstream inference is
+                // unchanged.
+                //
+                // This handling is further limited to cases where the declared base
+                // type is itself a union. We intentionally don't apply it when the
+                // base is a type variable that merely concretizes to a union.
+                const isUnionBase = isUnion(baseType);
+                let firstMemberDeclaredType: Type | undefined;
+                let sawMemberDeclaredType = false;
+                let hasDivergentMemberDeclaredTypes = false;
+                let divergesOnlyByTypeArgs = true;
+
                 doForEachSubtype(
                     baseTypeConcrete,
                     (baseSubtype) => {
@@ -2927,13 +3006,58 @@ export function createTypeEvaluator(
                             useDescriptorSetterType = false;
                             bindFunction = false;
                         }
+
+                        // If the base is a union, verify that the subtypes agree on a
+                        // single declared type for the member.
+                        if (isUnionBase) {
+                            const subtypeDeclaredType = symbol
+                                ? resolveDeclaredMemberType(
+                                      symbol,
+                                      classOrObjectBase,
+                                      memberAccessClass,
+                                      useDescriptorSetterType,
+                                      bindFunction,
+                                      selfType
+                                  )
+                                : undefined;
+
+                            if (subtypeDeclaredType) {
+                                if (!sawMemberDeclaredType) {
+                                    firstMemberDeclaredType = subtypeDeclaredType;
+                                    sawMemberDeclaredType = true;
+                                } else if (
+                                    !firstMemberDeclaredType ||
+                                    !isTypeSame(firstMemberDeclaredType, subtypeDeclaredType)
+                                ) {
+                                    hasDivergentMemberDeclaredTypes = true;
+
+                                    // The false positive we're addressing is specific
+                                    // to invariant type arguments of the same generic
+                                    // class. If the divergent types aren't instances of
+                                    // the same generic class, don't treat this as an
+                                    // ambiguous declared type.
+                                    if (
+                                        !firstMemberDeclaredType ||
+                                        !isClassInstance(firstMemberDeclaredType) ||
+                                        !isClassInstance(subtypeDeclaredType) ||
+                                        !ClassType.isSameGenericClass(
+                                            ClassType.cloneAsInstantiable(firstMemberDeclaredType),
+                                            ClassType.cloneAsInstantiable(subtypeDeclaredType)
+                                        )
+                                    ) {
+                                        divergesOnlyByTypeArgs = false;
+                                    }
+                                }
+                            }
+                        }
                     },
                     /* sortSubtypes */ true
                 );
 
-                if (isTypeVar(baseType)) {
-                    selfType = baseType;
+                if (hasDivergentMemberDeclaredTypes && divergesOnlyByTypeArgs) {
+                    return undefined;
                 }
+
                 break;
             }
 
@@ -3024,45 +3148,14 @@ export function createTypeEvaluator(
         }
 
         if (symbol) {
-            let declaredType = getDeclaredTypeOfSymbol(symbol)?.type;
-            if (declaredType) {
-                // If it's a descriptor, we need to get the setter type.
-                if (useDescriptorSetterType && isClassInstance(declaredType)) {
-                    const setter = getBoundMagicMethod(declaredType, '__set__');
-                    if (setter && isFunction(setter) && setter.shared.parameters.length >= 2) {
-                        declaredType = FunctionType.getParamType(setter, 1);
-
-                        if (isAnyOrUnknown(declaredType)) {
-                            return undefined;
-                        }
-                    }
-                }
-
-                if (classOrObjectBase) {
-                    if (memberAccessClass && isInstantiableClass(memberAccessClass)) {
-                        declaredType = partiallySpecializeType(
-                            declaredType,
-                            memberAccessClass,
-                            getTypeClassType(),
-                            selfType
-                        );
-                    }
-
-                    if (isFunctionOrOverloaded(declaredType)) {
-                        if (bindFunction) {
-                            declaredType = bindFunctionToClassOrObject(
-                                classOrObjectBase,
-                                declaredType,
-                                /* memberClass */ undefined,
-                                /* treatConstructorAsClassMethod */ undefined,
-                                selfType
-                            );
-                        }
-                    }
-                }
-
-                return declaredType;
-            }
+            return resolveDeclaredMemberType(
+                symbol,
+                classOrObjectBase,
+                memberAccessClass,
+                useDescriptorSetterType,
+                bindFunction,
+                selfType
+            );
         }
 
         return undefined;

--- a/packages/pyright-internal/src/tests/samples/memberAccess29.py
+++ b/packages/pyright-internal/src/tests/samples/memberAccess29.py
@@ -1,0 +1,65 @@
+# This sample tests assignments to an attribute when the base expression
+# evaluates to a union whose subtypes declare the attribute with different
+# (invariant) types. Assigning a value that is compatible with every subtype
+# (such as an empty container that relies on bidirectional inference) should
+# not produce a false positive.
+
+
+class A:
+    a: list[int]
+
+
+class B:
+    a: list[str]
+
+
+class C:
+    a: list[int]
+
+
+class D:
+    a: list[int]
+
+
+def func1(x: A | B):
+    # An empty list is compatible with both list[int] and list[str], so this
+    # should not generate an error.
+    x.a = []
+
+    # This should generate an error because list[int] is not assignable to B.a.
+    x.a = [1]
+
+    # This should generate an error because list[str] is not assignable to A.a.
+    x.a = ["hi"]
+
+
+def func2(x: C | D):
+    # The subtypes agree on the declared type (list[int]), so bidirectional
+    # inference still applies and there should be no error here.
+    x.a = []
+    x.a = [1]
+    reveal_type(x.a, expected_text="list[int]")
+
+
+class E:
+    e: int
+
+
+class F:
+    e: str
+
+
+def func3(x: E | F):
+    # The subtypes declare the member with unrelated types (int vs. str) rather
+    # than differing type arguments of the same generic class. This is not the
+    # false-positive scenario, so behavior is unchanged: assigning a value that
+    # is incompatible with one of the subtypes still errors, and the error is
+    # reported on the assigned expression (so an inline suppression continues to
+    # work).
+
+    # This should generate an error because "int" is not assignable to F.e.
+    x.e = 1
+
+    # An inline suppression on the assigned value still applies, confirming the
+    # error is not relocated by dropping the expected type.
+    x.e = 1  # type: ignore

--- a/packages/pyright-internal/src/tests/typeEvaluator4.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator4.test.ts
@@ -283,6 +283,11 @@ test('MemberAccess28', () => {
     TestUtils.validateResults(analysisResults, 1);
 });
 
+test('MemberAccess29', () => {
+    const analysisResults = TestUtils.typeAnalyzeSampleFiles(['memberAccess29.py']);
+    TestUtils.validateResults(analysisResults, 3);
+});
+
 test('DataClassNamedTuple1', () => {
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['dataclassNamedTuple1.py']);
 


### PR DESCRIPTION
## Summary

Fixes #11559.

Assigning to an attribute whose base expression is a union produced a false positive when the union''s subtypes declared that attribute with different invariant types:

```python
class A:
    a: list[int]

class B:
    a: list[str]

def foo(a: A | B):
    a.a = []  # Previously errored: "list[str]" is not assignable to "list[int]"
```

## Root cause

When the member-access assignment target has a union base, `getDeclaredTypeForExpression` looped over the (sorted) subtypes and committed to a single arbitrary subtype''s declared member type as the expected type for bidirectional inference of the RHS. The set-path (`getTypeOfMemberAccessWithBaseType`) then validated that single committed type against *every* subtype, so the type chosen for one subtype (`list[str]`) failed against the other (`list[int]`).

## Fix

For union bases, the declared member type is now computed for each subtype and compared with `isTypeSame`. If the subtypes diverge, `getDeclaredTypeForExpression` returns `undefined`, so the assigned value is evaluated without an expected type:

- An empty container (`[]`) infers as `list[Unknown]`, which is assignable to every subtype, so the false positive is gone.
- Concrete values (`[1]`, `["hi"]`) retain their element type and still correctly error against the incompatible subtype.
- When the subtypes agree on the declared type (e.g. both `list[int]`), that type is still returned, preserving bidirectional inference and narrowing.

The descriptor-setter / specialization / function-binding logic that finalizes the declared type was extracted into a `resolveDeclaredMemberType` helper so it can be reused both inside the subtype loop and for the non-union path.

## Tests

Added `memberAccess29.py` and the `MemberAccess29` test, covering both the divergent union case (`A | B`) and the same-type union case (`C | D`, which must still infer `list[int]`).
