### PR TITLE
Fix diagnostic categorization for ReadOnly TypedDict key modifications

### DIFF
--- a/packages/pyright-internal/src/analyzer/typedDicts.ts
+++ b/packages/pyright-internal/src/analyzer/typedDicts.ts
@@ -1559,6 +1559,7 @@ export function getTypeOfIndexedTypedDict(
                         type: evaluator.printType(baseType),
                     })
                 );
+                allDiagsInvolveNotRequiredKeys = false;
             }
 
             if (usage.method === 'set') {

--- a/packages/pyright-internal/src/tests/samples/typedDictReadOnly3.py
+++ b/packages/pyright-internal/src/tests/samples/typedDictReadOnly3.py
@@ -1,0 +1,23 @@
+# This sample tests diagnostic rule categorization for ReadOnly TypedDict key modifications.
+
+from typing import NotRequired, TypedDict
+from typing_extensions import ReadOnly
+
+
+class TD1(TypedDict):
+    a: ReadOnly[int]
+    b: NotRequired[ReadOnly[str]]
+
+
+def func1(td: TD1):
+    # This should generate an error because "a" is ReadOnly.
+    td["a"] = 1
+
+    # This should generate an error because "a" is ReadOnly.
+    del td["a"]
+
+    # This should generate an error because "b" is ReadOnly.
+    td["b"] = "hello"
+
+    # This should generate an error because "b" is ReadOnly.
+    del td["b"]

--- a/packages/pyright-internal/src/tests/typeEvaluator5.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator5.test.ts
@@ -348,6 +348,14 @@ test('TypedDictReadOnly2', () => {
     TestUtils.validateResults(analysisResults, 17);
 });
 
+test('TypedDictReadOnly3', () => {
+    const configOptions = new ConfigOptions(Uri.empty());
+    configOptions.diagnosticRuleSet.reportTypedDictNotRequiredAccess = 'none';
+
+    const analysisResults = TestUtils.typeAnalyzeSampleFiles(['typedDictReadOnly3.py'], configOptions);
+    TestUtils.validateResults(analysisResults, 4);
+});
+
 test('TypedDictClosed1', () => {
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['typedDictClosed1.py']);
     TestUtils.validateResults(analysisResults, 7);


### PR DESCRIPTION
### Summary of Changes

Fixes an issue where attempting to set or delete a `ReadOnly` key in a `TypedDict` (`d["read_only_key"] = val` or `del d["read_only_key"]`) was categorized under the diagnostic rule `reportTypedDictNotRequiredAccess` instead of `reportGeneralTypeIssues`.

### Problem & Root Cause

In `getTypeOfIndexedTypedDict` (`packages/pyright-internal/src/analyzer/typedDicts.ts`), `allDiagsInvolveNotRequiredKeys` tracks whether all generated diagnostic addendums involve access to non-required keys. If `allDiagsInvolveNotRequiredKeys` remains `true`, the overall diagnostic is emitted under `DiagnosticRule.reportTypedDictNotRequiredAccess` instead of `DiagnosticRule.reportGeneralTypeIssues`.

When evaluating an indexed `set` or `del` operation on a `ReadOnly` field:
```typescript
} else if (entry.isReadOnly && usage.method !== 'get') {
    diag.addMessage(
        LocAddendum.keyReadOnly().format({
            name: entryName,
            type: evaluator.printType(baseType),
        })
    );
}
```
`allDiagsInvolveNotRequiredKeys` was not updated to `false`. As a result, Pyright classified the `keyReadOnly` error under `reportTypedDictNotRequiredAccess`. In standard configuration (where `reportTypedDictNotRequiredAccess` is `'none'`), modifying or deleting a `ReadOnly` field resulted in a false negative with no diagnostics produced.

### Solution

Set `allDiagsInvolveNotRequiredKeys = false;` when adding a `keyReadOnly` diagnostic addendum for `set` or `del` operations on `ReadOnly` `TypedDict` keys so that the diagnostic is correctly categorized under `reportGeneralTypeIssues`.

### Validation Results

- Unit tests added in `typedDictReadOnly3.py` and `typeEvaluator5.test.ts` verifying that modifications and deletions of `ReadOnly` keys produce errors even when `reportTypedDictNotRequiredAccess` is disabled (`'none'`).
- `npm run check` passed cleanly.
- `npm run typecheck` passed cleanly.
- `git diff --check` passed cleanly.
