### PR TITLE
Fix value pattern narrowing for unrelated types

### DIFF
--- a/packages/pyright-internal/src/analyzer/patternMatching.ts
+++ b/packages/pyright-internal/src/analyzer/patternMatching.ts
@@ -1351,6 +1351,17 @@ function narrowTypeBasedOnValuePattern(
                             )
                         );
 
+                        if (
+                            returnType &&
+                            !evaluator.assignType(subjectSubtypeExpanded, valueSubtypeExpanded) &&
+                            !evaluator.assignType(valueSubtypeExpanded, subjectSubtypeExpanded)
+                        ) {
+                            // Equality can succeed between unrelated types, so retain the subject type.
+                            return evaluator.isTypeComparable(valueSubtypeExpanded, subjectSubtypeExpanded)
+                                ? subjectSubtypeExpanded
+                                : undefined;
+                        }
+
                         return returnType ? valueSubtypeUnexpanded : undefined;
                     }
                 )

--- a/packages/pyright-internal/src/tests/samples/matchValue1.py
+++ b/packages/pyright-internal/src/tests/samples/matchValue1.py
@@ -4,7 +4,7 @@
 from dataclasses import dataclass
 from enum import Enum, auto
 from http import HTTPStatus
-from typing import Annotated, Literal, TypeVar
+from typing import Annotated, ClassVar, Literal, TypeVar
 
 # pyright: reportIncompatibleMethodOverride=false
 
@@ -52,6 +52,21 @@ def test_class_var(value_to_match: str):
         case MyClass.class_var_1 as a1:
             reveal_type(a1, expected_text="Never")
             reveal_type(value_to_match, expected_text="Never")
+
+
+class CrossTypePattern:
+    def __eq__(self, other: object) -> bool: ...
+
+
+class CrossTypePatterns:
+    value: ClassVar[CrossTypePattern]
+
+
+def test_cross_type_value_pattern(value_to_match: str):
+    match value_to_match:
+        case CrossTypePatterns.value as a1:
+            reveal_type(a1, expected_text="str")
+            reveal_type(value_to_match, expected_text="str")
 
 
 TInt = TypeVar("TInt", bound=MyEnum1)


### PR DESCRIPTION
## Summary

- Preserve the subject type when a value pattern compares equal across unrelated types.
- Add regression coverage for both the original subject and the `as` binding.

## Problem

Value patterns use `==`, so a pattern object can compare equal to a subject of an unrelated type by implementing `__eq__`.

```python
from typing import ClassVar

class CrossTypePattern:
    def __eq__(self, other: object) -> bool:
        return other == "match"

class Patterns:
    value: ClassVar[CrossTypePattern]

def handle(value: str) -> None:
    match value:
        case Patterns.value as matched:
            reveal_type(value)    # Previously: CrossTypePattern
            reveal_type(matched)  # Previously: CrossTypePattern
```

At runtime, the successful branch still contains the original `str` object. Python's value-pattern contract says that the pattern succeeds when the resolved value compares equal to the subject with `==`; an `as` pattern binds that subject.

## Root cause

`narrowTypeBasedOnValuePattern` checked whether the pattern value's `__eq__` could accept the subject, then returned the pattern value's type for the positive branch. Equality can succeed across unrelated types, so that result incorrectly replaced the subject type.

## Solution

When the subject and pattern types are unrelated but still comparable through custom equality, retain the subject subtype. Existing narrowing remains unchanged when either type is assignable to the other, and unrelated non-comparable types are still eliminated.

## Tests

- `npx jest -t 'MatchValue1' --forceExit --runInBand`
  - Before the fix: failed with 2 type-text mismatches (`CrossTypePattern` instead of `str`).
  - After the fix: 1 passed.
- `node --max-old-space-size=8192 --expose-gc ./node_modules/jest/bin/jest src/tests/typeEvaluator6.test.ts --runInBand --forceExit`
  - 148 passed.
- `npm test -- --runInBand`
  - 62 suites passed; 2,549 tests passed.

## Validation

- `npm run check` — passed (syncpack, ESLint, and Prettier).
- `npm run typecheck` — passed for all three configured packages.
- `npm run build:cli:dev` — passed.
- `node packages/pyright/index.js packages/pyright-internal/src/tests/samples/matchValue1.py --pythonversion 3.13` — 0 errors, 0 warnings.
- `git diff --check` — passed.

All commands ran with Node 22.23.1, matching the CI major version.

## Compatibility and risk

This changes no public API, parser behavior, diagnostics, or serialized format. The change is limited to positive value-pattern narrowing for unrelated types that are comparable through equality. Existing enum, literal, numeric-promotion, boolean, and impossible-match cases remain covered by `MatchValue1`.

## Documentation

No documentation change is needed because this restores the existing Python value-pattern semantics.

## Related issues and prior work

No same-root-cause issue or PR was found in targeted open and closed searches for value patterns, subject narrowing, `__eq__`, wrong inferred types, and `narrowTypeBasedOnValuePattern`.

PR #9868 is adjacent but distinct: it established that equality can succeed across disjoint types for `x in y` narrowing. This change applies that safety boundary to structural value patterns.

## Non-goals

- Literal-pattern equality behavior.
- Negative value-pattern narrowing.
- Changes to enum matching or exhaustiveness.
