### PR TITLE
Fix defaulted subclass type specialization

### DIFF
--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -24320,9 +24320,19 @@ export function createTypeEvaluator(
             }
         }
 
-        // A class value remains unspecialized so it can be subscripted. Apply its
-        // default type arguments when comparing it against a type specialization.
-        if (TypeBase.isInstantiable(srcType) && srcType.props?.typeForm) {
+        // A class value normally remains unspecialized so it can be subscripted.
+        // If every type parameter has an explicit default, apply those defaults
+        // when comparing it against a type specialization. Classes with one or
+        // more defaultless parameters retain their unspecialized behavior, so
+        // this cannot introduce Unknown.
+        if (
+            TypeBase.isInstantiable(srcType) &&
+            srcType.props?.typeForm &&
+            !srcType.priv.typeArgs &&
+            !srcType.priv.includeSubclasses &&
+            srcType.shared.typeParams.length > 0 &&
+            srcType.shared.typeParams.every((typeParam) => typeParam.shared.isDefaultExplicit)
+        ) {
             srcType = specializeWithDefaultTypeArgs(srcType);
         }
 

--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -24322,9 +24322,9 @@ export function createTypeEvaluator(
 
         // A class value normally remains unspecialized so it can be subscripted.
         // If every type parameter has an explicit default, apply those defaults
-        // when comparing it against a type specialization. Classes with one or
-        // more defaultless parameters retain their unspecialized behavior, so
-        // this cannot introduce Unknown.
+        // when comparing it against a type specialization. Classes with defaultless
+        // parameters or defaults that resolve directly to Any or Unknown retain
+        // their unspecialized behavior, so they don't degrade inference.
         if (
             TypeBase.isInstantiable(srcType) &&
             srcType.props?.typeForm &&
@@ -24333,7 +24333,19 @@ export function createTypeEvaluator(
             srcType.shared.typeParams.length > 0 &&
             srcType.shared.typeParams.every((typeParam) => typeParam.shared.isDefaultExplicit)
         ) {
-            srcType = specializeWithDefaultTypeArgs(srcType);
+            const specializedSrcType = specializeWithDefaultTypeArgs(srcType);
+            const specializedTypeArgs =
+                specializedSrcType.priv.typeArgs ??
+                specializedSrcType.priv.tupleTypeArgs?.map((tupleTypeArg) => tupleTypeArg.type);
+            const hasGradualTypeArg = specializedTypeArgs?.some(
+                (typeArg) =>
+                    !!containsAnyOrUnknown(typeArg, /* recurse */ false) ||
+                    (isFunction(typeArg) && FunctionType.isGradualCallableForm(typeArg)) ||
+                    (isUnpackedClass(typeArg) && !!containsAnyOrUnknown(typeArg, /* recurse */ true))
+            );
+            if (hasGradualTypeArg === false) {
+                srcType = specializedSrcType;
+            }
         }
 
         // Is it a structural type (i.e. a protocol)? If so, we need to

--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -24320,6 +24320,12 @@ export function createTypeEvaluator(
             }
         }
 
+        // A class value remains unspecialized so it can be subscripted. Apply its
+        // default type arguments when comparing it against a type specialization.
+        if (TypeBase.isInstantiable(srcType) && srcType.props?.typeForm) {
+            srcType = specializeWithDefaultTypeArgs(srcType);
+        }
+
         // Is it a structural type (i.e. a protocol)? If so, we need to
         // perform a member-by-member check.
         const inheritanceChain: InheritanceChain = [];

--- a/packages/pyright-internal/src/tests/samples/typeVarDefaultClass5.py
+++ b/packages/pyright-internal/src/tests/samples/typeVarDefaultClass5.py
@@ -1,0 +1,23 @@
+# This sample tests specialization of a subclass that retains a defaulted
+# type parameter from its base class.
+
+from typing import Generic
+
+from typing_extensions import TypeVar  # pyright: ignore[reportMissingModuleSource]
+
+T = TypeVar("T")
+DefaultT = TypeVar("DefaultT", default=str)
+
+
+class Parent(Generic[T, DefaultT]):
+    pass
+
+
+class Child(Parent[int, DefaultT]):
+    pass
+
+
+valid: type[Child[str]] = Child
+
+# This should generate an error because Child uses str for DefaultT.
+invalid: type[Child[int]] = Child

--- a/packages/pyright-internal/src/tests/samples/typeVarDefaultClass5.py
+++ b/packages/pyright-internal/src/tests/samples/typeVarDefaultClass5.py
@@ -41,8 +41,8 @@ assert_type(Child[bool](), Child[bool])
 
 
 # A subclass can also retain a type parameter that has no default. In that
-# case the retained parameter specializes to Unknown, which is assignable to
-# any specialization, so neither of the assignments below should error.
+# case the class remains unspecialized, so neither assignment below should
+# generate an error.
 class ChildNoDefault(Parent[int, U]):
     pass
 

--- a/packages/pyright-internal/src/tests/samples/typeVarDefaultClass5.py
+++ b/packages/pyright-internal/src/tests/samples/typeVarDefaultClass5.py
@@ -1,13 +1,15 @@
 # This sample tests specialization of a subclass that retains a type
 # parameter from its base class, both with and without a default.
 
-from typing import Generic
+from typing import Any, Generic, assert_type
 
 from typing_extensions import TypeVar  # pyright: ignore[reportMissingModuleSource]
 
 T = TypeVar("T")
 U = TypeVar("U")
 DefaultT = TypeVar("DefaultT", default=str)
+FunctionDefaultT = TypeVar("FunctionDefaultT", default=str)
+AnyDefaultT = TypeVar("AnyDefaultT", default=Any)
 
 
 class Parent(Generic[T, DefaultT]):
@@ -22,6 +24,7 @@ valid: type[Child[str]] = Child
 
 # This should generate an error because Child uses str for DefaultT.
 invalid: type[Child[int]] = Child
+assert_type(Child[bool](), Child[bool])
 
 
 # A subclass can also retain a type parameter that has no default. In that
@@ -33,3 +36,44 @@ class ChildNoDefault(Parent[int, U]):
 
 retained_int: type[ChildNoDefault[int]] = ChildNoDefault
 retained_str: type[ChildNoDefault[str]] = ChildNoDefault
+
+
+class ParentMixed(Generic[T, U, DefaultT]):
+    pass
+
+
+class ChildMixed(ParentMixed[int, U, DefaultT]):
+    pass
+
+
+mixed_int: type[ChildMixed[int, str]] = ChildMixed
+mixed_bool: type[ChildMixed[bool, str]] = ChildMixed
+
+
+def use_mixed_function_default(
+    cls: type[ChildMixed[FunctionDefaultT, str]],
+) -> FunctionDefaultT:
+    raise NotImplementedError
+
+
+assert_type(use_mixed_function_default(ChildMixed), str)
+
+
+class ChildAnyDefault(Parent[int, AnyDefaultT]):
+    pass
+
+
+any_default_int: type[ChildAnyDefault[int]] = ChildAnyDefault
+any_default_str: type[ChildAnyDefault[str]] = ChildAnyDefault
+
+
+class NoDefaultParent(Generic[T]):
+    pass
+
+
+def use_function_default(cls: type[NoDefaultParent[FunctionDefaultT]]) -> FunctionDefaultT:
+    raise NotImplementedError
+
+
+# A bare generic class with no default shouldn't solve another TypeVar to Unknown.
+assert_type(use_function_default(NoDefaultParent), str)

--- a/packages/pyright-internal/src/tests/samples/typeVarDefaultClass5.py
+++ b/packages/pyright-internal/src/tests/samples/typeVarDefaultClass5.py
@@ -1,11 +1,12 @@
-# This sample tests specialization of a subclass that retains a defaulted
-# type parameter from its base class.
+# This sample tests specialization of a subclass that retains a type
+# parameter from its base class, both with and without a default.
 
 from typing import Generic
 
 from typing_extensions import TypeVar  # pyright: ignore[reportMissingModuleSource]
 
 T = TypeVar("T")
+U = TypeVar("U")
 DefaultT = TypeVar("DefaultT", default=str)
 
 
@@ -21,3 +22,14 @@ valid: type[Child[str]] = Child
 
 # This should generate an error because Child uses str for DefaultT.
 invalid: type[Child[int]] = Child
+
+
+# A subclass can also retain a type parameter that has no default. In that
+# case the retained parameter specializes to Unknown, which is assignable to
+# any specialization, so neither of the assignments below should error.
+class ChildNoDefault(Parent[int, U]):
+    pass
+
+
+retained_int: type[ChildNoDefault[int]] = ChildNoDefault
+retained_str: type[ChildNoDefault[str]] = ChildNoDefault

--- a/packages/pyright-internal/src/tests/samples/typeVarDefaultClass5.py
+++ b/packages/pyright-internal/src/tests/samples/typeVarDefaultClass5.py
@@ -1,15 +1,28 @@
 # This sample tests specialization of a subclass that retains a type
 # parameter from its base class, both with and without a default.
 
-from typing import Any, Generic, assert_type
+from collections.abc import Callable
+from typing import Any, Generic, assert_type, cast
 
-from typing_extensions import TypeVar  # pyright: ignore[reportMissingModuleSource]
+from typing_extensions import (  # pyright: ignore[reportMissingModuleSource]
+    ParamSpec,
+    TypeVar,
+    TypeVarTuple,
+    Unpack,
+)
 
 T = TypeVar("T")
 U = TypeVar("U")
 DefaultT = TypeVar("DefaultT", default=str)
 FunctionDefaultT = TypeVar("FunctionDefaultT", default=str)
 AnyDefaultT = TypeVar("AnyDefaultT", default=Any)
+DependentAnyDefaultT = TypeVar("DependentAnyDefaultT", default=AnyDefaultT)
+NestedAnyDefaultT = TypeVar("NestedAnyDefaultT", default=tuple[Any, ...])
+UnionAnyDefaultT = TypeVar("UnionAnyDefaultT", default=int | Any)
+P = ParamSpec("P")
+GradualP = ParamSpec("GradualP", default=...)
+Ts = TypeVarTuple("Ts")
+GradualTs = TypeVarTuple("GradualTs", default=Unpack[tuple[Any, ...]])
 
 
 class Parent(Generic[T, DefaultT]):
@@ -65,6 +78,79 @@ class ChildAnyDefault(Parent[int, AnyDefaultT]):
 
 any_default_int: type[ChildAnyDefault[int]] = ChildAnyDefault
 any_default_str: type[ChildAnyDefault[str]] = ChildAnyDefault
+
+
+def infer_any_default(cls: type[ChildAnyDefault[T]], value: T) -> T:
+    raise NotImplementedError
+
+
+assert_type(infer_any_default(ChildAnyDefault, 1), int)
+
+
+class DependentAnyDefaults(Generic[AnyDefaultT, DependentAnyDefaultT]):
+    pass
+
+
+def infer_dependent_any_default(cls: type[DependentAnyDefaults[T, T]], value: T) -> T:
+    raise NotImplementedError
+
+
+assert_type(infer_dependent_any_default(DependentAnyDefaults, 1), int)
+
+
+class ChildNestedAnyDefault(Parent[int, NestedAnyDefaultT]):
+    pass
+
+
+def infer_nested_any_default(cls: type[ChildNestedAnyDefault[T]]) -> T:
+    raise NotImplementedError
+
+
+assert_type(infer_nested_any_default(ChildNestedAnyDefault), tuple[Any, ...])
+
+
+class ChildUnionAnyDefault(Parent[int, UnionAnyDefaultT]):
+    pass
+
+
+def infer_union_any_default(cls: type[ChildUnionAnyDefault[T]], value: T) -> T:
+    raise NotImplementedError
+
+
+assert_type(infer_union_any_default(ChildUnionAnyDefault, 1), int)
+
+
+class GradualVariadic(Generic[*GradualTs]):
+    pass
+
+
+def infer_gradual_variadic(
+    cls: type[GradualVariadic[*Ts]],
+    *values: *Ts,
+) -> tuple[*Ts]:
+    raise NotImplementedError
+
+
+assert_type(infer_gradual_variadic(GradualVariadic, 1, ""), tuple[int, str])
+
+
+class GradualCallable(Generic[GradualP]):
+    pass
+
+
+def infer_gradual_callable(
+    cls: type[GradualCallable[P]],
+    callback: Callable[P, None],
+) -> Callable[P, None]:
+    raise NotImplementedError
+
+
+def int_callback(value: int) -> None:
+    pass
+
+
+int_callable = cast(Callable[[int], None], int_callback)
+assert_type(infer_gradual_callable(GradualCallable, int_callable), Callable[[int], None])
 
 
 class NoDefaultParent(Generic[T]):

--- a/packages/pyright-internal/src/tests/samples/typeVarDefaultClass6.py
+++ b/packages/pyright-internal/src/tests/samples/typeVarDefaultClass6.py
@@ -1,0 +1,170 @@
+# This sample tests realistic registries and factories that store class objects
+# for subclasses that retain defaulted type parameters.
+
+from ctypes import py_object
+from typing import Any, Generic, TypeAlias, assert_type, reveal_type
+
+from typing_extensions import TypeVar  # pyright: ignore[reportMissingModuleSource]
+
+
+class Response:
+    pass
+
+
+class JsonResponse(Response):
+    pass
+
+
+class TextResponse(Response):
+    pass
+
+
+class UserContext:
+    pass
+
+
+ContextT = TypeVar("ContextT")
+ResponseT = TypeVar("ResponseT", default=JsonResponse)
+CovariantResponseT = TypeVar("CovariantResponseT", covariant=True, default=JsonResponse)
+TagT = TypeVar("TagT")
+RowT = TypeVar("RowT")
+DefaultRowT = TypeVar("DefaultRowT", covariant=True, default=tuple[Any, ...])
+CTypesT = TypeVar("CTypesT")
+
+
+class Handler(Generic[ContextT, ResponseT]):
+    def __init__(self, response: ResponseT | None = None):
+        self.response = response
+
+
+class UserHandler(Handler[UserContext, ResponseT]):
+    pass
+
+
+class AuditedUserHandler(UserHandler[ResponseT]):
+    pass
+
+
+class Tagged(Generic[TagT]):
+    pass
+
+
+class CachedUserHandler(AuditedUserHandler[ResponseT], Tagged[str]):
+    pass
+
+
+valid_handler: type[UserHandler[JsonResponse]] = UserHandler
+
+# This should generate an error because the retained default is JsonResponse.
+invalid_handler: type[UserHandler[TextResponse]] = UserHandler
+
+valid_base_handler: type[Handler[UserContext, JsonResponse]] = CachedUserHandler
+
+# This should generate an error through the multi-level subclass chain.
+invalid_base_handler: type[Handler[UserContext, TextResponse]] = CachedUserHandler
+
+valid_tagged_handler: type[Tagged[str]] = CachedUserHandler
+
+
+class HandlerRegistry:
+    default_handler: type[UserHandler[JsonResponse]] = UserHandler
+    audited_handlers: tuple[
+        type[UserHandler[JsonResponse]],
+        type[UserHandler[JsonResponse]],
+    ] = (AuditedUserHandler, CachedUserHandler)
+
+    # This should generate an error for a registry with the wrong specialization.
+    text_handler: type[UserHandler[TextResponse]] = UserHandler
+
+
+DefaultUserHandler: TypeAlias = UserHandler[JsonResponse]
+DefaultUserHandlerFactory: TypeAlias = type[DefaultUserHandler]
+
+aliased_factory: DefaultUserHandlerFactory = UserHandler
+explicit_factory: type[UserHandler[TextResponse]] = UserHandler[TextResponse]
+
+# This should generate an error for an explicitly specialized class object.
+invalid_aliased_factory: DefaultUserHandlerFactory = UserHandler[TextResponse]
+
+assert_type(UserHandler(), UserHandler[JsonResponse])
+assert_type(UserHandler(TextResponse()), UserHandler[TextResponse])
+assert_type(UserHandler[TextResponse](TextResponse()), UserHandler[TextResponse])
+
+
+class Plugin(Generic[ContextT, ResponseT]):
+    pass
+
+
+class FrameworkPlugin(Plugin[ContextT, ResponseT]):
+    pass
+
+
+# The leading non-defaulted parameter keeps a bare partially-defaulted class
+# unspecialized, so explicit destination arguments remain usable.
+partial_default: type[FrameworkPlugin[int, JsonResponse]] = FrameworkPlugin
+partial_override: type[FrameworkPlugin[str, TextResponse]] = FrameworkPlugin
+reveal_type(FrameworkPlugin, expected_text="type[FrameworkPlugin[Unknown, JsonResponse]]")
+
+
+def infer_plugin_context(
+    cls: type[FrameworkPlugin[ContextT, JsonResponse]],
+    context: ContextT,
+) -> ContextT:
+    raise NotImplementedError
+
+
+assert_type(infer_plugin_context(FrameworkPlugin, 1), int)
+
+
+class InvariantService(Generic[ResponseT]):
+    pass
+
+
+invariant_exact: type[InvariantService[JsonResponse]] = InvariantService
+
+# This should generate an error because ResponseT is invariant.
+invariant_wider: type[InvariantService[Response]] = InvariantService
+
+
+class CovariantService(Generic[CovariantResponseT]):
+    pass
+
+
+covariant_exact: type[CovariantService[JsonResponse]] = CovariantService
+covariant_wider: type[CovariantService[Response]] = CovariantService
+
+# This should generate an error because JsonResponse is not a TextResponse.
+covariant_unrelated: type[CovariantService[TextResponse]] = CovariantService
+
+
+class Cursor(Generic[DefaultRowT]):
+    pass
+
+
+class Connection(Generic[RowT]):
+    cursor_factory: type[Cursor[RowT]]
+
+    def __init__(self):
+        # This should generate an error because bare Cursor uses tuple[Any, ...],
+        # which is not compatible with every possible RowT.
+        self.cursor_factory = Cursor
+
+
+tuple_cursor: type[Cursor[tuple[Any, ...]]] = Cursor
+object_cursor: type[Cursor[object]] = Cursor
+
+# This should generate an error because the nested default remains concrete.
+int_cursor: type[Cursor[int]] = Cursor
+
+assert_type(Cursor(), Cursor[tuple[Any, ...]])
+assert_type(Cursor[int](), Cursor[int])
+
+
+def infer_ctypes_value(cls: type[py_object[CTypesT]], value: CTypesT) -> CTypesT:
+    raise NotImplementedError
+
+
+# py_object defaults directly to Any, so the bare class must remain gradual.
+ctypes_int: type[py_object[int]] = py_object
+ctypes_str: type[py_object[str]] = py_object
+assert_type(infer_ctypes_value(py_object, 1), int)

--- a/packages/pyright-internal/src/tests/typeEvaluator5.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator5.test.ts
@@ -259,6 +259,11 @@ test('TypeVarDefaultClass4', () => {
     TestUtils.validateResults(analysisResults, 0);
 });
 
+test('TypeVarDefaultClass5', () => {
+    const analysisResults = TestUtils.typeAnalyzeSampleFiles(['typeVarDefaultClass5.py']);
+    TestUtils.validateResults(analysisResults, 1);
+});
+
 test('TypeVarDefaultTypeAlias1', () => {
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['typeVarDefaultTypeAlias1.py']);
     TestUtils.validateResults(analysisResults, 0);

--- a/packages/pyright-internal/src/tests/typeEvaluator5.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator5.test.ts
@@ -264,6 +264,11 @@ test('TypeVarDefaultClass5', () => {
     TestUtils.validateResults(analysisResults, 1);
 });
 
+test('TypeVarDefaultClass6', () => {
+    const analysisResults = TestUtils.typeAnalyzeSampleFiles(['typeVarDefaultClass6.py']);
+    TestUtils.validateResults(analysisResults, 8);
+});
+
 test('TypeVarDefaultTypeAlias1', () => {
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['typeVarDefaultTypeAlias1.py']);
     TestUtils.validateResults(analysisResults, 0);


### PR DESCRIPTION
## Summary

Generic class values remain unspecialized so they can still be subscripted, while their `typeForm` records the default-specialized type. During `type[...]` assignability, Pyright was building the inheritance chain from that unspecialized class value, so absent source type arguments were treated permissively and a defaulted subclass could be accepted through the wrong specialization.

When every retained class type parameter has an explicit, non-gradual default, specialize the temporary source used for class assignability with `specializeWithDefaultTypeArgs`. The normal variance-aware type-argument comparison then rejects incompatible `type[...]` specializations. Classes with defaultless parameters, or defaults that resolve to top-level `Any`, `Unknown`, a gradual callable, or a gradual unpacked tuple, retain their existing unspecialized inference behavior. Structurally concrete defaults such as `tuple[Any, ...]` remain enforceable.

## Coverage

Add the `generics_defaults_specialization.py` conformance case: bare `Child` is accepted as `type[Child[str]]` and rejected as `type[Child[int]]` when the retained base type parameter defaults to `str`.

Add realistic framework and library coverage for:

- registries and factories storing `type[Subclass[...]]`
- partial specialization with a leading non-defaulted parameter
- multi-level and multiple-inheritance subclass forwarding
- aliases, explicit specialization, runtime class subscription, and constructor inference
- invariant and covariant defaulted parameters
- direct and transitive `Any`, unions containing `Any`, gradual `ParamSpec` and `TypeVarTuple` defaults, and defaultless/`Unknown` inference
- nested structural defaults containing `Any`, including a psycopg-style `Cursor[tuple[Any, ...]]`
- the real-world gradual `ctypes.py_object[Any]` counterexample

## mypy_primer audit

All eight shards completed successfully on `d72de0181`.

- **SymPy:** 38,394 -> 38,220 errors (net -174). The artifact contains 228 removed and 54 added diagnostic headers: 47 same-location text replacements, 181 pure removals, and 7 pure additions. Temporary class-name tracing found `ctypes.py_object` as the only eligible bare defaulted class reached in SymPy; its direct `Any` default is skipped by the final guard, so these sites have no semantic path through the new specialization. Classified as unrelated primer/run diagnostic churn, not a regression.
- **psycopg:** four added assignments for sync/async cursor and server-cursor factories. Their retained default is the structurally concrete `TupleRow = tuple[Any, ...]`; these are expected corrections because a bare `Cursor[TupleRow]` is not valid for every connection `Row`.
- **scikit-learn:** two same-diagnostic ndarray rendering replacements with no count change; benign text churn.
- **All other projects:** no deltas; shards 2-7 were empty.

## Precision regression report

- Failure classification: **B - Pyright limitation**
- Relevant typeshed commit: **N/A**
- Precision regressions: **none**
- Mitigation: concrete defaults are enforced only for exact bare class values whose retained parameters all have explicit, non-gradual defaults. Defaultless and gradual defaults preserve prior inference rather than materializing `Unknown` or `Any`.

## Tests

- All 1,184 type-evaluator tests
- `npx jest typeEvaluator5.test typeEvaluator8.test --runInBand --forceExit -t "TypeVarDefault|TypeForm"` (25 tests)
- `npm run build` in `packages/pyright-internal`
- `npm run build:cli:dev`
- `npm run typecheck`
- `npm run check:eslint`
- `npm run check:prettier`
- Focused CLI checks for the conformance sample, realistic registry/factory sample, `ctypes.py_object`, mixed/defaultless inference, and nested structural `Any` defaults