### PR TITLE
Narrow closed TypedDicts on a key membership check

### DIFF
--- a/packages/pyright-internal/src/analyzer/typeGuards.ts
+++ b/packages/pyright-internal/src/analyzer/typeGuards.ts
@@ -2277,11 +2277,13 @@ function narrowTypeForTypedDictKey(
                     //     return subtype;
                     // }
 
-                    // if (isNever(tdEntry.valueType)) {
-                    //     // If the entry is typed as Never or the "extra items" is typed as Never,
-                    //     // then this key cannot be present in the TypedDict, and we can eliminate it.
-                    //     return undefined;
-                    // }
+                    if (isNever(tdEntry.valueType)) {
+                        // If the entry is typed as Never or the "extra items" is typed as Never,
+                        // then this key cannot be present in the TypedDict, and we can eliminate it.
+                        // A closed TypedDict has an "extra items" of Never, so this is what allows
+                        // a key check to discriminate between closed TypedDicts.
+                        return undefined;
+                    }
 
                     // If the entry is currently not required and not marked provided, we can mark
                     // it as provided after this guard expression confirms it is.

--- a/packages/pyright-internal/src/tests/samples/typedDictClosed11.py
+++ b/packages/pyright-internal/src/tests/samples/typedDictClosed11.py
@@ -3,7 +3,7 @@
 # is not one of its known items, so such a check can discriminate.
 
 
-from typing import TypedDict
+from typing import Never, NotRequired, TypedDict
 
 
 class Foo(TypedDict, closed=True):
@@ -56,3 +56,44 @@ def func4(u: Foo | Open) -> None:
         reveal_type(u, expected_text="Foo")
     else:
         reveal_type(u, expected_text="Open")
+
+
+class NeverItem(TypedDict):
+    always: int
+    never: Never
+
+
+def func5(td: NeverItem) -> None:
+    # A declared item typed as Never can never be present either, so the
+    # same elimination applies to it and not only to the "extra items"
+    # entry synthesized for a closed TypedDict.
+    if "never" in td:
+        reveal_type(td, expected_text="Never")
+    else:
+        reveal_type(td, expected_text="NeverItem")
+
+
+class Left(TypedDict, closed=True):
+    common: int
+    left: int
+
+
+class Right(TypedDict, closed=True):
+    common: int
+    right: NotRequired[int]
+
+
+def func6(u: Left | Right) -> None:
+    # "common" is a required known item of both, so neither is eliminated.
+    if "common" in u:
+        reveal_type(u, expected_text="Left | Right")
+    else:
+        reveal_type(u, expected_text="Never")
+
+
+def func7(td: Right) -> None:
+    # "right" is a known item that is not required, so the subtype is kept
+    # and the key is marked as provided rather than eliminated.
+    if "right" in td:
+        reveal_type(td, expected_text="Right")
+        reveal_type(td["right"], expected_text="int")

--- a/packages/pyright-internal/src/tests/samples/typedDictClosed11.py
+++ b/packages/pyright-internal/src/tests/samples/typedDictClosed11.py
@@ -1,0 +1,58 @@
+# This sample tests narrowing of a union of closed TypedDicts based on
+# an "in" check for a key. A closed TypedDict cannot contain a key that
+# is not one of its known items, so such a check can discriminate.
+
+
+from typing import TypedDict
+
+
+class Foo(TypedDict, closed=True):
+    foo: int
+
+
+class Bar(TypedDict, closed=True):
+    bar: int
+
+
+def func1(u: Foo | Bar) -> int:
+    if "foo" in u:
+        reveal_type(u, expected_text="Foo")
+        return u["foo"]
+    else:
+        reveal_type(u, expected_text="Bar")
+        return u["bar"]
+
+
+def func2(u: Foo | Bar) -> int:
+    if "bar" not in u:
+        reveal_type(u, expected_text="Foo")
+        return u["foo"]
+    else:
+        reveal_type(u, expected_text="Bar")
+        return u["bar"]
+
+
+class Baz(TypedDict, extra_items=int):
+    baz: int
+
+
+def func3(u: Foo | Baz) -> None:
+    # "Baz" allows extra items, so it cannot be eliminated here.
+    if "foo" in u:
+        reveal_type(u, expected_text="Foo | Baz")
+    else:
+        reveal_type(u, expected_text="Baz")
+
+
+class Open(TypedDict):
+    other: int
+
+
+def func4(u: Foo | Open) -> None:
+    # An open TypedDict without "extra_items" is narrowed on a key check
+    # even though it is not sound to do so; this is idiomatic and is
+    # relied upon in practice.
+    if "foo" in u:
+        reveal_type(u, expected_text="Foo")
+    else:
+        reveal_type(u, expected_text="Open")

--- a/packages/pyright-internal/src/tests/typeEvaluator5.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator5.test.ts
@@ -408,6 +408,11 @@ test('TypedDictClosed10', () => {
     TestUtils.validateResults(analysisResults, 0);
 });
 
+test('TypedDictClosed11', () => {
+    const analysisResults = TestUtils.typeAnalyzeSampleFiles(['typedDictClosed11.py']);
+    TestUtils.validateResults(analysisResults, 0);
+});
+
 test('DataclassTransform1', () => {
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['dataclassTransform1.py']);
 


### PR DESCRIPTION
Fixes #11518.

A union of closed TypedDicts can't be discriminated with an `in` check today:

```python
class Foo(TypedDict, closed=True):
    foo: int

class Bar(TypedDict, closed=True):
    bar: int

def get_field(u: Foo | Bar) -> int:
    if "foo" in u:
        return u["foo"]  # error: "foo" is not a defined key in "Bar"
    else:
        return u["bar"]
```

`Bar` is closed, so it can't hold a `"foo"` key and should be eliminated in the positive branch.

The cause is in `narrowTypeForTypedDictKey`. `getTypedDictMembersForClass` represents `closed=True` by synthesizing an "extra items" entry whose value type is `Never`, and the positive branch looks up `knownItems.get(key) ?? extraItems`. For a closed TypedDict and an unknown key that lookup returns the synthesized `Never` entry, which is not `undefined`, so the code treats it as a real entry and keeps the subtype.

The check for this was already written in that function, commented out. I enabled just the `isNever` half. The other commented block (returning `subtype` when there's no entry at all) stays as it is, because that's the one that would disable the deliberately-unsound narrowing of open TypedDicts discussed in #10805, and the comment above it explains why it's being kept for now.

Added `typedDictClosed11.py` with seven cases: the union from the issue, the same thing through `not in`, a `Foo | Baz` union where `Baz` declares `extra_items=int` and so must not be eliminated, a `Foo | Open` union where `Open` is an ordinary TypedDict, pinning that the existing idiomatic narrowing still happens, a TypedDict with an item declared as `Never`, a union of two closed TypedDicts sharing a required key, and a closed TypedDict with a `NotRequired` key that takes the mark-as-provided path. Put it in a new sample rather than extending `typedDictClosed1.py` so it doesn't collide with #11610, which is still open against that file.

The new sample reports five errors before the change and none after: the four from the issue (two failed `reveal_type` narrowings and the two key-access errors that follow) plus the declared-`Never` case. All eleven `TypedDictClosed` tests pass.

Ran the narrowing tests across all suites (54 passing) and the full typeEvaluator5 suite (68 passing) locally on Windows.
