### PR TITLE
Fix unused diagnostics for underscore-prefixed variables

### DIFF
--- a/packages/pyright-internal/src/analyzer/checker.ts
+++ b/packages/pyright-internal/src/analyzer/checker.ts
@@ -3881,11 +3881,15 @@ export class Checker extends ParseTreeWalker {
 
         const action = rule === DiagnosticRule.reportUnusedImport ? { action: Commands.unusedImport } : undefined;
         if (nameNode) {
-            this._fileInfo.diagnosticSink.addUnusedCodeWithTextRange(
-                LocMessage.unaccessedSymbol().format({ name: nameNode.d.value }),
-                nameNode,
-                action
-            );
+            const isAllowedUnusedVariable =
+                rule === DiagnosticRule.reportUnusedVariable && nameNode.d.value.startsWith('_');
+            if (!isAllowedUnusedVariable) {
+                this._fileInfo.diagnosticSink.addUnusedCodeWithTextRange(
+                    LocMessage.unaccessedSymbol().format({ name: nameNode.d.value }),
+                    nameNode,
+                    action
+                );
+            }
 
             if (rule !== undefined && message && diagnosticLevel !== 'none') {
                 this._evaluator.addDiagnostic(rule, message, nameNode);

--- a/packages/pyright-internal/src/tests/samples/unusedVariable2.py
+++ b/packages/pyright-internal/src/tests/samples/unusedVariable2.py
@@ -1,7 +1,7 @@
 # This sample tests that underscore-prefixed variables are not reported as unused.
 
 
-def func(_arg: int):
+def func(_arg: int, arg: int):
     _local = 1
 
     # This should generate both an error and an unused code diagnostic.

--- a/packages/pyright-internal/src/tests/samples/unusedVariable2.py
+++ b/packages/pyright-internal/src/tests/samples/unusedVariable2.py
@@ -1,0 +1,8 @@
+# This sample tests that underscore-prefixed variables are not reported as unused.
+
+
+def func(_arg: int):
+    _local = 1
+
+    # This should generate both an error and an unused code diagnostic.
+    regular = 1

--- a/packages/pyright-internal/src/tests/typeEvaluator8.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator8.test.ts
@@ -800,14 +800,27 @@ test('UnusedVariable1', () => {
 
 test('UnusedVariable2', () => {
     const configOptions = new ConfigOptions(Uri.empty());
+    const sampleLines = TestUtils.readSampleFile('unusedVariable2.py').split(/\r?\n/);
+
+    const validateUnusedNames = (analysisResults: TestUtils.FileAnalysisResult[]) => {
+        const unusedNames = analysisResults[0].unusedCodes.map((diagnostic) => {
+            assert.strictEqual(diagnostic.range.start.line, diagnostic.range.end.line);
+            const line = sampleLines[diagnostic.range.start.line];
+            return line.slice(diagnostic.range.start.character, diagnostic.range.end.character);
+        });
+
+        assert.deepStrictEqual(unusedNames, ['arg', 'regular']);
+    };
 
     configOptions.diagnosticRuleSet.reportUnusedVariable = 'none';
     const analysisResults1 = TestUtils.typeAnalyzeSampleFiles(['unusedVariable2.py'], configOptions);
     TestUtils.validateResults(analysisResults1, 0, 0, 0, 2);
+    validateUnusedNames(analysisResults1);
 
     configOptions.diagnosticRuleSet.reportUnusedVariable = 'error';
     const analysisResults2 = TestUtils.typeAnalyzeSampleFiles(['unusedVariable2.py'], configOptions);
     TestUtils.validateResults(analysisResults2, 1, 0, 0, 2);
+    validateUnusedNames(analysisResults2);
 });
 
 test('Descriptor1', () => {

--- a/packages/pyright-internal/src/tests/typeEvaluator8.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator8.test.ts
@@ -798,6 +798,18 @@ test('UnusedVariable1', () => {
     TestUtils.validateResults(analysisResults2, 3);
 });
 
+test('UnusedVariable2', () => {
+    const configOptions = new ConfigOptions(Uri.empty());
+
+    configOptions.diagnosticRuleSet.reportUnusedVariable = 'none';
+    const analysisResults1 = TestUtils.typeAnalyzeSampleFiles(['unusedVariable2.py'], configOptions);
+    TestUtils.validateResults(analysisResults1, 0, 0, 0, 1);
+
+    configOptions.diagnosticRuleSet.reportUnusedVariable = 'error';
+    const analysisResults2 = TestUtils.typeAnalyzeSampleFiles(['unusedVariable2.py'], configOptions);
+    TestUtils.validateResults(analysisResults2, 1, 0, 0, 1);
+});
+
 test('Descriptor1', () => {
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['descriptor1.py']);
 

--- a/packages/pyright-internal/src/tests/typeEvaluator8.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator8.test.ts
@@ -803,11 +803,11 @@ test('UnusedVariable2', () => {
 
     configOptions.diagnosticRuleSet.reportUnusedVariable = 'none';
     const analysisResults1 = TestUtils.typeAnalyzeSampleFiles(['unusedVariable2.py'], configOptions);
-    TestUtils.validateResults(analysisResults1, 0, 0, 0, 1);
+    TestUtils.validateResults(analysisResults1, 0, 0, 0, 2);
 
     configOptions.diagnosticRuleSet.reportUnusedVariable = 'error';
     const analysisResults2 = TestUtils.typeAnalyzeSampleFiles(['unusedVariable2.py'], configOptions);
-    TestUtils.validateResults(analysisResults2, 1, 0, 0, 1);
+    TestUtils.validateResults(analysisResults2, 1, 0, 0, 2);
 });
 
 test('Descriptor1', () => {


### PR DESCRIPTION
## Summary

- Stop emitting `UnusedCode` for unused variables and parameters whose names begin with `_`.
- Preserve unused-code highlighting for ordinary variables when `reportUnusedVariable` is disabled.
- Add regression coverage for both disabled and error diagnostic levels.

The diagnostic level already suppressed rule diagnostics for underscore-prefixed names, but unused-code tagging was still added independently.

Fixes #11387

## Testing

- `npm run check`
- `npm run build -- --noEmit` in `packages/pyright-internal`
- All eight `typeEvaluator` test suites (1183 tests)
