### PR TITLE
Preserve union-expanded constructor types

### DIFF
--- a/packages/pyright-internal/src/analyzer/constructors.ts
+++ b/packages/pyright-internal/src/analyzer/constructors.ts
@@ -510,30 +510,34 @@ function validateInitMethod(
         inferenceContext ? { ...inferenceContext, returnTypeOverride } : undefined
     );
 
-    let adjustedClassType = type;
-
     // Overload evaluation keeps the ordinary __init__ return as a placeholder
     // and carries argument-dependent constructed types through this separate field,
     // including when union-expanded argument lists are combined.
-    if (
-        callResult.specializedInitSelfType &&
-        isClassInstance(callResult.specializedInitSelfType) &&
-        ClassType.isSameGenericClass(callResult.specializedInitSelfType, adjustedClassType)
-    ) {
-        adjustedClassType = ClassType.cloneAsInstantiable(callResult.specializedInitSelfType);
-    }
+    const returnType = callResult.specializedInitSelfType
+        ? mapSubtypes(callResult.specializedInitSelfType, (specializedInitSelfSubtype) => {
+              let adjustedClassType = type;
+              if (
+                  isClassInstance(specializedInitSelfSubtype) &&
+                  ClassType.isSameGenericClass(specializedInitSelfSubtype, adjustedClassType)
+              ) {
+                  adjustedClassType = ClassType.cloneAsInstantiable(specializedInitSelfSubtype);
+              }
 
-    const returnType =
-        callResult.specializedInitSelfType &&
-        !type.priv.isTypeArgExplicit &&
-        (isAny(callResult.specializedInitSelfType) || isUnknown(callResult.specializedInitSelfType))
-            ? callResult.specializedInitSelfType
-            : applyExpectedTypeForConstructor(
+              if (
+                  !type.priv.isTypeArgExplicit &&
+                  (isAny(specializedInitSelfSubtype) || isUnknown(specializedInitSelfSubtype))
+              ) {
+                  return specializedInitSelfSubtype;
+              }
+
+              return applyExpectedTypeForConstructor(
                   evaluator,
                   adjustedClassType,
                   /* inferenceContext */ undefined,
                   constraints
               );
+          })
+        : applyExpectedTypeForConstructor(evaluator, type, /* inferenceContext */ undefined, constraints);
 
     if (callResult.isTypeIncomplete) {
         isTypeIncomplete = true;

--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -9948,12 +9948,13 @@ export function createTypeEvaluator(
         const overloadsUsedForCall: FunctionType[] = [];
         let isDefinitiveMatchFound = false;
         let hasInitSelfMaterializationAmbiguity = false;
+        let hasSpecializedInitSelfType = false;
         const speculativeNode = getSpeculativeNodeForCall(errorNode);
 
         for (let expandedTypesIndex = 0; expandedTypesIndex < expandedArgTypes.length; expandedTypesIndex++) {
             const overloadsUsedStartIndex = overloadsUsedForCall.length;
             let matchedOverload: FunctionType | undefined;
-            let specializedInitSelfType: Type | undefined;
+            let effectiveInitSelfType: Type | undefined;
             const argTypeOverride = expandedArgTypes[expandedTypesIndex];
             const hasArgTypeOverride = argTypeOverride.some((a) => a !== undefined);
             let possibleMatchResults: MatchedOverloadInfo[] = [];
@@ -10023,7 +10024,8 @@ export function createTypeEvaluator(
                         }
                     } else {
                         returnTypes.push(callResult.returnType);
-                        specializedInitSelfType = callResult.specializedInitSelfType;
+                        effectiveInitSelfType = getEffectiveOverloadReturnType(matchedOverloadInfo);
+                        hasSpecializedInitSelfType ||= !!callResult.specializedInitSelfType;
                         isDefinitiveMatchFound = true;
                         break;
                     }
@@ -10051,7 +10053,8 @@ export function createTypeEvaluator(
                 // Did the filtering produce a single result? If so, we're done.
                 if (possibleMatchResults.length === 1) {
                     returnTypes.push(possibleMatchResults[0].returnType);
-                    specializedInitSelfType = possibleMatchResults[0].specializedInitSelfType;
+                    effectiveInitSelfType = getEffectiveOverloadReturnType(possibleMatchResults[0]);
+                    hasSpecializedInitSelfType ||= !!possibleMatchResults[0].specializedInitSelfType;
                     matchedOverloads = [possibleMatchResults[0]];
                 } else {
                     const firstArgParamPairs = getOverloadArgParamPairs(possibleMatchResults[0]);
@@ -10148,13 +10151,14 @@ export function createTypeEvaluator(
                         }
                     }
 
+                    effectiveInitSelfType = returnType;
                     if (isInitSelfMaterializationAmbiguity) {
                         // Overloaded __init__ methods normally return None. Preserve that
                         // ordinary return as a placeholder while union-expanded calls are
                         // combined, and carry the effective constructed types separately.
                         // validateInitMethod consumes specializedInitSelfType to reconstruct
                         // the constructor result after call validation is complete.
-                        specializedInitSelfType = returnType;
+                        hasSpecializedInitSelfType = true;
                         hasInitSelfMaterializationAmbiguity = true;
                         returnTypes.push(possibleMatchResults[0].returnType);
                     } else {
@@ -10163,8 +10167,8 @@ export function createTypeEvaluator(
                 }
             }
 
-            if (specializedInitSelfType) {
-                specializedInitSelfTypes.push(specializedInitSelfType);
+            if (effectiveInitSelfType) {
+                specializedInitSelfTypes.push(effectiveInitSelfType);
             }
 
             if (!matchedOverload) {
@@ -10195,14 +10199,19 @@ export function createTypeEvaluator(
             isTypeIncomplete = true;
         }
 
+        // Union expansion requires one constructor handoff per expanded argument list.
+        // Materialization ambiguity requires a combined handoff even when there is only
+        // one argument list because multiple overload candidates contribute to its result.
+        const shouldCombineInitSelfTypes =
+            hasInitSelfMaterializationAmbiguity || (expandedArgTypes.length > 1 && hasSpecializedInitSelfType);
+
         return {
             argumentErrors: finalCallResult.argumentErrors,
             anyOrUnknownArg: finalCallResult.anyOrUnknownArg,
             returnType: combineTypes(returnTypes),
             isTypeIncomplete,
             specializedInitSelfType:
-                specializedInitSelfTypes.length > 0 &&
-                (hasInitSelfMaterializationAmbiguity || expandedArgTypes.length > 1)
+                specializedInitSelfTypes.length > 0 && shouldCombineInitSelfTypes
                     ? combineTypes(specializedInitSelfTypes)
                     : finalCallResult.specializedInitSelfType,
             overloadsUsedForCall,
@@ -10282,7 +10291,21 @@ export function createTypeEvaluator(
     }
 
     function getEffectiveOverloadReturnType(match: MatchedOverloadInfo): Type {
-        return match.specializedInitSelfType ?? match.returnType;
+        if (match.specializedInitSelfType) {
+            return match.specializedInitSelfType;
+        }
+
+        const boundToType = match.overload.priv.boundToType;
+        if (match.overload.shared.name === '__init__' && boundToType && isClassInstance(boundToType)) {
+            return solveAndApplyConstraints(boundToType, match.constraints, {
+                replaceUnsolved: {
+                    scopeIds: getTypeVarScopeIds(boundToType),
+                    tupleClassType: getTupleClassType(),
+                },
+            });
+        }
+
+        return match.returnType;
     }
 
     function getOverloadArgParamPairs(match: MatchedOverloadInfo): { argType: Type; paramType: Type }[] {

--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -9947,11 +9947,13 @@ export function createTypeEvaluator(
         let isTypeIncomplete = false;
         const overloadsUsedForCall: FunctionType[] = [];
         let isDefinitiveMatchFound = false;
+        let hasInitSelfMaterializationAmbiguity = false;
         const speculativeNode = getSpeculativeNodeForCall(errorNode);
 
         for (let expandedTypesIndex = 0; expandedTypesIndex < expandedArgTypes.length; expandedTypesIndex++) {
             const overloadsUsedStartIndex = overloadsUsedForCall.length;
             let matchedOverload: FunctionType | undefined;
+            let specializedInitSelfType: Type | undefined;
             const argTypeOverride = expandedArgTypes[expandedTypesIndex];
             const hasArgTypeOverride = argTypeOverride.some((a) => a !== undefined);
             let possibleMatchResults: MatchedOverloadInfo[] = [];
@@ -10021,6 +10023,7 @@ export function createTypeEvaluator(
                         }
                     } else {
                         returnTypes.push(callResult.returnType);
+                        specializedInitSelfType = callResult.specializedInitSelfType;
                         isDefinitiveMatchFound = true;
                         break;
                     }
@@ -10048,6 +10051,7 @@ export function createTypeEvaluator(
                 // Did the filtering produce a single result? If so, we're done.
                 if (possibleMatchResults.length === 1) {
                     returnTypes.push(possibleMatchResults[0].returnType);
+                    specializedInitSelfType = possibleMatchResults[0].specializedInitSelfType;
                     matchedOverloads = [possibleMatchResults[0]];
                 } else {
                     const firstArgParamPairs = getOverloadArgParamPairs(possibleMatchResults[0]);
@@ -10150,12 +10154,17 @@ export function createTypeEvaluator(
                         // combined, and carry the effective constructed types separately.
                         // validateInitMethod consumes specializedInitSelfType to reconstruct
                         // the constructor result after call validation is complete.
-                        specializedInitSelfTypes.push(returnType);
+                        specializedInitSelfType = returnType;
+                        hasInitSelfMaterializationAmbiguity = true;
                         returnTypes.push(possibleMatchResults[0].returnType);
                     } else {
                         returnTypes.push(returnType);
                     }
                 }
+            }
+
+            if (specializedInitSelfType) {
+                specializedInitSelfTypes.push(specializedInitSelfType);
             }
 
             if (!matchedOverload) {
@@ -10192,7 +10201,8 @@ export function createTypeEvaluator(
             returnType: combineTypes(returnTypes),
             isTypeIncomplete,
             specializedInitSelfType:
-                specializedInitSelfTypes.length > 0
+                specializedInitSelfTypes.length > 0 &&
+                (hasInitSelfMaterializationAmbiguity || expandedArgTypes.length > 1)
                     ? combineTypes(specializedInitSelfTypes)
                     : finalCallResult.specializedInitSelfType,
             overloadsUsedForCall,

--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -9948,7 +9948,7 @@ export function createTypeEvaluator(
         const overloadsUsedForCall: FunctionType[] = [];
         let isDefinitiveMatchFound = false;
         let hasInitSelfMaterializationAmbiguity = false;
-        let hasSpecializedInitSelfType = false;
+        let hasEffectiveInitSelfType = false;
         const speculativeNode = getSpeculativeNodeForCall(errorNode);
 
         for (let expandedTypesIndex = 0; expandedTypesIndex < expandedArgTypes.length; expandedTypesIndex++) {
@@ -10024,8 +10024,7 @@ export function createTypeEvaluator(
                         }
                     } else {
                         returnTypes.push(callResult.returnType);
-                        effectiveInitSelfType = getEffectiveOverloadReturnType(matchedOverloadInfo);
-                        hasSpecializedInitSelfType ||= !!callResult.specializedInitSelfType;
+                        effectiveInitSelfType = getEffectiveInitSelfType(matchedOverloadInfo);
                         isDefinitiveMatchFound = true;
                         break;
                     }
@@ -10053,8 +10052,7 @@ export function createTypeEvaluator(
                 // Did the filtering produce a single result? If so, we're done.
                 if (possibleMatchResults.length === 1) {
                     returnTypes.push(possibleMatchResults[0].returnType);
-                    effectiveInitSelfType = getEffectiveOverloadReturnType(possibleMatchResults[0]);
-                    hasSpecializedInitSelfType ||= !!possibleMatchResults[0].specializedInitSelfType;
+                    effectiveInitSelfType = getEffectiveInitSelfType(possibleMatchResults[0]);
                     matchedOverloads = [possibleMatchResults[0]];
                 } else {
                     const firstArgParamPairs = getOverloadArgParamPairs(possibleMatchResults[0]);
@@ -10151,14 +10149,13 @@ export function createTypeEvaluator(
                         }
                     }
 
-                    effectiveInitSelfType = returnType;
                     if (isInitSelfMaterializationAmbiguity) {
                         // Overloaded __init__ methods normally return None. Preserve that
                         // ordinary return as a placeholder while union-expanded calls are
                         // combined, and carry the effective constructed types separately.
                         // validateInitMethod consumes specializedInitSelfType to reconstruct
                         // the constructor result after call validation is complete.
-                        hasSpecializedInitSelfType = true;
+                        effectiveInitSelfType = returnType;
                         hasInitSelfMaterializationAmbiguity = true;
                         returnTypes.push(possibleMatchResults[0].returnType);
                     } else {
@@ -10169,12 +10166,19 @@ export function createTypeEvaluator(
 
             if (effectiveInitSelfType) {
                 specializedInitSelfTypes.push(effectiveInitSelfType);
+                hasEffectiveInitSelfType = true;
             }
 
             if (!matchedOverload) {
                 return { argumentErrors: true, isTypeIncomplete, overloadsUsedForCall };
             }
         }
+
+        // Union expansion requires one constructor handoff per expanded argument list.
+        // Materialization ambiguity requires a combined handoff even when there is only
+        // one argument list because multiple overload candidates contribute to its result.
+        const shouldCombineInitSelfTypes =
+            hasInitSelfMaterializationAmbiguity || (expandedArgTypes.length > 1 && hasEffectiveInitSelfType);
 
         // We found a match for all of the expanded argument lists. Copy the
         // resulting type var context back into the caller's type var context.
@@ -10186,7 +10190,9 @@ export function createTypeEvaluator(
 
         // And run through the first expanded argument list one more time to
         // populate the type cache.
-        const finalConstraints = constraints ?? matchedOverloads[0].constraints;
+        const finalConstraints = shouldCombineInitSelfTypes
+            ? matchedOverloads[0].constraints
+            : constraints ?? matchedOverloads[0].constraints;
         const finalCallResult = validateArgTypesWithContext(
             errorNode,
             matchedOverloads[0].matchResults,
@@ -10198,12 +10204,6 @@ export function createTypeEvaluator(
         if (finalCallResult.isTypeIncomplete) {
             isTypeIncomplete = true;
         }
-
-        // Union expansion requires one constructor handoff per expanded argument list.
-        // Materialization ambiguity requires a combined handoff even when there is only
-        // one argument list because multiple overload candidates contribute to its result.
-        const shouldCombineInitSelfTypes =
-            hasInitSelfMaterializationAmbiguity || (expandedArgTypes.length > 1 && hasSpecializedInitSelfType);
 
         return {
             argumentErrors: finalCallResult.argumentErrors,
@@ -10291,10 +10291,13 @@ export function createTypeEvaluator(
     }
 
     function getEffectiveOverloadReturnType(match: MatchedOverloadInfo): Type {
+        return getEffectiveInitSelfType(match) ?? match.returnType;
+    }
+
+    function getEffectiveInitSelfType(match: MatchedOverloadInfo): Type | undefined {
         if (match.specializedInitSelfType) {
             return match.specializedInitSelfType;
         }
-
         const boundToType = match.overload.priv.boundToType;
         if (match.overload.shared.name === '__init__' && boundToType && isClassInstance(boundToType)) {
             return solveAndApplyConstraints(boundToType, match.constraints, {
@@ -10305,7 +10308,7 @@ export function createTypeEvaluator(
             });
         }
 
-        return match.returnType;
+        return undefined;
     }
 
     function getOverloadArgParamPairs(match: MatchedOverloadInfo): { argType: Type; paramType: Type }[] {

--- a/packages/pyright-internal/src/tests/samples/overloadCall12.py
+++ b/packages/pyright-internal/src/tests/samples/overloadCall12.py
@@ -178,6 +178,20 @@ class AmbiguousTable(Generic[_T]):
         pass
 
 
+class PartiallySpecializedTable(Generic[_T]):
+    @overload
+    def __init__(self: "PartiallySpecializedTable[int]", values: list[int]) -> None: ...
+
+    @overload
+    def __init__(self: "PartiallySpecializedTable[str]", values: list[str]) -> None: ...
+
+    @overload
+    def __init__(self, values: set[_T]) -> None: ...
+
+    def __init__(self, values: list[Any] | set[Any]) -> None:
+        pass
+
+
 def check_constructors(values_any: list[Any], values_unknown: list, values_int: list[int]) -> None:
     reveal_type(Table(values_any), expected_text="Any")
     reveal_type(Table(values_unknown), expected_text="Unknown")
@@ -194,11 +208,15 @@ def check_constructor_union(
     values_unknown: list | bytes,
     values_int: list[int] | bytes,
     values_gradual: list[Any] | set,
+    values_partially_specialized: list[Any] | set[float],
 ) -> None:
     reveal_type(Table(values_any), expected_text="Any | Table[bytes]")
     reveal_type(Table(values_unknown), expected_text="Unknown | Table[bytes]")
     reveal_type(Table(values_int), expected_text="Table[int] | Table[bytes]")
     reveal_type(AmbiguousTable(values_gradual), expected_text="Any | Unknown")
+    reveal_type(
+        PartiallySpecializedTable(values_partially_specialized), expected_text="Any | PartiallySpecializedTable[float]"
+    )
     reveal_type(table.__init__(values_any), expected_text="None")
 
 

--- a/packages/pyright-internal/src/tests/samples/overloadCall12.py
+++ b/packages/pyright-internal/src/tests/samples/overloadCall12.py
@@ -161,6 +161,23 @@ class Table(Generic[_T]):
         pass
 
 
+class AmbiguousTable(Generic[_T]):
+    @overload
+    def __init__(self: "AmbiguousTable[int]", values: list[int]) -> None: ...
+
+    @overload
+    def __init__(self: "AmbiguousTable[str]", values: list[str]) -> None: ...
+
+    @overload
+    def __init__(self: "AmbiguousTable[int]", values: set[int]) -> None: ...
+
+    @overload
+    def __init__(self: "AmbiguousTable[str]", values: set[str]) -> None: ...
+
+    def __init__(self, values: list[Any] | set[Any]) -> None:
+        pass
+
+
 def check_constructors(values_any: list[Any], values_unknown: list, values_int: list[int]) -> None:
     reveal_type(Table(values_any), expected_text="Any")
     reveal_type(Table(values_unknown), expected_text="Unknown")
@@ -171,9 +188,18 @@ def check_constructors(values_any: list[Any], values_unknown: list, values_int: 
     Table[int](["bad"])
 
 
-def check_constructor_union(values_any: list[Any] | bytes, values_unknown: list | bytes) -> None:
-    reveal_type(Table(values_any), expected_text="Any")
-    reveal_type(Table(values_unknown), expected_text="Unknown")
+def check_constructor_union(
+    table: Table[Any],
+    values_any: list[Any] | bytes,
+    values_unknown: list | bytes,
+    values_int: list[int] | bytes,
+    values_gradual: list[Any] | set,
+) -> None:
+    reveal_type(Table(values_any), expected_text="Any | Table[bytes]")
+    reveal_type(Table(values_unknown), expected_text="Unknown | Table[bytes]")
+    reveal_type(Table(values_int), expected_text="Table[int] | Table[bytes]")
+    reveal_type(AmbiguousTable(values_gradual), expected_text="Any | Unknown")
+    reveal_type(table.__init__(values_any), expected_text="None")
 
 
 @overload

--- a/packages/pyright-internal/src/tests/samples/overloadCall12.py
+++ b/packages/pyright-internal/src/tests/samples/overloadCall12.py
@@ -192,6 +192,17 @@ class PartiallySpecializedTable(Generic[_T]):
         pass
 
 
+class InferredTable(Generic[_T]):
+    @overload
+    def __init__(self, values: list[_T]) -> None: ...
+
+    @overload
+    def __init__(self, values: set[_T]) -> None: ...
+
+    def __init__(self, values: list[Any] | set[Any]) -> None:
+        pass
+
+
 def check_constructors(values_any: list[Any], values_unknown: list, values_int: list[int]) -> None:
     reveal_type(Table(values_any), expected_text="Any")
     reveal_type(Table(values_unknown), expected_text="Unknown")
@@ -209,6 +220,7 @@ def check_constructor_union(
     values_int: list[int] | bytes,
     values_gradual: list[Any] | set,
     values_partially_specialized: list[Any] | set[float],
+    values_inferred: list[int] | set[str],
 ) -> None:
     reveal_type(Table(values_any), expected_text="Any | Table[bytes]")
     reveal_type(Table(values_unknown), expected_text="Unknown | Table[bytes]")
@@ -217,6 +229,7 @@ def check_constructor_union(
     reveal_type(
         PartiallySpecializedTable(values_partially_specialized), expected_text="Any | PartiallySpecializedTable[float]"
     )
+    reveal_type(InferredTable(values_inferred), expected_text="InferredTable[int] | InferredTable[str]")
     reveal_type(table.__init__(values_any), expected_text="None")
 
 


### PR DESCRIPTION
## Summary

- accumulate each union-expanded overloaded `__init__` branch's effective specialized self type, including definitive and single-possible branches
- reconstruct union-valued constructor handoffs subtype-by-subtype so gradual members and concrete constructed types are all preserved
- add focused coverage for mixed ambiguous/definitive branches, all-ambiguous branches, definitive constructor unions, explicit specialization, and the `None` `__init__` placeholder

Follow-up to #11601. This addresses the unresolved review finding in https://github.com/microsoft/pyright/pull/11601#discussion_r3754688682, where a later definitive branch such as `Table[bytes]` was omitted once an earlier materialization-ambiguous branch populated the separate constructor handoff.

## Tests

- `npx jest typeEvaluator6.test -t "OverloadCall12" --runInBand --forceExit`
- `npx jest typeEvaluator6.test -t "OverloadCall(6|11|12)|Constructor" --runInBand --forceExit`
- `npm run build` (`packages/pyright-internal`)
- `npm run typecheck`
- focused ESLint and Prettier checks for changed TypeScript files