### PR TITLE
Fix instance __dict__ lookup with custom metaclasses

### DIFF
--- a/packages/pyright-internal/src/analyzer/typeUtils.ts
+++ b/packages/pyright-internal/src/analyzer/typeUtils.ts
@@ -1771,7 +1771,7 @@ export function lookUpClassMember(
 
     // Skip the "type" class as an optimization because it is known to not
     // define any instance variables, and it's by far the most common metaclass.
-    if (metaclass && isClass(metaclass) && !ClassType.isBuiltIn(metaclass, 'type')) {
+    if (isInstantiableClass(classType) && metaclass && isClass(metaclass) && !ClassType.isBuiltIn(metaclass, 'type')) {
         const metaMemberItr = getClassMemberIterator(metaclass, memberName, MemberAccessFlags.SkipClassMembers);
         const metaMember = metaMemberItr.next()?.value;
 

--- a/packages/pyright-internal/src/tests/samples/classes3.py
+++ b/packages/pyright-internal/src/tests/samples/classes3.py
@@ -51,6 +51,17 @@ class Meta(type):
         return self.__name__
 
 
+class CustomClass(metaclass=Meta):
+    pass
+
+
+reveal_type(CustomClass.__dict__, expected_text="MappingProxyType[str, Any]")
+
+
+def custom_func(a: CustomClass):
+    reveal_type(a.__dict__, expected_text="dict[str, Any]")
+
+
 class NonMeta:
     def method1(self) -> str:
         # This should generate an error.


### PR DESCRIPTION
Fixes #11548.

Instances of classes with custom metaclasses could incorrectly resolve `**dict**` through the metaclass and inherit `type.**dict**`, producing `MappingProxyType[str, Any]` instead of the instance dictionary type.

Restrict metaclass member lookup to instantiable class objects. This preserves `MappingProxyType[str, Any]` for `Class.**dict**` while restoring `dict[str, Any]` for instances.

Tests cover both class-level and instance-level `**dict**` access.

Validation:
- `npx jest typeEvaluator3.test --forceExit --runInBand`
- `npm run build:cli:dev`
- Prettier
- ESLint
- `git diff --check`
