### PR TITLE
Fix bool narrowing for numeric literal patterns

### DIFF
--- a/packages/pyright-internal/src/analyzer/patternMatching.ts
+++ b/packages/pyright-internal/src/analyzer/patternMatching.ts
@@ -682,7 +682,8 @@ function narrowTypeBasedOnLiteralPattern(
                 isLiteralType(literalType) &&
                 isClassInstance(expandedSubtype) &&
                 isLiteralType(expandedSubtype) &&
-                evaluator.assignType(literalType, expandedSubtype)
+                (evaluator.assignType(literalType, expandedSubtype) ||
+                    isIntLiteralPatternEqualToBool(literalType, expandedSubtype))
             ) {
                 return undefined;
             }
@@ -708,6 +709,16 @@ function narrowTypeBasedOnLiteralPattern(
     }
 
     return evaluator.mapSubtypesExpandTypeVars(type, /* options */ undefined, (expandedSubtype, unexpandedSubtype) => {
+        if (
+            isClassInstance(literalType) &&
+            isLiteralType(literalType) &&
+            isClassInstance(expandedSubtype) &&
+            isLiteralType(expandedSubtype) &&
+            isIntLiteralPatternEqualToBool(literalType, expandedSubtype)
+        ) {
+            return expandedSubtype;
+        }
+
         if (evaluator.assignType(expandedSubtype, literalType)) {
             // We have to be careful here because the runtime uses an equality
             // check, but the expandedSubtype could be a superclass that is not
@@ -743,6 +754,23 @@ function narrowTypeBasedOnLiteralPattern(
         }
         return undefined;
     });
+}
+
+function isIntLiteralPatternEqualToBool(patternType: ClassType, subjectType: ClassType): boolean {
+    // Numeric literal patterns use equality, so 0 and 1 also match False and True.
+    // The inverse isn't true because singleton bool patterns use identity.
+    if (!ClassType.isBuiltIn(patternType, 'int') || !ClassType.isBuiltIn(subjectType, 'bool')) {
+        return false;
+    }
+
+    const patternValue = patternType.priv.literalValue;
+    const subjectValue = subjectType.priv.literalValue;
+    if ((typeof patternValue !== 'number' && typeof patternValue !== 'bigint') || typeof subjectValue !== 'boolean') {
+        return false;
+    }
+
+    const boolAsNumber = subjectValue ? 1 : 0;
+    return typeof patternValue === 'bigint' ? patternValue === BigInt(boolAsNumber) : patternValue === boolAsNumber;
 }
 
 // When a class pattern matches a generic class whose type parameters have an

--- a/packages/pyright-internal/src/tests/samples/matchLiteral1.py
+++ b/packages/pyright-internal/src/tests/samples/matchLiteral1.py
@@ -108,6 +108,30 @@ def test_subclass3(subj: Literal[1]):
             reveal_type(subj, expected_text="Literal[1]")
 
 
+def test_numeric_literal_matches_bool(subj: Literal[0, False]):
+    match subj:
+        case 0:
+            reveal_type(subj, expected_text="Literal[0, False]")
+        case _:
+            reveal_type(subj, expected_text="Never")
+
+
+def test_numeric_literal_matches_true(subj: Literal[1, True]):
+    match subj:
+        case 1:
+            reveal_type(subj, expected_text="Literal[1, True]")
+        case _:
+            reveal_type(subj, expected_text="Never")
+
+
+def test_bool_literal_uses_identity(subj: Literal[0, False]):
+    match subj:
+        case False:
+            reveal_type(subj, expected_text="Literal[False]")
+        case _:
+            reveal_type(subj, expected_text="Literal[0]")
+
+
 T1 = TypeVar("T1", Literal["A"], Literal["B"])
 
 


### PR DESCRIPTION
## Summary

- Preserve `Literal[False]` and `Literal[True]` when matching the numeric literal patterns `0` and `1`.
- Remove those bool literals from the fallthrough branch because numeric literal patterns compare with equality.
- Keep singleton bool patterns identity-based, so `case False` does not match `Literal[0]`.

## Problem

Numeric literal patterns use equality at runtime. This means `case 0` matches both `0` and `False`, and `case 1` matches both `1` and `True`.

```python
from typing import Literal

def f(value: Literal[0, False]) -> None:
    match value:
        case 0:
            reveal_type(value)  # Literal[0, False]
        case _:
            reveal_type(value)  # Never
```

Pyright previously narrowed the matched branch to `Literal[0]` and the fallthrough branch to `Literal[False]`, which is unsound relative to runtime behavior.

## Root cause

Literal-pattern narrowing relied on assignability between the pattern literal and subject literal. That does not capture Python's equality relationship between `0`/`False` and `1`/`True`.

## Solution

Handle the asymmetric numeric-pattern equality case explicitly:

- an int literal pattern `0` or `1` retains the equal bool literal in the positive branch;
- the same bool literal is removed from the negative branch;
- bool singleton patterns remain unchanged because they use identity rather than equality.

## Tests

Added focused coverage for:

- `case 0` over `Literal[0, False]`;
- `case 1` over `Literal[1, True]`;
- `case False` retaining the identity-based distinction from `Literal[0]`.

## Validation

- `npm run typecheck`
- `npm run build:cli:dev`
- `npm run check`
- `npm run build` in `packages/pyright-internal`
- `npx jest -t 'MatchLiteral1' --forceExit --runInBand`
- `npx jest src/tests/typeEvaluator6.test.ts --runInBand`
- `npm test -- --runInBand` (62 suites, 2549 tests)
- CLI repro on Python 3.10 and 3.13

## Compatibility and risk

The change is limited to literal-pattern narrowing for int patterns against bool literal subjects. Tests cover both positive and negative branches and the inverse singleton-bool boundary.

## Documentation

No documentation changes are needed; this aligns analyzer behavior with Python's existing structural pattern-matching semantics.

## Related issues and prior work

#11026 and #11028 addressed broader literal-pattern narrowing involving non-literal and supertype subjects. This change covers the distinct bool/int literal equality edge case.
