### PR TITLE
Fix tuple slice type evaluation for slices with start >= stop

### DIFF
--- a/packages/pyright-internal/src/analyzer/tuples.ts
+++ b/packages/pyright-internal/src/analyzer/tuples.ts
@@ -550,11 +550,11 @@ export function getSlicedTupleType(
     const startValue = getTupleSliceParam(evaluator, sliceNode.d.startValue, 0, tupleTypeArgs);
     const endValue = getTupleSliceParam(evaluator, sliceNode.d.endValue, tupleTypeArgs.length, tupleTypeArgs);
 
-    if (startValue === undefined || endValue === undefined || endValue < startValue) {
+    if (startValue === undefined || endValue === undefined) {
         return undefined;
     }
 
-    const slicedTypeArgs = tupleTypeArgs.slice(startValue, endValue);
+    const slicedTypeArgs = startValue < endValue ? tupleTypeArgs.slice(startValue, endValue) : [];
     return ClassType.cloneAsInstance(specializeTupleClass(tupleType, slicedTypeArgs));
 }
 

--- a/packages/pyright-internal/src/tests/samples/tuple20.py
+++ b/packages/pyright-internal/src/tests/samples/tuple20.py
@@ -1,0 +1,15 @@
+# Sample test for tuple slicing with start index >= stop index.
+
+t: tuple[int, str, bool] = (1, "a", True)
+
+# Slicing where start >= stop produces an empty tuple (tuple[()])
+# in Python runtime.
+
+a = t[2:1]
+reveal_type(a, expected_text="tuple[()]")
+
+b = t[-1:-2]
+reveal_type(b, expected_text="tuple[()]")
+
+c = t[5:1]
+reveal_type(c, expected_text="tuple[()]")

--- a/packages/pyright-internal/src/tests/typeEvaluator8.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator8.test.ts
@@ -610,6 +610,12 @@ test('Tuple19', () => {
     TestUtils.validateResults(analysisResults, 1);
 });
 
+test('Tuple20', () => {
+    const analysisResults = TestUtils.typeAnalyzeSampleFiles(['tuple20.py']);
+
+    TestUtils.validateResults(analysisResults, 0);
+});
+
 test('NamedTuple1', () => {
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['namedTuple1.py']);
 


### PR DESCRIPTION
### Summary

Fixes type evaluation of fixed-length tuple slicing when `start >= stop` (e.g. `t[2:1]`, `t[-1:-2]`, `t[5:1]`).

In Python runtime, slicing a tuple with `start >= stop` produces an empty tuple `()` of length 0.

Previously, `getSlicedTupleType` returned `undefined` whenever `endValue < startValue`. When `getSlicedTupleType` returned `undefined`, Pyright fell back to evaluating `tuple.__getitem__(slice)`, which degraded the inferred type of a fixed-length heterogeneous tuple slice (such as `t[2:1]` where `t: tuple[int, str, bool]`) to an unbounded union type `tuple[int | str | bool, ...]`.

### Behavior Change

Pyright now correctly evaluates fixed-length tuple slicing with `start >= stop` to an empty tuple type `tuple[()]`.

### Implementation Details

In `packages/pyright-internal/src/analyzer/tuples.ts`, `getSlicedTupleType` no longer returns `undefined` when `endValue < startValue`. Instead, it checks `startValue < endValue` and uses an empty array `[]` when `startValue >= endValue`, which cleanly specializes to `tuple[()]`.

### Validation

- Added new sample test `tuple20.py` and test case `Tuple20` in `typeEvaluator8.test.ts`.
- Ran full test suite in `packages/pyright-internal` (`npm run test`): 24 test suites passed (798 passed, 0 failed).
- Ran workspace check script (`npm run check`): 4 packages typechecked cleanly with 0 errors.
- Ran `git diff --check`: 0 issues found.
