### PR TITLE
Support complete enum literal union equivalence

### DIFF
--- a/packages/pyright-internal/src/analyzer/binder.ts
+++ b/packages/pyright-internal/src/analyzer/binder.ts
@@ -164,6 +164,26 @@ interface NarrowExprOptions {
     allowDiscriminatedNarrowing?: boolean;
 }
 
+function isStaticClassAssignmentTarget(target: ExpressionNode): boolean {
+    switch (target.nodeType) {
+        case ParseNodeType.Name:
+            return true;
+
+        case ParseNodeType.TypeAnnotation:
+            return isStaticClassAssignmentTarget(target.d.valueExpr);
+
+        case ParseNodeType.Tuple:
+        case ParseNodeType.List:
+            return target.d.items.every((item) => isStaticClassAssignmentTarget(item));
+
+        case ParseNodeType.Unpack:
+            return isStaticClassAssignmentTarget(target.d.expr);
+
+        default:
+            return false;
+    }
+}
+
 // For each flow node within an execution context, we'll add a small
 // amount to the complexity factor. Without this, the complexity
 // calculation fails to take into account large numbers of non-cyclical
@@ -3724,6 +3744,10 @@ export class Binder extends ParseTreeWalker {
     }
 
     private _bindPossibleTupleNamedTarget(target: ExpressionNode, addedSymbols?: Map<string, Symbol>) {
+        if (this._currentScope.type === ScopeType.Class && !isStaticClassAssignmentTarget(target)) {
+            this._currentScope.hasPotentiallyDynamicSymbolTable = true;
+        }
+
         switch (target.nodeType) {
             case ParseNodeType.Name: {
                 this._bindNameToScope(this._currentScope, target, addedSymbols);

--- a/packages/pyright-internal/src/analyzer/binder.ts
+++ b/packages/pyright-internal/src/analyzer/binder.ts
@@ -184,6 +184,63 @@ function isStaticClassAssignmentTarget(target: ExpressionNode): boolean {
     }
 }
 
+function getCalledBuiltInName(
+    scope: Scope,
+    expression: ExpressionNode,
+    visitedSymbols = new Set<Symbol>()
+): string | undefined {
+    if (expression.nodeType === ParseNodeType.Name) {
+        const symbolWithScope = scope.lookUpSymbolRecursive(expression.d.value);
+        if (!symbolWithScope || visitedSymbols.has(symbolWithScope.symbol)) {
+            return undefined;
+        }
+        visitedSymbols.add(symbolWithScope.symbol);
+
+        if (symbolWithScope.scope.type === ScopeType.Builtin) {
+            return expression.d.value;
+        }
+
+        const declarations = symbolWithScope.symbol.getDeclarations();
+        const declaration = declarations[declarations.length - 1];
+        if (
+            declaration?.type === DeclarationType.Variable &&
+            (declaration.inferredTypeSource?.nodeType === ParseNodeType.Name ||
+                declaration.inferredTypeSource?.nodeType === ParseNodeType.MemberAccess)
+        ) {
+            return getCalledBuiltInName(scope, declaration.inferredTypeSource, visitedSymbols);
+        }
+
+        if (
+            declaration?.type === DeclarationType.Alias &&
+            declaration.moduleName === 'builtins' &&
+            declaration.symbolName
+        ) {
+            return declaration.symbolName;
+        }
+    } else if (
+        expression.nodeType === ParseNodeType.MemberAccess &&
+        expression.d.leftExpr.nodeType === ParseNodeType.Name
+    ) {
+        const symbolWithScope = scope.lookUpSymbolRecursive(expression.d.leftExpr.d.value);
+        const declarations = symbolWithScope?.symbol.getDeclarations() ?? [];
+        const declaration = declarations[declarations.length - 1];
+        if (
+            declaration?.type === DeclarationType.Alias &&
+            declaration.moduleName === 'builtins' &&
+            !declaration.symbolName
+        ) {
+            return expression.d.member.d.value;
+        }
+    }
+
+    return undefined;
+}
+
+function doesCallExposeClassNamespace(scope: Scope, node: CallNode): boolean {
+    const builtInName = getCalledBuiltInName(scope, node.d.leftExpr);
+    return builtInName === 'exec' || ((builtInName === 'locals' || builtInName === 'vars') && node.d.args.length === 0);
+}
+
 // For each flow node within an execution context, we'll add a small
 // amount to the complexity factor. Without this, the complexity
 // calculation fails to take into account large numbers of non-cyclical
@@ -769,6 +826,10 @@ export class Binder extends ParseTreeWalker {
     }
 
     override visitCall(node: CallNode): boolean {
+        if (this._currentScope.type === ScopeType.Class && doesCallExposeClassNamespace(this._currentScope, node)) {
+            this._currentScope.hasPotentiallyDynamicSymbolTable = true;
+        }
+
         this._disableTrueFalseTargets(() => {
             this.walk(node.d.leftExpr);
 

--- a/packages/pyright-internal/src/analyzer/binder.ts
+++ b/packages/pyright-internal/src/analyzer/binder.ts
@@ -238,7 +238,11 @@ function getCalledBuiltInName(
 
 function doesCallExposeClassNamespace(scope: Scope, node: CallNode): boolean {
     const builtInName = getCalledBuiltInName(scope, node.d.leftExpr);
-    return builtInName === 'exec' || ((builtInName === 'locals' || builtInName === 'vars') && node.d.args.length === 0);
+    return (
+        builtInName === 'exec' ||
+        (builtInName === 'eval' && node.d.args.length === 1) ||
+        ((builtInName === 'locals' || builtInName === 'vars') && node.d.args.length === 0)
+    );
 }
 
 // For each flow node within an execution context, we'll add a small

--- a/packages/pyright-internal/src/analyzer/scope.ts
+++ b/packages/pyright-internal/src/analyzer/scope.ts
@@ -122,8 +122,8 @@ export class Scope {
     slotsNames: string[] | undefined;
 
     // Indicates that the class body contains an assignment target that
-    // cannot be represented as a statically-known class symbol. Arbitrary
-    // call side effects are outside the static symbol model.
+    // cannot be represented as a statically-known class symbol or exposes
+    // its namespace to runtime mutation.
     hasPotentiallyDynamicSymbolTable = false;
 
     constructor(

--- a/packages/pyright-internal/src/analyzer/scope.ts
+++ b/packages/pyright-internal/src/analyzer/scope.ts
@@ -121,6 +121,11 @@ export class Scope {
     // for class scopes).
     slotsNames: string[] | undefined;
 
+    // Indicates that the class body contains an assignment target that
+    // cannot be represented as a statically-known class symbol. Arbitrary
+    // call side effects are outside the static symbol model.
+    hasPotentiallyDynamicSymbolTable = false;
+
     constructor(
         type: ScopeType,
         parent?: Scope,

--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -8989,6 +8989,144 @@ export function createTypeEvaluator(
         return typeFormResult;
     }
 
+    function expandEnumTypeForLiteralComparison(typeToExpand: Type, comparisonType: Type): Type {
+        if (!containsTopLevelLiteralEnum(comparisonType)) {
+            return typeToExpand;
+        }
+
+        typeToExpand = makeTopLevelTypeVarsConcrete(typeToExpand);
+        const literalEnumClasses = collectLiteralEnumClasses(comparisonType);
+        return expandEnumTypeForLiteralClasses(typeToExpand, literalEnumClasses);
+    }
+
+    function containsTopLevelLiteralEnum(type: Type): boolean {
+        if (isClassInstance(type) && ClassType.isEnumClass(type) && type.priv.literalValue instanceof EnumLiteral) {
+            return true;
+        }
+
+        if (!isUnion(type)) {
+            return false;
+        }
+
+        return type.priv.includesEnumLiteral;
+    }
+
+    function expandEnumTypeForLiteralClasses(typeToExpand: Type, literalEnumClasses: ClassType[]): Type {
+        if (literalEnumClasses.length === 0) {
+            return typeToExpand;
+        }
+
+        return mapSubtypes(typeToExpand, (subtype) => {
+            if (
+                isClassInstance(subtype) &&
+                ClassType.isEnumClass(subtype) &&
+                subtype.priv.literalValue === undefined &&
+                literalEnumClasses.some((enumClass) => ClassType.isSameGenericClass(enumClass, subtype))
+            ) {
+                const literalTypes = enumerateLiteralsForType(evaluatorInterface, subtype);
+                if (literalTypes && literalTypes.length > 0) {
+                    return combineTypes(literalTypes);
+                }
+            }
+
+            return subtype;
+        });
+    }
+
+    function collectLiteralEnumClasses(
+        type: Type,
+        literalEnumClasses: ClassType[] = [],
+        recursively = false,
+        recursionCount = 0
+    ): ClassType[] {
+        if (recursionCount > maxTypeRecursionCount) {
+            return literalEnumClasses;
+        }
+        recursionCount++;
+
+        doForEachSubtype(type, (subtype) => {
+            if (!isClass(subtype)) {
+                return;
+            }
+
+            if (
+                isClassInstance(subtype) &&
+                ClassType.isEnumClass(subtype) &&
+                subtype.priv.literalValue instanceof EnumLiteral &&
+                !literalEnumClasses.some((enumClass) => ClassType.isSameGenericClass(enumClass, subtype))
+            ) {
+                literalEnumClasses.push(subtype);
+            }
+
+            if (recursively && subtype.priv.typeArgs) {
+                if (subtype.priv.tupleTypeArgs) {
+                    subtype.priv.tupleTypeArgs.forEach((typeArg) =>
+                        collectLiteralEnumClasses(typeArg.type, literalEnumClasses, recursively, recursionCount)
+                    );
+                } else {
+                    subtype.priv.typeArgs.forEach((typeArg) =>
+                        collectLiteralEnumClasses(typeArg, literalEnumClasses, recursively, recursionCount)
+                    );
+                }
+            }
+        });
+
+        return literalEnumClasses;
+    }
+
+    function normalizeEnumTypes(typeToNormalize: Type, literalEnumClasses: ClassType[], recursionCount = 0): Type {
+        if (recursionCount > maxTypeRecursionCount) {
+            return typeToNormalize;
+        }
+        recursionCount++;
+
+        typeToNormalize = expandEnumTypeForLiteralClasses(typeToNormalize, literalEnumClasses);
+
+        if (isUnion(typeToNormalize)) {
+            return mapSubtypes(typeToNormalize, (subtype) =>
+                normalizeEnumTypes(subtype, literalEnumClasses, recursionCount)
+            );
+        }
+
+        if (!isClass(typeToNormalize) || !typeToNormalize.priv.typeArgs) {
+            return typeToNormalize;
+        }
+
+        if (typeToNormalize.priv.tupleTypeArgs) {
+            let typeChanged = false;
+            const tupleTypeArgs = typeToNormalize.priv.tupleTypeArgs.map((typeArg) => {
+                const normalizedType = normalizeEnumTypes(typeArg.type, literalEnumClasses, recursionCount);
+                if (normalizedType !== typeArg.type) {
+                    typeChanged = true;
+                }
+
+                return { ...typeArg, type: normalizedType };
+            });
+
+            return typeChanged
+                ? specializeTupleClass(
+                      typeToNormalize,
+                      tupleTypeArgs,
+                      !!typeToNormalize.priv.isTypeArgExplicit,
+                      !!typeToNormalize.priv.isUnpacked
+                  )
+                : typeToNormalize;
+        }
+
+        let typeChanged = false;
+        const typeArgs = typeToNormalize.priv.typeArgs.map((typeArg) => {
+            const normalizedType = normalizeEnumTypes(typeArg, literalEnumClasses, recursionCount);
+            if (normalizedType !== typeArg) {
+                typeChanged = true;
+            }
+            return normalizedType;
+        });
+
+        return typeChanged
+            ? ClassType.specialize(typeToNormalize, typeArgs, typeToNormalize.priv.isTypeArgExplicit)
+            : typeToNormalize;
+    }
+
     function getTypeOfAssertType(node: CallNode, inferenceContext: InferenceContext | undefined): TypeResult {
         if (
             node.d.args.length !== 2 ||
@@ -9017,13 +9155,22 @@ export function createTypeEvaluator(
         // what mypy does -- and what various library authors expect.
         const arg0Type = stripTypeGuard(arg0TypeResult.type);
 
-        if (
-            !isTypeSame(assertedType, arg0Type, {
-                treatAnySameAsUnknown: true,
-                ignorePseudoGeneric: true,
-                ignoreConditions: true,
-            })
-        ) {
+        const typeSameOptions = {
+            treatAnySameAsUnknown: true,
+            ignorePseudoGeneric: true,
+            ignoreConditions: true,
+        };
+        let typesMatch = isTypeSame(assertedType, arg0Type, typeSameOptions);
+
+        if (!typesMatch) {
+            const literalEnumClasses = collectLiteralEnumClasses(assertedType, [], /* recursively */ true);
+            collectLiteralEnumClasses(arg0Type, literalEnumClasses, /* recursively */ true);
+            const normalizedAssertedType = normalizeEnumTypes(assertedType, literalEnumClasses);
+            const normalizedArg0Type = normalizeEnumTypes(arg0Type, literalEnumClasses);
+            typesMatch = isTypeSame(normalizedAssertedType, normalizedArg0Type, typeSameOptions);
+        }
+
+        if (!typesMatch) {
             const srcDestTypes = printSrcDestTypes(arg0TypeResult.type, assertedType, { expandTypeAlias: true });
 
             addDiagnostic(
@@ -18305,6 +18452,18 @@ export function createTypeEvaluator(
 
             const effectiveMetaclass = computeEffectiveMetaclass(classType, node.d.name);
 
+            if (
+                ClassType.isEnumClass(classType) &&
+                (AnalyzerNodeInfo.getScope(node)?.hasPotentiallyDynamicSymbolTable ||
+                    !isInstantiableClass(effectiveMetaclass) ||
+                    !ClassType.isBuiltIn(effectiveMetaclass, ['EnumMeta', 'EnumType']) ||
+                    classType.shared.mro.some(
+                        (mroClass) => isClass(mroClass) && ClassType.areEnumMembersUnknown(mroClass)
+                    ))
+            ) {
+                classType.shared.flags |= ClassTypeFlags.EnumMembersUnknown;
+            }
+
             // Clear the "partially constructed" flag.
             classType.shared.flags &= ~ClassTypeFlags.PartiallyEvaluated;
 
@@ -25182,6 +25341,11 @@ export function createTypeEvaluator(
                 setConstraintsForFreeTypeVars(destType, UnknownType.create(), constraints);
             }
             return true;
+        }
+
+        srcType = expandEnumTypeForLiteralComparison(srcType, destType);
+        if ((flags & AssignTypeFlags.Invariant) !== 0) {
+            destType = expandEnumTypeForLiteralComparison(destType, srcType);
         }
 
         if (isUnion(destType)) {

--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -9038,7 +9038,7 @@ export function createTypeEvaluator(
             if (
                 isClassInstance(subtype) &&
                 ClassType.isEnumClass(subtype) &&
-                !ClassType.areEnumMembersUnknown(subtype) &&
+                !ClassType.isEnumMemberSetMayBeIncomplete(subtype) &&
                 subtype.priv.literalValue === undefined &&
                 literalEnumClasses.some((enumClass) => ClassType.isSameGenericClass(enumClass, subtype))
             ) {
@@ -18542,14 +18542,19 @@ export function createTypeEvaluator(
 
             if (
                 ClassType.isEnumClass(classType) &&
-                (AnalyzerNodeInfo.getScope(node)?.hasPotentiallyDynamicSymbolTable ||
+                (node.d.decorators.length > 0 ||
+                    AnalyzerNodeInfo.getScope(node)?.hasPotentiallyDynamicSymbolTable ||
                     !isInstantiableClass(effectiveMetaclass) ||
                     !ClassType.isBuiltIn(effectiveMetaclass, ['EnumMeta', 'EnumType']) ||
                     classType.shared.mro.some(
-                        (mroClass) => isClass(mroClass) && ClassType.areEnumMembersUnknown(mroClass)
+                        (mroClass) =>
+                            isClass(mroClass) &&
+                            (ClassType.isEnumMemberSetMayBeIncomplete(mroClass) ||
+                                (!ClassType.isBuiltIn(mroClass, 'Enum') &&
+                                    ClassType.getSymbolTable(mroClass).has('_missing_')))
                     ))
             ) {
-                classType.shared.flags |= ClassTypeFlags.EnumMembersUnknown;
+                classType.shared.flags |= ClassTypeFlags.EnumMemberSetMayBeIncomplete;
             }
 
             // Clear the "partially constructed" flag.

--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -8989,7 +8989,14 @@ export function createTypeEvaluator(
         return typeFormResult;
     }
 
-    function expandEnumTypeForLiteralComparison(typeToExpand: Type, comparisonType: Type): Type {
+    function expandEnumTypeForLiteralComparison(
+        typeToExpand: Type,
+        comparisonType: Type,
+        concretizeTypeVars: boolean
+    ): Type {
+        // Assignment checks apply this at each recursive assignType call so existing
+        // variance and constraint handling remains intact. Keep this equivalence
+        // relation aligned with the recursive normalization used by assert_type below.
         if (!containsTopLevelLiteralEnum(comparisonType)) {
             return typeToExpand;
         }
@@ -9005,7 +9012,7 @@ export function createTypeEvaluator(
         // the original type rather than replacing the TypeVar with its bound. Doing so
         // keeps unrelated invariant comparisons like `list[T]` vs `list[ColorLiterals]`
         // unaffected.
-        const concreteType = makeTopLevelTypeVarsConcrete(typeToExpand);
+        const concreteType = concretizeTypeVars ? makeTopLevelTypeVarsConcrete(typeToExpand) : typeToExpand;
         const expandedType = expandEnumTypeForLiteralClasses(concreteType, literalEnumClasses);
         return expandedType === concreteType ? typeToExpand : expandedType;
     }
@@ -9056,6 +9063,31 @@ export function createTypeEvaluator(
         }
         recursionCount++;
 
+        if (recursively && isFunction(type)) {
+            type.shared.parameters.forEach((_, index) =>
+                collectLiteralEnumClasses(
+                    FunctionType.getParamType(type, index),
+                    literalEnumClasses,
+                    recursively,
+                    recursionCount
+                )
+            );
+
+            const returnType = FunctionType.getEffectiveReturnType(type);
+            if (returnType) {
+                collectLiteralEnumClasses(returnType, literalEnumClasses, recursively, recursionCount);
+            }
+        } else if (recursively && isOverloaded(type)) {
+            OverloadedType.getOverloads(type).forEach((overload) =>
+                collectLiteralEnumClasses(overload, literalEnumClasses, recursively, recursionCount)
+            );
+
+            const implementation = OverloadedType.getImplementation(type);
+            if (implementation) {
+                collectLiteralEnumClasses(implementation, literalEnumClasses, recursively, recursionCount);
+            }
+        }
+
         doForEachSubtype(type, (subtype) => {
             if (!isClass(subtype)) {
                 return;
@@ -9098,6 +9130,47 @@ export function createTypeEvaluator(
             return mapSubtypes(typeToNormalize, (subtype) =>
                 normalizeEnumTypes(subtype, literalEnumClasses, recursionCount)
             );
+        }
+
+        if (isFunction(typeToNormalize)) {
+            let typeChanged = false;
+            const parameterTypes = typeToNormalize.shared.parameters.map((_, index) => {
+                const parameterType = FunctionType.getParamType(typeToNormalize, index);
+                const normalizedType = normalizeEnumTypes(parameterType, literalEnumClasses, recursionCount);
+                typeChanged ||= normalizedType !== parameterType;
+                return normalizedType;
+            });
+
+            const returnType = FunctionType.getEffectiveReturnType(typeToNormalize);
+            const normalizedReturnType = returnType
+                ? normalizeEnumTypes(returnType, literalEnumClasses, recursionCount)
+                : undefined;
+            typeChanged ||= normalizedReturnType !== returnType;
+
+            return typeChanged
+                ? FunctionType.specialize(typeToNormalize, {
+                      parameterTypes,
+                      parameterDefaultTypes: typeToNormalize.priv.specializedTypes?.parameterDefaultTypes,
+                      returnType: normalizedReturnType,
+                  })
+                : typeToNormalize;
+        }
+
+        if (isOverloaded(typeToNormalize)) {
+            let typeChanged = false;
+            const overloads = OverloadedType.getOverloads(typeToNormalize).map((overload) => {
+                const normalizedType = normalizeEnumTypes(overload, literalEnumClasses, recursionCount);
+                typeChanged ||= normalizedType !== overload;
+                return isFunction(normalizedType) ? normalizedType : overload;
+            });
+
+            const implementation = OverloadedType.getImplementation(typeToNormalize);
+            const normalizedImplementation = implementation
+                ? normalizeEnumTypes(implementation, literalEnumClasses, recursionCount)
+                : undefined;
+            typeChanged ||= normalizedImplementation !== implementation;
+
+            return typeChanged ? OverloadedType.create(overloads, normalizedImplementation) : typeToNormalize;
         }
 
         if (!isClass(typeToNormalize) || !typeToNormalize.priv.typeArgs) {
@@ -9175,6 +9248,9 @@ export function createTypeEvaluator(
         let typesMatch = isTypeSame(assertedType, arg0Type, typeSameOptions);
 
         if (!typesMatch) {
+            // Unlike assignType, assert_type requires exact structural identity, so
+            // normalize both types recursively. Keep this equivalence relation aligned
+            // with expandEnumTypeForLiteralComparison, which assignType applies as it recurses.
             const literalEnumClasses = collectLiteralEnumClasses(assertedType, [], /* recursively */ true);
             collectLiteralEnumClasses(arg0Type, literalEnumClasses, /* recursively */ true);
             const normalizedAssertedType = normalizeEnumTypes(assertedType, literalEnumClasses);
@@ -25355,9 +25431,10 @@ export function createTypeEvaluator(
             return true;
         }
 
-        srcType = expandEnumTypeForLiteralComparison(srcType, destType);
-        if ((flags & AssignTypeFlags.Invariant) !== 0) {
-            destType = expandEnumTypeForLiteralComparison(destType, srcType);
+        const isInvariant = (flags & AssignTypeFlags.Invariant) !== 0;
+        srcType = expandEnumTypeForLiteralComparison(srcType, destType, /* concretizeTypeVars */ !isInvariant);
+        if (isInvariant) {
+            destType = expandEnumTypeForLiteralComparison(destType, srcType, /* concretizeTypeVars */ false);
         }
 
         if (isUnion(destType)) {

--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -9031,6 +9031,7 @@ export function createTypeEvaluator(
             if (
                 isClassInstance(subtype) &&
                 ClassType.isEnumClass(subtype) &&
+                !ClassType.areEnumMembersUnknown(subtype) &&
                 subtype.priv.literalValue === undefined &&
                 literalEnumClasses.some((enumClass) => ClassType.isSameGenericClass(enumClass, subtype))
             ) {
@@ -27828,6 +27829,19 @@ export function createTypeEvaluator(
                 // Retain unknowns for code flow analysis convergence and for
                 // unknown type reporting in strict mode.
                 if (isUnknown(assignedSubtype)) {
+                    return assignedSubtype;
+                }
+
+                // Preserve assignment narrowing when an enum literal is assigned
+                // to its non-literal enum class. A single-member enum is equivalent
+                // to its only literal, but the assigned value is still more precise.
+                if (
+                    isClassInstance(assignedSubtype) &&
+                    assignedSubtype.priv.literalValue instanceof EnumLiteral &&
+                    isClassInstance(declaredSubtype) &&
+                    declaredSubtype.priv.literalValue === undefined &&
+                    ClassType.isSameGenericClass(assignedSubtype, declaredSubtype)
+                ) {
                     return assignedSubtype;
                 }
 

--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -8994,9 +8994,20 @@ export function createTypeEvaluator(
             return typeToExpand;
         }
 
-        typeToExpand = makeTopLevelTypeVarsConcrete(typeToExpand);
         const literalEnumClasses = collectLiteralEnumClasses(comparisonType);
-        return expandEnumTypeForLiteralClasses(typeToExpand, literalEnumClasses);
+        if (literalEnumClasses.length === 0) {
+            return typeToExpand;
+        }
+
+        // Concretize top-level TypeVars only to probe for a matching enum subtype.
+        // If no enum expansion actually occurs (for example, an unrelated source
+        // TypeVar whose bound is not one of the comparison's enum classes), preserve
+        // the original type rather than replacing the TypeVar with its bound. Doing so
+        // keeps unrelated invariant comparisons like `list[T]` vs `list[ColorLiterals]`
+        // unaffected.
+        const concreteType = makeTopLevelTypeVarsConcrete(typeToExpand);
+        const expandedType = expandEnumTypeForLiteralClasses(concreteType, literalEnumClasses);
+        return expandedType === concreteType ? typeToExpand : expandedType;
     }
 
     function containsTopLevelLiteralEnum(type: Type): boolean {

--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -18539,11 +18539,21 @@ export function createTypeEvaluator(
             }
 
             const effectiveMetaclass = computeEffectiveMetaclass(classType, node.d.name);
+            const enumMemberSetMayBeDynamicallyModified =
+                ClassType.isEnumClass(classType) &&
+                (AnalyzerNodeInfo.getScope(node)?.hasPotentiallyDynamicSymbolTable ||
+                    classType.shared.mro.some(
+                        (mroClass) => isClass(mroClass) && ClassType.isEnumMemberSetMayBeDynamicallyModified(mroClass)
+                    ));
+
+            if (enumMemberSetMayBeDynamicallyModified) {
+                classType.shared.flags |= ClassTypeFlags.EnumMemberSetMayBeDynamicallyModified;
+            }
 
             if (
                 ClassType.isEnumClass(classType) &&
                 (node.d.decorators.length > 0 ||
-                    AnalyzerNodeInfo.getScope(node)?.hasPotentiallyDynamicSymbolTable ||
+                    enumMemberSetMayBeDynamicallyModified ||
                     !isInstantiableClass(effectiveMetaclass) ||
                     !ClassType.isBuiltIn(effectiveMetaclass, ['EnumMeta', 'EnumType']) ||
                     classType.shared.mro.some(

--- a/packages/pyright-internal/src/analyzer/typeGuards.ts
+++ b/packages/pyright-internal/src/analyzer/typeGuards.ts
@@ -2770,9 +2770,12 @@ export function enumerateLiteralsForType(evaluator: TypeEvaluator, type: ClassTy
     }
 
     if (ClassType.isEnumClass(type)) {
-        // Enum expansion doesn't apply to enum classes that derive
-        // from enum.Flag.
-        if (type.shared.mro.some((mroClass) => isClass(mroClass) && ClassType.isBuiltIn(mroClass, 'Flag'))) {
+        // Enum expansion doesn't apply if the member set cannot be statically
+        // enumerated or if the class derives from enum.Flag.
+        if (
+            ClassType.isEnumMemberSetMayBeDynamicallyModified(type) ||
+            type.shared.mro.some((mroClass) => isClass(mroClass) && ClassType.isBuiltIn(mroClass, 'Flag'))
+        ) {
             return undefined;
         }
 

--- a/packages/pyright-internal/src/analyzer/typeGuards.ts
+++ b/packages/pyright-internal/src/analyzer/typeGuards.ts
@@ -2772,7 +2772,10 @@ export function enumerateLiteralsForType(evaluator: TypeEvaluator, type: ClassTy
     if (ClassType.isEnumClass(type)) {
         // Enum expansion doesn't apply to enum classes that derive
         // from enum.Flag.
-        if (type.shared.baseClasses.some((baseClass) => isClass(baseClass) && ClassType.isBuiltIn(baseClass, 'Flag'))) {
+        if (
+            ClassType.areEnumMembersUnknown(type) ||
+            type.shared.mro.some((mroClass) => isClass(mroClass) && ClassType.isBuiltIn(mroClass, 'Flag'))
+        ) {
             return undefined;
         }
 

--- a/packages/pyright-internal/src/analyzer/typeGuards.ts
+++ b/packages/pyright-internal/src/analyzer/typeGuards.ts
@@ -2772,10 +2772,7 @@ export function enumerateLiteralsForType(evaluator: TypeEvaluator, type: ClassTy
     if (ClassType.isEnumClass(type)) {
         // Enum expansion doesn't apply to enum classes that derive
         // from enum.Flag.
-        if (
-            ClassType.areEnumMembersUnknown(type) ||
-            type.shared.mro.some((mroClass) => isClass(mroClass) && ClassType.isBuiltIn(mroClass, 'Flag'))
-        ) {
+        if (type.shared.mro.some((mroClass) => isClass(mroClass) && ClassType.isBuiltIn(mroClass, 'Flag'))) {
             return undefined;
         }
 

--- a/packages/pyright-internal/src/analyzer/types.ts
+++ b/packages/pyright-internal/src/analyzer/types.ts
@@ -674,6 +674,10 @@ export const enum ClassTypeFlags {
     // The statically-known enum members may not represent the complete
     // runtime member set.
     EnumMemberSetMayBeIncomplete = 1 << 25,
+
+    // The enum class body can modify its namespace in a way that the binder
+    // cannot represent as statically-known member symbols.
+    EnumMemberSetMayBeDynamicallyModified = 1 << 26,
 }
 
 export interface DataClassBehaviors {
@@ -1249,6 +1253,10 @@ export namespace ClassType {
 
     export function isEnumMemberSetMayBeIncomplete(classType: ClassType) {
         return !!(classType.shared.flags & ClassTypeFlags.EnumMemberSetMayBeIncomplete);
+    }
+
+    export function isEnumMemberSetMayBeDynamicallyModified(classType: ClassType) {
+        return !!(classType.shared.flags & ClassTypeFlags.EnumMemberSetMayBeDynamicallyModified);
     }
 
     export function isPropertyClass(classType: ClassType) {

--- a/packages/pyright-internal/src/analyzer/types.ts
+++ b/packages/pyright-internal/src/analyzer/types.ts
@@ -670,6 +670,10 @@ export const enum ClassTypeFlags {
     // This class is rejected when used as the second argument to
     // an isinstance or issubclass call.
     IllegalIsinstanceClass = 1 << 24,
+
+    // The statically-known enum members may not represent the complete
+    // runtime member set.
+    EnumMembersUnknown = 1 << 25,
 }
 
 export interface DataClassBehaviors {
@@ -1241,6 +1245,10 @@ export namespace ClassType {
 
     export function isEnumClass(classType: ClassType) {
         return !!(classType.shared.flags & ClassTypeFlags.EnumClass);
+    }
+
+    export function areEnumMembersUnknown(classType: ClassType) {
+        return !!(classType.shared.flags & ClassTypeFlags.EnumMembersUnknown);
     }
 
     export function isPropertyClass(classType: ClassType) {
@@ -2602,6 +2610,7 @@ export interface UnionDetailsPriv {
     literalClasses: LiteralTypes;
     typeAliasSources: Set<UnionType> | undefined;
     includesRecursiveTypeAlias: boolean;
+    includesEnumLiteral: boolean;
 }
 
 export interface UnionType extends TypeBase<TypeCategory.Union> {
@@ -2630,6 +2639,7 @@ export namespace UnionType {
                 },
                 typeAliasSources: undefined,
                 includesRecursiveTypeAlias: false,
+                includesEnumLiteral: false,
             },
         };
 
@@ -2637,6 +2647,10 @@ export namespace UnionType {
     }
 
     export function addType(unionType: UnionType, newType: UnionableType) {
+        if (isClass(newType) && ClassType.isEnumClass(newType) && newType.priv.literalValue instanceof EnumLiteral) {
+            unionType.priv.includesEnumLiteral = true;
+        }
+
         // If we're adding a string, integer or enum literal, add it to the
         // corresponding literal map to speed up some operations. It's not
         // uncommon for unions to contain hundreds of literals.

--- a/packages/pyright-internal/src/analyzer/types.ts
+++ b/packages/pyright-internal/src/analyzer/types.ts
@@ -673,7 +673,7 @@ export const enum ClassTypeFlags {
 
     // The statically-known enum members may not represent the complete
     // runtime member set.
-    EnumMembersUnknown = 1 << 25,
+    EnumMemberSetMayBeIncomplete = 1 << 25,
 }
 
 export interface DataClassBehaviors {
@@ -1247,8 +1247,8 @@ export namespace ClassType {
         return !!(classType.shared.flags & ClassTypeFlags.EnumClass);
     }
 
-    export function areEnumMembersUnknown(classType: ClassType) {
-        return !!(classType.shared.flags & ClassTypeFlags.EnumMembersUnknown);
+    export function isEnumMemberSetMayBeIncomplete(classType: ClassType) {
+        return !!(classType.shared.flags & ClassTypeFlags.EnumMemberSetMayBeIncomplete);
     }
 
     export function isPropertyClass(classType: ClassType) {
@@ -2610,6 +2610,7 @@ export interface UnionDetailsPriv {
     literalClasses: LiteralTypes;
     typeAliasSources: Set<UnionType> | undefined;
     includesRecursiveTypeAlias: boolean;
+    // This cached value relies on all union construction adding subtypes through UnionType.addType.
     includesEnumLiteral: boolean;
 }
 

--- a/packages/pyright-internal/src/tests/samples/enum15.py
+++ b/packages/pyright-internal/src/tests/samples/enum15.py
@@ -135,6 +135,23 @@ def test_callable_equivalence(
     )  # This should generate an error
 
 
+def test_nested_shape_parity(
+    enum_shape: tuple[list[Color], Callable[[Color], Color]],
+    literal_shape: tuple[
+        list[ColorLiterals], Callable[[ColorLiterals], ColorLiterals]
+    ],
+) -> None:
+    assignment1: tuple[
+        list[ColorLiterals], Callable[[ColorLiterals], ColorLiterals]
+    ] = enum_shape
+    assignment2: tuple[list[Color], Callable[[Color], Color]] = literal_shape
+    assert_type(
+        enum_shape,
+        tuple[list[ColorLiterals], Callable[[ColorLiterals], ColorLiterals]],
+    )
+    assert_type(literal_shape, tuple[list[Color], Callable[[Color], Color]])
+
+
 class Number(IntEnum):
     ONE = 1
     TWO = 2
@@ -226,6 +243,14 @@ def test_flag_narrowing(
         pass
     else:
         assert_type(indirect, IndirectFlags)
+
+
+def test_indirect_flag_match(value: IndirectFlags) -> int:  # This should generate an error
+    match value:
+        case IndirectFlags.FIRST:
+            return 1
+        case IndirectFlags.SECOND:
+            return 2
 
 
 direct_combination = DirectFlags.FIRST | DirectFlags.SECOND
@@ -402,6 +427,33 @@ def test_dynamic_assigned_alias(value: DynamicAssignedAlias) -> None:
     dynamic_literal: DynamicAssignedAliasLiteral = value  # This should generate an error
 
 
+class DynamicEval(Enum):
+    FIRST = 1
+    eval("locals().update({'SECOND': 2})")
+
+
+DynamicEvalLiteral = Literal[DynamicEval.FIRST]
+
+
+def test_dynamic_eval(value: DynamicEval) -> None:
+    dynamic_literal: DynamicEvalLiteral = value  # This should generate an error
+
+
+run_eval = eval
+
+
+class DynamicEvalAlias(Enum):
+    FIRST = 1
+    run_eval("locals().update({'SECOND': 2})")
+
+
+DynamicEvalAliasLiteral = Literal[DynamicEvalAlias.FIRST]
+
+
+def test_dynamic_eval_alias(value: DynamicEvalAlias) -> None:
+    dynamic_literal: DynamicEvalAliasLiteral = value  # This should generate an error
+
+
 class ShadowedLocals(Enum):
     FIRST = 1
     SECOND = 2
@@ -454,3 +506,38 @@ def test_custom_metaclass_exhaustiveness(value: CustomMetaEnum) -> int:
 def test_custom_metaclass_assignment_narrowing() -> None:
     value: CustomMetaEnum = CustomMetaEnum.FIRST
     reveal_type(value, expected_text="Literal[CustomMetaEnum.FIRST]")
+
+
+class MissingValueEnum(Enum):
+    FIRST = 1
+
+    @classmethod
+    def _missing_(cls, value: object) -> "MissingValueEnum":
+        return object.__new__(cls)
+
+
+MissingValueEnumLiteral = Literal[MissingValueEnum.FIRST]
+
+
+def test_missing_value_hook(value: MissingValueEnum) -> None:
+    literal_value: MissingValueEnumLiteral = value  # This should generate an error
+
+
+def install_missing_hook[T](cls: type[T]) -> type[T]:
+    def missing(cls: type[T], value: object) -> T:
+        return object.__new__(cls)
+
+    setattr(cls, "_missing_", classmethod(missing))
+    return cls
+
+
+@install_missing_hook
+class DecoratedEnum(Enum):
+    FIRST = 1
+
+
+DecoratedEnumLiteral = Literal[DecoratedEnum.FIRST]
+
+
+def test_decorated_enum(value: DecoratedEnum) -> None:
+    literal_value: DecoratedEnumLiteral = value  # This should generate an error

--- a/packages/pyright-internal/src/tests/samples/enum15.py
+++ b/packages/pyright-internal/src/tests/samples/enum15.py
@@ -229,6 +229,25 @@ def return_bound_enum[T: Color](value: T, other: T) -> ColorLiterals:
     return value
 
 
+def test_type_var_invariant_source[T: Color, U: int](
+    enum_bound_list: list[T],
+    unrelated_list: list[U],
+    literal_color_list: list[ColorLiterals],
+) -> None:
+    # A source TypeVar bound to the enum expands in an invariant position, so
+    # list[T] and list[ColorLiterals] are treated as equivalent in both
+    # directions.
+    to_literals: list[ColorLiterals] = enum_bound_list
+    assert_type(enum_bound_list, list[T])
+
+    # An unrelated source TypeVar must not be collapsed to its bound while
+    # probing for enum expansion, so the invariant comparison still fails and
+    # the TypeVar remains intact.
+    bad_to_literals: list[ColorLiterals] = unrelated_list  # This should generate an error
+    bad_from_literals: list[U] = literal_color_list  # This should generate an error
+    assert_type(unrelated_list, list[U])
+
+
 def test_assignment_narrowing() -> None:
     color: Color = Color.RED
     assert_type(color, Literal[Color.RED])

--- a/packages/pyright-internal/src/tests/samples/enum15.py
+++ b/packages/pyright-internal/src/tests/samples/enum15.py
@@ -2,7 +2,7 @@
 # their literal members.
 
 from enum import Enum, EnumType, Flag, IntEnum, IntFlag, StrEnum, auto
-from typing import Literal, assert_type
+from typing import Final, Literal, assert_type
 
 
 class Color(Enum):
@@ -60,6 +60,18 @@ def test_single_member_equivalence(single: Single, literal_single: SingleLiteral
     value2: Single = literal_single
     assert_type(single, SingleLiteral)
     assert_type(literal_single, Single)
+
+
+SINGLE_DEFAULT: Final[Single] = Single.ONLY
+
+
+def test_single_member_narrowing(value: Single | float | None) -> float | None:
+    if value is SINGLE_DEFAULT:
+        reveal_type(value, expected_text="Literal[Single.ONLY]")
+        return None
+
+    reveal_type(value, expected_text="float | None")
+    return value
 
 
 def test_union_equivalence(
@@ -250,7 +262,11 @@ def test_type_var_invariant_source[T: Color, U: int](
 
 def test_assignment_narrowing() -> None:
     color: Color = Color.RED
+    single: Single = Single.ONLY
+    flag: DirectFlags = DirectFlags.FIRST
     assert_type(color, Literal[Color.RED])
+    reveal_type(single, expected_text="Literal[Single.ONLY]")
+    reveal_type(flag, expected_text="Literal[DirectFlags.FIRST]")
 
 
 class Aliased(Enum):
@@ -336,4 +352,19 @@ def test_custom_metaclass(value: CustomMetaEnum) -> None:
     if value is CustomMetaEnum.FIRST:
         pass
     else:
-        assert_type(value, CustomMetaEnum)
+        assert_type(value, Literal[CustomMetaEnum.SECOND])
+
+
+def test_custom_metaclass_exhaustiveness(value: CustomMetaEnum) -> int:
+    # Closedness gates complete-union equivalence without changing the existing
+    # narrowing and exhaustiveness behavior for statically known members.
+    match value:
+        case CustomMetaEnum.FIRST:
+            return 1
+        case CustomMetaEnum.SECOND:
+            return 2
+
+
+def test_custom_metaclass_assignment_narrowing() -> None:
+    value: CustomMetaEnum = CustomMetaEnum.FIRST
+    reveal_type(value, expected_text="Literal[CustomMetaEnum.FIRST]")

--- a/packages/pyright-internal/src/tests/samples/enum15.py
+++ b/packages/pyright-internal/src/tests/samples/enum15.py
@@ -1,7 +1,7 @@
 # This sample tests equivalence between enum classes and complete unions of
 # their literal members.
 
-from enum import Enum, EnumType, Flag, IntEnum, IntFlag, StrEnum, auto
+from enum import Enum, EnumType, Flag, IntEnum, IntFlag, StrEnum, auto, unique
 import builtins
 from collections.abc import Callable
 from typing import Final, Literal, assert_type
@@ -541,3 +541,19 @@ DecoratedEnumLiteral = Literal[DecoratedEnum.FIRST]
 
 def test_decorated_enum(value: DecoratedEnum) -> None:
     literal_value: DecoratedEnumLiteral = value  # This should generate an error
+
+
+@unique
+class UniqueEnum(Enum):
+    FIRST = 1
+    SECOND = 2
+
+
+UniqueEnumLiterals = Literal[UniqueEnum.FIRST, UniqueEnum.SECOND]
+
+
+def test_member_preserving_decorator(value: UniqueEnum) -> None:
+    # Even known member-preserving decorators are treated conservatively because
+    # arbitrary class decorators can add or remove enum members at runtime.
+    literal_value: UniqueEnumLiterals = value  # This should generate an error
+    assert_type(value, UniqueEnumLiterals)  # This should generate an error

--- a/packages/pyright-internal/src/tests/samples/enum15.py
+++ b/packages/pyright-internal/src/tests/samples/enum15.py
@@ -1,0 +1,320 @@
+# This sample tests equivalence between enum classes and complete unions of
+# their literal members.
+
+from enum import Enum, EnumType, Flag, IntEnum, IntFlag, StrEnum, auto
+from typing import Literal, assert_type
+
+
+class Color(Enum):
+    RED = 1
+    GREEN = 2
+    BLUE = 3
+
+
+ColorLiterals = Literal[Color.RED, Color.GREEN, Color.BLUE]
+
+
+def test_simple_equivalence(color: Color, literal_color: ColorLiterals) -> None:
+    value1: ColorLiterals = color
+    value2: Color = literal_color
+    assert_type(color, ColorLiterals)
+    assert_type(literal_color, Color)
+
+
+PartialColorLiterals = Literal[Color.RED, Color.GREEN]
+ColorLiteralSuperset = Literal[Color.RED, Color.GREEN, Color.BLUE, 0]
+
+
+def test_incomplete_and_superset_unions(
+    color: Color,
+    partial_color: PartialColorLiterals,
+    color_superset: ColorLiteralSuperset,
+    color_list: list[Color],
+    partial_color_list: list[PartialColorLiterals],
+    color_superset_list: list[ColorLiteralSuperset],
+) -> None:
+    partial: PartialColorLiterals = color  # This should generate an error
+    superset: ColorLiteralSuperset = color
+    enum_value: Color = partial_color
+    assert_type(color, PartialColorLiterals)  # This should generate an error
+    assert_type(partial_color, Color)  # This should generate an error
+    assert_type(color, ColorLiteralSuperset)  # This should generate an error
+    assert_type(superset, Color)
+    assert_type(color_superset, Color)  # This should generate an error
+
+    partial_list1: list[PartialColorLiterals] = color_list  # This should generate an error
+    partial_list2: list[Color] = partial_color_list  # This should generate an error
+    superset_list1: list[ColorLiteralSuperset] = color_list  # This should generate an error
+    superset_list2: list[Color] = color_superset_list  # This should generate an error
+
+
+class Single(Enum):
+    ONLY = 1
+
+
+SingleLiteral = Literal[Single.ONLY]
+
+
+def test_single_member_equivalence(single: Single, literal_single: SingleLiteral) -> None:
+    value1: SingleLiteral = single
+    value2: Single = literal_single
+    assert_type(single, SingleLiteral)
+    assert_type(literal_single, Single)
+
+
+def test_union_equivalence(
+    color_or_int: Color | int, literal_color_or_int: ColorLiterals | int
+) -> None:
+    value1: ColorLiterals | int = color_or_int
+    value2: Color | int = literal_color_or_int
+    assert_type(color_or_int, ColorLiterals | int)
+    assert_type(literal_color_or_int, Color | int)
+
+
+def test_invariant_identity(
+    color_list: list[Color],
+    color_dict: dict[Color, int],
+    color_or_int_list: list[Color | int],
+) -> None:
+    value1: list[Color] = color_list
+    value2: dict[Color, int] = color_dict
+    value3: list[Color | int] = color_or_int_list
+    assert_type(color_list, list[Color])
+    assert_type(color_dict, dict[Color, int])
+    assert_type(color_or_int_list, list[Color | int])
+
+
+def test_invariant_equivalence(
+    color_list: list[Color],
+    literal_color_list: list[ColorLiterals],
+    color_dict: dict[Color, int],
+    literal_color_dict: dict[ColorLiterals, int],
+    color_or_int_list: list[Color | int],
+    literal_color_or_int_list: list[ColorLiterals | int],
+) -> None:
+    value1: list[ColorLiterals] = color_list
+    value2: list[Color] = literal_color_list
+    value3: dict[ColorLiterals, int] = color_dict
+    value4: dict[Color, int] = literal_color_dict
+    value5: list[ColorLiterals | int] = color_or_int_list
+    value6: list[Color | int] = literal_color_or_int_list
+    assert_type(color_list, list[ColorLiterals])
+    assert_type(literal_color_list, list[Color])
+    assert_type(color_dict, dict[ColorLiterals, int])
+    assert_type(literal_color_dict, dict[Color, int])
+    assert_type(color_or_int_list, list[ColorLiterals | int])
+    assert_type(literal_color_or_int_list, list[Color | int])
+
+
+class Number(IntEnum):
+    ONE = 1
+    TWO = 2
+
+
+NumberLiterals = Literal[Number.ONE, Number.TWO]
+
+
+class Text(StrEnum):
+    FIRST = "first"
+    SECOND = "second"
+
+
+TextLiterals = Literal[Text.FIRST, Text.SECOND]
+
+
+def test_non_flag_enum_subclasses(
+    number: Number, literal_number: NumberLiterals, text: Text, literal_text: TextLiterals
+) -> None:
+    number_value1: NumberLiterals = number
+    number_value2: Number = literal_number
+    text_value1: TextLiterals = text
+    text_value2: Text = literal_text
+    assert_type(number, NumberLiterals)
+    assert_type(literal_number, Number)
+    assert_type(text, TextLiterals)
+    assert_type(literal_text, Text)
+
+
+class Automatic(Enum):
+    FIRST = auto()
+    SECOND = auto()
+
+
+AutomaticLiterals = Literal[Automatic.FIRST, Automatic.SECOND]
+
+
+def test_auto_values(
+    value: Automatic, literal_value: AutomaticLiterals
+) -> None:
+    value1: AutomaticLiterals = value
+    value2: Automatic = literal_value
+    assert_type(value, AutomaticLiterals)
+    assert_type(literal_value, Automatic)
+
+
+class DirectFlags(Flag):
+    FIRST = 1
+    SECOND = 2
+
+
+DirectFlagLiterals = Literal[DirectFlags.FIRST, DirectFlags.SECOND]
+
+
+class IntegerFlags(IntFlag):
+    FIRST = 1
+    SECOND = 2
+
+
+IntegerFlagLiterals = Literal[IntegerFlags.FIRST, IntegerFlags.SECOND]
+
+
+class FlagBase(Flag):
+    pass
+
+
+class IndirectFlags(FlagBase):
+    FIRST = 1
+    SECOND = 2
+
+
+IndirectFlagLiterals = Literal[IndirectFlags.FIRST, IndirectFlags.SECOND]
+
+
+def test_flag_narrowing(
+    direct: DirectFlags, integer: IntegerFlags, indirect: IndirectFlags
+) -> None:
+    if direct is DirectFlags.FIRST:
+        pass
+    else:
+        assert_type(direct, DirectFlags)
+
+    if integer is IntegerFlags.FIRST:
+        pass
+    else:
+        assert_type(integer, IntegerFlags)
+
+    if indirect is IndirectFlags.FIRST:
+        pass
+    else:
+        assert_type(indirect, IndirectFlags)
+
+
+direct_combination = DirectFlags.FIRST | DirectFlags.SECOND
+integer_combination = IntegerFlags.FIRST | IntegerFlags.SECOND
+indirect_combination = IndirectFlags.FIRST | IndirectFlags.SECOND
+
+# These should generate errors because arbitrary combined flag values are not
+# equivalent to a union of the declared flag members.
+direct_literal: DirectFlagLiterals = direct_combination  # This should generate an error
+integer_literal: IntegerFlagLiterals = integer_combination  # This should generate an error
+indirect_literal: IndirectFlagLiterals = indirect_combination  # This should generate an error
+
+
+def infer_optional[T](value: T | None) -> T:
+    assert value is not None
+    return value
+
+
+def choose[T](left: T, right: T) -> T:
+    return left
+
+
+def test_type_var_inference(color: Color, literal_color: ColorLiterals) -> None:
+    assert_type(infer_optional(color), Color)
+    assert_type(choose(color, literal_color), Color)
+    assert_type(choose(literal_color, color), Color)
+
+
+def return_bound_enum[T: Color](value: T, other: T) -> ColorLiterals:
+    return value
+
+
+def test_assignment_narrowing() -> None:
+    color: Color = Color.RED
+    assert_type(color, Literal[Color.RED])
+
+
+class Aliased(Enum):
+    FIRST = 1
+    ALSO_FIRST = FIRST
+    SECOND = 2
+
+
+AliasedLiterals = Literal[Aliased.FIRST, Aliased.SECOND]
+
+
+def test_aliases(value: Aliased, literal_value: AliasedLiterals) -> None:
+    value1: AliasedLiterals = value
+    value2: Aliased = literal_value
+    assert_type(value, AliasedLiterals)
+    assert_type(literal_value, Aliased)
+
+
+def get_unknown_value() -> object:
+    return object()
+
+
+class UnknownValues(Enum):
+    FIRST = get_unknown_value()
+    SECOND = get_unknown_value()
+
+
+UnknownValueLiterals = Literal[UnknownValues.FIRST, UnknownValues.SECOND]
+
+
+def test_unknown_values(
+    value: UnknownValues, literal_value: UnknownValueLiterals
+) -> None:
+    value1: UnknownValueLiterals = value
+    value2: UnknownValues = literal_value
+    assert_type(value, UnknownValueLiterals)
+    assert_type(literal_value, UnknownValues)
+
+
+class Empty(Enum):
+    pass
+
+
+def test_empty_enum(value: Empty) -> None:
+    value2: Empty = value
+    assert_type(value, Empty)
+
+
+class DynamicBody(Enum):
+    FIRST = 1
+    locals()["SECOND"] = 2
+
+
+DynamicBodyLiteral = Literal[DynamicBody.FIRST]
+
+
+def test_dynamic_body(value: DynamicBody) -> None:
+    # The indexed assignment is visible to static analysis, so the known
+    # member subset is not treated as complete.
+    dynamic_literal: DynamicBodyLiteral = value  # This should generate an error
+
+    if value is DynamicBody.FIRST:
+        pass
+    else:
+        assert_type(value, DynamicBody)
+
+
+class CustomEnumType(EnumType):
+    pass
+
+
+class CustomMetaEnum(Enum, metaclass=CustomEnumType):
+    FIRST = 1
+    SECOND = 2
+
+
+CustomMetaEnumLiterals = Literal[CustomMetaEnum.FIRST, CustomMetaEnum.SECOND]
+
+
+def test_custom_metaclass(value: CustomMetaEnum) -> None:
+    custom_literal: CustomMetaEnumLiterals = value  # This should generate an error
+
+    if value is CustomMetaEnum.FIRST:
+        pass
+    else:
+        assert_type(value, CustomMetaEnum)

--- a/packages/pyright-internal/src/tests/samples/enum15.py
+++ b/packages/pyright-internal/src/tests/samples/enum15.py
@@ -2,7 +2,11 @@
 # their literal members.
 
 from enum import Enum, EnumType, Flag, IntEnum, IntFlag, StrEnum, auto
+import builtins
+from collections.abc import Callable
 from typing import Final, Literal, assert_type
+
+from builtins import locals as builtin_locals
 
 
 class Color(Enum):
@@ -116,6 +120,19 @@ def test_invariant_equivalence(
     assert_type(literal_color_dict, dict[Color, int])
     assert_type(color_or_int_list, list[ColorLiterals | int])
     assert_type(literal_color_or_int_list, list[Color | int])
+
+
+def test_callable_equivalence(
+    callback: Callable[[Color], Color],
+    literal_callback: Callable[[ColorLiterals], ColorLiterals],
+    partial_callback: Callable[[PartialColorLiterals], PartialColorLiterals],
+) -> None:
+    assert_type(callback, Callable[[ColorLiterals], ColorLiterals])
+    assert_type(literal_callback, Callable[[Color], Color])
+    assert_type(partial_callback, Callable[[Color], Color])  # This should generate an error
+    assert_type(
+        callback, Callable[[PartialColorLiterals], Color]
+    )  # This should generate an error
 
 
 class Number(IntEnum):
@@ -246,10 +263,10 @@ def test_type_var_invariant_source[T: Color, U: int](
     unrelated_list: list[U],
     literal_color_list: list[ColorLiterals],
 ) -> None:
-    # A source TypeVar bound to the enum expands in an invariant position, so
-    # list[T] and list[ColorLiterals] are treated as equivalent in both
-    # directions.
-    to_literals: list[ColorLiterals] = enum_bound_list
+    # A bound TypeVar cannot expand in an invariant position because T may be
+    # narrower than Color, and widening list[T] would allow unsafe mutation.
+    to_literals: list[ColorLiterals] = enum_bound_list  # This should generate an error
+    from_literals: list[T] = literal_color_list  # This should generate an error
     assert_type(enum_bound_list, list[T])
 
     # An unrelated source TypeVar must not be collapsed to its bound while
@@ -332,6 +349,75 @@ def test_dynamic_body(value: DynamicBody) -> None:
         pass
     else:
         assert_type(value, DynamicBody)
+
+
+class DynamicUpdate(Enum):
+    FIRST = 1
+    locals().update({"SECOND": 2})
+
+
+DynamicUpdateLiteral = Literal[DynamicUpdate.FIRST]
+
+
+def test_dynamic_update(value: DynamicUpdate) -> None:
+    dynamic_literal: DynamicUpdateLiteral = value  # This should generate an error
+
+
+class DynamicQualifiedUpdate(Enum):
+    FIRST = 1
+    builtins.locals().update({"SECOND": 2})
+
+
+DynamicQualifiedUpdateLiteral = Literal[DynamicQualifiedUpdate.FIRST]
+
+
+def test_dynamic_qualified_update(value: DynamicQualifiedUpdate) -> None:
+    dynamic_literal: DynamicQualifiedUpdateLiteral = value  # This should generate an error
+
+
+class DynamicAliasedUpdate(Enum):
+    FIRST = 1
+    builtin_locals().update({"SECOND": 2})
+
+
+DynamicAliasedUpdateLiteral = Literal[DynamicAliasedUpdate.FIRST]
+
+
+def test_dynamic_aliased_update(value: DynamicAliasedUpdate) -> None:
+    dynamic_literal: DynamicAliasedUpdateLiteral = value  # This should generate an error
+
+
+run_exec = exec
+
+
+class DynamicAssignedAlias(Enum):
+    FIRST = 1
+    run_exec("SECOND = 2")
+
+
+DynamicAssignedAliasLiteral = Literal[DynamicAssignedAlias.FIRST]
+
+
+def test_dynamic_assigned_alias(value: DynamicAssignedAlias) -> None:
+    dynamic_literal: DynamicAssignedAliasLiteral = value  # This should generate an error
+
+
+class ShadowedLocals(Enum):
+    FIRST = 1
+    SECOND = 2
+
+    @staticmethod
+    def locals() -> dict[str, int]:
+        return {}
+
+    locals().update({"THIRD": 3})
+
+
+ShadowedLocalsLiterals = Literal[ShadowedLocals.FIRST, ShadowedLocals.SECOND]
+
+
+def test_shadowed_locals(value: ShadowedLocals) -> None:
+    literal_value: ShadowedLocalsLiterals = value
 
 
 class CustomEnumType(EnumType):

--- a/packages/pyright-internal/src/tests/samples/enum16.py
+++ b/packages/pyright-internal/src/tests/samples/enum16.py
@@ -1,0 +1,519 @@
+# This sample tests enum literal union equivalence in application and library
+# patterns, along with nearby cases that must remain nominal.
+
+import inspect
+from collections.abc import Sequence
+from enum import Enum, EnumType, Flag, IntEnum, IntFlag, StrEnum
+from typing import Final, Literal, Never, assert_never, assert_type
+
+
+class Route(Enum):
+    USERS = "users"
+    HEALTH = "health"
+    ADMIN = "admin"
+
+
+RouteLiterals = Literal[Route.USERS, Route.HEALTH, Route.ADMIN]
+PartialRouteLiterals = Literal[Route.USERS, Route.HEALTH]
+RouteLiteralSuperset = RouteLiterals | Literal["fallback"]
+
+
+class Priority(IntEnum):
+    LOW = 1
+    NORMAL = 2
+    HIGH = 3
+
+
+PriorityLiterals = Literal[Priority.LOW, Priority.NORMAL, Priority.HIGH]
+
+
+class HttpMethod(StrEnum):
+    GET = "GET"
+    READ = GET
+    POST = "POST"
+    DELETE = "DELETE"
+
+
+HttpMethodLiterals = Literal[HttpMethod.GET, HttpMethod.POST, HttpMethod.DELETE]
+
+
+def test_application_enums(
+    route: Route,
+    literal_route: RouteLiterals,
+    priority: Priority,
+    literal_priority: PriorityLiterals,
+    method: HttpMethod,
+    literal_method: HttpMethodLiterals,
+) -> None:
+    route_literals: RouteLiterals = route
+    route_enum: Route = literal_route
+    priority_literals: PriorityLiterals = priority
+    priority_enum: Priority = literal_priority
+    method_literals: HttpMethodLiterals = method
+    method_enum: HttpMethod = literal_method
+
+    assert_type(route, RouteLiterals)
+    assert_type(literal_route, Route)
+    assert_type(priority, PriorityLiterals)
+    assert_type(literal_priority, Priority)
+    assert_type(method, HttpMethodLiterals)
+    assert_type(literal_method, HttpMethod)
+
+
+def test_optional_and_extra_union_arms(
+    optional_route: Route | None,
+    optional_literal_route: RouteLiterals | None,
+    priority_or_text: Priority | str,
+    literal_priority_or_text: PriorityLiterals | str,
+) -> None:
+    optional1: RouteLiterals | None = optional_route
+    optional2: Route | None = optional_literal_route
+    extra_arm1: PriorityLiterals | str = priority_or_text
+    extra_arm2: Priority | str = literal_priority_or_text
+
+    assert_type(optional_route, RouteLiterals | None)
+    assert_type(optional_literal_route, Route | None)
+    assert_type(priority_or_text, PriorityLiterals | str)
+    assert_type(literal_priority_or_text, Priority | str)
+
+
+def test_assignment_narrowing() -> None:
+    route: Route = Route.USERS
+    priority: Priority = Priority.NORMAL
+    method: HttpMethod = HttpMethod.READ
+
+    reveal_type(route, expected_text="Literal[Route.USERS]")
+    reveal_type(priority, expected_text="Literal[Priority.NORMAL]")
+    reveal_type(method, expected_text="Literal[HttpMethod.GET]")
+
+
+def route_path(route: Route) -> str:
+    match route:
+        case Route.USERS:
+            return "/users"
+        case Route.HEALTH:
+            return "/health"
+        case Route.ADMIN:
+            return "/admin"
+
+
+def priority_weight(priority: Priority) -> int:
+    if priority is Priority.LOW:
+        return 1
+    elif priority is Priority.NORMAL:
+        return 5
+    else:
+        reveal_type(priority, expected_text="Literal[Priority.HIGH]")
+        return 10
+
+
+def method_name(method: HttpMethod) -> str:
+    if method is HttpMethod.GET:
+        return "read"
+    if method is HttpMethod.POST:
+        return "create"
+    if method is HttpMethod.DELETE:
+        return "delete"
+
+    assert_never(method)
+
+
+class DefaultTimeout(Enum):
+    token = -1
+
+
+DEFAULT_TIMEOUT: Final[DefaultTimeout] = DefaultTimeout.token
+Timeout = float | DefaultTimeout | None
+
+
+def resolve_timeout(value: Timeout, fallback: float) -> float | None:
+    # This mirrors the singleton sentinel used by urllib3 and pip.
+    if value is DEFAULT_TIMEOUT:
+        reveal_type(value, expected_text="Literal[DefaultTimeout.token]")
+        return fallback
+
+    reveal_type(value, expected_text="float | None")
+    if value is not None and value <= 0:
+        return None
+    return value
+
+
+def test_singleton_assignment_narrowing() -> None:
+    value: DefaultTimeout = DefaultTimeout.token
+    reveal_type(value, expected_text="Literal[DefaultTimeout.token]")
+
+
+ParameterKinds = Literal[
+    inspect.Parameter.POSITIONAL_ONLY,
+    inspect.Parameter.POSITIONAL_OR_KEYWORD,
+    inspect.Parameter.VAR_POSITIONAL,
+    inspect.Parameter.KEYWORD_ONLY,
+    inspect.Parameter.VAR_KEYWORD,
+]
+
+
+def replace_parameter_kind(
+    parameter: inspect.Parameter, requested: ParameterKinds | None
+) -> ParameterKinds:
+    # This mirrors discord.py assigning inspect._ParameterKind to its complete
+    # public literal alias without a type-ignore comment.
+    if requested is None:
+        requested = parameter.kind
+
+    assert_type(requested, ParameterKinds)
+    assert_type(parameter.kind, ParameterKinds)
+    return requested
+
+
+class Registry[K, V]:
+    def __init__(self, values: dict[K, V]) -> None:
+        self._values = values
+
+    def register(self, key: K, value: V) -> None:
+        self._values[key] = value
+
+    def get(self, key: K) -> V:
+        return self._values[key]
+
+
+ApplicationState = tuple[
+    list[dict[Route, tuple[Priority | None, HttpMethod]]],
+    Registry[HttpMethod, dict[Route, Priority]],
+]
+LiteralApplicationState = tuple[
+    list[dict[RouteLiterals, tuple[PriorityLiterals | None, HttpMethodLiterals]]],
+    Registry[HttpMethodLiterals, dict[RouteLiterals, PriorityLiterals]],
+]
+
+
+def test_invariant_registries(
+    enum_registry: Registry[Route, list[Priority | None]],
+    literal_registry: Registry[RouteLiterals, list[PriorityLiterals | None]],
+    enum_state: ApplicationState,
+    literal_state: LiteralApplicationState,
+) -> None:
+    registry1: Registry[RouteLiterals, list[PriorityLiterals | None]] = enum_registry
+    registry2: Registry[Route, list[Priority | None]] = literal_registry
+    state1: LiteralApplicationState = enum_state
+    state2: ApplicationState = literal_state
+
+    assert_type(
+        enum_registry, Registry[RouteLiterals, list[PriorityLiterals | None]]
+    )
+    assert_type(literal_registry, Registry[Route, list[Priority | None]])
+    assert_type(enum_state, LiteralApplicationState)
+    assert_type(literal_state, ApplicationState)
+
+
+class RuntimeValueEnum(Enum):
+    FIRST = object()
+    SECOND = object()
+
+
+RuntimeValueLiterals = Literal[RuntimeValueEnum.FIRST, RuntimeValueEnum.SECOND]
+
+
+def test_statically_known_runtime_values(
+    value: RuntimeValueEnum, literal_value: RuntimeValueLiterals
+) -> None:
+    complete: RuntimeValueLiterals = value
+    nominal: RuntimeValueEnum = literal_value
+    assert_type(value, RuntimeValueLiterals)
+
+
+def test_incomplete_and_superset_unions(
+    route: Route,
+    partial_route: PartialRouteLiterals,
+    route_superset: RouteLiteralSuperset,
+    routes: list[Route],
+    partial_routes: list[PartialRouteLiterals],
+    route_supersets: list[RouteLiteralSuperset],
+) -> None:
+    incomplete: PartialRouteLiterals = route  # This should generate an error
+    enum_from_partial: Route = partial_route
+    superset: RouteLiteralSuperset = route
+    enum_from_superset: Route = route_superset  # This should generate an error
+
+    assert_type(route, PartialRouteLiterals)  # This should generate an error
+    assert_type(route, RouteLiteralSuperset)  # This should generate an error
+
+    incomplete_list1: list[PartialRouteLiterals] = routes  # This should generate an error
+    incomplete_list2: list[Route] = partial_routes  # This should generate an error
+    superset_list1: list[RouteLiteralSuperset] = routes  # This should generate an error
+    superset_list2: list[Route] = route_supersets  # This should generate an error
+
+
+class OtherRoute(Enum):
+    USERS = "users"
+    HEALTH = "health"
+    ADMIN = "admin"
+
+
+OtherRouteLiterals = Literal[
+    OtherRoute.USERS, OtherRoute.HEALTH, OtherRoute.ADMIN
+]
+
+
+def test_unrelated_enums(
+    route: Route,
+    other_route: OtherRoute,
+    routes: list[Route],
+    other_routes: list[OtherRouteLiterals],
+) -> None:
+    other_literals: OtherRouteLiterals = route  # This should generate an error
+    route_literals: RouteLiterals = other_route  # This should generate an error
+    other_list: list[OtherRouteLiterals] = routes  # This should generate an error
+    route_list: list[Route] = other_routes  # This should generate an error
+
+
+class Feature(Flag):
+    SEARCH = 1
+    EXPORT = 2
+
+
+FeatureLiterals = Literal[Feature.SEARCH, Feature.EXPORT]
+
+
+class FeatureBase(Flag):
+    pass
+
+
+class ExtendedFeature(FeatureBase):
+    CHAT = 1
+    AUDIT = 2
+
+
+ExtendedFeatureLiterals = Literal[ExtendedFeature.CHAT, ExtendedFeature.AUDIT]
+
+
+class Permission(IntFlag):
+    READ = 1
+    WRITE = 2
+    ADMIN = 4
+
+
+PermissionLiterals = Literal[Permission.READ, Permission.WRITE, Permission.ADMIN]
+
+
+class PermissionBase(IntFlag):
+    pass
+
+
+class WorkspacePermission(PermissionBase):
+    VIEW = 1
+    EDIT = 2
+
+
+WorkspacePermissionLiterals = Literal[
+    WorkspacePermission.VIEW, WorkspacePermission.EDIT
+]
+
+
+def test_flag_types_remain_nominal(
+    feature: Feature,
+    extended: ExtendedFeature,
+    permission: Permission,
+    workspace_permission: WorkspacePermission,
+) -> None:
+    feature_members: FeatureLiterals = feature  # This should generate an error
+    extended_members: ExtendedFeatureLiterals = extended  # This should generate an error
+    permission_members: PermissionLiterals = permission  # This should generate an error
+    workspace_members: WorkspacePermissionLiterals = (
+        workspace_permission  # This should generate an error
+    )
+
+
+feature_combination = Feature.SEARCH | Feature.EXPORT
+extended_combination = ExtendedFeature.CHAT | ExtendedFeature.AUDIT
+permission_combination = Permission.READ | Permission.WRITE
+workspace_combination = WorkspacePermission.VIEW | WorkspacePermission.EDIT
+
+feature_members: FeatureLiterals = feature_combination  # This should generate an error
+extended_members: ExtendedFeatureLiterals = (
+    extended_combination  # This should generate an error
+)
+permission_members: PermissionLiterals = permission_combination  # This should generate an error
+workspace_members: WorkspacePermissionLiterals = (
+    workspace_combination  # This should generate an error
+)
+
+
+class LibraryEnumType(EnumType):
+    pass
+
+
+class LibraryIntEnum(IntEnum, metaclass=LibraryEnumType):
+    pass
+
+
+class BucketType(LibraryIntEnum):
+    DEFAULT = 0
+    USER = 1
+    CHANNEL = 2
+
+
+BucketTypeLiterals = Literal[
+    BucketType.DEFAULT, BucketType.USER, BucketType.CHANNEL
+]
+
+
+def bucket_key(bucket: BucketType) -> int:
+    # This mirrors Steam's exhaustive match over its custom enum hierarchy.
+    match bucket:
+        case BucketType.DEFAULT:
+            return 0
+        case BucketType.USER:
+            return 1
+        case BucketType.CHANNEL:
+            return 2
+
+
+def test_custom_metaclass(
+    bucket: BucketType, literal_bucket: BucketTypeLiterals
+) -> None:
+    members: BucketTypeLiterals = bucket  # This should generate an error
+    nominal: BucketType = literal_bucket
+    assert_type(bucket, BucketTypeLiterals)  # This should generate an error
+
+    if bucket is BucketType.DEFAULT:
+        pass
+    elif bucket is BucketType.USER:
+        pass
+    else:
+        reveal_type(bucket, expected_text="Literal[BucketType.CHANNEL]")
+
+
+def test_custom_metaclass_assignment_narrowing() -> None:
+    bucket: BucketType = BucketType.USER
+    reveal_type(bucket, expected_text="Literal[BucketType.USER]")
+
+
+class DynamicPlugin(Enum):
+    BUILTIN = "builtin"
+    locals()["THIRD_PARTY"] = "third-party"
+
+
+KnownPluginLiteral = Literal[DynamicPlugin.BUILTIN]
+
+
+def test_dynamic_members(value: DynamicPlugin) -> None:
+    known: KnownPluginLiteral = value  # This should generate an error
+    assert_type(value, KnownPluginLiteral)  # This should generate an error
+
+    if value is DynamicPlugin.BUILTIN:
+        pass
+    else:
+        reveal_type(value, expected_text="DynamicPlugin")
+
+
+def dynamic_plugin_key(value: DynamicPlugin) -> str:  # This should generate an error
+    match value:
+        case DynamicPlugin.BUILTIN:
+            return "builtin"
+
+
+def assert_known_plugin(value: DynamicPlugin) -> None:
+    if value is DynamicPlugin.BUILTIN:
+        return
+
+    assert_never(value)  # This should generate an error
+
+
+class EmptyRoute(Enum):
+    pass
+
+
+def test_empty_enum(value: EmptyRoute) -> None:
+    impossible: Never = value  # This should generate an error
+    reveal_type(value, expected_text="EmptyRoute")
+
+
+def optional_identity[T](value: T | None) -> T:
+    assert value is not None
+    return value
+
+
+def choose[T](left: T, right: T) -> T:
+    return left
+
+
+def preserve_route[T: Route](value: T) -> T:
+    return value
+
+
+def test_type_var_inference(
+    route: Route, literal_route: Literal[Route.USERS]
+) -> None:
+    reveal_type(optional_identity(route), expected_text="Route")
+    reveal_type(choose(route, literal_route), expected_text="Route")
+    reveal_type(choose(literal_route, route), expected_text="Route")
+    # A bound TypeVar widens an enum literal to its nominal bound.
+    reveal_type(preserve_route(literal_route), expected_text="Route")
+    reveal_type(preserve_route(route), expected_text="Route")
+
+
+def test_bound_type_var_invariance[T: Route](
+    values: list[T], literal_values: list[RouteLiterals]
+) -> None:
+    expanded: list[RouteLiterals] = values  # This should generate an error
+    narrowed: list[T] = literal_values  # This should generate an error
+    assert_type(values, list[T])
+
+
+def test_variance_boundaries(
+    routes: Sequence[Route],
+    literal_routes: Sequence[RouteLiterals],
+    partial_routes: Sequence[PartialRouteLiterals],
+    route_list: list[Route],
+    literal_route_list: list[RouteLiterals],
+    partial_route_list: list[PartialRouteLiterals],
+) -> None:
+    complete_covariant1: Sequence[RouteLiterals] = routes
+    complete_covariant2: Sequence[Route] = literal_routes
+    partial_covariant: Sequence[Route] = partial_routes
+    invalid_covariant: Sequence[PartialRouteLiterals] = (
+        routes  # This should generate an error
+    )
+
+    complete_invariant1: list[RouteLiterals] = route_list
+    complete_invariant2: list[Route] = literal_route_list
+    invalid_invariant1: list[PartialRouteLiterals] = (
+        route_list  # This should generate an error
+    )
+    invalid_invariant2: list[Route] = partial_route_list  # This should generate an error
+
+
+def test_registry_invariance_boundaries(
+    routes: Registry[Route, int],
+    literal_routes: Registry[RouteLiterals, int],
+    partial_routes: Registry[PartialRouteLiterals, int],
+) -> None:
+    complete1: Registry[RouteLiterals, int] = routes
+    complete2: Registry[Route, int] = literal_routes
+    incomplete1: Registry[PartialRouteLiterals, int] = (
+        routes  # This should generate an error
+    )
+    incomplete2: Registry[Route, int] = partial_routes  # This should generate an error
+
+
+def test_valid_comparison_before_invalid(
+    routes: dict[Route, int],
+    literal_routes: dict[RouteLiterals, int],
+) -> None:
+    complete: dict[RouteLiterals, int] = routes
+    identity: dict[Route, int] = routes
+    unrelated: dict[OtherRouteLiterals, int] = routes  # This should generate an error
+    incomplete: dict[PartialRouteLiterals, int] = routes  # This should generate an error
+    reverse: dict[Route, int] = literal_routes
+    complete_again: dict[RouteLiterals, int] = routes
+
+
+def test_invalid_comparison_before_valid(
+    routes: dict[Route, int],
+    literal_routes: dict[RouteLiterals, int],
+) -> None:
+    incomplete: dict[PartialRouteLiterals, int] = routes  # This should generate an error
+    unrelated: dict[OtherRouteLiterals, int] = routes  # This should generate an error
+    identity: dict[Route, int] = routes
+    complete: dict[RouteLiterals, int] = routes
+    reverse: dict[Route, int] = literal_routes

--- a/packages/pyright-internal/src/tests/typeEvaluator3.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator3.test.ts
@@ -1115,7 +1115,7 @@ test('Enum14', () => {
 test('Enum15', () => {
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['enum15.py']);
 
-    TestUtils.validateResults(analysisResults, 16);
+    TestUtils.validateResults(analysisResults, 24);
 });
 
 test('EnumAuto1', () => {

--- a/packages/pyright-internal/src/tests/typeEvaluator3.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator3.test.ts
@@ -1115,7 +1115,7 @@ test('Enum14', () => {
 test('Enum15', () => {
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['enum15.py']);
 
-    TestUtils.validateResults(analysisResults, 29);
+    TestUtils.validateResults(analysisResults, 31);
 });
 
 test('EnumAuto1', () => {

--- a/packages/pyright-internal/src/tests/typeEvaluator3.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator3.test.ts
@@ -1115,7 +1115,7 @@ test('Enum14', () => {
 test('Enum15', () => {
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['enum15.py']);
 
-    TestUtils.validateResults(analysisResults, 14);
+    TestUtils.validateResults(analysisResults, 16);
 });
 
 test('EnumAuto1', () => {

--- a/packages/pyright-internal/src/tests/typeEvaluator3.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator3.test.ts
@@ -1118,6 +1118,12 @@ test('Enum15', () => {
     TestUtils.validateResults(analysisResults, 31);
 });
 
+test('Enum16', () => {
+    const analysisResults = TestUtils.typeAnalyzeSampleFiles(['enum16.py']);
+
+    TestUtils.validateResults(analysisResults, 38);
+});
+
 test('EnumAuto1', () => {
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['enumAuto1.py']);
 

--- a/packages/pyright-internal/src/tests/typeEvaluator3.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator3.test.ts
@@ -1112,6 +1112,12 @@ test('Enum14', () => {
     TestUtils.validateResults(analysisResults, 3);
 });
 
+test('Enum15', () => {
+    const analysisResults = TestUtils.typeAnalyzeSampleFiles(['enum15.py']);
+
+    TestUtils.validateResults(analysisResults, 14);
+});
+
 test('EnumAuto1', () => {
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['enumAuto1.py']);
 

--- a/packages/pyright-internal/src/tests/typeEvaluator3.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator3.test.ts
@@ -1115,7 +1115,7 @@ test('Enum14', () => {
 test('Enum15', () => {
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['enum15.py']);
 
-    TestUtils.validateResults(analysisResults, 24);
+    TestUtils.validateResults(analysisResults, 29);
 });
 
 test('EnumAuto1', () => {

--- a/packages/pyright-internal/src/typeServer/typeGuards.ts
+++ b/packages/pyright-internal/src/typeServer/typeGuards.ts
@@ -33,10 +33,7 @@ export function enumerateLiteralsForType(evaluator: ITypeServerEvaluator, type: 
     if (ClassType.isEnumClass(type)) {
         // Enum expansion doesn't apply to enum classes that derive
         // from enum.Flag.
-        if (
-            ClassType.areEnumMembersUnknown(type) ||
-            type.shared.mro.some((mroClass) => isClass(mroClass) && ClassType.isBuiltIn(mroClass, 'Flag'))
-        ) {
+        if (type.shared.mro.some((mroClass) => isClass(mroClass) && ClassType.isBuiltIn(mroClass, 'Flag'))) {
             return undefined;
         }
 

--- a/packages/pyright-internal/src/typeServer/typeGuards.ts
+++ b/packages/pyright-internal/src/typeServer/typeGuards.ts
@@ -31,9 +31,12 @@ export function enumerateLiteralsForType(evaluator: ITypeServerEvaluator, type: 
     }
 
     if (ClassType.isEnumClass(type)) {
-        // Enum expansion doesn't apply to enum classes that derive
-        // from enum.Flag.
-        if (type.shared.mro.some((mroClass) => isClass(mroClass) && ClassType.isBuiltIn(mroClass, 'Flag'))) {
+        // Enum expansion doesn't apply if the member set cannot be statically
+        // enumerated or if the class derives from enum.Flag.
+        if (
+            ClassType.isEnumMemberSetMayBeDynamicallyModified(type) ||
+            type.shared.mro.some((mroClass) => isClass(mroClass) && ClassType.isBuiltIn(mroClass, 'Flag'))
+        ) {
             return undefined;
         }
 

--- a/packages/pyright-internal/src/typeServer/typeGuards.ts
+++ b/packages/pyright-internal/src/typeServer/typeGuards.ts
@@ -33,7 +33,10 @@ export function enumerateLiteralsForType(evaluator: ITypeServerEvaluator, type: 
     if (ClassType.isEnumClass(type)) {
         // Enum expansion doesn't apply to enum classes that derive
         // from enum.Flag.
-        if (type.shared.baseClasses.some((baseClass) => isClass(baseClass) && ClassType.isBuiltIn(baseClass, 'Flag'))) {
+        if (
+            ClassType.areEnumMembersUnknown(type) ||
+            type.shared.mro.some((mroClass) => isClass(mroClass) && ClassType.isBuiltIn(mroClass, 'Flag'))
+        ) {
             return undefined;
         }
 


### PR DESCRIPTION
## Summary

- Treat non-`Flag` enum classes and complete unions of their literal members as contextually equivalent for assignment and `assert_type`
- Support the equivalence in both directions, including invariant `list`/`dict` and enum-containing union positions
- Exclude `Flag`, `IntFlag`, and indirect `Flag` subclasses using full-MRO checks
- Conservatively disable expansion when the statically known enum member set may be incomplete

## Design

Enum identity remains nominal by default. The evaluator expands a bare enum only after the destination shape establishes that an enum-literal comparison is needed. A cached union bit makes this destination guard O(1), so unrelated assignments do not enumerate enum symbol tables.

Invariant comparisons normalize both sides locally, which supports reverse substitution such as `list[Literal[Color.RED, Color.GREEN]]` to `list[Color]` without globally rewriting enum types. Free TypeVar solving runs before expansion, preserving broad enum inference; bound source TypeVars are concretized only within the known literal-union assignment context.

`assert_type` uses the same expansion primitive and recursively normalizes nested generic, tuple, and union shapes only after ordinary type identity fails.

Enum expansion is disabled for full-MRO `Flag` ancestry, custom or unknown enum metaclasses, and class bodies with assignment targets that cannot be represented in the static class symbol table. This avoids treating a known subset as complete for detectable dynamic member creation while keeping aliases, `auto()`, and statically named members with unknown values supported.

## Relation to #11584

This implementation was developed independently from current `main` and does not modify or supersede #11584. It corrects edge cases identified during independent review of that approach:

- full-MRO `Flag`/`IntFlag` exclusion rather than direct-base-only checks
- reverse invariant equivalence
- destination guarding before member enumeration
- conservative handling of detectable incomplete member sets and custom metaclasses
- preservation of TypeVar inference and enum identity
- recursive `assert_type` equivalence for required nested shapes

## Conformance

The exact current upstream `python/typing` `conformance/tests/enums_expansion.py` was run with a rebuilt CLI. Before this change, Pyright reported the intentional `Flag` diagnostic at line 56 plus failures at lines 85-86. After this change, output contains exactly the intentional line 56 diagnostic: `1 error, 0 warnings, 0 informations`.

## Tests

- `cd packages/pyright-internal && npm run build`
- `cd packages/pyright-internal && npx jest typeEvaluator3.test -t Enum --forceExit --runInBand`
- all `typeEvaluator1.test` through `typeEvaluator8.test`: 1183 tests passed
- type-server test bundle and `src/tests/typeServer`: 24 tests passed
- `npm run typecheck`
- `npm run check:eslint`
- `npm run check:prettier`
- `git diff --check`
- rebuilt CLI against the exact upstream enum expansion conformance file