### PR TITLE
Support version-conditional TypedDict fields

### DIFF
--- a/packages/pyright-internal/src/analyzer/analyzerNodeInfo.ts
+++ b/packages/pyright-internal/src/analyzer/analyzerNodeInfo.ts
@@ -15,6 +15,7 @@ import {
     ComprehensionNode,
     ExecutionScopeNode,
     FunctionNode,
+    IfNode,
     LambdaNode,
     ModuleNode,
     ParseNode,
@@ -68,6 +69,9 @@ export interface AnalyzerNodeInfo {
     // flow graph.
     codeFlowComplexity?: number;
 
+    // Statically evaluated value of an if statement's condition.
+    staticConditionValue?: boolean;
+
     // List of __all__ symbols in the module.
     dunderAllInfo?: DunderAllInfo | undefined;
 }
@@ -104,6 +108,10 @@ export function cleanNodeAnalysisInfo(node: ParseNode) {
 
     if (info?.codeFlowComplexity) {
         info.codeFlowComplexity = undefined;
+    }
+
+    if (info?.staticConditionValue !== undefined) {
+        info.staticConditionValue = undefined;
     }
 
     if (info?.dunderAllInfo) {
@@ -192,6 +200,16 @@ export function getCodeFlowComplexity(node: ExecutionScopeNode) {
 export function setCodeFlowComplexity(node: ExecutionScopeNode, complexity: number) {
     const info = getAnalyzerInfoForWrite(node);
     info.codeFlowComplexity = complexity;
+}
+
+export function getStaticConditionValue(node: IfNode): boolean | undefined {
+    const info = getAnalyzerInfo(node);
+    return info?.staticConditionValue;
+}
+
+export function setStaticConditionValue(node: IfNode, value: boolean | undefined) {
+    const info = getAnalyzerInfoForWrite(node);
+    info.staticConditionValue = value;
 }
 
 export function getDunderAllInfo(node: ModuleNode): DunderAllInfo | undefined {

--- a/packages/pyright-internal/src/analyzer/binder.ts
+++ b/packages/pyright-internal/src/analyzer/binder.ts
@@ -1481,6 +1481,7 @@ export class Binder extends ParseTreeWalker {
                 this._typingImportAliases,
                 this._sysImportAliases
             );
+            AnalyzerNodeInfo.setStaticConditionValue(node, constExprValue);
 
             this._bindConditional(node.d.testExpr, thenLabel, elseLabel);
 

--- a/packages/pyright-internal/src/analyzer/checker.ts
+++ b/packages/pyright-internal/src/analyzer/checker.ts
@@ -4608,32 +4608,59 @@ export class Checker extends ParseTreeWalker {
         });
     }
 
-    // Verifies the rules specified in PEP 589 about TypedDict classes.
-    // They cannot have statements other than type annotations, doc
-    // strings, and "pass" statements or ellipses.
+    // Verifies the rules specified for TypedDict class bodies.
+    // They cannot have statements other than type annotations, doc strings,
+    // "pass" statements, ellipses, and statically evaluable if statements.
     private _validateTypedDictClassSuite(suiteNode: SuiteNode) {
         const emitBadStatementError = (node: ParseNode) => {
             this._evaluator.addDiagnostic(DiagnosticRule.reportGeneralTypeIssues, LocMessage.typedDictBadVar(), node);
         };
 
-        suiteNode.d.statements.forEach((statement) => {
-            if (!AnalyzerNodeInfo.isCodeUnreachable(statement)) {
-                if (statement.nodeType === ParseNodeType.StatementList) {
-                    for (const substatement of statement.d.statements) {
-                        if (
-                            substatement.nodeType !== ParseNodeType.TypeAnnotation &&
-                            substatement.nodeType !== ParseNodeType.Ellipsis &&
-                            substatement.nodeType !== ParseNodeType.StringList &&
-                            substatement.nodeType !== ParseNodeType.Pass
-                        ) {
-                            emitBadStatementError(substatement);
-                        }
-                    }
-                } else {
-                    emitBadStatementError(statement);
-                }
+        function validateStatement(statement: StatementNode) {
+            if (AnalyzerNodeInfo.isCodeUnreachable(statement)) {
+                return;
             }
-        });
+
+            if (statement.nodeType === ParseNodeType.StatementList) {
+                for (const substatement of statement.d.statements) {
+                    if (
+                        substatement.nodeType !== ParseNodeType.TypeAnnotation &&
+                        substatement.nodeType !== ParseNodeType.Ellipsis &&
+                        substatement.nodeType !== ParseNodeType.StringList &&
+                        substatement.nodeType !== ParseNodeType.Pass
+                    ) {
+                        emitBadStatementError(substatement);
+                    }
+                }
+
+                return;
+            }
+
+            if (statement.nodeType === ParseNodeType.If) {
+                const conditionValue = AnalyzerNodeInfo.getStaticConditionValue(statement);
+                if (conditionValue === undefined) {
+                    emitBadStatementError(statement);
+                    return;
+                }
+
+                const reachableSuite = conditionValue ? statement.d.ifSuite : statement.d.elseSuite;
+                if (reachableSuite?.nodeType === ParseNodeType.If) {
+                    validateStatement(reachableSuite);
+                } else if (reachableSuite) {
+                    validateSuite(reachableSuite);
+                }
+
+                return;
+            }
+
+            emitBadStatementError(statement);
+        }
+
+        function validateSuite(suite: SuiteNode) {
+            suite.d.statements.forEach((statement) => validateStatement(statement));
+        }
+
+        validateSuite(suiteNode);
     }
 
     private _validateTypeGuardFunction(node: FunctionNode, functionType: FunctionType, isMethod: boolean) {

--- a/packages/pyright-internal/src/tests/samples/typedDict26.py
+++ b/packages/pyright-internal/src/tests/samples/typedDict26.py
@@ -1,0 +1,18 @@
+# This sample tests version-conditional items in a TypedDict definition.
+
+import sys
+from typing import TypedDict
+
+
+class ConditionalTypedDict(TypedDict):
+    always: int
+    if sys.version_info >= (3, 12):
+        present: str
+    if sys.version_info >= (4, 0):
+        future: bytes
+
+
+ConditionalTypedDict(always=1, present="")
+
+# This should generate an error because the test targets Python 3.13.
+ConditionalTypedDict(always=1, present="", future=b"")

--- a/packages/pyright-internal/src/tests/samples/typedDict27.py
+++ b/packages/pyright-internal/src/tests/samples/typedDict27.py
@@ -1,0 +1,70 @@
+# This sample tests branch handling for conditional items in a TypedDict definition.
+
+import sys as _sys
+from typing import TypedDict
+
+
+class BranchingTypedDict(TypedDict):
+    if _sys.version_info < (3, 13):
+        before: int
+    elif _sys.version_info < (3, 14):
+        current: str
+    else:
+        after: bytes
+
+
+BranchingTypedDict(current="")
+
+# These should generate errors because the test targets Python 3.13.
+BranchingTypedDict(before=1)
+BranchingTypedDict(after=b"")
+
+
+class LiteralConditionalTypedDict(TypedDict):
+    if True:
+        literal: int
+    else:
+        unreachable: str
+
+
+LiteralConditionalTypedDict(literal=1)
+
+# This should generate an error because the item is in an unreachable branch.
+LiteralConditionalTypedDict(unreachable="")
+
+
+class ConditionalValueTypedDict(TypedDict):
+    if _sys.version_info >= (3, 13):
+        value: str
+    else:
+        value: int
+
+
+ConditionalValueTypedDict(value="")
+
+# This should generate an error because the active value type is str.
+ConditionalValueTypedDict(value=1)
+
+
+class DynamicConditionalTypedDict(TypedDict):
+    if False:
+        unreachable: str
+    # This should generate an error because the condition cannot be evaluated statically.
+    elif bool():
+        conditional: int
+
+
+class InvalidStatementTypedDict(TypedDict):
+    if True:
+        # This should generate an error because assignments are not allowed.
+        invalid: int = 1
+
+    if False:
+        # This statement is unreachable and should not generate an error.
+        ignored: int = 1
+
+
+class InvalidControlFlowTypedDict(TypedDict):
+    # This should generate an error because only statically evaluable if statements are allowed.
+    while False:
+        never: int

--- a/packages/pyright-internal/src/tests/typeEvaluator7.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator7.test.ts
@@ -790,6 +790,24 @@ test('TypedDict25', () => {
     TestUtils.validateResults(analysisResults, 0);
 });
 
+test('TypedDict26', () => {
+    const configOptions = new ConfigOptions(Uri.empty());
+    configOptions.defaultPythonVersion = pythonVersion3_13;
+
+    const analysisResults = TestUtils.typeAnalyzeSampleFiles(['typedDict26.py'], configOptions);
+
+    TestUtils.validateResults(analysisResults, 1);
+});
+
+test('TypedDict27', () => {
+    const configOptions = new ConfigOptions(Uri.empty());
+    configOptions.defaultPythonVersion = pythonVersion3_13;
+
+    const analysisResults = TestUtils.typeAnalyzeSampleFiles(['typedDict27.py'], configOptions);
+
+    TestUtils.validateResults(analysisResults, 7);
+});
+
 test('TypedDictInline1', () => {
     const configOptions = new ConfigOptions(Uri.empty());
     configOptions.diagnosticRuleSet.enableExperimentalFeatures = true;


### PR DESCRIPTION
## Summary
- allow statically evaluable `if`/`elif`/`else` statements in class-syntax TypedDict bodies as required by the typing spec
- reuse the binder's static-condition result so only the reachable branch contributes fields and is validated
- continue rejecting dynamically evaluated conditions and non-`if` control flow in TypedDict bodies

## Tests
- `npx jest typeEvaluator7.test -t "TypedDict2[67]" --forceExit`
- `npx jest typeEvaluator5.test typeEvaluator7.test typeEvaluator8.test -t "TypedDict|Conditional1|StaticExpression" --forceExit`
- `npm run build` (`packages/pyright-internal`)
- `npm run check:eslint -- --quiet`
- `npm run check:prettier`