### PR TITLE
Fix printing of type arguments for specialized recursive type aliases

### DIFF
--- a/packages/pyright-internal/src/analyzer/typePrinter.ts
+++ b/packages/pyright-internal/src/analyzer/typePrinter.ts
@@ -42,6 +42,8 @@ import {
     Variance,
 } from './types';
 import {
+    applySolvedTypeVars,
+    buildSolution,
     convertToInstance,
     doForEachSubtype,
     isNoneInstance,
@@ -321,8 +323,10 @@ function printTypeInternal(
                 }
 
                 // If it's a TypeVar, don't use the alias name. Instead, use the full
-                // name, which may have a scope associated with it.
-                if (type.category !== TypeCategory.TypeVar) {
+                // name, which may have a scope associated with it. The exception is
+                // the synthesized TypeVar that represents a recursive type alias;
+                // it has no user-visible name of its own.
+                if (type.category !== TypeCategory.TypeVar || type.shared.recursiveAlias) {
                     return aliasName;
                 }
             } finally {
@@ -342,7 +346,11 @@ function printTypeInternal(
         // If this is a recursive TypeVar, we've already expanded it once, so
         // just print its name at this point.
         if (isTypeVar(type) && type.shared.isSynthesized && type.shared.recursiveAlias) {
-            return type.shared.recursiveAlias.name;
+            // If the alias was specialized, fall through so the type arguments
+            // are printed along with the alias name.
+            if (!aliasInfo?.typeArgs) {
+                return type.shared.recursiveAlias.name;
+            }
         }
 
         if (aliasInfo) {
@@ -560,10 +568,33 @@ function printTypeInternal(
                     // aliases, return the type alias name.
                     if (type.shared.recursiveAlias) {
                         if ((printTypeFlags & PrintTypeFlags.ExpandTypeAlias) !== 0 && type.shared.boundType) {
+                            let boundType = TypeBase.isInstance(type)
+                                ? convertToInstance(type.shared.boundType)
+                                : type.shared.boundType;
+
+                            // If the alias was specialized, apply the type arguments to
+                            // the bound type. The type arguments are also retained on the
+                            // expanded type so recursive references within it are printed
+                            // using the specialized form rather than the alias's own
+                            // type parameters.
+                            const typeParams = type.shared.recursiveAlias.typeParams;
+                            if (aliasInfo?.typeArgs && typeParams) {
+                                boundType = applySolvedTypeVars(
+                                    boundType,
+                                    buildSolution(typeParams, aliasInfo.typeArgs)
+                                );
+
+                                const boundTypeAliasInfo = boundType.props?.typeAliasInfo;
+                                if (boundTypeAliasInfo && !boundTypeAliasInfo.typeArgs) {
+                                    boundType = TypeBase.cloneForTypeAlias(boundType, {
+                                        ...boundTypeAliasInfo,
+                                        typeArgs: aliasInfo.typeArgs,
+                                    });
+                                }
+                            }
+
                             return printTypeInternal(
-                                TypeBase.isInstance(type)
-                                    ? convertToInstance(type.shared.boundType)
-                                    : type.shared.boundType,
+                                boundType,
                                 printTypeFlags,
                                 returnTypeCallback,
                                 uniqueNameMap,

--- a/packages/pyright-internal/src/analyzer/typeUtils.ts
+++ b/packages/pyright-internal/src/analyzer/typeUtils.ts
@@ -1044,10 +1044,11 @@ export function transformPossibleRecursiveTypeAlias(type: Type | undefined, recu
             }
 
             const solution = buildSolution(type.shared.recursiveAlias.typeParams, aliasInfo.typeArgs);
-            return transformPossibleRecursiveTypeAlias(
+            const transformedType = transformPossibleRecursiveTypeAlias(
                 applySolvedTypeVars(unspecializedType, solution),
                 recursionCount
             );
+            return TypeBase.cloneForTypeAlias(transformedType, aliasInfo);
         }
 
         if (isUnion(type) && type.priv.includesRecursiveTypeAlias) {

--- a/packages/pyright-internal/src/tests/samples/recursiveTypeAlias18.py
+++ b/packages/pyright-internal/src/tests/samples/recursiveTypeAlias18.py
@@ -1,0 +1,83 @@
+# This sample tests that the type arguments of a specialized generic
+# recursive type alias are retained when the type is printed.
+
+from typing import TypeAlias, TypeVar
+
+
+type Alias1[T] = tuple[T, Alias1[T] | None]
+
+
+def func1(x: Alias1[str]):
+    reveal_type(x, expected_text="tuple[str, Alias1[str] | None]")
+    reveal_type(x[0], expected_text="str")
+    reveal_type(x[1], expected_text="Alias1[str] | None")
+
+
+S = TypeVar("S")
+Alias2: TypeAlias = "tuple[S, Alias2[S] | None]"
+
+
+def func2(x: Alias2[int]):
+    reveal_type(x, expected_text="tuple[int, Alias2[int] | None]")
+    reveal_type(x[1], expected_text="Alias2[int] | None")
+
+
+type Alias3[T] = list[T | Alias3[T]]
+
+
+def func3(x: Alias3[str]):
+    reveal_type(x, expected_text="list[str | Alias3[str]]")
+    reveal_type(x[0], expected_text="str | Alias3[str]")
+
+
+type Alias4[T, S] = tuple[T, S, Alias4[S, T] | None]
+
+
+def func4(x: Alias4[int, str]):
+    reveal_type(x, expected_text="tuple[int, str, Alias4[str, int] | None]")
+    reveal_type(x[2], expected_text="Alias4[str, int] | None")
+
+
+# The recursive reference is specialized with a type that is itself
+# derived from the alias's type parameter.
+type Alias5[T] = list[Alias5[list[T]]] | T
+
+
+def func5(x: Alias5[int]):
+    reveal_type(x, expected_text="list[Alias5[list[int]]] | int")
+
+
+type Alias6[*Ts] = tuple[*Ts, Alias6[*Ts] | None]
+
+
+def func6(x: Alias6[int, str]):
+    reveal_type(x, expected_text="tuple[int, str, Alias6[int, str] | None]")
+
+
+# An unspecialized reference to a generic recursive type alias
+# implicitly uses Unknown type arguments.
+def func7(x: Alias1):
+    reveal_type(x, expected_text="tuple[Unknown, Alias1[Unknown] | None]")
+
+
+# A non-generic recursive type alias continues to print using its
+# (unparameterized) name.
+type Alias8 = int | list[Alias8]
+
+
+def func8(x: Alias8):
+    reveal_type(x, expected_text="int | list[Alias8]")
+
+
+# The specialization is also reflected in diagnostic messages.
+def func9(x: Alias1[int]): ...
+
+
+def func10(x: Alias1[str]):
+    # This should generate an error because Alias1[str] is not
+    # assignable to Alias1[int].
+    func9(x)
+
+    # This should generate an error because Alias1[str] | None is not
+    # assignable to Alias1[int].
+    func9(x[1])

--- a/packages/pyright-internal/src/tests/typeEvaluator3.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator3.test.ts
@@ -874,6 +874,12 @@ test('RecursiveTypeAlias17', () => {
     TestUtils.validateResults(analysisResults, 2);
 });
 
+test('RecursiveTypeAlias18', () => {
+    const analysisResults = TestUtils.typeAnalyzeSampleFiles(['recursiveTypeAlias18.py']);
+
+    TestUtils.validateResults(analysisResults, 2);
+});
+
 test('Classes1', () => {
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['classes1.py']);
 

--- a/packages/pyright-internal/src/tests/typeEvaluator3.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator3.test.ts
@@ -878,6 +878,24 @@ test('RecursiveTypeAlias18', () => {
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['recursiveTypeAlias18.py']);
 
     TestUtils.validateResults(analysisResults, 2);
+
+    expect(analysisResults[0].errors[0].message.replace(/\u00a0/g, ' ')).toBe(
+        [
+            'Argument of type "Alias1[str]" cannot be assigned to parameter "x" of type "Alias1[int]" in function "func9"',
+            '  "tuple[str, Alias1[str] | None]" is not assignable to "tuple[int, Alias1[int] | None]"',
+            '    Tuple entry 1 is incorrect type',
+            '      "str" is not assignable to "int"',
+        ].join('\n')
+    );
+    expect(analysisResults[0].errors[1].message.replace(/\u00a0/g, ' ')).toBe(
+        [
+            'Argument of type "Alias1[str] | None" cannot be assigned to parameter "x" of type "Alias1[int]" in function "func9"',
+            '  Type "Alias1[str] | None" is not assignable to type "Alias1[int]"',
+            '    "tuple[str, Alias1[str] | None]" is not assignable to "tuple[int, Alias1[int] | None]"',
+            '      Tuple entry 1 is incorrect type',
+            '        "str" is not assignable to "int"',
+        ].join('\n')
+    );
 });
 
 test('Classes1', () => {


### PR DESCRIPTION
### Problem

A specialized generic recursive type alias loses its type arguments when its type is converted to text, so `reveal_type`, hover, and diagnostic messages report an incorrect type.

```python
type Pair[T] = tuple[T, Pair[T] | None]


def func1(x: Pair[str]):
    reveal_type(x)  # tuple[str, Pair | None]
    reveal_type(x[1])  # Pair[T@Pair] | None
```

| Expression | Current | Expected |
| --- | --- | --- |
| `x` | `tuple[str, Pair \| None]` | `tuple[str, Pair[str] \| None]` |
| `x[1]` | `Pair[T@Pair] \| None` | `Pair[str] \| None` |

The evaluated types are correct — `x[1][0]` evaluates to `str`, and `assert_type(x[1], Pair[str] | None)` passes — so this is purely a defect in the printed form. But the printed form is what users see, and `T@Pair` is an internal, unsolved type parameter that has no meaning at the use site. It also leaks into diagnostics:

```python
def func2(x: Pair[int]): ...


def func3(x: Pair[str]):
    func2(x[1])
```

```
error: Argument of type "Pair | None" cannot be assigned to parameter "x" of type "Pair[int]"
```

The message names the wrong type; after the fix it reads `Argument of type "Pair[str] | None" ...`, which actually explains the error.

This is not specific to PEP 695 syntax — the same happens with the older spelling:

```python
S = TypeVar("S")
Pair2: TypeAlias = "tuple[S, Pair2[S] | None]"


def func4(x: Pair2[int]):
    reveal_type(x[1])  # Pair2[S@Pair2] | None
```

Non-generic recursive aliases are unaffected (`type Alias = int | list[Alias]` already prints as `int | list[Alias]`).

### Root cause

A recursive type alias is represented as a synthesized `TypeVar` whose `shared.boundType` holds the *unspecialized* alias definition, with the specialization recorded separately in `props.typeAliasInfo.typeArgs`.

`printTypeInternal` expands such an alias by printing `shared.boundType` directly (`typePrinter.ts`, the `TypeCategory.TypeVar` case). It never applies `typeAliasInfo.typeArgs`, so:

- the expanded body carries the alias's own type parameters, and its `typeAliasInfo` has no `typeArgs` at all;
- when the recursion guard is then hit, the alias is printed from that body — with its declared type parameters (`Pair[T@Pair]`) or, on the path that returns `shared.recursiveAlias.name` early, with no type arguments (`Pair`).

### Fix

`packages/pyright-internal/src/analyzer/typePrinter.ts`, three small changes on the same path:

1. When expanding a recursive alias, apply `typeAliasInfo.typeArgs` to `boundType` via the existing `buildSolution` / `applySolvedTypeVars` helpers, and retain those arguments on the expanded type's `typeAliasInfo` so recursive references inside it print in specialized form. Unspecialized aliases take the previous code path unchanged.
2. In the recursion guard, only return the bare `shared.recursiveAlias.name` when the alias has no `typeArgs`; otherwise fall through to the existing alias-name-plus-arguments printing.
3. Let the synthesized TypeVar that represents a recursive alias return the alias name from that printing block. The surrounding `type.category !== TypeCategory.TypeVar` check exists so a *normal* TypeVar prints its scoped name instead of an alias name; a recursive-alias placeholder has no user-visible name of its own, so it is exempted.

No evaluator, binder, or checker logic is touched. The added work runs only while printing a specialized recursive alias, not during type evaluation.

### Behavior change

Only the text representation of types changes, always in the direction of more information:

| Expression | Before | After |
| --- | --- | --- |
| `x: Alias1[str]` where `type Alias1[T] = tuple[T, Alias1[T] \| None]` | `tuple[str, Alias1 \| None]` | `tuple[str, Alias1[str] \| None]` |
| `x[1]` | `Alias1[T@Alias1] \| None` | `Alias1[str] \| None` |
| `type Alias5[T] = list[Alias5[list[T]]] \| T`, `x: Alias5[int]` | `list[Alias5] \| int` | `list[Alias5[list[int]]] \| int` |
| `type Alias6[*Ts] = tuple[*Ts, Alias6[*Ts] \| None]`, `x: Alias6[int, str]` | `tuple[int, str, Alias6 \| None]` | `tuple[int, str, Alias6[int, str] \| None]` |
| `x: Alias1` (unparameterized) | `tuple[Unknown, Alias1 \| None]` | `tuple[Unknown, Alias1[Unknown] \| None]` |
| `type Alias8 = int \| list[Alias8]`, `x: Alias8` | `int \| list[Alias8]` | unchanged |

Per `.github/agents/pyright-test-policy.md`: no existing test was modified, no diagnostic was removed or suppressed, and there is no precision regression — every affected type prints strictly more information than before.

### Tests

New sample `packages/pyright-internal/src/tests/samples/recursiveTypeAlias18.py`, registered as `RecursiveTypeAlias18` in `typeEvaluator3.test.ts`. It covers:

- the original failing case, in both PEP 695 and `TypeAlias` + `TypeVar` spellings;
- a two-type-parameter alias whose recursive reference reorders them (`Alias4[T, S] = tuple[T, S, Alias4[S, T] | None]` → `Alias4[str, int]`);
- a recursive reference specialized with a type derived from the type parameter (`Alias5[T] = list[Alias5[list[T]]] | T`);
- a `TypeVarTuple` alias;
- an unparameterized reference to a generic recursive alias (implicit `Unknown` arguments);
- a non-generic recursive alias, which must keep printing without type arguments — this one passes before and after;
- two intentional errors, asserting the specialization now appears in diagnostic messages.

On clean `upstream/main` @ `dde0aae1` the sample produces 11 `Type text mismatch` failures plus the 2 intended errors (`Expected 2 errors, got 13`); with the fix it passes.

### Validation

Run in a clean worktree at `upstream/main` @ `dde0aae1`:

| Command | Result |
| --- | --- |
| `npx jest typeEvaluator3 -t "RecursiveTypeAlias18"` (before fix) | fails: `Expected 2 errors, got 13`, 11 type-text mismatches |
| `npx jest typeEvaluator3 -t "RecursiveTypeAlias"` (after fix) | 18 passed |
| `npm run test:norebuild` (after `npm run webpack:testserver`) | 62 suites, **2550 passed, 0 failed** |
| `npm run check:prettier` | `All matched files use Prettier code style!` |
| `npm run check:eslint` | clean |
| `npm run check:syncpack` | `No issues found` |
| `npm run typecheck` | clean in all 3 packages |
| `npx tsc --noEmit` in `packages/pyright-internal` | clean |
| `git diff --check` | clean |

Not run: `build/perfCompare.py`, which requires an external Python corpus. The changed code is on the type-to-text path, which runs when producing hover text and diagnostic messages rather than during type evaluation, and the added `applySolvedTypeVars` call is reached only while printing a *specialized recursive* alias. Full-suite wall time was unchanged within noise (≈127–131 s across runs).

### Compatibility

No public API, no configuration option, no diagnostic rule, no dependency, and no lockfile change. Diagnostic categories, counts, and source ranges are unchanged; only the type text embedded in some messages differs.
