### PR TITLE
Fix negative type narrowing for mapping patterns with multiple key entries

### DIFF
--- a/packages/pyright-internal/src/analyzer/patternMatching.ts
+++ b/packages/pyright-internal/src/analyzer/patternMatching.ts
@@ -469,58 +469,91 @@ function narrowTypeBasedOnMappingPattern(
             return combineTypes(mappingInfo.filter((m) => !m.isDefinitelyMapping).map((m) => m.subtype));
         }
 
-        if (pattern.d.entries.length !== 1 || pattern.d.entries[0].nodeType !== ParseNodeType.PatternMappingKeyEntry) {
-            return type;
-        }
-
         // Handle the case where the type is a union that includes a TypedDict with
-        // a field discriminated by a literal.
-        const keyPattern = pattern.d.entries[0].d.keyPattern;
-        const valuePattern = pattern.d.entries[0].d.valuePattern;
-        if (
-            keyPattern.nodeType !== ParseNodeType.PatternLiteral ||
-            valuePattern.nodeType !== ParseNodeType.PatternAs ||
-            !valuePattern.d.orPatterns.every((orPattern) => orPattern.nodeType === ParseNodeType.PatternLiteral)
-        ) {
-            return type;
+        // fields discriminated by literals or match patterns.
+        const keyEntryInfos: { keyValue: string; valueTypes?: Type[] }[] = [];
+        let hasUnsupportedKeyPattern = false;
+
+        for (const entry of pattern.d.entries) {
+            if (entry.nodeType === ParseNodeType.PatternMappingExpandEntry) {
+                continue;
+            }
+            if (entry.nodeType !== ParseNodeType.PatternMappingKeyEntry) {
+                hasUnsupportedKeyPattern = true;
+                break;
+            }
+
+            const keyPattern = entry.d.keyPattern;
+            if (keyPattern.nodeType !== ParseNodeType.PatternLiteral) {
+                hasUnsupportedKeyPattern = true;
+                break;
+            }
+
+            const keyType = evaluator.getTypeOfExpression(keyPattern.d.expr).type;
+            if (
+                !isClassInstance(keyType) ||
+                !ClassType.isBuiltIn(keyType, 'str') ||
+                keyType.priv.literalValue === undefined
+            ) {
+                hasUnsupportedKeyPattern = true;
+                break;
+            }
+            const keyValue = keyType.priv.literalValue as string;
+
+            const valuePattern = entry.d.valuePattern;
+            let valueTypes: Type[] | undefined;
+
+            if (
+                valuePattern.nodeType === ParseNodeType.PatternAs &&
+                valuePattern.d.orPatterns.every((orPattern) => orPattern.nodeType === ParseNodeType.PatternLiteral)
+            ) {
+                valueTypes = valuePattern.d.orPatterns.map(
+                    (orPattern) => evaluator.getTypeOfExpression((orPattern as PatternLiteralNode).d.expr).type
+                );
+            } else if (
+                valuePattern.nodeType === ParseNodeType.PatternAs &&
+                valuePattern.d.orPatterns.length === 1 &&
+                (valuePattern.d.orPatterns[0].nodeType === ParseNodeType.PatternCapture ||
+                    valuePattern.d.orPatterns[0].nodeType === ParseNodeType.PatternValue)
+            ) {
+                valueTypes = undefined;
+            } else {
+                hasUnsupportedKeyPattern = true;
+                break;
+            }
+
+            keyEntryInfos.push({ keyValue, valueTypes });
         }
 
-        const keyType = evaluator.getTypeOfExpression(keyPattern.d.expr).type;
-
-        // The key type must be a str literal.
-        if (
-            !isClassInstance(keyType) ||
-            !ClassType.isBuiltIn(keyType, 'str') ||
-            keyType.priv.literalValue === undefined
-        ) {
+        if (hasUnsupportedKeyPattern || keyEntryInfos.length === 0) {
             return type;
         }
-        const keyValue = keyType.priv.literalValue as string;
-
-        const valueTypes = valuePattern.d.orPatterns.map(
-            (orPattern) => evaluator.getTypeOfExpression((orPattern as PatternLiteralNode).d.expr).type
-        );
 
         return mapSubtypes(type, (subtype) => {
             if (isClassInstance(subtype) && ClassType.isTypedDictClass(subtype)) {
                 const typedDictMembers = getTypedDictMembersForClass(evaluator, subtype, /* allowNarrowed */ true);
-                const member = typedDictMembers.knownItems.get(keyValue);
 
-                if (member && (member.isRequired || member.isProvided) && isClassInstance(member.valueType)) {
-                    const memberValueType = member.valueType;
-
-                    // If there's at least one literal value pattern that matches
-                    // the literal type of the member, we can eliminate this type.
-                    if (
-                        valueTypes.some(
-                            (valueType) =>
-                                isClassInstance(valueType) &&
-                                ClassType.isSameGenericClass(valueType, memberValueType) &&
-                                valueType.priv.literalValue === memberValueType.priv.literalValue
-                        )
-                    ) {
-                        return undefined;
+                const matchesAllEntries = keyEntryInfos.every((entryInfo) => {
+                    const member = typedDictMembers.knownItems.get(entryInfo.keyValue);
+                    if (!member || (!member.isRequired && !member.isProvided) || !isClassInstance(member.valueType)) {
+                        return false;
                     }
+
+                    if (entryInfo.valueTypes === undefined) {
+                        return true;
+                    }
+
+                    const memberValueType = member.valueType;
+                    return entryInfo.valueTypes.some(
+                        (valueType) =>
+                            isClassInstance(valueType) &&
+                            ClassType.isSameGenericClass(valueType, memberValueType) &&
+                            valueType.priv.literalValue === memberValueType.priv.literalValue
+                    );
+                });
+
+                if (matchesAllEntries) {
+                    return undefined;
                 }
             }
 

--- a/packages/pyright-internal/src/analyzer/patternMatching.ts
+++ b/packages/pyright-internal/src/analyzer/patternMatching.ts
@@ -513,8 +513,7 @@ function narrowTypeBasedOnMappingPattern(
             } else if (
                 valuePattern.nodeType === ParseNodeType.PatternAs &&
                 valuePattern.d.orPatterns.length === 1 &&
-                (valuePattern.d.orPatterns[0].nodeType === ParseNodeType.PatternCapture ||
-                    valuePattern.d.orPatterns[0].nodeType === ParseNodeType.PatternValue)
+                valuePattern.d.orPatterns[0].nodeType === ParseNodeType.PatternCapture
             ) {
                 valueTypes = undefined;
             } else {

--- a/packages/pyright-internal/src/tests/samples/matchMapping1.py
+++ b/packages/pyright-internal/src/tests/samples/matchMapping1.py
@@ -150,5 +150,26 @@ def test_not_required_narrowing(subj: TD1) -> None:
             # This should generate an error.
             print(subj["v1"])
 
+
             print(subj["v2"])
             print(subj["v3"])
+
+
+class MsgA(TypedDict):
+    v: Literal[1]
+    kind: Literal["a"]
+    data_a: int
+
+
+class MsgB(TypedDict):
+    v: Literal[1]
+    kind: Literal["b"]
+    data_b: str
+
+
+def test_negative_narrowing3(msg: MsgA | MsgB) -> None:
+    match msg:
+        case {"v": 1, "kind": "a"}:
+            reveal_type(msg, expected_text="MsgA")
+        case _:
+            reveal_type(msg, expected_text="MsgB")

--- a/packages/pyright-internal/src/tests/samples/matchMapping1.py
+++ b/packages/pyright-internal/src/tests/samples/matchMapping1.py
@@ -1,6 +1,7 @@
 # This sample tests type checking for match statements (as
 # described in PEP 634) that contain mapping patterns.
 
+from enum import Enum
 from typing import Literal, TypedDict
 
 from typing_extensions import NotRequired  # pyright: ignore[reportMissingModuleSource]
@@ -173,3 +174,33 @@ def test_negative_narrowing3(msg: MsgA | MsgB) -> None:
             reveal_type(msg, expected_text="MsgA")
         case _:
             reveal_type(msg, expected_text="MsgB")
+
+
+class Color(Enum):
+    RED = 1
+    BLUE = 2
+
+
+class RedMsg(TypedDict):
+    color: Literal[Color.RED]
+
+
+class BlueMsg(TypedDict):
+    color: Literal[Color.BLUE]
+
+
+def test_value_pattern_negative_narrowing(msg: RedMsg | BlueMsg) -> None:
+    match msg:
+        case {"color": Color.RED}:
+            reveal_type(msg, expected_text="RedMsg")
+        case _:
+            reveal_type(msg, expected_text="RedMsg | BlueMsg")
+
+
+def test_capture_pattern_negative_narrowing(msg: MsgA | MsgB) -> None:
+    match msg:
+        case {"v": 1, "kind": x}:
+            reveal_type(msg, expected_text="MsgA | MsgB")
+            reveal_type(x, expected_text="Literal['a', 'b']")
+        case _:
+            reveal_type(msg, expected_text="Never")


### PR DESCRIPTION
### Minimal Reproduction Case

```python
from typing import Literal, TypedDict

class MsgA(TypedDict):
    v: Literal[1]
    kind: Literal["a"]
    data_a: int

class MsgB(TypedDict):
    v: Literal[1]
    kind: Literal["b"]
    data_b: str

def test_negative_narrowing(msg: MsgA | MsgB) -> None:
    match msg:
        case {"v": 1, "kind": "a"}:
            reveal_type(msg)  # MsgA
        case _:
            reveal_type(msg)  # Expected: MsgB, Actual pre-fix: MsgA | MsgB
```

### Current vs Expected Behavior

- **Current Behavior**: When a mapping pattern contains two or more key entries (e.g. `case {"v": 1, "kind": "a"}:`), Pyright does not eliminate matching `TypedDict` subtypes from the subject in the fallthrough (`case _:`) branch. Consequently, `reveal_type(msg)` in `case _:` reports `MsgA | MsgB`.
- **Expected Behavior**: Any subject instance matching `case {"v": 1, "kind": "a"}:` is guaranteed to be `MsgA`. The fallthrough `case _:` branch cannot receive `MsgA`, so `msg` must be narrowed to `MsgB`.

### Rationale

In Python 3.10+ pattern matching (PEP 634), matching a subject against a mapping pattern checks whether the subject is a mapping and contains matching values for all specified key entries. When a subject is a union of `TypedDict` types, a `TypedDict` subtype whose literal field values match all key entries of a mapping pattern will always match that `case` clause. In negative type narrowing (`!isPositiveTest`), such matching `TypedDict` subtypes must be eliminated from the remaining subject type in fallthrough branches.

### Root Cause

In `packages/pyright-internal/src/analyzer/patternMatching.ts`, `narrowTypeBasedOnMappingPattern` previously hardcoded a single-key check (`pattern.d.entries.length === 1`) when `!isPositiveTest`. Mapping patterns with two or more key entries were skipped, preventing negative type narrowing for multi-key patterns.

### Proposed Fix

Generalize `narrowTypeBasedOnMappingPattern` under `!isPositiveTest` to parse all key entries in `pattern.d.entries`. If a `TypedDict` subtype matches all key entries in the mapping pattern (matching string literal key names, literal value types, or wildcard/capture variables), eliminate that `TypedDict` subtype from the remaining type.

### Test Coverage

Added regression test `test_negative_narrowing3` to `packages/pyright-internal/src/tests/samples/matchMapping1.py`.

### Validation Results

- `npx jest src/tests/typeEvaluator6.test.ts` passed (148/148 tests passed).
- `npx tsc --noEmit` passed with 0 errors.
- `git diff --check` passed with 0 formatting or whitespace errors.
