### PR TITLE
Fix TypedDict narrowing for literal key unions

### DIFF
--- a/packages/pyright-internal/src/analyzer/typeGuards.ts
+++ b/packages/pyright-internal/src/analyzer/typeGuards.ts
@@ -677,9 +677,12 @@ export function getTypeNarrowingCallback(
                                     const constraintIndex = keyNarrowingInfo.conditionIndexMap.get(
                                         literalKeyType.priv.literalValue as string
                                     )!;
-                                    return addConditionToType(narrowedTypeForKey, [
-                                        { typeVar: keyNarrowingInfo.conditionTypeVar, constraintIndex },
-                                    ]);
+                                    const condition = [{ typeVar: keyNarrowingInfo.conditionTypeVar, constraintIndex }];
+                                    return mapSubtypes(narrowedTypeForKey, (subtype) =>
+                                        TypeCondition.isCompatible(getTypeCondition(subtype), condition)
+                                            ? addConditionToType(subtype, condition)
+                                            : undefined
+                                    );
                                 })
                             );
                         } else {

--- a/packages/pyright-internal/src/analyzer/typeGuards.ts
+++ b/packages/pyright-internal/src/analyzer/typeGuards.ts
@@ -592,8 +592,45 @@ export function getTypeNarrowingCallback(
                     testExpression.d.operator === OperatorType.In ? isPositiveTest : !isPositiveTest;
 
                 return (type: Type) => {
+                    let narrowedType = narrowTypeForContainerType(evaluator, type, rightType, adjIsPositiveTest);
+
+                    if (
+                        adjIsPositiveTest &&
+                        someSubtypes(
+                            rightType,
+                            (subtype) => isClassInstance(subtype) && ClassType.isTypedDictClass(subtype)
+                        )
+                    ) {
+                        const literalKeyTypes = getStringLiteralTypes(narrowedType);
+                        if (literalKeyTypes && literalKeyTypes.length > 1) {
+                            const conditionTypeVar = createTypedDictKeyConditionTypeVar(
+                                testExpression,
+                                literalKeyTypes
+                            );
+                            const conditionIndexMap = new Map(
+                                literalKeyTypes.map((keyType, index) => [keyType.priv.literalValue as string, index])
+                            );
+
+                            narrowedType = mapSubtypes(narrowedType, (subtype) => {
+                                if (
+                                    isClassInstance(subtype) &&
+                                    ClassType.isBuiltIn(subtype, 'str') &&
+                                    typeof subtype.priv.literalValue === 'string'
+                                ) {
+                                    const constraintIndex = conditionIndexMap.get(subtype.priv.literalValue);
+                                    if (constraintIndex !== undefined) {
+                                        return addConditionToType(subtype, [
+                                            { typeVar: conditionTypeVar, constraintIndex },
+                                        ]);
+                                    }
+                                }
+                                return subtype;
+                            });
+                        }
+                    }
+
                     return {
-                        type: narrowTypeForContainerType(evaluator, type, rightType, adjIsPositiveTest),
+                        type: narrowedType,
                         isIncomplete: !!rightTypeResult.isIncomplete,
                     };
                 };
@@ -609,17 +646,41 @@ export function getTypeNarrowingCallback(
                 const leftTypeResult = evaluator.getTypeOfExpression(testExpression.d.leftExpr);
                 const leftType = leftTypeResult.type;
 
-                if (isClassInstance(leftType) && ClassType.isBuiltIn(leftType, 'str') && isLiteralType(leftType)) {
-                    const adjIsPositiveTest =
-                        testExpression.d.operator === OperatorType.In ? isPositiveTest : !isPositiveTest;
+                const literalKeyTypes = getStringLiteralTypes(leftType);
+                const adjIsPositiveTest =
+                    testExpression.d.operator === OperatorType.In ? isPositiveTest : !isPositiveTest;
+                if (literalKeyTypes && (literalKeyTypes.length === 1 || adjIsPositiveTest)) {
                     return (type: Type) => {
-                        return {
-                            type: narrowTypeForTypedDictKey(
+                        let narrowedType: Type;
+                        if (literalKeyTypes.length === 1) {
+                            narrowedType = narrowTypeForTypedDictKey(
                                 evaluator,
                                 type,
-                                ClassType.cloneAsInstantiable(leftType),
+                                ClassType.cloneAsInstantiable(literalKeyTypes[0]),
                                 adjIsPositiveTest
-                            ),
+                            );
+                        } else {
+                            const conditionTypeVar = createTypedDictKeyConditionTypeVar(
+                                testExpression,
+                                literalKeyTypes
+                            );
+                            narrowedType = combineTypes(
+                                literalKeyTypes.map((literalKeyType, constraintIndex) =>
+                                    addConditionToType(
+                                        narrowTypeForTypedDictKey(
+                                            evaluator,
+                                            type,
+                                            ClassType.cloneAsInstantiable(literalKeyType),
+                                            /* isPositiveTest */ true
+                                        ),
+                                        [{ typeVar: conditionTypeVar, constraintIndex }]
+                                    )
+                                )
+                            );
+                        }
+
+                        return {
+                            type: narrowedType,
                             isIncomplete: !!leftTypeResult.isIncomplete,
                         };
                     };
@@ -2237,6 +2298,41 @@ export function narrowTypeForContainerElementType(evaluator: TypeEvaluator, refe
             return referenceSubtype;
         });
     });
+}
+
+function getStringLiteralTypes(type: Type): ClassType[] | undefined {
+    const literalTypes: ClassType[] = [];
+    let isValid = true;
+
+    doForEachSubtype(type, (subtype) => {
+        if (
+            isClassInstance(subtype) &&
+            ClassType.isBuiltIn(subtype, 'str') &&
+            typeof subtype.priv.literalValue === 'string'
+        ) {
+            literalTypes.push(subtype);
+        } else {
+            isValid = false;
+        }
+    });
+
+    if (!isValid || literalTypes.length === 0) {
+        return undefined;
+    }
+
+    return literalTypes.sort((a, b) => (a.priv.literalValue as string).localeCompare(b.priv.literalValue as string));
+}
+
+function createTypedDictKeyConditionTypeVar(node: ExpressionNode, literalKeyTypes: ClassType[]): TypeVarType {
+    const typeVar = TypeVarType.cloneForScopeId(
+        TypeVarType.createInstance('__typedDictKeyNarrowing'),
+        `typedDictKeyNarrowing.${node.id}`,
+        /* scopeName */ undefined,
+        /* scopeType */ undefined
+    );
+    typeVar.shared.isSynthesized = true;
+    literalKeyTypes.forEach((literalKeyType) => TypeVarType.addConstraint(typeVar, literalKeyType));
+    return typeVar;
 }
 
 // Attempts to narrow a type based on whether it is a TypedDict with

--- a/packages/pyright-internal/src/analyzer/typeGuards.ts
+++ b/packages/pyright-internal/src/analyzer/typeGuards.ts
@@ -592,41 +592,35 @@ export function getTypeNarrowingCallback(
                     testExpression.d.operator === OperatorType.In ? isPositiveTest : !isPositiveTest;
 
                 return (type: Type) => {
+                    const keyNarrowingInfo = createTypedDictKeyNarrowingInfo(testExpression, type);
                     let narrowedType = narrowTypeForContainerType(evaluator, type, rightType, adjIsPositiveTest);
 
                     if (
                         adjIsPositiveTest &&
+                        keyNarrowingInfo &&
+                        keyNarrowingInfo.literalKeyTypes.length > 1 &&
                         someSubtypes(
                             rightType,
                             (subtype) => isClassInstance(subtype) && ClassType.isTypedDictClass(subtype)
                         )
                     ) {
-                        const literalKeyTypes = getStringLiteralTypes(narrowedType);
-                        if (literalKeyTypes && literalKeyTypes.length > 1) {
-                            const conditionTypeVar = createTypedDictKeyConditionTypeVar(
-                                testExpression,
-                                literalKeyTypes
-                            );
-                            const conditionIndexMap = new Map(
-                                literalKeyTypes.map((keyType, index) => [keyType.priv.literalValue as string, index])
-                            );
-
-                            narrowedType = mapSubtypes(narrowedType, (subtype) => {
-                                if (
-                                    isClassInstance(subtype) &&
-                                    ClassType.isBuiltIn(subtype, 'str') &&
-                                    typeof subtype.priv.literalValue === 'string'
-                                ) {
-                                    const constraintIndex = conditionIndexMap.get(subtype.priv.literalValue);
-                                    if (constraintIndex !== undefined) {
-                                        return addConditionToType(subtype, [
-                                            { typeVar: conditionTypeVar, constraintIndex },
-                                        ]);
-                                    }
+                        narrowedType = mapSubtypes(narrowedType, (subtype) => {
+                            if (
+                                isClassInstance(subtype) &&
+                                ClassType.isBuiltIn(subtype, 'str') &&
+                                typeof subtype.priv.literalValue === 'string'
+                            ) {
+                                const constraintIndex = keyNarrowingInfo.conditionIndexMap.get(
+                                    subtype.priv.literalValue
+                                );
+                                if (constraintIndex !== undefined) {
+                                    return addConditionToType(subtype, [
+                                        { typeVar: keyNarrowingInfo.conditionTypeVar, constraintIndex },
+                                    ]);
                                 }
-                                return subtype;
-                            });
-                        }
+                            }
+                            return subtype;
+                        });
                     }
 
                     return {
@@ -646,36 +640,42 @@ export function getTypeNarrowingCallback(
                 const leftTypeResult = evaluator.getTypeOfExpression(testExpression.d.leftExpr);
                 const leftType = leftTypeResult.type;
 
-                const literalKeyTypes = getStringLiteralTypes(leftType);
+                const keyNarrowingInfo = createTypedDictKeyNarrowingInfo(testExpression, leftType);
                 const adjIsPositiveTest =
                     testExpression.d.operator === OperatorType.In ? isPositiveTest : !isPositiveTest;
-                if (literalKeyTypes && (literalKeyTypes.length === 1 || adjIsPositiveTest)) {
+                if (keyNarrowingInfo && (keyNarrowingInfo.literalKeyTypes.length === 1 || adjIsPositiveTest)) {
                     return (type: Type) => {
                         let narrowedType: Type;
-                        if (literalKeyTypes.length === 1) {
+                        if (keyNarrowingInfo.literalKeyTypes.length === 1) {
                             narrowedType = narrowTypeForTypedDictKey(
                                 evaluator,
                                 type,
-                                ClassType.cloneAsInstantiable(literalKeyTypes[0]),
+                                ClassType.cloneAsInstantiable(keyNarrowingInfo.literalKeyTypes[0]),
                                 adjIsPositiveTest
                             );
                         } else {
-                            const conditionTypeVar = createTypedDictKeyConditionTypeVar(
-                                testExpression,
-                                literalKeyTypes
-                            );
                             narrowedType = combineTypes(
-                                literalKeyTypes.map((literalKeyType, constraintIndex) =>
-                                    addConditionToType(
-                                        narrowTypeForTypedDictKey(
-                                            evaluator,
-                                            type,
-                                            ClassType.cloneAsInstantiable(literalKeyType),
-                                            /* isPositiveTest */ true
-                                        ),
-                                        [{ typeVar: conditionTypeVar, constraintIndex }]
-                                    )
-                                )
+                                keyNarrowingInfo.literalKeyTypes.map((literalKeyType) => {
+                                    let narrowedTypeForKey = narrowTypeForTypedDictKey(
+                                        evaluator,
+                                        type,
+                                        ClassType.cloneAsInstantiable(literalKeyType),
+                                        /* isPositiveTest */ true
+                                    );
+
+                                    // Retain an undeclared key alternative so indexed access can
+                                    // report it rather than silently filtering it out.
+                                    if (isNever(narrowedTypeForKey)) {
+                                        narrowedTypeForKey = type;
+                                    }
+
+                                    const constraintIndex = keyNarrowingInfo.conditionIndexMap.get(
+                                        literalKeyType.priv.literalValue as string
+                                    )!;
+                                    return addConditionToType(narrowedTypeForKey, [
+                                        { typeVar: keyNarrowingInfo.conditionTypeVar, constraintIndex },
+                                    ]);
+                                })
                             );
                         }
 
@@ -2323,16 +2323,34 @@ function getStringLiteralTypes(type: Type): ClassType[] | undefined {
     return literalTypes.sort((a, b) => (a.priv.literalValue as string).localeCompare(b.priv.literalValue as string));
 }
 
-function createTypedDictKeyConditionTypeVar(node: ExpressionNode, literalKeyTypes: ClassType[]): TypeVarType {
-    const typeVar = TypeVarType.cloneForScopeId(
+interface TypedDictKeyNarrowingInfo {
+    literalKeyTypes: ClassType[];
+    conditionTypeVar: TypeVarType;
+    conditionIndexMap: Map<string, number>;
+}
+
+function createTypedDictKeyNarrowingInfo(node: ExpressionNode, type: Type): TypedDictKeyNarrowingInfo | undefined {
+    const literalKeyTypes = getStringLiteralTypes(type);
+    if (!literalKeyTypes) {
+        return undefined;
+    }
+
+    const conditionTypeVar = TypeVarType.cloneForScopeId(
         TypeVarType.createInstance('__typedDictKeyNarrowing'),
         `typedDictKeyNarrowing.${node.id}`,
         /* scopeName */ undefined,
         /* scopeType */ undefined
     );
-    typeVar.shared.isSynthesized = true;
-    literalKeyTypes.forEach((literalKeyType) => TypeVarType.addConstraint(typeVar, literalKeyType));
-    return typeVar;
+    conditionTypeVar.shared.isSynthesized = true;
+    literalKeyTypes.forEach((literalKeyType) => TypeVarType.addConstraint(conditionTypeVar, literalKeyType));
+
+    return {
+        literalKeyTypes,
+        conditionTypeVar,
+        conditionIndexMap: new Map(
+            literalKeyTypes.map((keyType, index) => [keyType.priv.literalValue as string, index])
+        ),
+    };
 }
 
 // Attempts to narrow a type based on whether it is a TypedDict with

--- a/packages/pyright-internal/src/analyzer/typeGuards.ts
+++ b/packages/pyright-internal/src/analyzer/typeGuards.ts
@@ -653,7 +653,12 @@ export function getTypeNarrowingCallback(
                                 ClassType.cloneAsInstantiable(keyNarrowingInfo.literalKeyTypes[0]),
                                 adjIsPositiveTest
                             );
-                        } else {
+                        } else if (
+                            someSubtypes(
+                                type,
+                                (subtype) => isClassInstance(subtype) && ClassType.isTypedDictClass(subtype)
+                            )
+                        ) {
                             narrowedType = combineTypes(
                                 keyNarrowingInfo.literalKeyTypes.map((literalKeyType) => {
                                     let narrowedTypeForKey = narrowTypeForTypedDictKey(
@@ -677,6 +682,8 @@ export function getTypeNarrowingCallback(
                                     ]);
                                 })
                             );
+                        } else {
+                            narrowedType = type;
                         }
 
                         return {

--- a/packages/pyright-internal/src/analyzer/typedDicts.ts
+++ b/packages/pyright-internal/src/analyzer/typedDicts.ts
@@ -1526,7 +1526,9 @@ export function getTypeOfIndexedTypedDict(
     const conditionFilter = getTypeCondition(baseType);
     const setType =
         usage.method === 'set' && usage.setType && conditionFilter
-            ? evaluator.mapSubtypesExpandTypeVars(usage.setType.type, { conditionFilter }, (subtype) => subtype)
+            ? evaluator.mapSubtypesExpandTypeVars(usage.setType.type, /* options */ undefined, (subtype) =>
+                  TypeCondition.isCompatible(getTypeCondition(subtype), conditionFilter) ? subtype : undefined
+              )
             : usage.setType?.type;
     const resultingType = mapSubtypes(indexType, (subtype) => {
         if (!TypeCondition.isCompatible(getTypeCondition(subtype), conditionFilter)) {

--- a/packages/pyright-internal/src/analyzer/typedDicts.ts
+++ b/packages/pyright-internal/src/analyzer/typedDicts.ts
@@ -57,6 +57,7 @@ import {
     NeverType,
     OverloadedType,
     Type,
+    TypeCondition,
     TypedDictEntries,
     TypedDictEntry,
     TypeVarScopeType,
@@ -68,6 +69,7 @@ import {
     buildSolutionFromSpecializedClass,
     computeMroLinearization,
     convertToInstance,
+    getTypeCondition,
     getTypeVarScopeId,
     isLiteralType,
     mapSubtypes,
@@ -1521,7 +1523,12 @@ export function getTypeOfIndexedTypedDict(
     let diag = new DiagnosticAddendum();
     let allDiagsInvolveNotRequiredKeys = true;
 
+    const conditionFilter = getTypeCondition(baseType);
     const resultingType = mapSubtypes(indexType, (subtype) => {
+        if (!TypeCondition.isCompatible(getTypeCondition(subtype), conditionFilter)) {
+            return undefined;
+        }
+
         if (isAnyOrUnknown(subtype)) {
             return subtype;
         }

--- a/packages/pyright-internal/src/analyzer/typedDicts.ts
+++ b/packages/pyright-internal/src/analyzer/typedDicts.ts
@@ -1524,6 +1524,10 @@ export function getTypeOfIndexedTypedDict(
     let allDiagsInvolveNotRequiredKeys = true;
 
     const conditionFilter = getTypeCondition(baseType);
+    const setType =
+        usage.method === 'set' && usage.setType && conditionFilter
+            ? evaluator.mapSubtypesExpandTypeVars(usage.setType.type, { conditionFilter }, (subtype) => subtype)
+            : usage.setType?.type;
     const resultingType = mapSubtypes(indexType, (subtype) => {
         if (!TypeCondition.isCompatible(getTypeCondition(subtype), conditionFilter)) {
             return undefined;
@@ -1569,7 +1573,7 @@ export function getTypeOfIndexedTypedDict(
             }
 
             if (usage.method === 'set') {
-                if (!evaluator.assignType(entry.valueType, usage.setType?.type ?? AnyType.create(), diag)) {
+                if (!evaluator.assignType(entry.valueType, setType ?? AnyType.create(), diag)) {
                     allDiagsInvolveNotRequiredKeys = false;
                 }
             } else if (usage.method === 'del' && entry.isRequired) {

--- a/packages/pyright-internal/src/analyzer/types.ts
+++ b/packages/pyright-internal/src/analyzer/types.ts
@@ -3975,7 +3975,13 @@ function _addTypeIfUnique(unionType: UnionType, typeToAdd: UnionableType, elideR
 
             // If the typeToAdd is a TypedDict that is the same class as the
             // existing type, see if one of them is a proper subset of the other.
-            if (ClassType.isTypedDictClass(type) && ClassType.isSameGenericClass(type, typeToAdd)) {
+            // Preserve variants with distinct type conditions because they encode
+            // correlations between narrowed keys and values.
+            if (
+                ClassType.isTypedDictClass(type) &&
+                ClassType.isSameGenericClass(type, typeToAdd) &&
+                TypeCondition.isSame(type.props?.condition, typeToAdd.props?.condition)
+            ) {
                 // Do not proceed if the TypedDicts are generic and have different type arguments.
                 if (!type.priv.typeArgs && !typeToAdd.priv.typeArgs) {
                     if (ClassType.isTypedDictNarrower(typeToAdd, type)) {

--- a/packages/pyright-internal/src/tests/samples/typeNarrowingTypedDict3.py
+++ b/packages/pyright-internal/src/tests/samples/typeNarrowingTypedDict3.py
@@ -1,6 +1,6 @@
 # This sample tests assignment-based narrowing for TypedDict values.
 
-from typing import TypedDict
+from typing import Required, TypedDict
 
 
 class MyDict1(TypedDict, total=False):
@@ -37,15 +37,23 @@ def read_present_or_undeclared_key(value: MyDict1):
             value[key]
 
 
+def read_literal_keys_from_regular_dict(value: dict[str, int]):
+    for key in ("first", "second"):
+        if key in value:
+            reveal_type(value, expected_text="dict[str, int]")
+
+
 class MutableDict(TypedDict, total=False):
-    first: int
-    second: int
+    first: Required[int]
+    second: str
 
 
 def mutate_present_keys(value: MutableDict):
     for key in ("first", "second"):
         if key in value:
-            value[key] = 1
+            value[key] = value[key]
+
+            # This should generate an error for the required key alternative.
             del value[key]
 
 

--- a/packages/pyright-internal/src/tests/samples/typeNarrowingTypedDict3.py
+++ b/packages/pyright-internal/src/tests/samples/typeNarrowingTypedDict3.py
@@ -30,6 +30,39 @@ def read_present_keys(value: MyDict1):
             value["key1"]
 
 
+def read_present_or_undeclared_key(value: MyDict1):
+    for key in ("key1", "missing"):
+        if key in value:
+            # This should generate an error for the undeclared key alternative.
+            value[key]
+
+
+class MutableDict(TypedDict, total=False):
+    first: int
+    second: int
+
+
+def mutate_present_keys(value: MutableDict):
+    for key in ("first", "second"):
+        if key in value:
+            value[key] = 1
+            del value[key]
+
+
+class IntValueDict(TypedDict, total=False):
+    int_value: int
+
+
+class StrValueDict(TypedDict, total=False):
+    str_value: str
+
+
+def read_present_key_from_union(value: IntValueDict | StrValueDict):
+    for key in ("int_value", "str_value"):
+        if key in value:
+            reveal_type(value[key], expected_text="int* | str*")
+
+
 class MyDict2(TypedDict, total=False):
     key3: MyDict1
     key4: MyDict1

--- a/packages/pyright-internal/src/tests/samples/typeNarrowingTypedDict3.py
+++ b/packages/pyright-internal/src/tests/samples/typeNarrowingTypedDict3.py
@@ -19,6 +19,17 @@ if "key2" in my_dict1:
     my_dict1["key2"]
 
 
+def read_present_keys(value: MyDict1):
+    for key in ("key1", "key2"):
+        if key in value:
+            reveal_type(key, expected_text="Literal['key1', 'key2']")
+            value[key]
+
+            # This should generate an error because checking the variable key
+            # doesn't prove that this specific key is present.
+            value["key1"]
+
+
 class MyDict2(TypedDict, total=False):
     key3: MyDict1
     key4: MyDict1

--- a/packages/pyright-internal/src/tests/samples/typeNarrowingTypedDict3.py
+++ b/packages/pyright-internal/src/tests/samples/typeNarrowingTypedDict3.py
@@ -51,6 +51,14 @@ class MutableDict(TypedDict, total=False):
 def mutate_present_keys(value: MutableDict):
     for key in ("first", "second"):
         if key in value:
+            # This should generate an error because int is incompatible with
+            # the "second" key alternative.
+            value[key] = 1
+
+            # This should generate an error because str is incompatible with
+            # the "first" key alternative.
+            value[key] = "x"
+
             value[key] = value[key]
 
             # This should generate an error for the required key alternative.

--- a/packages/pyright-internal/src/tests/typeEvaluator1.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator1.test.ts
@@ -558,7 +558,7 @@ test('TypeNarrowingTypedDict2', () => {
 test('TypeNarrowingTypedDict3', () => {
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['typeNarrowingTypedDict3.py']);
 
-    TestUtils.validateResults(analysisResults, 4);
+    TestUtils.validateResults(analysisResults, 5);
 });
 
 test('typeNarrowingCallable1', () => {

--- a/packages/pyright-internal/src/tests/typeEvaluator1.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator1.test.ts
@@ -558,7 +558,7 @@ test('TypeNarrowingTypedDict2', () => {
 test('TypeNarrowingTypedDict3', () => {
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['typeNarrowingTypedDict3.py']);
 
-    TestUtils.validateResults(analysisResults, 5);
+    TestUtils.validateResults(analysisResults, 6);
 });
 
 test('typeNarrowingCallable1', () => {

--- a/packages/pyright-internal/src/tests/typeEvaluator1.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator1.test.ts
@@ -558,7 +558,7 @@ test('TypeNarrowingTypedDict2', () => {
 test('TypeNarrowingTypedDict3', () => {
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['typeNarrowingTypedDict3.py']);
 
-    TestUtils.validateResults(analysisResults, 6);
+    TestUtils.validateResults(analysisResults, 7);
 });
 
 test('typeNarrowingCallable1', () => {

--- a/packages/pyright-internal/src/tests/typeEvaluator1.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator1.test.ts
@@ -558,7 +558,7 @@ test('TypeNarrowingTypedDict2', () => {
 test('TypeNarrowingTypedDict3', () => {
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['typeNarrowingTypedDict3.py']);
 
-    TestUtils.validateResults(analysisResults, 7);
+    TestUtils.validateResults(analysisResults, 9);
 });
 
 test('typeNarrowingCallable1', () => {


### PR DESCRIPTION
Fixes #11575.

  Preserve the correlation between literal key alternatives and narrowed TypedDict variants after a membership check. This allows guarded indexed access while retaining diagnostics for unrelated optional
  keys.

  Tests:
  - TypeNarrowingTypedDict1–3
  - complete typeEvaluator1 test suite
  - TypeScript compilation
  - scoped ESLint and Prettier checks
  - git diff --check