### PR TITLE
Align pyright-typeserver version with 1.1.412

### DIFF
--- a/packages/pyright-typeserver/package-lock.json
+++ b/packages/pyright-typeserver/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "pyright-typeserver",
-    "version": "1.1.410",
+    "version": "1.1.412",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "pyright-typeserver",
-            "version": "1.1.410",
+            "version": "1.1.412",
             "license": "MIT",
             "bin": {
                 "pyright-typeserver": "pyright-typeserver.js"

--- a/packages/pyright-typeserver/package.json
+++ b/packages/pyright-typeserver/package.json
@@ -2,7 +2,7 @@
     "name": "pyright-typeserver",
     "displayName": "Pyright Type Server",
     "description": "Type Server Protocol (TSP) server for the Python language, powered by Pyright",
-    "version": "1.1.410",
+    "version": "1.1.412",
     "license": "MIT",
     "author": {
         "name": "Microsoft Corporation"


### PR DESCRIPTION
Aligns the newly added `pyright-typeserver` package with the repository's fixed 1.1.412 release version.

The original 1.1.412 version bump predated this package and therefore did not include its manifest or lockfile.

Validation:
- `npm publish --dry-run` from `packages/pyright-typeserver`
- `npm run check`
- `npm run typecheck`