### PR TITLE
Fix TypeGuard and TypeIs narrowing for unbound method calls

### DIFF
--- a/packages/pyright-internal/src/analyzer/typeGuards.ts
+++ b/packages/pyright-internal/src/analyzer/typeGuards.ts
@@ -722,8 +722,10 @@ export function getTypeNarrowingCallback(
             const callMember = lookUpObjectMember(callType, '__call__');
             if (callMember) {
                 const memberType = evaluator.getTypeOfMember(callMember);
-                if (isFunction(memberType) && isFunctionReturnTypeGuard(memberType)) {
-                    isPossiblyTypeGuard = true;
+                if (isFunction(memberType)) {
+                    isPossiblyTypeGuard = isFunctionReturnTypeGuard(memberType);
+                } else if (isOverloaded(memberType)) {
+                    isPossiblyTypeGuard = OverloadedType.getOverloads(memberType).some(isFunctionReturnTypeGuard);
                 }
             }
         }
@@ -752,11 +754,21 @@ export function getTypeNarrowingCallback(
                     }
                 }
 
-                const positionalArgs = testExpression.d.args.filter(
-                    (arg) => arg.d.argCategory === ArgCategory.Simple && !arg.d.name
-                );
-                if (targetParamIndex < positionalArgs.length) {
-                    return positionalArgs[targetParamIndex].d.valueExpr;
+                // Map positional arguments to parameters. If an unpacked argument
+                // appears at or before the target index, the mapping is ambiguous,
+                // so don't attempt to narrow.
+                let positionalIndex = 0;
+                for (const arg of testExpression.d.args) {
+                    if (arg.d.name) {
+                        continue;
+                    }
+                    if (arg.d.argCategory !== ArgCategory.Simple) {
+                        return undefined;
+                    }
+                    if (positionalIndex === targetParamIndex) {
+                        return arg.d.valueExpr;
+                    }
+                    positionalIndex++;
                 }
 
                 return undefined;
@@ -766,7 +778,12 @@ export function getTypeNarrowingCallback(
             if (isFunction(callType)) {
                 arg0Expr = getTargetArgExpr(callType);
             } else if (isOverloaded(callType)) {
+                // Consider only the overloads that return a TypeGuard or TypeIs so
+                // that eligibility and argument mapping come from the same signature.
                 for (const overload of OverloadedType.getOverloads(callType)) {
+                    if (!isFunctionReturnTypeGuard(overload)) {
+                        continue;
+                    }
                     arg0Expr = getTargetArgExpr(overload);
                     if (arg0Expr) {
                         break;

--- a/packages/pyright-internal/src/analyzer/typeGuards.ts
+++ b/packages/pyright-internal/src/analyzer/typeGuards.ts
@@ -702,38 +702,47 @@ export function getTypeNarrowingCallback(
         }
 
         // Look for a TypeGuard function.
-        if (testExpression.d.args.length >= 1) {
-            const arg0Expr = testExpression.d.args[0].d.valueExpr;
-            if (isMatchingExpressionOrWalrusRhs(evaluator, reference, arg0Expr)) {
-                // Does this look like it's a custom type guard function?
-                let isPossiblyTypeGuard = false;
+        const isFunctionReturnTypeGuard = (type: FunctionType) => {
+            return (
+                type.shared.declaredReturnType &&
+                isClassInstance(type.shared.declaredReturnType) &&
+                ClassType.isBuiltIn(type.shared.declaredReturnType, ['TypeGuard', 'TypeIs'])
+            );
+        };
 
-                const isFunctionReturnTypeGuard = (type: FunctionType) => {
-                    return (
-                        type.shared.declaredReturnType &&
-                        isClassInstance(type.shared.declaredReturnType) &&
-                        ClassType.isBuiltIn(type.shared.declaredReturnType, ['TypeGuard', 'TypeIs'])
-                    );
-                };
+        const callTypeResult = evaluator.getTypeOfExpression(testExpression.d.leftExpr, EvalFlags.CallBaseDefaults);
+        const callType = callTypeResult.type;
 
-                const callTypeResult = evaluator.getTypeOfExpression(
-                    testExpression.d.leftExpr,
-                    EvalFlags.CallBaseDefaults
+        let isPossiblyTypeGuard = false;
+        if (isFunction(callType) && isFunctionReturnTypeGuard(callType)) {
+            isPossiblyTypeGuard = true;
+        } else if (
+            isOverloaded(callType) &&
+            OverloadedType.getOverloads(callType).some((o) => isFunctionReturnTypeGuard(o))
+        ) {
+            isPossiblyTypeGuard = true;
+        } else if (isClassInstance(callType)) {
+            isPossiblyTypeGuard = true;
+        }
+
+        if (isPossiblyTypeGuard) {
+            const isUnboundMethod = (type: FunctionType) => {
+                return (
+                    testExpression.d.leftExpr.nodeType === ParseNodeType.MemberAccess &&
+                    !FunctionType.isStaticMethod(type) &&
+                    type.priv.strippedFirstParamType === undefined
                 );
-                const callType = callTypeResult.type;
+            };
 
-                if (isFunction(callType) && isFunctionReturnTypeGuard(callType)) {
-                    isPossiblyTypeGuard = true;
-                } else if (
-                    isOverloaded(callType) &&
-                    OverloadedType.getOverloads(callType).some((o) => isFunctionReturnTypeGuard(o))
-                ) {
-                    isPossiblyTypeGuard = true;
-                } else if (isClassInstance(callType)) {
-                    isPossiblyTypeGuard = true;
-                }
+            const isUnbound =
+                (isFunction(callType) && isUnboundMethod(callType)) ||
+                (isOverloaded(callType) && OverloadedType.getOverloads(callType).some((o) => isUnboundMethod(o)));
 
-                if (isPossiblyTypeGuard) {
+            const targetArgIndex = isUnbound ? 1 : 0;
+
+            if (testExpression.d.args.length > targetArgIndex) {
+                const arg0Expr = testExpression.d.args[targetArgIndex].d.valueExpr;
+                if (isMatchingExpressionOrWalrusRhs(evaluator, reference, arg0Expr)) {
                     // Evaluate the type guard call expression.
                     const functionReturnTypeResult = evaluator.getTypeOfExpression(testExpression);
                     const functionReturnType = functionReturnTypeResult.type;

--- a/packages/pyright-internal/src/analyzer/typeGuards.ts
+++ b/packages/pyright-internal/src/analyzer/typeGuards.ts
@@ -702,9 +702,9 @@ export function getTypeNarrowingCallback(
         }
 
         // Look for a TypeGuard function.
-        const isFunctionReturnTypeGuard = (type: FunctionType) => {
+        const isFunctionReturnTypeGuard = (type: FunctionType): boolean => {
             return (
-                type.shared.declaredReturnType &&
+                !!type.shared.declaredReturnType &&
                 isClassInstance(type.shared.declaredReturnType) &&
                 ClassType.isBuiltIn(type.shared.declaredReturnType, ['TypeGuard', 'TypeIs'])
             );
@@ -714,63 +714,98 @@ export function getTypeNarrowingCallback(
         const callType = callTypeResult.type;
 
         let isPossiblyTypeGuard = false;
-        if (isFunction(callType) && isFunctionReturnTypeGuard(callType)) {
-            isPossiblyTypeGuard = true;
-        } else if (
-            isOverloaded(callType) &&
-            OverloadedType.getOverloads(callType).some((o) => isFunctionReturnTypeGuard(o))
-        ) {
-            isPossiblyTypeGuard = true;
+        if (isFunction(callType)) {
+            isPossiblyTypeGuard = isFunctionReturnTypeGuard(callType);
+        } else if (isOverloaded(callType)) {
+            isPossiblyTypeGuard = OverloadedType.getOverloads(callType).some(isFunctionReturnTypeGuard);
         } else if (isClassInstance(callType)) {
-            isPossiblyTypeGuard = true;
+            const callMember = lookUpObjectMember(callType, '__call__');
+            if (callMember) {
+                const memberType = evaluator.getTypeOfMember(callMember);
+                if (isFunction(memberType) && isFunctionReturnTypeGuard(memberType)) {
+                    isPossiblyTypeGuard = true;
+                }
+            }
         }
 
         if (isPossiblyTypeGuard) {
-            const isUnboundMethod = (type: FunctionType) => {
-                return (
+            const getTargetArgExpr = (fnType: FunctionType): ExpressionNode | undefined => {
+                const isUnbound =
                     testExpression.d.leftExpr.nodeType === ParseNodeType.MemberAccess &&
-                    !FunctionType.isStaticMethod(type) &&
-                    type.priv.strippedFirstParamType === undefined
+                    fnType.priv.boundToType !== undefined &&
+                    isInstantiableClass(fnType.priv.boundToType) &&
+                    !FunctionType.isStaticMethod(fnType) &&
+                    fnType.priv.strippedFirstParamType === undefined;
+
+                const targetParamIndex = isUnbound ? 1 : 0;
+                if (targetParamIndex >= fnType.shared.parameters.length) {
+                    return undefined;
+                }
+
+                const targetParam = fnType.shared.parameters[targetParamIndex];
+                if (targetParam.name) {
+                    const kwArg = testExpression.d.args.find(
+                        (arg) => arg.d.argCategory === ArgCategory.Simple && arg.d.name?.d.value === targetParam.name
+                    );
+                    if (kwArg) {
+                        return kwArg.d.valueExpr;
+                    }
+                }
+
+                const positionalArgs = testExpression.d.args.filter(
+                    (arg) => arg.d.argCategory === ArgCategory.Simple && !arg.d.name
                 );
+                if (targetParamIndex < positionalArgs.length) {
+                    return positionalArgs[targetParamIndex].d.valueExpr;
+                }
+
+                return undefined;
             };
 
-            const isUnbound =
-                (isFunction(callType) && isUnboundMethod(callType)) ||
-                (isOverloaded(callType) && OverloadedType.getOverloads(callType).some((o) => isUnboundMethod(o)));
-
-            const targetArgIndex = isUnbound ? 1 : 0;
-
-            if (testExpression.d.args.length > targetArgIndex) {
-                const arg0Expr = testExpression.d.args[targetArgIndex].d.valueExpr;
-                if (isMatchingExpressionOrWalrusRhs(evaluator, reference, arg0Expr)) {
-                    // Evaluate the type guard call expression.
-                    const functionReturnTypeResult = evaluator.getTypeOfExpression(testExpression);
-                    const functionReturnType = functionReturnTypeResult.type;
-
-                    if (
-                        isClassInstance(functionReturnType) &&
-                        ClassType.isBuiltIn(functionReturnType, ['TypeGuard', 'TypeIs']) &&
-                        functionReturnType.priv.typeArgs &&
-                        functionReturnType.priv.typeArgs.length > 0
-                    ) {
-                        const isStrictTypeGuard = ClassType.isBuiltIn(functionReturnType, 'TypeIs');
-                        const typeGuardType = functionReturnType.priv.typeArgs[0];
-                        const isIncomplete = !!callTypeResult.isIncomplete || !!functionReturnTypeResult.isIncomplete;
-
-                        return (type: Type) => {
-                            return {
-                                type: narrowTypeForUserDefinedTypeGuard(
-                                    evaluator,
-                                    type,
-                                    typeGuardType,
-                                    isPositiveTest,
-                                    isStrictTypeGuard,
-                                    testExpression
-                                ),
-                                isIncomplete,
-                            };
-                        };
+            let arg0Expr: ExpressionNode | undefined;
+            if (isFunction(callType)) {
+                arg0Expr = getTargetArgExpr(callType);
+            } else if (isOverloaded(callType)) {
+                for (const overload of OverloadedType.getOverloads(callType)) {
+                    arg0Expr = getTargetArgExpr(overload);
+                    if (arg0Expr) {
+                        break;
                     }
+                }
+            } else if (isClassInstance(callType)) {
+                if (testExpression.d.args.length >= 1) {
+                    arg0Expr = testExpression.d.args[0].d.valueExpr;
+                }
+            }
+
+            if (arg0Expr && isMatchingExpressionOrWalrusRhs(evaluator, reference, arg0Expr)) {
+                // Evaluate the type guard call expression.
+                const functionReturnTypeResult = evaluator.getTypeOfExpression(testExpression);
+                const functionReturnType = functionReturnTypeResult.type;
+
+                if (
+                    isClassInstance(functionReturnType) &&
+                    ClassType.isBuiltIn(functionReturnType, ['TypeGuard', 'TypeIs']) &&
+                    functionReturnType.priv.typeArgs &&
+                    functionReturnType.priv.typeArgs.length > 0
+                ) {
+                    const isStrictTypeGuard = ClassType.isBuiltIn(functionReturnType, 'TypeIs');
+                    const typeGuardType = functionReturnType.priv.typeArgs[0];
+                    const isIncomplete = !!callTypeResult.isIncomplete || !!functionReturnTypeResult.isIncomplete;
+
+                    return (type: Type) => {
+                        return {
+                            type: narrowTypeForUserDefinedTypeGuard(
+                                evaluator,
+                                type,
+                                typeGuardType,
+                                isPositiveTest,
+                                isStrictTypeGuard,
+                                testExpression
+                            ),
+                            isIncomplete,
+                        };
+                    };
                 }
             }
         }

--- a/packages/pyright-internal/src/tests/samples/typeGuardMethod1.py
+++ b/packages/pyright-internal/src/tests/samples/typeGuardMethod1.py
@@ -1,0 +1,51 @@
+# This sample tests TypeGuard and TypeIs narrowing for bound, unbound,
+# and static method calls.
+
+from typing import Any, TypeGuard, TypeIs
+
+
+class Checker:
+    def is_str(self, val: object) -> TypeGuard[str]:
+        return isinstance(val, str)
+
+    def is_int(self, val: object) -> TypeIs[int]:
+        return isinstance(val, int)
+
+    @staticmethod
+    def is_float(val: object) -> TypeGuard[float]:
+        return isinstance(val, float)
+
+
+def test_bound_method(c: Checker, x: object):
+    if c.is_str(x):
+        reveal_type(x, expected_text="str")
+    else:
+        reveal_type(x, expected_text="object")
+
+
+def test_bound_method_typeis(c: Checker, x: int | str):
+    if c.is_int(x):
+        reveal_type(x, expected_text="int")
+    else:
+        reveal_type(x, expected_text="str")
+
+
+def test_unbound_method(c: Checker, x: object):
+    if Checker.is_str(c, x):
+        reveal_type(x, expected_text="str")
+    else:
+        reveal_type(x, expected_text="object")
+
+
+def test_unbound_method_typeis(c: Checker, x: int | str):
+    if Checker.is_int(c, x):
+        reveal_type(x, expected_text="int")
+    else:
+        reveal_type(x, expected_text="str")
+
+
+def test_static_method(x: object):
+    if Checker.is_float(x):
+        reveal_type(x, expected_text="float")
+    else:
+        reveal_type(x, expected_text="object")

--- a/packages/pyright-internal/src/tests/samples/typeGuardMethod1.py
+++ b/packages/pyright-internal/src/tests/samples/typeGuardMethod1.py
@@ -1,7 +1,8 @@
 # This sample tests TypeGuard and TypeIs narrowing for bound, unbound,
-# static, reordered keyword, and module-qualified function calls.
+# static, class, overloaded, callable-instance, reordered keyword, and
+# module-qualified function calls.
 
-from typing import Any, TypeGuard, TypeIs
+from typing import Any, TypeGuard, TypeIs, overload
 import typeGuard1
 
 
@@ -15,6 +16,14 @@ class Checker:
     @staticmethod
     def is_float(val: object) -> TypeGuard[float]:
         return isinstance(val, float)
+
+    @classmethod
+    def is_bytes(cls, val: object) -> TypeGuard[bytes]:
+        return isinstance(val, bytes)
+
+    @classmethod
+    def is_bool(cls, val: object) -> TypeIs[bool]:
+        return isinstance(val, bool)
 
 
 def test_bound_method(c: Checker, x: object):
@@ -73,3 +82,71 @@ def test_module_qualified_free_function(a: tuple[int, ...]):
         reveal_type(a, expected_text="tuple[int, int]")
     else:
         reveal_type(a, expected_text="tuple[int, ...]")
+
+
+def test_class_method_via_instance(c: Checker, x: object):
+    if c.is_bytes(x):
+        reveal_type(x, expected_text="bytes")
+    else:
+        reveal_type(x, expected_text="object")
+
+
+def test_class_method_via_class(x: object):
+    if Checker.is_bytes(x):
+        reveal_type(x, expected_text="bytes")
+    else:
+        reveal_type(x, expected_text="object")
+
+
+def test_class_method_keyword(x: object):
+    if Checker.is_bytes(val=x):
+        reveal_type(x, expected_text="bytes")
+    else:
+        reveal_type(x, expected_text="object")
+
+
+def test_class_method_typeis(x: bool | str):
+    if Checker.is_bool(x):
+        reveal_type(x, expected_text="bool")
+    else:
+        reveal_type(x, expected_text="str")
+
+
+class OverloadedCallable:
+    @overload
+    def __call__(self, other: int, extra: int, /) -> bool: ...
+    @overload
+    def __call__(self, val: object) -> TypeGuard[str]: ...
+    def __call__(self, val: object, extra: int | None = None) -> bool | TypeGuard[str]:
+        return isinstance(val, str)
+
+
+def test_overloaded_callable_instance(f: OverloadedCallable, x: object):
+    if f(x):
+        reveal_type(x, expected_text="str")
+    else:
+        reveal_type(x, expected_text="object")
+
+
+@overload
+def is_str_overloaded(other: int, extra: int, /) -> bool: ...
+@overload
+def is_str_overloaded(val: object) -> TypeGuard[str]: ...
+def is_str_overloaded(val: object, extra: int | None = None) -> bool | TypeGuard[str]:
+    return isinstance(val, str)
+
+
+def test_overloaded_function_keyword(x: object):
+    # The first (non-guard) overload uses a different parameter name, so the
+    # guard-returning overload must be the one used for argument mapping.
+    if is_str_overloaded(val=x):
+        reveal_type(x, expected_text="str")
+    else:
+        reveal_type(x, expected_text="object")
+
+
+def test_overloaded_function_positional(x: object):
+    if is_str_overloaded(x):
+        reveal_type(x, expected_text="str")
+    else:
+        reveal_type(x, expected_text="object")

--- a/packages/pyright-internal/src/tests/samples/typeGuardMethod1.py
+++ b/packages/pyright-internal/src/tests/samples/typeGuardMethod1.py
@@ -1,7 +1,8 @@
 # This sample tests TypeGuard and TypeIs narrowing for bound, unbound,
-# and static method calls.
+# static, reordered keyword, and module-qualified function calls.
 
 from typing import Any, TypeGuard, TypeIs
+import typeGuard1
 
 
 class Checker:
@@ -23,6 +24,13 @@ def test_bound_method(c: Checker, x: object):
         reveal_type(x, expected_text="object")
 
 
+def test_bound_method_keyword(c: Checker, x: object):
+    if c.is_str(val=x):
+        reveal_type(x, expected_text="str")
+    else:
+        reveal_type(x, expected_text="object")
+
+
 def test_bound_method_typeis(c: Checker, x: int | str):
     if c.is_int(x):
         reveal_type(x, expected_text="int")
@@ -37,6 +45,15 @@ def test_unbound_method(c: Checker, x: object):
         reveal_type(x, expected_text="object")
 
 
+def test_unbound_method_keyword(c: Checker, x: object):
+    if Checker.is_str(val=x, self=c):
+        reveal_type(x, expected_text="str")
+        reveal_type(c, expected_text="Checker")
+    else:
+        reveal_type(x, expected_text="object")
+        reveal_type(c, expected_text="Checker")
+
+
 def test_unbound_method_typeis(c: Checker, x: int | str):
     if Checker.is_int(c, x):
         reveal_type(x, expected_text="int")
@@ -49,3 +66,10 @@ def test_static_method(x: object):
         reveal_type(x, expected_text="float")
     else:
         reveal_type(x, expected_text="object")
+
+
+def test_module_qualified_free_function(a: tuple[int, ...]):
+    if typeGuard1.is_two_element_tuple(a):
+        reveal_type(a, expected_text="tuple[int, int]")
+    else:
+        reveal_type(a, expected_text="tuple[int, ...]")

--- a/packages/pyright-internal/src/tests/typeEvaluator1.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator1.test.ts
@@ -315,6 +315,12 @@ test('TypeNarrowingTypeIs1', () => {
     TestUtils.validateResults(analysisResults, 3);
 });
 
+test('TypeGuardMethod1', () => {
+    const analysisResults = TestUtils.typeAnalyzeSampleFiles(['typeGuardMethod1.py']);
+
+    TestUtils.validateResults(analysisResults, 0);
+});
+
 test('TypeNarrowingTypeEquals1', () => {
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['typeNarrowingTypeEquals1.py']);
 


### PR DESCRIPTION
### Summary

Fixes a bug where `TypeGuard` and `TypeIs` type narrowing was evaluated against the wrong argument index for unbound method calls (e.g. `Checker.is_str(c, x)`).

### Root Cause

When evaluating custom `TypeGuard` / `TypeIs` return types in `typeGuards.ts`, Pyright checked whether the expression being narrowed matched `testExpression.d.args[0]`.
However, when an instance method or class method is invoked directly on a class as an unbound method call (e.g. `Checker.is_str(c, x)`), argument 0 in `testExpression.d.args` is the `self` or `cls` argument (`c`), while argument 1 corresponds to the first non-self parameter (`x`) which is targeted by the `TypeGuard`/`TypeIs` return type.

Because Pyright unconditionally checked `args[0]`, unbound method calls failed to narrow argument 1.

### Fix

`typeGuards.ts` now derives the guarded argument from the callee's signature rather than assuming `args[0]`:

- For an unbound instance or class method called via member access on a class (`ParseNodeType.MemberAccess` with `strippedFirstParamType === undefined`), the target parameter index is 1; otherwise 0.
- The target argument is located by parameter name when passed as a keyword, otherwise by positional index. If an unpacked argument (`*args` / `**kwargs`) appears at or before the target position, the mapping is ambiguous and no narrowing is attempted.
- For overloaded callees, only overloads that return `TypeGuard`/`TypeIs` are considered, so eligibility and argument mapping come from the same signature.
- Callable instances are recognized as guard calls when `__call__` returns `TypeGuard`/`TypeIs`, including when `__call__` is overloaded.

### Testing

- Added regression test sample `packages/pyright-internal/src/tests/samples/typeGuardMethod1.py` covering bound methods, unbound methods, static methods, class methods (called via instance and via class, positional and keyword), overloaded functions whose earlier non-guard overload uses different parameter names, overloaded callable instances, reordered keyword arguments, and module-qualified free functions, for both `TypeGuard` and `TypeIs`.
- Registered `TypeGuardMethod1` in `typeEvaluator1.test.ts`.
- `npx jest typeEvaluator` — 1183 tests pass across all 8 suites.
- `npx tsc --noEmit` and `prettier --check` pass on the changed sources.
