### PR TITLE
Report a specific diagnostic for walrus in a comprehension iterable expression

### DIFF
--- a/packages/pyright-internal/src/localization/localize.ts
+++ b/packages/pyright-internal/src/localization/localize.ts
@@ -1235,6 +1235,7 @@ export namespace Localizer {
             new ParameterizedString<{ names: string }>(getRawString('Diagnostic.variadicTypeParamTooManyClass'));
         export const walrusIllegal = () => getRawString('Diagnostic.walrusIllegal');
         export const walrusNotAllowed = () => getRawString('Diagnostic.walrusNotAllowed');
+        export const walrusNotAllowedInComprehension = () => getRawString('Diagnostic.walrusNotAllowedInComprehension');
         export const wildcardInFunction = () => getRawString('Diagnostic.wildcardInFunction');
         export const wildcardPatternTypeUnknown = () => getRawString('Diagnostic.wildcardPatternTypeUnknown');
         export const wildcardPatternTypePartiallyUnknown = () =>

--- a/packages/pyright-internal/src/localization/package.nls.en-us.json
+++ b/packages/pyright-internal/src/localization/package.nls.en-us.json
@@ -1764,6 +1764,7 @@
         },
         "walrusIllegal": "Operator \":=\" requires Python 3.8 or newer",
         "walrusNotAllowed": "Operator \":=\" is not allowed in this context without surrounding parentheses",
+        "walrusNotAllowedInComprehension": "Operator \":=\" is not allowed within a comprehension iterable expression",
         "wildcardInFunction": {
             "message": "Wildcard import not allowed within a class or function",
             "comment": "{Locked='import'}"

--- a/packages/pyright-internal/src/parser/parser.ts
+++ b/packages/pyright-internal/src/parser/parser.ts
@@ -3380,7 +3380,12 @@ export class Parser {
             return leftExpr;
         }
 
-        if (!this._assignmentExpressionsAllowed || disallowAssignmentExpression) {
+        if (!this._assignmentExpressionsAllowed) {
+            // Assignment expressions are disallowed anywhere within the iterable
+            // expression of a comprehension's "for" clause, even if parenthesized.
+            // This differs from the "requires surrounding parentheses" case below.
+            this._addSyntaxError(LocMessage.walrusNotAllowedInComprehension(), walrusToken);
+        } else if (disallowAssignmentExpression) {
             this._addSyntaxError(LocMessage.walrusNotAllowed(), walrusToken);
         }
 

--- a/packages/pyright-internal/src/tests/samples/assignmentExprMessage1.py
+++ b/packages/pyright-internal/src/tests/samples/assignmentExprMessage1.py
@@ -1,0 +1,18 @@
+# This sample tests that assignment expressions used within the iterable
+# expression of a comprehension "for" clause are reported with a message
+# that specifically calls out the comprehension-iterable restriction from
+# PEP 572. Unlike a bare assignment expression used as a comprehension
+# "if" condition, this restriction cannot be resolved by adding parentheses.
+
+x = []
+
+
+# This should generate an error because an assignment expression is not
+# allowed within a comprehension's iterable expression, even when it is
+# surrounded by parentheses.
+[a for a in (b := x)]
+
+# This should generate an error because a bare (unparenthesized) assignment
+# expression is not allowed as a comprehension "if" condition. Here, adding
+# parentheses would make the code legal.
+[a for a in x if c := a]

--- a/packages/pyright-internal/src/tests/typeEvaluator1.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator1.test.ts
@@ -1215,3 +1215,22 @@ test('AssignmentExpr9', () => {
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['assignmentExpr9.py']);
     TestUtils.validateResults(analysisResults, 0);
 });
+
+test('AssignmentExprMessage1', () => {
+    const analysisResults = TestUtils.typeAnalyzeSampleFiles(['assignmentExprMessage1.py']);
+
+    TestUtils.validateResults(analysisResults, 2);
+
+    // A walrus within a comprehension's iterable expression cannot be fixed by
+    // adding parentheses, so it must use the comprehension-specific message
+    // rather than the generic "requires surrounding parentheses" message.
+    expect(analysisResults[0].errors[0].message).toBe(
+        'Operator ":=" is not allowed within a comprehension iterable expression'
+    );
+
+    // A bare walrus used as a comprehension "if" condition still uses the
+    // generic message because parenthesizing it makes the code legal.
+    expect(analysisResults[0].errors[1].message).toBe(
+        'Operator ":=" is not allowed in this context without surrounding parentheses'
+    );
+});


### PR DESCRIPTION
## Summary

An assignment expression (`:=`) used anywhere within the **iterable expression** of a comprehension's `for` clause is a syntax error under [PEP 572](https://peps.python.org/pep-0572/#scope-of-the-target), and — unlike a walrus used bare as a comprehension `if` condition — it **cannot** be made legal by adding parentheses. Pyright already reports this as an error, but it reused the generic message:

```
Operator ":=" is not allowed in this context without surrounding parentheses
```

That message is misleading here: the offending walrus in the reproduction is already parenthesized, and no amount of parenthesization will fix it. This addresses #11514.

## Minimal reproduction

```python
result = [
    y
    for y in [
        z
        for k in range(10)
        if (z := k * 2) % 3 == 0   # inner comprehension is the outer iterable
    ]
]
```

CPython:

```
SyntaxError: assignment expression cannot be used in a comprehension iterable expression
```

### Current behavior
Pyright reports `Operator ":=" is not allowed in this context without surrounding parentheses`, even though the walrus is parenthesized.

### Corrected behavior
Pyright reports `Operator ":=" is not allowed within a comprehension iterable expression`.

## Root cause

In `parser.ts`, `_parseAssignmentExpression` emitted `walrusNotAllowed` for two distinct conditions that were OR'd together:

```ts
if (!this._assignmentExpressionsAllowed || disallowAssignmentExpression) {
    this._addSyntaxError(LocMessage.walrusNotAllowed(), walrusToken);
}
```

These two flags actually represent different restrictions:

- `!this._assignmentExpressionsAllowed` is set **only** by `_disallowAssignmentExpression`, whose **only** caller wraps parsing of a comprehension `for ... in <iterable>` sequence expression. This is the "walrus in a comprehension iterable" restriction, which parentheses do not resolve.
- `disallowAssignmentExpression` corresponds to a bare walrus that requires surrounding parentheses (e.g. an unparenthesized walrus used as a comprehension `if` condition, or a bare walrus where a `test` expression is expected). Here parentheses **do** resolve the error, so the existing message is correct.

## Implementation

- Split the condition so the comprehension-iterable case emits a new dedicated message `walrusNotAllowedInComprehension`, while the parentheses case keeps `walrusNotAllowed`. The iterable case is checked first so it wins when both apply (parentheses would not help there either).
- Added the `walrusNotAllowedInComprehension` key to `localize.ts` and `package.nls.en-us.json`.

Error detection (which cases are flagged, and the diagnostic range) is unchanged — only the message text differs for the comprehension-iterable case.

## Tests

- New sample `assignmentExprMessage1.py` and test `AssignmentExprMessage1` assert the exact message for both branches: the comprehension-iterable case gets the new message, and a bare walrus in a comprehension `if` keeps the generic message.
- The existing `AssignmentExpr4` test (which already exercises iterable-walrus cases) continues to pass with its error count unchanged, confirming detection is unaffected.

## Validation

Run in `packages/pyright-internal`:

- `npx tsc --noEmit` — passes.
- `npx prettier@2.8.8 -c` on all changed TS/JSON files — "All matched files use Prettier code style!".
- `git diff --check` — clean.
- `npx jest parser tokenizer typeEvaluator1` — all pass (includes the new `AssignmentExprMessage1` and the unchanged `AssignmentExpr4`).
- Full `npx jest` — all suites pass except LSP/type-server integration suites, which fail to run in this environment because they require the full monorepo bootstrap and the webpack test-server bundle (`Cannot find module 'fs-extra'` / `Server bundle does not exist`); these are unrelated to this change.

## Compatibility

No API changes. The only behavioral difference is a more accurate diagnostic message for walrus operators inside a comprehension iterable expression; the set of reported errors and their source ranges are unchanged.
