### PR TITLE
Fix inherited asymmetric descriptor detection

### DIFF
--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -7022,8 +7022,10 @@ export function createTypeEvaluator(
 
         let isAsymmetric = false;
 
-        const getterSymbolResult = lookUpClassMember(classType, '__get__', MemberAccessFlags.SkipBaseClasses);
-        const setterSymbolResult = lookUpClassMember(classType, '__set__', MemberAccessFlags.SkipBaseClasses);
+        // Accessors can be defined at different levels of the descriptor's MRO.
+        // Compare the effective inherited getter and setter types.
+        const getterSymbolResult = lookUpClassMember(classType, '__get__');
+        const setterSymbolResult = lookUpClassMember(classType, '__set__');
 
         if (!getterSymbolResult || !setterSymbolResult) {
             isAsymmetric = false;

--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -6843,8 +6843,8 @@ export function createTypeEvaluator(
 
         // Determine if we're calling __set__ on an asymmetric descriptor or property.
         let isAsymmetricAccessor = false;
-        if (usage.method === 'set' && isClass(methodClassType)) {
-            if (isAsymmetricDescriptorClass(methodClassType)) {
+        if (usage.method === 'set') {
+            if (isAsymmetricDescriptorClass(concreteMemberType)) {
                 isAsymmetricAccessor = true;
             }
         }

--- a/packages/pyright-internal/src/tests/samples/descriptor5.py
+++ b/packages/pyright-internal/src/tests/samples/descriptor5.py
@@ -1,0 +1,42 @@
+# This sample tests that assignment through an inherited asymmetric descriptor
+# does not narrow subsequent reads to the setter's input type.
+
+from typing import Any, assert_type, cast
+
+
+class Getter[T]:
+    def __get__(self, instance: Any, owner: Any = None) -> T:
+        return cast(Any, None)
+
+
+class Descriptor[T, U](Getter[T]):
+    def __set__(self, instance: Any, value: T | U) -> None:
+        pass
+
+
+class IntFromStr(Descriptor[int, str]):
+    pass
+
+
+class Container:
+    value: IntFromStr
+
+
+container = Container()
+container.value = "1"
+assert_type(container.value, int)
+
+
+class AsymmetricProperty:
+    @property
+    def value(self) -> int:
+        return 0
+
+    @value.setter
+    def value(self, new_value: str) -> None:
+        pass
+
+
+prop = AsymmetricProperty()
+prop.value = "1"
+assert_type(prop.value, int)

--- a/packages/pyright-internal/src/tests/samples/descriptor5.py
+++ b/packages/pyright-internal/src/tests/samples/descriptor5.py
@@ -27,6 +27,28 @@ container.value = "1"
 assert_type(container.value, int)
 
 
+class SetterBase:
+    def __get__(self, instance: Any, owner: Any = None) -> int | str:
+        return cast(Any, None)
+
+    def __set__(self, instance: Any, value: int | str) -> None:
+        pass
+
+
+class GetterOverride(SetterBase):
+    def __get__(self, instance: Any, owner: Any = None) -> int:
+        return 0
+
+
+class OverrideContainer:
+    value: GetterOverride
+
+
+override_container = OverrideContainer()
+override_container.value = "1"
+assert_type(override_container.value, int)
+
+
 class AsymmetricProperty:
     @property
     def value(self) -> int:

--- a/packages/pyright-internal/src/tests/typeEvaluator8.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator8.test.ts
@@ -822,6 +822,12 @@ test('Descriptor4', () => {
     TestUtils.validateResults(analysisResults, 0);
 });
 
+test('Descriptor5', () => {
+    const analysisResults = TestUtils.typeAnalyzeSampleFiles(['descriptor5.py']);
+
+    TestUtils.validateResults(analysisResults, 0);
+});
+
 test('Partial1', () => {
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['partial1.py']);
 


### PR DESCRIPTION
## Summary

- detect asymmetric descriptors using the effective inherited `__get__` and `__set__` methods
- preserve assignment/read asymmetry when accessors live at different levels of the descriptor MRO
- add regression coverage for an inherited generic getter plus a wider setter, with a property control

## Root cause

`isAsymmetricDescriptorClass` looked up both accessors with `SkipBaseClasses`. A descriptor that inherited `__get__` but declared `__set__` locally therefore appeared symmetric. After assignment, flow analysis incorrectly narrowed subsequent reads to the setter input literal instead of the getter return type.

Fixes #11401

## Validation

- `npx jest packages/pyright-internal/src/tests/typeEvaluator8.test.ts --runInBand` — 161/161 passed
- `npm run typecheck` — passed all three packages
- `npm run check` — syncpack, ESLint, and Prettier passed
- `git diff --check` — passed
