### PR TITLE
Fix negative type narrowing for isinstance/issubclass with type[T] variable or tuple

### DIFF
--- a/packages/pyright-internal/src/analyzer/typeGuards.ts
+++ b/packages/pyright-internal/src/analyzer/typeGuards.ts
@@ -1246,14 +1246,27 @@ export function getIsInstanceClassTypes(
 
                 if (isInstantiableClass(subtype) && ClassType.isBuiltIn(subtype, 'Callable')) {
                     subtype = convertToInstantiable(getUnknownTypeForCallable());
+                } else if (TypeBase.isInstance(subtype)) {
+                    if (
+                        ClassType.isBuiltIn(subtype, 'type') &&
+                        subtype.priv.typeArgs &&
+                        isAnyOrUnknown(subtype.priv.typeArgs[0])
+                    ) {
+                        foundNonClassType = true;
+                        return;
+                    }
+                    subtype = convertToInstantiable(subtype);
                 }
             }
 
             if (isInstantiableClass(subtype)) {
+                if (subtype.priv.includeSubclasses) {
+                    subtype = ClassType.cloneIncludeSubclasses(subtype, /* includeSubclasses */ false);
+                }
                 // If this is a reference to a class that has type promotions (e.g.
                 // float or complex), remove the promotions for purposes of the
                 // isinstance check).
-                if (!subtype.priv.includeSubclasses && subtype.priv.includePromotions) {
+                if (subtype.priv.includePromotions) {
                     subtype = ClassType.cloneRemoveTypePromotions(subtype);
                 }
                 classTypeList.push(subtype);

--- a/packages/pyright-internal/src/analyzer/typeGuards.ts
+++ b/packages/pyright-internal/src/analyzer/typeGuards.ts
@@ -1246,27 +1246,27 @@ export function getIsInstanceClassTypes(
 
                 if (isInstantiableClass(subtype) && ClassType.isBuiltIn(subtype, 'Callable')) {
                     subtype = convertToInstantiable(getUnknownTypeForCallable());
-                } else if (TypeBase.isInstance(subtype)) {
-                    if (
-                        ClassType.isBuiltIn(subtype, 'type') &&
-                        subtype.priv.typeArgs &&
-                        isAnyOrUnknown(subtype.priv.typeArgs[0])
-                    ) {
-                        foundNonClassType = true;
-                        return;
+                } else if (TypeBase.isInstance(subtype) && ClassType.isBuiltIn(subtype, 'type')) {
+                    if (subtype.priv.typeArgs && subtype.priv.typeArgs.length > 0) {
+                        const typeArg = subtype.priv.typeArgs[0];
+                        if (isAnyOrUnknown(typeArg)) {
+                            foundNonClassType = true;
+                            return;
+                        }
+                        if (isInstantiableClass(typeArg)) {
+                            subtype = typeArg;
+                        } else if (isClass(typeArg) && TypeBase.isInstance(typeArg)) {
+                            subtype = convertToInstantiable(typeArg);
+                        }
                     }
-                    subtype = convertToInstantiable(subtype);
                 }
             }
 
             if (isInstantiableClass(subtype)) {
-                if (subtype.priv.includeSubclasses) {
-                    subtype = ClassType.cloneIncludeSubclasses(subtype, /* includeSubclasses */ false);
-                }
                 // If this is a reference to a class that has type promotions (e.g.
                 // float or complex), remove the promotions for purposes of the
                 // isinstance check).
-                if (subtype.priv.includePromotions) {
+                if (!subtype.priv.includeSubclasses && subtype.priv.includePromotions) {
                     subtype = ClassType.cloneRemoveTypePromotions(subtype);
                 }
                 classTypeList.push(subtype);
@@ -1553,8 +1553,12 @@ function narrowTypeForInstance(
                 // note this case specially so we don't do any narrowing, which
                 // will generate false positives.
                 if (filterIsSuperclass) {
-                    if (!isTypeIsCheck && concreteFilterType.priv.includeSubclasses) {
-                        // If the filter type includes subclasses, we can't eliminate
+                    if (
+                        !isTypeIsCheck &&
+                        concreteFilterType.priv.includeSubclasses &&
+                        !ClassType.isFinal(concreteFilterType)
+                    ) {
+                        // If the filter type includes subclasses and is not final, we can't eliminate
                         // this type in the negative direction. We'll relax this for
                         // TypeIs checks.
                         isClassRelationshipIndeterminate = true;

--- a/packages/pyright-internal/src/tests/samples/typeNarrowingIsinstance22.py
+++ b/packages/pyright-internal/src/tests/samples/typeNarrowingIsinstance22.py
@@ -1,0 +1,47 @@
+# This sample tests type narrowing for isinstance and issubclass when
+# the class argument is passed as a type[T] variable or tuple of type[T].
+
+# pyright: reportMissingModuleSource=false
+
+from typing_extensions import reveal_type
+
+
+class A:
+    pass
+
+
+class B:
+    pass
+
+
+class C:
+    pass
+
+
+def test_tuple_param(x: A | B | C, types: tuple[type[A], type[B]]):
+    if isinstance(x, types):
+        reveal_type(x, expected_text="A | B")
+    else:
+        reveal_type(x, expected_text="C")
+
+
+def test_tuple_annotated_local(x: A | B | C):
+    types: tuple[type[A], type[B]] = (A, B)
+    if isinstance(x, types):
+        reveal_type(x, expected_text="A | B")
+    else:
+        reveal_type(x, expected_text="C")
+
+
+def test_single_class_param(x: A | B, cls: type[A]):
+    if isinstance(x, cls):
+        reveal_type(x, expected_text="A")
+    else:
+        reveal_type(x, expected_text="B")
+
+
+def test_issubclass_param(sub_cls: type[A] | type[B], cls: type[A]):
+    if issubclass(sub_cls, cls):
+        reveal_type(sub_cls, expected_text="type[A]")
+    else:
+        reveal_type(sub_cls, expected_text="type[B]")

--- a/packages/pyright-internal/src/tests/samples/typeNarrowingIsinstance22.py
+++ b/packages/pyright-internal/src/tests/samples/typeNarrowingIsinstance22.py
@@ -3,6 +3,7 @@
 
 # pyright: reportMissingModuleSource=false
 
+from typing import final
 from typing_extensions import reveal_type
 
 
@@ -14,34 +15,23 @@ class B:
     pass
 
 
-class C:
+@final
+class FinalClass:
     pass
 
 
-def test_tuple_param(x: A | B | C, types: tuple[type[A], type[B]]):
-    if isinstance(x, types):
-        reveal_type(x, expected_text="A | B")
-    else:
-        reveal_type(x, expected_text="C")
-
-
-def test_tuple_annotated_local(x: A | B | C):
-    types: tuple[type[A], type[B]] = (A, B)
-    if isinstance(x, types):
-        reveal_type(x, expected_text="A | B")
-    else:
-        reveal_type(x, expected_text="C")
-
-
-def test_single_class_param(x: A | B, cls: type[A]):
+def test_positive_narrowing(x: A | B, cls: type[A]):
     if isinstance(x, cls):
         reveal_type(x, expected_text="A")
+
+
+def test_positive_tuple_param(x: A | B, types: tuple[type[A], type[B]]):
+    if isinstance(x, types):
+        reveal_type(x, expected_text="A | B")
+
+
+def test_final_class_param(x: FinalClass | B, cls: type[FinalClass]):
+    if isinstance(x, cls):
+        reveal_type(x, expected_text="FinalClass")
     else:
         reveal_type(x, expected_text="B")
-
-
-def test_issubclass_param(sub_cls: type[A] | type[B], cls: type[A]):
-    if issubclass(sub_cls, cls):
-        reveal_type(sub_cls, expected_text="type[A]")
-    else:
-        reveal_type(sub_cls, expected_text="type[B]")

--- a/packages/pyright-internal/src/tests/typeEvaluator1.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator1.test.ts
@@ -507,6 +507,12 @@ test('TypeNarrowingIsinstance21', () => {
     TestUtils.validateResults(analysisResults, 0);
 });
 
+test('TypeNarrowingIsinstance22', () => {
+    const analysisResults = TestUtils.typeAnalyzeSampleFiles(['typeNarrowingIsinstance22.py']);
+
+    TestUtils.validateResults(analysisResults, 0);
+});
+
 test('TypeNarrowingTupleLength1', () => {
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['typeNarrowingTupleLength1.py']);
 


### PR DESCRIPTION
### Summary
Fixes an issue where `isinstance()` and `issubclass()` type narrowing failed to extract class filters when passed a variable of type `type[T]` or `tuple[type[T], ...]`. Also enables sound negative type narrowing when `T` is a `@final` class.

### Problem & Root Cause
1. `getIsInstanceClassTypes` extracts element class types for `isinstance`/`issubclass`. When given a variable of type `type[T]` or `tuple[type[A], type[B]]`, the elements in `tupleTypeArgs` are `ClassInstance`s of `type` (e.g. `type[A]`), rather than instantiable class types `A`. Previously, `getIsInstanceClassTypes` set `foundNonClassType = true` on `type[T]` instances, failing to extract the target filter types and resulting in no type narrowing.
2. In negative narrowing (`isPositiveTest = false`), non-final classes typed as `type[T]` must preserve `includeSubclasses = true` because `type[T]` may hold a runtime subclass of `T`. However, when `T` is `@final` (e.g. `@final` class or built-in final type), `T` cannot have runtime subclasses, making negative narrowing sound.

### Fix
1. In `getIsInstanceClassTypes`:
   - Specifically check for `ClassInstance`s of `type` (`ClassType.isBuiltIn(subtype, 'type')`) and extract their type arguments (`type[T] -> T`).
   - Reject `type[Any]` or `type[Unknown]` as concrete class filters.
   - Preserve `includeSubclasses = true` on extracted instantiable class types.
2. In `narrowTypeForInstanceOrSubclassInternal`:
   - Allow negative elimination when `ClassType.isFinal(concreteFilterType)` is true, permitting sound negative narrowing for final class `type[T]` variables.

### Verification
- All 160 unit tests in `typeEvaluator1.test.ts` pass cleanly (160/160).
- `git diff --check`, `npm run check`, and `npm run typecheck` pass with 0 errors.
