### PR TITLE
Fix lambda contextual typing with keyword-only callables

### DIFF
--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -15264,6 +15264,7 @@ export function createTypeEvaluator(
             // more sophisticated in the future, but it becomes very complex to handle
             // all of the permutations.
             let sawParamMismatch = false;
+            let sawLambdaArgsParam = false;
 
             node.d.params.forEach((param, index) => {
                 let paramType: Type | undefined;
@@ -15277,7 +15278,8 @@ export function createTypeEvaluator(
                         // from the expected parameter.
                         if (
                             expectedParam.param.category === param.d.category &&
-                            !param.d.name === !expectedParam.param.name
+                            !param.d.name === !expectedParam.param.name &&
+                            (expectedParam.kind !== ParamKind.Keyword || sawLambdaArgsParam)
                         ) {
                             paramType = expectedParam.type;
                         } else {
@@ -15348,6 +15350,10 @@ export function createTypeEvaluator(
                 );
 
                 FunctionType.addParam(functionType, functionParam);
+
+                if (param.d.category === ParamCategory.ArgsList) {
+                    sawLambdaArgsParam = true;
+                }
             });
 
             if (paramsArePositionOnly && functionType.shared.parameters.length > 0) {

--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -15264,7 +15264,7 @@ export function createTypeEvaluator(
             // more sophisticated in the future, but it becomes very complex to handle
             // all of the permutations.
             let sawParamMismatch = false;
-            let sawLambdaArgsParam = false;
+            let expectedParamIndex = 0;
             const positionOnlySeparatorIndex = node.d.params.findIndex(
                 (param) => param.d.category === ParamCategory.Simple && !param.d.name
             );
@@ -15273,8 +15273,17 @@ export function createTypeEvaluator(
                 let paramType: Type | undefined;
 
                 if (expectedParamDetails && !sawParamMismatch) {
-                    if (index < expectedParamDetails.params.length) {
-                        const expectedParam = expectedParamDetails.params[index];
+                    const isKeywordOnlySeparator = param.d.category === ParamCategory.ArgsList && !param.d.name;
+
+                    if (isKeywordOnlySeparator) {
+                        if (
+                            expectedParamIndex < expectedParamDetails.params.length &&
+                            expectedParamDetails.params[expectedParamIndex].kind !== ParamKind.Keyword
+                        ) {
+                            sawParamMismatch = true;
+                        }
+                    } else if (expectedParamIndex < expectedParamDetails.params.length) {
+                        const expectedParam = expectedParamDetails.params[expectedParamIndex];
                         const isPositionOnlyParam =
                             (positionOnlySeparatorIndex >= 0 && index < positionOnlySeparatorIndex) ||
                             (positionOnlySeparatorIndex < 0 &&
@@ -15283,7 +15292,6 @@ export function createTypeEvaluator(
                                 isPrivateName(param.d.name.d.value));
                         const isCompatibleKeywordParam =
                             expectedParam.kind !== ParamKind.Keyword ||
-                            sawLambdaArgsParam ||
                             (!isPositionOnlyParam && param.d.name?.d.value === expectedParam.param.name);
 
                         // If the parameter category matches and both of the parameters are
@@ -15298,6 +15306,8 @@ export function createTypeEvaluator(
                         } else {
                             sawParamMismatch = true;
                         }
+
+                        expectedParamIndex++;
                     } else if (param.d.defaultValue) {
                         // If the lambda param has a default value but there is no associated
                         // parameter in the expected type, assume that the default value is
@@ -15363,10 +15373,6 @@ export function createTypeEvaluator(
                 );
 
                 FunctionType.addParam(functionType, functionParam);
-
-                if (param.d.category === ParamCategory.ArgsList) {
-                    sawLambdaArgsParam = true;
-                }
             });
 
             if (paramsArePositionOnly && functionType.shared.parameters.length > 0) {

--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -15265,6 +15265,9 @@ export function createTypeEvaluator(
             // all of the permutations.
             let sawParamMismatch = false;
             let sawLambdaArgsParam = false;
+            const positionOnlySeparatorIndex = node.d.params.findIndex(
+                (param) => param.d.category === ParamCategory.Simple && !param.d.name
+            );
 
             node.d.params.forEach((param, index) => {
                 let paramType: Type | undefined;
@@ -15272,6 +15275,16 @@ export function createTypeEvaluator(
                 if (expectedParamDetails && !sawParamMismatch) {
                     if (index < expectedParamDetails.params.length) {
                         const expectedParam = expectedParamDetails.params[index];
+                        const isPositionOnlyParam =
+                            (positionOnlySeparatorIndex >= 0 && index < positionOnlySeparatorIndex) ||
+                            (positionOnlySeparatorIndex < 0 &&
+                                paramsArePositionOnly &&
+                                !!param.d.name &&
+                                isPrivateName(param.d.name.d.value));
+                        const isCompatibleKeywordParam =
+                            expectedParam.kind !== ParamKind.Keyword ||
+                            sawLambdaArgsParam ||
+                            (!isPositionOnlyParam && param.d.name?.d.value === expectedParam.param.name);
 
                         // If the parameter category matches and both of the parameters are
                         // either separators (/ or *) or not separators, copy the type
@@ -15279,7 +15292,7 @@ export function createTypeEvaluator(
                         if (
                             expectedParam.param.category === param.d.category &&
                             !param.d.name === !expectedParam.param.name &&
-                            (expectedParam.kind !== ParamKind.Keyword || sawLambdaArgsParam)
+                            isCompatibleKeywordParam
                         ) {
                             paramType = expectedParam.type;
                         } else {

--- a/packages/pyright-internal/src/tests/samples/lambda4.py
+++ b/packages/pyright-internal/src/tests/samples/lambda4.py
@@ -1,7 +1,7 @@
 # This sample tests the case where a lambda is assigned to
 # a union type that contains multiple callables.
 
-from typing import Callable, Generic, Protocol, Self, TypeVar
+from typing import Callable, Generic, Protocol, Self, TypeVar, assert_type
 
 
 U1 = Callable[[int, str], bool] | Callable[[str], bool]
@@ -111,3 +111,20 @@ positional_callable_union: Callable[[PositionalCallable], PositionalCallable] | 
 
 # This should generate an error.
 keyword_only_callback: KeywordOnlyCallback = lambda x: x
+
+
+class KeywordOnlyIntCallback(Protocol):
+    def __call__(self, *, value: int) -> int: ...
+
+
+same_name_keyword_only_callback: KeywordOnlyIntCallback = lambda value: assert_type(value, int)
+
+
+class VariadicKeywordOnlyCallback(Protocol):
+    def __call__(self, *args: object, value: int) -> int: ...
+
+
+variadic_keyword_only_callback: VariadicKeywordOnlyCallback = lambda *args, value: assert_type(value, int)
+
+# This should generate an error.
+position_only_keyword_callback: KeywordOnlyIntCallback = lambda value, /: value

--- a/packages/pyright-internal/src/tests/samples/lambda4.py
+++ b/packages/pyright-internal/src/tests/samples/lambda4.py
@@ -126,5 +126,13 @@ class VariadicKeywordOnlyCallback(Protocol):
 
 variadic_keyword_only_callback: VariadicKeywordOnlyCallback = lambda *args, value: assert_type(value, int)
 
+# The bare `*` separator should not consume the contextual parameter index.
+bare_keyword_only_callback: KeywordOnlyIntCallback = lambda *, value: assert_type(value, int)
+
+# This should generate an error because the keyword-only parameter name differs.
+variadic_keyword_only_callback_different_name: VariadicKeywordOnlyCallback = lambda *args, other: reveal_type(
+    other, expected_text="Unknown"
+)
+
 # This should generate an error.
 position_only_keyword_callback: KeywordOnlyIntCallback = lambda value, /: value

--- a/packages/pyright-internal/src/tests/samples/lambda4.py
+++ b/packages/pyright-internal/src/tests/samples/lambda4.py
@@ -1,7 +1,7 @@
 # This sample tests the case where a lambda is assigned to
 # a union type that contains multiple callables.
 
-from typing import Callable, Protocol, TypeVar
+from typing import Callable, Generic, Protocol, Self, TypeVar
 
 
 U1 = Callable[[int, str], bool] | Callable[[str], bool]
@@ -76,3 +76,38 @@ U3 = Takes[Takes[int]] | Takes[Takes[str]]
 def accepts_u3(u: U3):
     # This should generate an error.
     u(lambda v: v.lower())
+
+
+class KeywordOnlyCallable:
+    def __call__(self, *, kwarg: int) -> Self: ...
+
+
+keyword_only_union: Callable[[KeywordOnlyCallable], KeywordOnlyCallable] | KeywordOnlyCallable = lambda x: x
+
+
+class GenericKeywordOnlyCallable(Generic[T]):
+    def __call__(self, *, kwarg: T) -> Self: ...
+
+
+generic_keyword_only_union: (
+    Callable[[GenericKeywordOnlyCallable[int]], GenericKeywordOnlyCallable[int]] | GenericKeywordOnlyCallable[int]
+) = lambda x: x
+
+
+class KeywordOnlyCallback(Protocol):
+    def __call__(self, *, value: int) -> Self: ...
+
+
+protocol_keyword_only_union: Callable[[KeywordOnlyCallback], KeywordOnlyCallback] | KeywordOnlyCallback = lambda x: x
+
+ordinary_callable_union: Callable[[int], int] | Callable[[str], str] = lambda x: x
+
+
+class PositionalCallable:
+    def __call__(self, value: int) -> Self: ...
+
+
+positional_callable_union: Callable[[PositionalCallable], PositionalCallable] | PositionalCallable = lambda x: x
+
+# This should generate an error.
+keyword_only_callback: KeywordOnlyCallback = lambda x: x

--- a/packages/pyright-internal/src/tests/typeEvaluator1.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator1.test.ts
@@ -726,7 +726,7 @@ test('Lambda3', () => {
 test('Lambda4', () => {
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['lambda4.py']);
 
-    TestUtils.validateResults(analysisResults, 2);
+    TestUtils.validateResults(analysisResults, 3);
 });
 
 test('Lambda5', () => {

--- a/packages/pyright-internal/src/tests/typeEvaluator1.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator1.test.ts
@@ -726,7 +726,7 @@ test('Lambda3', () => {
 test('Lambda4', () => {
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['lambda4.py']);
 
-    TestUtils.validateResults(analysisResults, 4);
+    TestUtils.validateResults(analysisResults, 5);
 });
 
 test('Lambda5', () => {

--- a/packages/pyright-internal/src/tests/typeEvaluator1.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator1.test.ts
@@ -726,7 +726,7 @@ test('Lambda3', () => {
 test('Lambda4', () => {
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['lambda4.py']);
 
-    TestUtils.validateResults(analysisResults, 3);
+    TestUtils.validateResults(analysisResults, 4);
 });
 
 test('Lambda5', () => {


### PR DESCRIPTION
Fixes #11603.

When a lambda was contextually typed from a union of callable candidates, a keyword-only parameter from one candidate could incorrectly provide the type for a positional lambda parameter. This caused the wrong candidate to influence inference instead of being rejected.

Treat a keyword-only contextual parameter as compatible only with a lambda parameter that follows `*` or `*args`. Otherwise, skip that candidate and continue with the remaining contextual signatures.

Tests cover the reported case, generic and callback-protocol variants, ordinary callable unions, positional callable objects, and the incompatible keyword-only case.

Validation:
- `Lambda4`: 1/1 passed
- lambda subset: 16/16 passed
- `typeEvaluator1.test.ts`: 159/159 passed
- `npm run build:cli:dev`
- Prettier
- ESLint
- `git diff --check`
