### PR TITLE
Fix TypedDict in narrowing wrongly eliminating subtype for extra_items keys

### DIFF
--- a/packages/pyright-internal/src/analyzer/typeGuards.ts
+++ b/packages/pyright-internal/src/analyzer/typeGuards.ts
@@ -2257,7 +2257,8 @@ function narrowTypeForTypedDictKey(
 
             if (isClassInstance(subtype) && ClassType.isTypedDictClass(subtype)) {
                 const entries = getTypedDictMembersForClass(evaluator, subtype, /* allowNarrowed */ true);
-                const tdEntry = entries.knownItems.get(literalKey.priv.literalValue as string) ?? entries.extraItems;
+                const knownItemEntry = entries.knownItems.get(literalKey.priv.literalValue as string);
+                const tdEntry = knownItemEntry ?? entries.extraItems;
 
                 if (isPositiveTest) {
                     // The code that is commented out below implements the behavior that is technically
@@ -2309,7 +2310,12 @@ function narrowTypeForTypedDictKey(
                         )
                     );
                 } else {
-                    return tdEntry !== undefined && (tdEntry.isRequired || tdEntry.isProvided) ? undefined : subtype;
+                    // Only a known item can be guaranteed to be present. If the key
+                    // matched the "extra items" entry, the key may or may not be
+                    // present, so the subtype cannot be eliminated in this case.
+                    return knownItemEntry !== undefined && (knownItemEntry.isRequired || knownItemEntry.isProvided)
+                        ? undefined
+                        : subtype;
                 }
             }
 

--- a/packages/pyright-internal/src/tests/samples/typedDictClosed1.py
+++ b/packages/pyright-internal/src/tests/samples/typedDictClosed1.py
@@ -48,6 +48,17 @@ def func2(movie: Movie) -> None:
     movie["other3"] = 1
 
 
+def func3(movie: Movie) -> None:
+    # "name" is a required known item, so it is always present and the
+    # negative branch of the "in" check must remain unreachable.
+    if "name" in movie:
+        return
+
+    # This would generate a type incompatibility error if the statement
+    # above were incorrectly considered reachable.
+    movie["other4"] = 1
+
+
 class MovieBase(TypedDict, extra_items=ReadOnly[str | None]):
     name: str
 

--- a/packages/pyright-internal/src/tests/samples/typedDictClosed1.py
+++ b/packages/pyright-internal/src/tests/samples/typedDictClosed1.py
@@ -35,6 +35,19 @@ def func1(movie: Movie) -> None:
     movie["other2"] = 1
 
 
+def func2(movie: Movie) -> None:
+    # An extra item is not guaranteed to be present, so the negative
+    # branch of the "in" check must remain reachable.
+    if "novel_adaptation" in movie:
+        return
+
+    reveal_type(movie, expected_text="Movie")
+
+    # This should generate a type incompatibility error. If the statements
+    # above are incorrectly marked unreachable, no error is reported here.
+    movie["other3"] = 1
+
+
 class MovieBase(TypedDict, extra_items=ReadOnly[str | None]):
     name: str
 

--- a/packages/pyright-internal/src/tests/typeEvaluator5.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator5.test.ts
@@ -350,7 +350,7 @@ test('TypedDictReadOnly2', () => {
 
 test('TypedDictClosed1', () => {
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['typedDictClosed1.py']);
-    TestUtils.validateResults(analysisResults, 7);
+    TestUtils.validateResults(analysisResults, 8);
 });
 
 test('TypedDictClosed2', () => {


### PR DESCRIPTION
For a TypedDict with `extra_items` (PEP 728), a membership check on a key that is not a known item wrongly makes the negative branch unreachable:

```python
class Movie(TypedDict, extra_items=bool):
    name: str

def func(movie: Movie) -> None:
    if "novel_adaptation" in movie:
        return
    reveal_type(movie)  # branch is wrongly marked unreachable today
```

The cause is in `narrowTypeForTypedDictKey`: the negative branch used `knownItems.get(key) ?? extraItems`, so a key that only matched the extra_items pseudo-entry was treated like a known provided item and eliminated the subtype. An extra item may or may not be present at runtime, so its absence can never rule the type out. Only a known item that is required or provided can do that.

The positive branch keeps its current behavior, it still uses the extra_items entry to mark the key as provided after the check.

Testing: added a case to `typedDictClosed1.py` where code after a negative `in` check on an extra key must stay reachable (it asserts an unrelated type error is still reported there, which the unreachability bug swallows). Without the fix that sample reports 7 errors instead of 8, with it all 10 TypedDictClosed tests pass and the full typeEvaluator suite is green: 1184 tests across 8 suites, 0 failures.