### PR TITLE
Fix except* type inference for BaseException subclasses

### DIFF
--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -20147,7 +20147,10 @@ export function createTypeEvaluator(
             }
 
             if (isInstantiableClass(exceptionType)) {
-                if (ClassType.isBuiltIn(exceptionType, 'BaseException')) {
+                if (
+                    derivesFromStdlibClass(exceptionType, 'BaseException') &&
+                    !derivesFromStdlibClass(exceptionType, 'Exception')
+                ) {
                     includesBaseException = true;
                 }
                 return ClassType.cloneAsInstance(exceptionType);

--- a/packages/pyright-internal/src/tests/samples/exceptionGroup1.py
+++ b/packages/pyright-internal/src/tests/samples/exceptionGroup1.py
@@ -125,3 +125,33 @@ def func8():
     except* BaseException as e:
         reveal_type(e, expected_text="BaseExceptionGroup[BaseException]")
         pass
+
+
+def func9():
+    try:
+        pass
+
+    except* KeyboardInterrupt as e:
+        reveal_type(e, expected_text="BaseExceptionGroup[KeyboardInterrupt]")
+
+    except* (ValueError, KeyboardInterrupt) as e:
+        reveal_type(e, expected_text="BaseExceptionGroup[ValueError | KeyboardInterrupt]")
+
+
+class CustomBaseException(BaseException):
+    pass
+
+
+class CustomException(Exception):
+    pass
+
+
+def func10():
+    try:
+        pass
+
+    except* CustomBaseException as e:
+        reveal_type(e, expected_text="BaseExceptionGroup[CustomBaseException]")
+
+    except* CustomException as e:
+        reveal_type(e, expected_text="ExceptionGroup[CustomException]")

--- a/packages/pyright-internal/src/tests/typeEvaluator7.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator7.test.ts
@@ -1023,7 +1023,7 @@ test('exceptionGroup1', () => {
 
     configOptions.defaultPythonVersion = pythonVersion3_10;
     const analysisResults1 = TestUtils.typeAnalyzeSampleFiles(['exceptionGroup1.py'], configOptions);
-    TestUtils.validateResults(analysisResults1, 34);
+    TestUtils.validateResults(analysisResults1, 46);
 
     configOptions.defaultPythonVersion = pythonVersion3_11;
     const analysisResults2 = TestUtils.typeAnalyzeSampleFiles(['exceptionGroup1.py'], configOptions);


### PR DESCRIPTION
## Summary

- Infer `BaseExceptionGroup[T]` for `except*` targets that derive from `BaseException` but not from `Exception`.
- Add regression coverage for built-in, tuple, and custom exception subclasses while preserving `ExceptionGroup[T]` for ordinary `Exception` subclasses.

## Problem

For an `except* KeyboardInterrupt as exc` clause, Pyright currently reveals
`ExceptionGroup[KeyboardInterrupt]`. At runtime, `ExceptionGroup` can contain
only `Exception` subclasses, so a group containing `KeyboardInterrupt` is a
`BaseExceptionGroup`.

## Root cause

The exception-group evaluator selected `BaseExceptionGroup` only when the
target was exactly the built-in `BaseException` class. It did not account for
subclasses such as `KeyboardInterrupt`, `SystemExit`, or user-defined
`BaseException` subclasses.

## Solution

Use the existing standard-library MRO helper to select `BaseExceptionGroup`
when any `except*` target derives from `BaseException` without also deriving
from `Exception`. The existing `ExceptionGroup` behavior remains unchanged for
`Exception` subclasses.

## Tests

- `PYLANCE_JEST_TRANSPILE_ONLY=1 node --max-old-space-size=8192 --expose-gc ./node_modules/jest/bin/jest src/tests/typeEvaluator7.test.ts --runInBand --forceExit -t exceptionGroup1` — passed.
- `PYLANCE_JEST_TRANSPILE_ONLY=1 node --max-old-space-size=8192 --expose-gc ./node_modules/jest/bin/jest src/tests/typeEvaluator7.test.ts --runInBand --forceExit` — 165 tests passed.
- `node --max-old-space-size=8192 --expose-gc ./node_modules/jest/bin/jest --forceExit --testPathIgnorePatterns src/tests/benchmarks --runInBand` — 62 suites and 2,549 tests passed.

## Validation

- `npm run check` — syncpack, ESLint, and Prettier passed.
- `npx lerna exec --stream --no-bail -- "tsc --noEmit"` — TypeScript passed in all four packages.
- `npm run build:cli:dev` — CLI bundle built successfully.
- `npm run build:extension:dev` — VS Code extension bundle built successfully.
- The rebuilt CLI reveals `BaseExceptionGroup[KeyboardInterrupt]` for the original reproduction and continues to reveal `ExceptionGroup[ValueError]` for the control case.
- An initial parallel `npm test` run completed 61 of 62 suites and timed out in the unrelated language-server background-diagnostics test. All four variants of that test then passed in isolation, and the complete serial suite passed as reported above.

## Compatibility and risk

This is an analyzer-only correction for Python 3.11+ `except*` target
inference. It does not change the public API, diagnostics, parsing, or runtime
behavior. The predicate reuses existing MRO metadata and retains the previous
result for all `Exception` subclasses.

## Documentation

No documentation change is needed because this aligns inferred types with the
existing Python exception-group semantics.

## Related issues and prior work

#9467 introduced the `ExceptionGroup` versus `BaseExceptionGroup` distinction
for #9466. This change covers the remaining subclass boundary in that logic.
No new issue was created for this focused correction.
