### PR TITLE
Use shared authenticated npm config in pipelines

### DIFF
--- a/build/azuredevops/azure-pipelines-release.yml
+++ b/build/azuredevops/azure-pipelines-release.yml
@@ -21,6 +21,9 @@ variables:
     value: pyright
   - name: AZURE_ARTIFACTS_FEED
     value: 'https://devdiv.pkgs.visualstudio.com/DevDiv/_packaging/Pylance_PublicPackages/npm/registry/'
+  # Route npm child processes through the runtime-generated authenticated CFS config.
+  - name: NPM_CONFIG_USERCONFIG
+    value: $(Agent.TempDirectory)/cfs.npmrc
 
 extends:
   template: azure-pipelines/MicroBuild.1ES.Official.Publish.yml@MicroBuildTemplate
@@ -213,9 +216,13 @@ extends:
                   targetPath: $(Pipeline.Workspace)/$(ARTIFACT_NAME_PACKAGE)
             steps:
               - checkout: none
+              - template: /build/templates/npmAuthenticate.yml@self
               # Next step fails the build if https://github.com/microsoft/pyright/issues/10350 repros.
+              # Yarn does not reliably honor NPM_CONFIG_USERCONFIG, so place the
+              # authenticated config in its working directory too.
               - script: |
                   mkdir pyrightTest
+                  cp "$(Agent.TempDirectory)/cfs.npmrc" pyrightTest/.npmrc
                   cd pyrightTest
                   yarn
                   yarn add --dev $(Pipeline.Workspace)/$(ARTIFACT_NAME_PACKAGE)/$(PACKAGE_NAME)
@@ -273,6 +280,7 @@ extends:
                   targetPath: '$(System.ArtifactsDirectory)'
               # https://code.visualstudio.com/api/working-with-extensions/publishing-extension
               # Install dependencies and VS Code Extension Manager (vsce >= v2.26.1 needed)
+              - template: /build/templates/npmAuthenticate.yml@self
               - script: |
                   npm install -g @vscode/vsce
                 displayName: 'Install vsce and dependencies'

--- a/build/azuredevops/azure-pipelines.yml
+++ b/build/azuredevops/azure-pipelines.yml
@@ -10,6 +10,9 @@ variables:
     value: 'real'
   - name: TeamName
     value: Pyright
+  # Route npm child processes through the runtime-generated authenticated CFS config.
+  - name: NPM_CONFIG_USERCONFIG
+    value: $(Agent.TempDirectory)/cfs.npmrc
 extends:
   template: azure-pipelines/MicroBuild.1ES.Official.yml@MicroBuildTemplate
   parameters:
@@ -44,6 +47,7 @@ extends:
                 displayName: Use Node 24.15.0
                 inputs:
                   versionSpec: 24.15.0
+              - template: /build/templates/npmAuthenticate.yml@self
               - task: CmdLine@2
                 displayName: npm install
                 inputs:

--- a/build/templates/npmAuthenticate.yml
+++ b/build/templates/npmAuthenticate.yml
@@ -1,16 +1,18 @@
+# Generate and authenticate a CFS-governed npm feed .npmrc at runtime (ICM 839806358).
+#
+# We intentionally do NOT commit the internal DevDiv registry into this public
+# repository, so ordinary local npm/yarn runs and fork-PR CI keep using the
+# public npm registry. Only trusted Azure DevOps jobs route installs through the
+# CFS feed, by pointing NPM_CONFIG_USERCONFIG at the temporary file below.
 steps:
-  - task: npmAuthenticate@0
-    inputs:
-      workingFile: .npmrc
+  - pwsh: |
+      @(
+        'registry=https://devdiv.pkgs.visualstudio.com/DevDiv/_packaging/Pylance_PublicPackages/npm/registry/',
+        'always-auth=true'
+      ) | Set-Content -Path "$(Agent.TempDirectory)/cfs.npmrc"
+    displayName: 'Create CFS .npmrc (runtime, not committed)'
 
   - task: npmAuthenticate@0
+    displayName: 'Authenticate CFS feed'
     inputs:
-      workingFile: packages/pyright/.npmrc
-
-  - task: npmAuthenticate@0
-    inputs:
-      workingFile: packages/pyright-internal/.npmrc
-
-  - task: npmAuthenticate@0
-    inputs:
-      workingFile: packages/vscode-pyright/.npmrc
+      workingFile: $(Agent.TempDirectory)/cfs.npmrc


### PR DESCRIPTION
## Summary

Uses one runtime-generated, authenticated npm configuration for all workspace installs in the Pyright Azure pipelines.

The release install runs npm in every Lerna workspace. Per-package authentication did not cover newly added workspaces, causing an authenticated-feed failure during the 1.1.412 release build. `NPM_CONFIG_USERCONFIG` now routes all npm child processes through the same authenticated configuration.

The release pipeline also copies that configuration for Yarn validation and authenticates the Marketplace job's global npm install.

## Validation

- `npm run check`
- Audited every install path in both Azure pipeline definitions