### PR TITLE
Support enum assignment to complete literal unions

### DIFF
--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -9016,9 +9016,17 @@ export function createTypeEvaluator(
         // The spec is unclear on whether this is the correct behavior, but it seems to be
         // what mypy does -- and what various library authors expect.
         const arg0Type = stripTypeGuard(arg0TypeResult.type);
+        let arg0TypeForComparison = arg0Type;
+
+        if (isClassInstance(arg0Type) && arg0Type.priv.literalValue === undefined && ClassType.isEnumClass(arg0Type)) {
+            const expandedLiteralTypes = enumerateLiteralsForType(evaluatorInterface, arg0Type);
+            if (expandedLiteralTypes && expandedLiteralTypes.length > 0) {
+                arg0TypeForComparison = combineTypes(expandedLiteralTypes);
+            }
+        }
 
         if (
-            !isTypeSame(assertedType, arg0Type, {
+            !isTypeSame(assertedType, arg0TypeForComparison, {
                 treatAnySameAsUnknown: true,
                 ignorePseudoGeneric: true,
                 ignoreConditions: true,
@@ -25185,6 +25193,20 @@ export function createTypeEvaluator(
         }
 
         if (isUnion(destType)) {
+            if (isClassInstance(srcType) && srcType.priv.literalValue === undefined && ClassType.isEnumClass(srcType)) {
+                const expandedLiteralTypes = enumerateLiteralsForType(evaluatorInterface, srcType);
+                if (expandedLiteralTypes && expandedLiteralTypes.length > 0) {
+                    return assignType(
+                        destType,
+                        combineTypes(expandedLiteralTypes),
+                        diag,
+                        constraints,
+                        flags,
+                        recursionCount
+                    );
+                }
+            }
+
             // If both the source and dest are unions, use assignFromUnionType which has
             // special-case logic to handle this case.
             if (isUnion(srcType)) {

--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -27698,6 +27698,19 @@ export function createTypeEvaluator(
                 // one we choose) or one or both include gradual types (Any, etc.),
                 // in which case we'll want to stick with the declared subtype.
                 if (assignType(assignedSubtype, declaredSubtype)) {
+                    // Preserve an assigned enum literal rather than widening it back to the
+                    // declared enum type when the enum has only one member.
+                    if (
+                        isClassInstance(assignedSubtype) &&
+                        assignedSubtype.priv.literalValue !== undefined &&
+                        ClassType.isEnumClass(assignedSubtype) &&
+                        isClassInstance(declaredSubtype) &&
+                        declaredSubtype.priv.literalValue === undefined &&
+                        ClassType.isSameGenericClass(assignedSubtype, declaredSubtype)
+                    ) {
+                        return assignedSubtype;
+                    }
+
                     // We need to be careful with TypedDict types that have
                     // narrowed fields. In this case, we want to return the
                     // assigned type.

--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -9017,6 +9017,7 @@ export function createTypeEvaluator(
         // what mypy does -- and what various library authors expect.
         const arg0Type = stripTypeGuard(arg0TypeResult.type);
         let arg0TypeForComparison = arg0Type;
+        let assertedTypeForComparison = assertedType;
 
         if (isClassInstance(arg0Type) && arg0Type.priv.literalValue === undefined && ClassType.isEnumClass(arg0Type)) {
             const expandedLiteralTypes = enumerateLiteralsForType(evaluatorInterface, arg0Type);
@@ -9026,7 +9027,18 @@ export function createTypeEvaluator(
         }
 
         if (
-            !isTypeSame(assertedType, arg0TypeForComparison, {
+            isClassInstance(assertedType) &&
+            assertedType.priv.literalValue === undefined &&
+            ClassType.isEnumClass(assertedType)
+        ) {
+            const expandedLiteralTypes = enumerateLiteralsForType(evaluatorInterface, assertedType);
+            if (expandedLiteralTypes && expandedLiteralTypes.length > 0) {
+                assertedTypeForComparison = combineTypes(expandedLiteralTypes);
+            }
+        }
+
+        if (
+            !isTypeSame(assertedTypeForComparison, arg0TypeForComparison, {
                 treatAnySameAsUnknown: true,
                 ignorePseudoGeneric: true,
                 ignoreConditions: true,

--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -2340,6 +2340,19 @@ export function createTypeEvaluator(
         });
     }
 
+    function expandEnumTypeToLiteralUnion(type: Type): Type {
+        return mapSubtypes(type, (subtype) => {
+            if (isClassInstance(subtype) && subtype.priv.literalValue === undefined && ClassType.isEnumClass(subtype)) {
+                const expandedLiteralTypes = enumerateLiteralsForType(evaluatorInterface, subtype);
+                if (expandedLiteralTypes && expandedLiteralTypes.length > 0) {
+                    return combineTypes(expandedLiteralTypes);
+                }
+            }
+
+            return subtype;
+        });
+    }
+
     function solveAndApplyConstraints(
         type: Type,
         constraints: ConstraintTracker,
@@ -9016,26 +9029,8 @@ export function createTypeEvaluator(
         // The spec is unclear on whether this is the correct behavior, but it seems to be
         // what mypy does -- and what various library authors expect.
         const arg0Type = stripTypeGuard(arg0TypeResult.type);
-        let arg0TypeForComparison = arg0Type;
-        let assertedTypeForComparison = assertedType;
-
-        if (isClassInstance(arg0Type) && arg0Type.priv.literalValue === undefined && ClassType.isEnumClass(arg0Type)) {
-            const expandedLiteralTypes = enumerateLiteralsForType(evaluatorInterface, arg0Type);
-            if (expandedLiteralTypes && expandedLiteralTypes.length > 0) {
-                arg0TypeForComparison = combineTypes(expandedLiteralTypes);
-            }
-        }
-
-        if (
-            isClassInstance(assertedType) &&
-            assertedType.priv.literalValue === undefined &&
-            ClassType.isEnumClass(assertedType)
-        ) {
-            const expandedLiteralTypes = enumerateLiteralsForType(evaluatorInterface, assertedType);
-            if (expandedLiteralTypes && expandedLiteralTypes.length > 0) {
-                assertedTypeForComparison = combineTypes(expandedLiteralTypes);
-            }
-        }
+        const arg0TypeForComparison = expandEnumTypeToLiteralUnion(arg0Type);
+        const assertedTypeForComparison = expandEnumTypeToLiteralUnion(assertedType);
 
         if (
             !isTypeSame(assertedTypeForComparison, arg0TypeForComparison, {
@@ -25204,21 +25199,12 @@ export function createTypeEvaluator(
             return true;
         }
 
-        if (isUnion(destType)) {
-            if (isClassInstance(srcType) && srcType.priv.literalValue === undefined && ClassType.isEnumClass(srcType)) {
-                const expandedLiteralTypes = enumerateLiteralsForType(evaluatorInterface, srcType);
-                if (expandedLiteralTypes && expandedLiteralTypes.length > 0) {
-                    return assignType(
-                        destType,
-                        combineTypes(expandedLiteralTypes),
-                        diag,
-                        constraints,
-                        flags,
-                        recursionCount
-                    );
-                }
-            }
+        const expandedEnumSrcType = expandEnumTypeToLiteralUnion(srcType);
+        if (expandedEnumSrcType !== srcType) {
+            return assignType(destType, expandedEnumSrcType, diag, constraints, flags, recursionCount);
+        }
 
+        if (isUnion(destType)) {
             // If both the source and dest are unions, use assignFromUnionType which has
             // special-case logic to handle this case.
             if (isUnion(srcType)) {

--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -2353,6 +2353,23 @@ export function createTypeEvaluator(
         });
     }
 
+    function expandEnumTypeToLiteralUnionForDestination(srcType: Type, destType: Type): Type {
+        return mapSubtypes(srcType, (srcSubtype) => {
+            const expandedSrcSubtype = expandEnumTypeToLiteralUnion(srcSubtype);
+            if (expandedSrcSubtype === srcSubtype) {
+                return srcSubtype;
+            }
+
+            const destContainsType = (type: Type) =>
+                isUnion(destType) ? UnionType.containsType(destType, type) : isTypeSame(destType, type);
+            const destContainsAllLiterals = isUnion(expandedSrcSubtype)
+                ? expandedSrcSubtype.priv.subtypes.every(destContainsType)
+                : destContainsType(expandedSrcSubtype);
+
+            return destContainsAllLiterals ? expandedSrcSubtype : srcSubtype;
+        });
+    }
+
     function solveAndApplyConstraints(
         type: Type,
         constraints: ConstraintTracker,
@@ -25199,7 +25216,7 @@ export function createTypeEvaluator(
             return true;
         }
 
-        const expandedEnumSrcType = expandEnumTypeToLiteralUnion(srcType);
+        const expandedEnumSrcType = expandEnumTypeToLiteralUnionForDestination(srcType, destType);
         if (expandedEnumSrcType !== srcType) {
             return assignType(destType, expandedEnumSrcType, diag, constraints, flags, recursionCount);
         }

--- a/packages/pyright-internal/src/tests/samples/enum1.py
+++ b/packages/pyright-internal/src/tests/samples/enum1.py
@@ -31,6 +31,25 @@ def test_enum_literal_union(value: TestEnum3, literal_value: TestEnum3Literal) -
     underlying_values: Literal[0, 1, 2, 3] = value
 
 
+def test_enum_literal_union_in_union(
+    value: TestEnum3 | int, literal_value: TestEnum3Literal | int
+) -> None:
+    assert_type(value, TestEnum3Literal | int)
+    assert_type(literal_value, TestEnum3 | int)
+
+
+class TestSingleMemberEnum(Enum):
+    ONLY = 1
+
+
+def test_single_member_enum(
+    value: TestSingleMemberEnum, literal_value: Literal[TestSingleMemberEnum.ONLY]
+) -> None:
+    full_union: Literal[TestSingleMemberEnum.ONLY] = value
+    assert_type(value, Literal[TestSingleMemberEnum.ONLY])
+    assert_type(literal_value, TestSingleMemberEnum)
+
+
 def test_enum_without_known_members(value: Enum) -> None:
     # This should generate an error because no literal members can be enumerated.
     full_union: TestEnum3Literal = value

--- a/packages/pyright-internal/src/tests/samples/enum1.py
+++ b/packages/pyright-internal/src/tests/samples/enum1.py
@@ -18,9 +18,10 @@ class TestEnum3(Enum):
 TestEnum3Literal = Literal[TestEnum3.A, TestEnum3.B, TestEnum3.C, TestEnum3.D]
 
 
-def test_enum_literal_union(value: TestEnum3) -> None:
+def test_enum_literal_union(value: TestEnum3, literal_value: TestEnum3Literal) -> None:
     full_union: TestEnum3Literal = value
     assert_type(value, TestEnum3Literal)
+    assert_type(literal_value, TestEnum3)
 
     # This should generate an error because the union is incomplete.
     incomplete_union: Literal[TestEnum3.A, TestEnum3.B, TestEnum3.C] = value
@@ -57,6 +58,9 @@ class TestIntEnumLiteralUnion(IntEnum):
 
 def test_int_enum_literal_union(value: TestIntEnumLiteralUnion) -> None:
     full_union: Literal[TestIntEnumLiteralUnion.A, TestIntEnumLiteralUnion.B] = value
+    # This should generate an error because enum literals are distinct from
+    # literals of their underlying values.
+    underlying_values: Literal[1, 2] = value
 
 
 class TestStrEnumLiteralUnion(StrEnum):
@@ -66,6 +70,9 @@ class TestStrEnumLiteralUnion(StrEnum):
 
 def test_str_enum_literal_union(value: TestStrEnumLiteralUnion) -> None:
     full_union: Literal[TestStrEnumLiteralUnion.A, TestStrEnumLiteralUnion.B] = value
+    # This should generate an error because enum literals are distinct from
+    # literals of their underlying values.
+    underlying_values: Literal["a", "b"] = value
 
 
 class TestFlagLiteralUnion(Flag):

--- a/packages/pyright-internal/src/tests/samples/enum1.py
+++ b/packages/pyright-internal/src/tests/samples/enum1.py
@@ -38,6 +38,16 @@ def test_enum_literal_union_in_union(
     assert_type(literal_value, TestEnum3 | int)
 
 
+def test_enum_invariant_containers(
+    values: list[TestEnum3],
+    value_map: dict[TestEnum3, int],
+    mixed_values: list[TestEnum3 | int],
+) -> None:
+    same_values: list[TestEnum3] = values
+    same_value_map: dict[TestEnum3, int] = value_map
+    same_mixed_values: list[TestEnum3 | int] = mixed_values
+
+
 class TestSingleMemberEnum(Enum):
     ONLY = 1
 

--- a/packages/pyright-internal/src/tests/samples/enum1.py
+++ b/packages/pyright-internal/src/tests/samples/enum1.py
@@ -1,7 +1,7 @@
 # This sample tests the type checker's handling of Enum.
 
 from enum import Enum, EnumMeta, Flag, IntEnum, StrEnum, auto
-from typing import Generic, Literal, Self, TypeVar, assert_type
+from typing import Final, Generic, Literal, Self, TypeVar, assert_type
 
 
 TestEnum1 = Enum("TestEnum1", "   A   B, , ,C , \t D\t")
@@ -50,6 +50,17 @@ def test_enum_invariant_containers(
 
 class TestSingleMemberEnum(Enum):
     ONLY = 1
+
+
+single_member_sentinel: Final[TestSingleMemberEnum] = TestSingleMemberEnum.ONLY
+reveal_type(single_member_sentinel, expected_text="Literal[TestSingleMemberEnum.ONLY]")
+
+
+def resolve_single_member_sentinel(value: float | TestSingleMemberEnum) -> float:
+    if value is single_member_sentinel:
+        return 0.0
+    reveal_type(value, expected_text="float")
+    return value
 
 
 def test_single_member_enum(

--- a/packages/pyright-internal/src/tests/samples/enum1.py
+++ b/packages/pyright-internal/src/tests/samples/enum1.py
@@ -1,7 +1,7 @@
 # This sample tests the type checker's handling of Enum.
 
-from enum import Enum, EnumMeta, IntEnum
-from typing import Self
+from enum import Enum, EnumMeta, Flag, IntEnum, StrEnum, auto
+from typing import Generic, Literal, Self, TypeVar, assert_type
 
 
 TestEnum1 = Enum("TestEnum1", "   A   B, , ,C , \t D\t")
@@ -13,6 +13,69 @@ class TestEnum3(Enum):
     B = 1
     C = 2
     D = 3
+
+
+TestEnum3Literal = Literal[TestEnum3.A, TestEnum3.B, TestEnum3.C, TestEnum3.D]
+
+
+def test_enum_literal_union(value: TestEnum3) -> None:
+    full_union: TestEnum3Literal = value
+    assert_type(value, TestEnum3Literal)
+
+    # This should generate an error because the union is incomplete.
+    incomplete_union: Literal[TestEnum3.A, TestEnum3.B, TestEnum3.C] = value
+
+    # This should generate an error because enum literals are distinct from
+    # literals of their underlying values.
+    underlying_values: Literal[0, 1, 2, 3] = value
+
+
+def test_enum_without_known_members(value: Enum) -> None:
+    # This should generate an error because no literal members can be enumerated.
+    full_union: TestEnum3Literal = value
+
+
+TTestEnum3 = TypeVar("TTestEnum3", bound=TestEnum3)
+
+
+class EnumContainer(Generic[TTestEnum3]):
+    pass
+
+
+def accept_enum_container(value: EnumContainer[TestEnum3Literal]) -> None:
+    pass
+
+
+def test_generic_enum_literal_union(value: EnumContainer[TestEnum3]) -> None:
+    accept_enum_container(value)
+
+
+class TestIntEnumLiteralUnion(IntEnum):
+    A = 1
+    B = 2
+
+
+def test_int_enum_literal_union(value: TestIntEnumLiteralUnion) -> None:
+    full_union: Literal[TestIntEnumLiteralUnion.A, TestIntEnumLiteralUnion.B] = value
+
+
+class TestStrEnumLiteralUnion(StrEnum):
+    A = "a"
+    B = "b"
+
+
+def test_str_enum_literal_union(value: TestStrEnumLiteralUnion) -> None:
+    full_union: Literal[TestStrEnumLiteralUnion.A, TestStrEnumLiteralUnion.B] = value
+
+
+class TestFlagLiteralUnion(Flag):
+    A = auto()
+    B = auto()
+
+
+def test_flag_literal_union(value: TestFlagLiteralUnion) -> None:
+    # This should generate an error because Flag values can be combined.
+    full_union: Literal[TestFlagLiteralUnion.A, TestFlagLiteralUnion.B] = value
 
 
 a = TestEnum1["A"]

--- a/packages/pyright-internal/src/tests/typeEvaluator3.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator3.test.ts
@@ -1025,7 +1025,7 @@ test('MethodOverride7', () => {
 test('Enum1', () => {
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['enum1.py']);
 
-    TestUtils.validateResults(analysisResults, 3);
+    TestUtils.validateResults(analysisResults, 7);
 });
 
 test('Enum2', () => {

--- a/packages/pyright-internal/src/tests/typeEvaluator3.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator3.test.ts
@@ -1025,7 +1025,7 @@ test('MethodOverride7', () => {
 test('Enum1', () => {
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['enum1.py']);
 
-    TestUtils.validateResults(analysisResults, 7);
+    TestUtils.validateResults(analysisResults, 9);
 });
 
 test('Enum2', () => {


### PR DESCRIPTION
Fixes #11573.

The typing specification treats a non-Flag enum as equivalent to the union of all of its literal members.

Pyright already handled assignment from an enum literal union to the enum type, but the reverse direction failed because a broad enum source was tested independently against each destination literal.

Expand non-literal enums to their complete literal-member union before union assignability checks. Apply the same normalization symmetrically for `assert_type`.

The change preserves existing behavior for:
- incomplete literal unions
- `enum.Flag`
- enums without known members
- underlying `int` and `str` literals

Tests cover ordinary Enum, IntEnum, StrEnum, the generic case from the issue, symmetric `assert_type` checks, incomplete unions, Flag, and underlying literals.

Validation:
- `typeEvaluator3.test.ts`: 172/172 passed
- `npm run build:cli:dev`
- Prettier
- ESLint
- `git diff --check`
- conformance and generic reproducers
