### PR TITLE
Fix heterogeneous TypeVarTuple constraint solving

### DIFF
--- a/packages/pyright-internal/src/analyzer/constraintSolver.ts
+++ b/packages/pyright-internal/src/analyzer/constraintSolver.ts
@@ -1413,7 +1413,9 @@ function widenTypeForTypeVarTuple(
 
         if (evaluator.assignType(typeArg1.type, typeArg2.type, undefined, undefined, undefined, recursionCount)) {
             widenedType = typeArg1.type;
-        } else if (evaluator.assignType(typeArg2.type, typeArg1.type, undefined, undefined, undefined, recursionCount)) {
+        } else if (
+            evaluator.assignType(typeArg2.type, typeArg1.type, undefined, undefined, undefined, recursionCount)
+        ) {
             widenedType = typeArg2.type;
         } else {
             widenedType = combineTypes([typeArg1.type, typeArg2.type], {

--- a/packages/pyright-internal/src/analyzer/constraintSolver.ts
+++ b/packages/pyright-internal/src/analyzer/constraintSolver.ts
@@ -849,7 +849,7 @@ function assignUnconstrainedTypeVar(
                         newLowerBound = adjSrcType;
                     }
                 } else if (isTypeVarTuple(destType)) {
-                    const widenedType = widenTypeForTypeVarTuple(evaluator, curLowerBound, adjSrcType);
+                    const widenedType = widenTypeForTypeVarTuple(evaluator, curLowerBound, adjSrcType, isInvariant);
                     if (!widenedType) {
                         diag?.addMessage(
                             LocAddendum.typeAssignmentMismatch().format(
@@ -1344,12 +1344,12 @@ function typeVarOccursIn(typeVar: TypeVarType, type: Type): boolean {
 // For normal TypeVars, the constraint solver can widen a type by combining
 // two otherwise incompatible types into a union. For TypeVarTuples, we need
 // to do the equivalent operation for unpacked tuples.
-function widenTypeForTypeVarTuple(evaluator: TypeEvaluator, type1: Type, type2: Type): Type | undefined {
-    // The typing spec indicates that the type should always be "exactly
-    // the same type" if a TypeVarTuple is used in multiple locations.
-    // This is problematic for a number of reasons, but in the interest
-    // of sticking to the spec, we'll enforce that here.
-
+function widenTypeForTypeVarTuple(
+    evaluator: TypeEvaluator,
+    type1: Type,
+    type2: Type,
+    isInvariant: boolean
+): Type | undefined {
     // If the two types are not unpacked tuples, we can't combine them.
     if (!isUnpackedClass(type1) || !isUnpackedClass(type2)) {
         return undefined;
@@ -1367,11 +1367,55 @@ function widenTypeForTypeVarTuple(evaluator: TypeEvaluator, type1: Type, type2: 
     const strippedType1 = stripLiteralValueForUnpackedTuple(evaluator, type1);
     const strippedType2 = stripLiteralValueForUnpackedTuple(evaluator, type2);
 
+    if (!isUnpackedClass(strippedType1) || !isUnpackedClass(strippedType2)) {
+        return undefined;
+    }
+
+    const tupleTypeArgs1 = strippedType1.priv.tupleTypeArgs;
+    const tupleTypeArgs2 = strippedType2.priv.tupleTypeArgs;
+    if (!tupleTypeArgs1 || !tupleTypeArgs2) {
+        return undefined;
+    }
+
+    for (let i = 0; i < tupleTypeArgs1.length; i++) {
+        const typeArg1 = tupleTypeArgs1[i];
+        const typeArg2 = tupleTypeArgs2[i];
+
+        if (typeArg1.isUnbounded !== typeArg2.isUnbounded || !!typeArg1.isOptional !== !!typeArg2.isOptional) {
+            return undefined;
+        }
+    }
+
     if (isTypeSame(strippedType1, strippedType2)) {
         return strippedType1;
     }
 
-    return undefined;
+    if (isInvariant) {
+        return undefined;
+    }
+
+    const tupleTypeArgs: TupleTypeArg[] = tupleTypeArgs1.map((typeArg1, index) => {
+        const typeArg2 = tupleTypeArgs2[index];
+        let widenedType: Type;
+
+        if (evaluator.assignType(typeArg1.type, typeArg2.type)) {
+            widenedType = typeArg1.type;
+        } else if (evaluator.assignType(typeArg2.type, typeArg1.type)) {
+            widenedType = typeArg2.type;
+        } else {
+            widenedType = combineTypes([typeArg1.type, typeArg2.type], {
+                maxSubtypeCount: maxSubtypeCountForTypeVarLowerBound,
+            });
+        }
+
+        return {
+            type: widenedType,
+            isUnbounded: typeArg1.isUnbounded,
+            isOptional: typeArg1.isOptional,
+        };
+    });
+
+    return specializeTupleClass(strippedType1, tupleTypeArgs, /* isTypeArgExplicit */ true, /* isUnpacked */ true);
 }
 
 // If the provided type is an unpacked tuple, this function strips the

--- a/packages/pyright-internal/src/analyzer/constraintSolver.ts
+++ b/packages/pyright-internal/src/analyzer/constraintSolver.ts
@@ -849,7 +849,13 @@ function assignUnconstrainedTypeVar(
                         newLowerBound = adjSrcType;
                     }
                 } else if (isTypeVarTuple(destType)) {
-                    const widenedType = widenTypeForTypeVarTuple(evaluator, curLowerBound, adjSrcType, isInvariant);
+                    const widenedType = widenTypeForTypeVarTuple(
+                        evaluator,
+                        curLowerBound,
+                        adjSrcType,
+                        isInvariant,
+                        recursionCount
+                    );
                     if (!widenedType) {
                         diag?.addMessage(
                             LocAddendum.typeAssignmentMismatch().format(
@@ -1348,7 +1354,8 @@ function widenTypeForTypeVarTuple(
     evaluator: TypeEvaluator,
     type1: Type,
     type2: Type,
-    isInvariant: boolean
+    isInvariant: boolean,
+    recursionCount: number
 ): Type | undefined {
     // If the two types are not unpacked tuples, we can't combine them.
     if (!isUnpackedClass(type1) || !isUnpackedClass(type2)) {
@@ -1390,6 +1397,12 @@ function widenTypeForTypeVarTuple(
         return strippedType1;
     }
 
+    // The typing spec indicates that a TypeVarTuple bound in multiple locations
+    // should resolve to "exactly the same type". In an invariant context we honor
+    // that strictly and bail out when the tuples differ. In non-invariant contexts,
+    // however, requiring an exact match is overly restrictive and rejects valid
+    // heterogeneous bindings, so we instead widen element-wise (mirroring how normal
+    // TypeVars widen incompatible lower bounds into a union).
     if (isInvariant) {
         return undefined;
     }
@@ -1398,9 +1411,9 @@ function widenTypeForTypeVarTuple(
         const typeArg2 = tupleTypeArgs2[index];
         let widenedType: Type;
 
-        if (evaluator.assignType(typeArg1.type, typeArg2.type)) {
+        if (evaluator.assignType(typeArg1.type, typeArg2.type, undefined, undefined, undefined, recursionCount)) {
             widenedType = typeArg1.type;
-        } else if (evaluator.assignType(typeArg2.type, typeArg1.type)) {
+        } else if (evaluator.assignType(typeArg2.type, typeArg1.type, undefined, undefined, undefined, recursionCount)) {
             widenedType = typeArg2.type;
         } else {
             widenedType = combineTypes([typeArg1.type, typeArg2.type], {

--- a/packages/pyright-internal/src/tests/samples/typeVarTuple11.py
+++ b/packages/pyright-internal/src/tests/samples/typeVarTuple11.py
@@ -51,11 +51,11 @@ def func3(p1: tuple[int], p2: tuple[int, str], p3: tuple[int, int]):
     v4 = func2((3, "hi"), p2)
     reveal_type(v4, expected_text="str")
 
-    # This should generate an error.
-    func2((3, 3), p2)
+    v5 = func2((3, 3), p2)
+    reveal_type(v5, expected_text="int | str")
 
-    v5 = func2((3, 3), p3)
-    reveal_type(v5, expected_text="int")
+    v6 = func2((3, 3), p3)
+    reveal_type(v6, expected_text="int")
 
 
 def func4(a: int, *args: *_Xs, **kwargs: str) -> tuple[int, *_Xs]: ...
@@ -69,3 +69,11 @@ reveal_type(c2, expected_text="tuple[int]")
 
 # This should generate an error.
 c3 = func4(b="3", c="5")
+
+
+def func5(a: Array[*_Xs], b: Array[*_Xs]) -> None: ...
+
+
+def func6(a: Array[int], b: Array[str]):
+    # This should generate an error because Array is invariant.
+    func5(a, b)

--- a/packages/pyright-internal/src/tests/samples/typeVarTuple32.py
+++ b/packages/pyright-internal/src/tests/samples/typeVarTuple32.py
@@ -1,0 +1,37 @@
+# This sample tests solving a TypeVarTuple from heterogeneous arguments.
+
+from typing import TypeVarTuple
+
+Ts = TypeVarTuple("Ts")
+
+
+def same_tuple(arg1: tuple[*Ts], arg2: tuple[*Ts]) -> tuple[*Ts]:
+    raise NotImplementedError
+
+
+same_tuple((0,), ("",))
+
+
+def check_same_tuple(x: int, y: str):
+    result = same_tuple((x,), (y,))
+    reveal_type(result, expected_text="tuple[int | str]")
+
+
+class Base:
+    pass
+
+
+class Sub(Base):
+    pass
+
+
+def check_subtypes(base: Base, sub: Sub):
+    result = same_tuple((base, sub), (sub, base))
+    reveal_type(result, expected_text="tuple[Base, Base]")
+
+
+def same_args(*args: tuple[*Ts]) -> None:
+    pass
+
+
+same_args((0,), ("",))

--- a/packages/pyright-internal/src/tests/samples/typeVarTuple33.py
+++ b/packages/pyright-internal/src/tests/samples/typeVarTuple33.py
@@ -1,0 +1,347 @@
+# This sample tests realistic applications and counterexamples for solving
+# repeated TypeVarTuples from heterogeneous arguments.
+
+from typing import Any, Callable, Generic, Literal, Never, TypeVar, TypeVarTuple, overload
+
+Ts = TypeVarTuple("Ts")
+R = TypeVar("R")
+
+
+class Dimension:
+    pass
+
+
+class StaticDimension(Dimension):
+    pass
+
+
+class BatchDimension(Dimension):
+    pass
+
+
+class Tensor(Generic[*Ts]):
+    @property
+    def shape(self) -> tuple[*Ts]:
+        raise NotImplementedError
+
+
+def broadcast_shape(left: tuple[*Ts], right: tuple[*Ts]) -> tuple[*Ts]:
+    raise NotImplementedError
+
+
+def check_tensor_shapes(
+    image: Tensor[BatchDimension, StaticDimension],
+    dynamic: Tensor[BatchDimension, Dimension],
+):
+    shape = broadcast_shape(image.shape, dynamic.shape)
+    reveal_type(shape, expected_text="tuple[BatchDimension, Dimension]")
+
+
+class UserId:
+    pass
+
+
+class LegacyUserId:
+    pass
+
+
+class Payload:
+    pass
+
+
+class EncodedPayload:
+    pass
+
+
+def zip_record_types(left: tuple[*Ts], right: tuple[*Ts]) -> tuple[*Ts]:
+    raise NotImplementedError
+
+
+def check_zipped_records(
+    left: tuple[UserId, Payload],
+    right: tuple[LegacyUserId, EncodedPayload],
+):
+    row = zip_record_types(left, right)
+    reveal_type(row, expected_text="tuple[UserId | LegacyUserId, Payload | EncodedPayload]")
+
+
+def check_different_lengths(
+    short: tuple[UserId],
+    long: tuple[UserId, Payload],
+):
+    # This should generate an error because the tuple lengths differ.
+    zip_record_types(short, long)
+
+
+class FirstA:
+    pass
+
+
+class FirstB:
+    pass
+
+
+class FirstC:
+    pass
+
+
+class SecondA:
+    pass
+
+
+class SecondB:
+    pass
+
+
+class SecondC:
+    pass
+
+
+def merge_rows(*rows: tuple[*Ts]) -> tuple[*Ts]:
+    raise NotImplementedError
+
+
+def check_repeated_rows(
+    first: tuple[FirstA, SecondA],
+    second: tuple[FirstB, SecondB],
+    third: tuple[FirstC, SecondC],
+):
+    row = merge_rows(first, second, third)
+    reveal_type(row, expected_text="tuple[FirstA | FirstB | FirstC, SecondA | SecondB | SecondC]")
+
+
+literal_row = zip_record_types((1, "left"), (2, "right"))
+reveal_type(literal_row, expected_text="tuple[int, str]")
+
+
+class Base:
+    pass
+
+
+class Sub(Base):
+    pass
+
+
+def parser_base() -> tuple[Base, UserId]:
+    raise NotImplementedError
+
+
+def parser_sub() -> tuple[Sub, LegacyUserId]:
+    raise NotImplementedError
+
+
+def combine_parsers(
+    left: Callable[[], tuple[*Ts]],
+    right: Callable[[], tuple[*Ts]],
+) -> tuple[*Ts]:
+    raise NotImplementedError
+
+
+parser_result = combine_parsers(parser_base, parser_sub)
+reveal_type(parser_result, expected_text="tuple[Base, UserId | LegacyUserId]")
+
+
+def parser_short() -> tuple[UserId]:
+    raise NotImplementedError
+
+
+def parser_long() -> tuple[UserId, Payload]:
+    raise NotImplementedError
+
+
+# This should generate an error because covariance must not erase a length mismatch.
+combine_parsers(parser_short, parser_long)
+
+
+def parse_objects(identifier: object, payload: object) -> str:
+    return ""
+
+
+def parse_exact(identifier: UserId, payload: Payload) -> str:
+    return ""
+
+
+def run_examples(
+    callback: Callable[[*Ts], R],
+    first: tuple[*Ts],
+    second: tuple[*Ts],
+) -> tuple[R, tuple[*Ts]]:
+    raise NotImplementedError
+
+
+example_result = run_examples(
+    parse_objects,
+    (UserId(), Payload()),
+    (LegacyUserId(), EncodedPayload()),
+)
+reveal_type(
+    example_result,
+    expected_text="tuple[str, tuple[UserId | LegacyUserId, Payload | EncodedPayload]]",
+)
+
+
+# This should generate an error because parse_exact cannot consume the widened row.
+run_examples(
+    parse_exact,
+    (UserId(), Payload()),
+    (LegacyUserId(), EncodedPayload()),
+)
+
+
+def merge_consumers(
+    left: Callable[[*Ts], None],
+    right: Callable[[*Ts], None],
+) -> tuple[*Ts]:
+    raise NotImplementedError
+
+
+def consume_object(value: object) -> None:
+    pass
+
+
+def consume_base(value: Base) -> None:
+    pass
+
+
+def consume_user_id(value: UserId) -> None:
+    pass
+
+
+def consume_legacy_user_id(value: LegacyUserId) -> None:
+    pass
+
+
+consumer_args = merge_consumers(consume_object, consume_base)
+reveal_type(consumer_args, expected_text="tuple[Base]")
+
+
+# This should generate an error because a union is unsafe in a contravariant position.
+merge_consumers(consume_user_id, consume_legacy_user_id)
+
+
+class Array(Generic[*Ts]):
+    pass
+
+
+def combine_arrays(left: Array[*Ts], right: Array[*Ts]) -> Array[*Ts]:
+    raise NotImplementedError
+
+
+def check_invariant_arrays(
+    left: Array[BatchDimension, StaticDimension],
+    same: Array[BatchDimension, StaticDimension],
+    dynamic: Array[BatchDimension, Dimension],
+):
+    exact = combine_arrays(left, same)
+    reveal_type(exact, expected_text="Array[BatchDimension, StaticDimension]")
+
+    # This should generate an error because Array is invariant.
+    combine_arrays(left, dynamic)
+
+
+def check_special_types(any_value: Any, known: UserId, never_value: Never):
+    known_then_any = zip_record_types((known,), (any_value,))
+    reveal_type(known_then_any, expected_text="tuple[UserId]")
+
+    any_then_known = zip_record_types((any_value,), (known,))
+    reveal_type(any_then_known, expected_text="tuple[Any]")
+
+    known_then_never = zip_record_types((known,), (never_value,))
+    reveal_type(known_then_never, expected_text="tuple[UserId]")
+
+    never_then_known = zip_record_types((never_value,), (known,))
+    reveal_type(never_then_known, expected_text="tuple[UserId]")
+
+
+def check_unknown(unknown_value, known: UserId):
+    reveal_type(unknown_value, expected_text="Unknown")
+
+    known_then_unknown = zip_record_types((known,), (unknown_value,))
+    reveal_type(known_then_unknown, expected_text="tuple[UserId]")
+
+    unknown_then_known = zip_record_types((unknown_value,), (known,))
+    reveal_type(unknown_then_known, expected_text="tuple[UserId]")
+
+
+TBound = TypeVar("TBound", bound=Base)
+TConstrained = TypeVar("TConstrained", int, str)
+
+
+def merge_bound(
+    left: tuple[TBound, *Ts],
+    right: tuple[TBound, *Ts],
+) -> tuple[TBound, *Ts]:
+    raise NotImplementedError
+
+
+def merge_constrained(
+    left: tuple[TConstrained, *Ts],
+    right: tuple[TConstrained, *Ts],
+) -> tuple[TConstrained, *Ts]:
+    raise NotImplementedError
+
+
+class NotBase:
+    pass
+
+
+def check_surrounding_typevars(
+    base: Base,
+    sub: Sub,
+    not_base: NotBase,
+    user_id: UserId,
+    legacy_id: LegacyUserId,
+    flag: bool,
+):
+    bound_result = merge_bound((base, user_id), (sub, legacy_id))
+    reveal_type(bound_result, expected_text="tuple[Base, UserId | LegacyUserId]")
+
+    constrained_result = merge_constrained((1, user_id), (2 if flag else 3, legacy_id))
+    reveal_type(constrained_result, expected_text="tuple[int, UserId | LegacyUserId]")
+
+    # This should generate an error because NotBase violates TBound's bound.
+    merge_bound((base, user_id), (not_base, user_id))
+
+    # This should generate an error because a constrained TypeVar cannot widen to int | str.
+    merge_constrained((1, user_id), ("", user_id))
+
+
+@overload
+def merge_tagged(
+    tag: Literal["number"],
+    left: tuple[int, *Ts],
+    right: tuple[int, *Ts],
+) -> tuple[Literal["number"], *Ts]:
+    ...
+
+
+@overload
+def merge_tagged(
+    tag: Literal["text"],
+    left: tuple[str, *Ts],
+    right: tuple[str, *Ts],
+) -> tuple[Literal["text"], *Ts]:
+    ...
+
+
+def merge_tagged(tag: Any, left: Any, right: Any) -> Any:
+    raise NotImplementedError
+
+
+tagged_result = merge_tagged(
+    "number",
+    (1, UserId(), Payload()),
+    (2, LegacyUserId(), EncodedPayload()),
+)
+reveal_type(
+    tagged_result,
+    expected_text="tuple[Literal['number'], UserId | LegacyUserId, Payload | EncodedPayload]",
+)
+
+
+# This should generate errors because widening Ts must not hide a bad overload discriminator.
+merge_tagged(
+    "number",
+    (1, UserId()),
+    ("", UserId()),
+)

--- a/packages/pyright-internal/src/tests/samples/typeVarTuple4.py
+++ b/packages/pyright-internal/src/tests/samples/typeVarTuple4.py
@@ -55,11 +55,11 @@ def func3(p1: tuple[int], p2: tuple[int, str], p3: tuple[int, int]):
     v4 = func2((3, "hi"), p2)
     reveal_type(v4, expected_text="str")
 
-    # This should generate an error.
-    func2((3, 3), p2)
+    v5 = func2((3, 3), p2)
+    reveal_type(v5, expected_text="int | str")
 
-    v5 = func2((3, 3), p3)
-    reveal_type(v5, expected_text="int")
+    v6 = func2((3, 3), p3)
+    reveal_type(v6, expected_text="int")
 
 
 def func4(a: int, *args: Unpack[_Xs], **kwargs: str) -> tuple[int, Unpack[_Xs]]: ...
@@ -73,3 +73,11 @@ reveal_type(c2, expected_text="tuple[int]")
 
 # This should generate an error.
 c3 = func4(b="3", c="5")
+
+
+def func5(a: Array[Unpack[_Xs]], b: Array[Unpack[_Xs]]) -> None: ...
+
+
+def func6(a: Array[int], b: Array[str]):
+    # This should generate an error because Array is invariant.
+    func5(a, b)

--- a/packages/pyright-internal/src/tests/typeEvaluator6.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator6.test.ts
@@ -467,6 +467,14 @@ test('TypeVarTuple32', () => {
     TestUtils.validateResults(analysisResults, 0);
 });
 
+test('TypeVarTuple33', () => {
+    const configOptions = new ConfigOptions(Uri.empty());
+
+    configOptions.defaultPythonVersion = pythonVersion3_11;
+    const analysisResults = TestUtils.typeAnalyzeSampleFiles(['typeVarTuple33.py'], configOptions);
+    TestUtils.validateResults(analysisResults, 9);
+});
+
 test('Match1', () => {
     const configOptions = new ConfigOptions(Uri.empty());
 

--- a/packages/pyright-internal/src/tests/typeEvaluator6.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator6.test.ts
@@ -459,6 +459,14 @@ test('TypeVarTuple31', () => {
     assert.ok(!/\bOO\b/.test(revealedType), `"OO" TypeVar escaped into inferred type: ${revealedType}`);
 });
 
+test('TypeVarTuple32', () => {
+    const configOptions = new ConfigOptions(Uri.empty());
+
+    configOptions.defaultPythonVersion = pythonVersion3_11;
+    const analysisResults = TestUtils.typeAnalyzeSampleFiles(['typeVarTuple32.py'], configOptions);
+    TestUtils.validateResults(analysisResults, 0);
+});
+
 test('Match1', () => {
     const configOptions = new ConfigOptions(Uri.empty());
 


### PR DESCRIPTION
## Summary

- widen repeated `TypeVarTuple` constraints per position in non-invariant inference
- preserve precise common supertypes when one element type subsumes another, otherwise infer an element-wise union
- preserve invariant generic matching, tuple-length checks, and tuple shape metadata
- cover the upstream `generics_typevartuple_basic.py` line 90 and `generics_typevartuple_args.py` line 76 conformance cases

## Tests

- `cd packages/pyright-internal && npm run build`
- `cd packages/pyright-internal && npx jest typeEvaluator6.test typeEvaluator2.test -t "TypeVarTuple|Solver" --forceExit --runInBand`
- `cd packages/pyright-internal && npx jest typeEvaluator6.test typeEvaluator2.test -t "TypeVarTuple(4|11|32)$|Solver35$" --forceExit --runInBand`
- targeted ESLint and Prettier checks