### PR TITLE
Add npm-only release recovery mode

### DIFF
--- a/build/azuredevops/azure-pipelines-release.yml
+++ b/build/azuredevops/azure-pipelines-release.yml
@@ -10,6 +10,10 @@ parameters:
     values:
       - full
       - npmOnly
+  - name: releaseTag
+    displayName: Release tag (required for npmOnly)
+    type: string
+    default: ''
 resources:
   repositories:
     - repository: MicroBuildTemplate
@@ -53,7 +57,7 @@ extends:
       - ES365AIMigrationTooling
     stages:
       - stage: BuildVsix
-        condition: and(succeeded(), eq('${{ parameters.releaseMode }}', 'full'))
+        condition: and(not(canceled()), succeeded(), eq('${{ parameters.releaseMode }}', 'full'))
         jobs:
           - job: build_vsix
             displayName: Build VSIX
@@ -179,10 +183,25 @@ extends:
                 submodules: true
                 fetchTags: false
                 persistCredentials: True
+              - ${{ if eq(parameters.releaseMode, 'npmOnly') }}:
+                  - bash: |
+                      set -euo pipefail
+                      tag='${{ parameters.releaseTag }}'
+                      if [[ ! "$tag" =~ ^1\.1\.[0-9]+$ ]]; then
+                        echo "##vso[task.logissue type=error]releaseTag must match 1.1.<patch>"
+                        exit 1
+                      fi
+                      git fetch origin "refs/tags/$tag:refs/tags/$tag"
+                      git checkout --detach "$tag"
+                    displayName: Check out release tag
               - task: NodeTool@0
                 displayName: Use Node 24.15.0
                 inputs:
                   versionSpec: 24.15.0
+              - ${{ if eq(parameters.releaseMode, 'npmOnly') }}:
+                  - script: |
+                      node -e "const actual=require('./packages/pyright/package.json').version; const expected='${{ parameters.releaseTag }}'; if(actual!==expected){console.error('Expected package version '+expected+', got '+actual); process.exit(1)}"
+                    displayName: Validate release tag version
               - template: /build/templates/npmAuthenticate.yml@self
               - task: CmdLine@2
                 displayName: npm install
@@ -206,21 +225,16 @@ extends:
                   Contents: '${{ variables.PACKAGE_NAME }}'
                   TargetFolder: '$(Build.ArtifactStagingDirectory)/${{ variables.ARTIFACT_NAME_PACKAGE }}'
 
-      - stage: CreateRelease
-        condition: and(succeeded(), eq('${{ parameters.releaseMode }}', 'full'))
+      - stage: ValidateNpm
         dependsOn:
-          - BuildVsix
           - BuildNpm
         jobs:
-          - job: create_release
-            displayName: Create GitHub Release
+          - job: validate_npm
+            displayName: Validate NPM package
             templateContext:
               type: releaseJob
-              isProduction: true
+              isProduction: false
               inputs:
-                - input: pipelineArtifact
-                  artifactName: $(ARTIFACT_NAME_VSIX)
-                  targetPath: $(Pipeline.Workspace)/$(ARTIFACT_NAME_VSIX)
                 - input: pipelineArtifact
                   artifactName: $(ARTIFACT_NAME_PACKAGE)
                   targetPath: $(Pipeline.Workspace)/$(ARTIFACT_NAME_PACKAGE)
@@ -238,6 +252,27 @@ extends:
                   yarn add --dev $(Pipeline.Workspace)/$(ARTIFACT_NAME_PACKAGE)/$(PACKAGE_NAME)
                   node_modules/.bin/pyright --version
                 displayName: Validate npm package
+
+      - stage: CreateRelease
+        condition: and(not(canceled()), succeeded(), eq('${{ parameters.releaseMode }}', 'full'))
+        dependsOn:
+          - BuildVsix
+          - ValidateNpm
+        jobs:
+          - job: create_release
+            displayName: Create GitHub Release
+            templateContext:
+              type: releaseJob
+              isProduction: true
+              inputs:
+                - input: pipelineArtifact
+                  artifactName: $(ARTIFACT_NAME_VSIX)
+                  targetPath: $(Pipeline.Workspace)/$(ARTIFACT_NAME_VSIX)
+                - input: pipelineArtifact
+                  artifactName: $(ARTIFACT_NAME_PACKAGE)
+                  targetPath: $(Pipeline.Workspace)/$(ARTIFACT_NAME_PACKAGE)
+            steps:
+              - checkout: none
               - task: GitHubRelease@1 #https://learn.microsoft.com/en-us/azure/devops/pipelines/tasks/reference/github-release-v1?view=azure-pipelines
                 displayName: 'Create GitHub Release'
                 inputs:
@@ -253,7 +288,7 @@ extends:
                     $(Pipeline.Workspace)/$(ARTIFACT_NAME_PACKAGE)/$(PACKAGE_NAME)
 
       - stage: WaitForValidation
-        condition: and(succeeded(), eq('${{ parameters.releaseMode }}', 'full'))
+        condition: and(not(canceled()), succeeded(), eq('${{ parameters.releaseMode }}', 'full'))
         dependsOn:
           - CreateRelease
         jobs:
@@ -273,7 +308,7 @@ extends:
                   onTimeout: 'reject' # require sign-off
 
       - stage: PublishToMarketplace
-        condition: and(succeeded(), eq('${{ parameters.releaseMode }}', 'full'))
+        condition: and(not(canceled()), succeeded(), eq('${{ parameters.releaseMode }}', 'full'))
         dependsOn:
           - WaitForValidation
         jobs:
@@ -313,7 +348,8 @@ extends:
       - stage: PublishToNpm
         condition: |
           and(
-            in(dependencies.BuildNpm.result, 'Succeeded', 'SucceededWithIssues'),
+            not(canceled()),
+            in(dependencies.ValidateNpm.result, 'Succeeded', 'SucceededWithIssues'),
             or(
               eq('${{ parameters.releaseMode }}', 'npmOnly'),
               and(
@@ -323,7 +359,7 @@ extends:
             )
           )
         dependsOn:
-          - BuildNpm
+          - ValidateNpm
           - WaitForValidation
           - PublishToMarketplace
         jobs:

--- a/build/azuredevops/azure-pipelines-release.yml
+++ b/build/azuredevops/azure-pipelines-release.yml
@@ -2,6 +2,14 @@ trigger:
   branches:
     include:
       - refs/tags/*
+parameters:
+  - name: releaseMode
+    displayName: Release mode
+    type: string
+    default: full
+    values:
+      - full
+      - npmOnly
 resources:
   repositories:
     - repository: MicroBuildTemplate
@@ -45,6 +53,7 @@ extends:
       - ES365AIMigrationTooling
     stages:
       - stage: BuildVsix
+        condition: and(succeeded(), eq('${{ parameters.releaseMode }}', 'full'))
         jobs:
           - job: build_vsix
             displayName: Build VSIX
@@ -198,6 +207,7 @@ extends:
                   TargetFolder: '$(Build.ArtifactStagingDirectory)/${{ variables.ARTIFACT_NAME_PACKAGE }}'
 
       - stage: CreateRelease
+        condition: and(succeeded(), eq('${{ parameters.releaseMode }}', 'full'))
         dependsOn:
           - BuildVsix
           - BuildNpm
@@ -243,6 +253,7 @@ extends:
                     $(Pipeline.Workspace)/$(ARTIFACT_NAME_PACKAGE)/$(PACKAGE_NAME)
 
       - stage: WaitForValidation
+        condition: and(succeeded(), eq('${{ parameters.releaseMode }}', 'full'))
         dependsOn:
           - CreateRelease
         jobs:
@@ -262,6 +273,7 @@ extends:
                   onTimeout: 'reject' # require sign-off
 
       - stage: PublishToMarketplace
+        condition: and(succeeded(), eq('${{ parameters.releaseMode }}', 'full'))
         dependsOn:
           - WaitForValidation
         jobs:
@@ -299,7 +311,19 @@ extends:
                     vsce publish --pat $aadToken --packagePath $(System.ArtifactsDirectory)/$(VSIX_NAME) --noVerify --manifestPath $(System.ArtifactsDirectory)/extension.manifest --signaturePath $(System.ArtifactsDirectory)/extension.signature.p7s
 
       - stage: PublishToNpm
+        condition: |
+          and(
+            in(dependencies.BuildNpm.result, 'Succeeded', 'SucceededWithIssues'),
+            or(
+              eq('${{ parameters.releaseMode }}', 'npmOnly'),
+              and(
+                in(dependencies.WaitForValidation.result, 'Succeeded', 'SucceededWithIssues'),
+                in(dependencies.PublishToMarketplace.result, 'Succeeded', 'SucceededWithIssues')
+              )
+            )
+          )
         dependsOn:
+          - BuildNpm
           - WaitForValidation
           - PublishToMarketplace
         jobs:
@@ -328,4 +352,4 @@ extends:
                   folderLocation: $(Build.StagingDirectory)/dist
                   waitForReleaseCompletion: true
                   owners: rchiodo@microsoft.com
-                  approvers: grwheele@microsoft.com
+                  approvers: brcan@microsoft.com

--- a/build/azuredevops/azure-pipelines-release.yml
+++ b/build/azuredevops/azure-pipelines-release.yml
@@ -233,7 +233,11 @@ extends:
                   targetPath: '$(Build.ArtifactStagingDirectory)/$(ARTIFACT_NAME_PACKAGE)'
                   artifactName: $(ARTIFACT_NAME_PACKAGE)
             steps:
-              - checkout: none
+              - checkout: self
+                fetchDepth: 1
+                clean: true
+                fetchTags: false
+                persistCredentials: true
               - pwsh: |
                   if ($env:RELEASE_TAG -notmatch '^1\.1\.\d+$') {
                       Write-Error 'releaseTag must match 1.1.<patch>'
@@ -251,6 +255,17 @@ extends:
                   if ($sourceBuild.sourceBranch -ne "refs/tags/$env:RELEASE_TAG") {
                     Write-Error "Source build used $($sourceBuild.sourceBranch), expected refs/tags/$env:RELEASE_TAG"
                   }
+                    git fetch origin "refs/tags/$env:RELEASE_TAG:refs/tags/$env:RELEASE_TAG"
+                    if ($LASTEXITCODE -ne 0) {
+                      Write-Error "Unable to fetch release tag $env:RELEASE_TAG"
+                    }
+                    $tagCommit = git rev-list -n 1 "refs/tags/$env:RELEASE_TAG"
+                    if ($LASTEXITCODE -ne 0 -or -not $tagCommit) {
+                      Write-Error "Unable to resolve release tag $env:RELEASE_TAG"
+                    }
+                    if ($sourceBuild.sourceVersion -ne $tagCommit) {
+                      Write-Error "Source build used commit $($sourceBuild.sourceVersion), but tag $env:RELEASE_TAG resolves to $tagCommit"
+                    }
                 displayName: Validate recovery parameters
                 env:
                   RELEASE_TAG: ${{ parameters.releaseTag }}

--- a/build/azuredevops/azure-pipelines-release.yml
+++ b/build/azuredevops/azure-pipelines-release.yml
@@ -14,6 +14,10 @@ parameters:
     displayName: Release tag (required for npmOnly)
     type: string
     default: ''
+  - name: sourceBuildId
+    displayName: Source build ID (required for npmOnly)
+    type: number
+    default: 0
 resources:
   repositories:
     - repository: MicroBuildTemplate
@@ -36,6 +40,12 @@ variables:
   # Route npm child processes through the runtime-generated authenticated CFS config.
   - name: NPM_CONFIG_USERCONFIG
     value: $(Agent.TempDirectory)/cfs.npmrc
+  - ${{ if eq(parameters.releaseMode, 'npmOnly') }}:
+      - name: EXPECTED_RELEASE_TAG
+        value: ${{ parameters.releaseTag }}
+  - ${{ else }}:
+      - name: EXPECTED_RELEASE_TAG
+        value: $(Build.SourceBranchName)
 
 extends:
   template: azure-pipelines/MicroBuild.1ES.Official.Publish.yml@MicroBuildTemplate
@@ -166,6 +176,7 @@ extends:
                   TargetFolder: build_output
 
       - stage: BuildNpm
+        condition: and(not(canceled()), succeeded(), eq('${{ parameters.releaseMode }}', 'full'))
         dependsOn: # Blank to allow running in parallel with BuildVsix
         jobs:
           - job: build_npm
@@ -183,25 +194,10 @@ extends:
                 submodules: true
                 fetchTags: false
                 persistCredentials: True
-              - ${{ if eq(parameters.releaseMode, 'npmOnly') }}:
-                  - bash: |
-                      set -euo pipefail
-                      tag='${{ parameters.releaseTag }}'
-                      if [[ ! "$tag" =~ ^1\.1\.[0-9]+$ ]]; then
-                        echo "##vso[task.logissue type=error]releaseTag must match 1.1.<patch>"
-                        exit 1
-                      fi
-                      git fetch origin "refs/tags/$tag:refs/tags/$tag"
-                      git checkout --detach "$tag"
-                    displayName: Check out release tag
               - task: NodeTool@0
                 displayName: Use Node 24.15.0
                 inputs:
                   versionSpec: 24.15.0
-              - ${{ if eq(parameters.releaseMode, 'npmOnly') }}:
-                  - script: |
-                      node -e "const actual=require('./packages/pyright/package.json').version; const expected='${{ parameters.releaseTag }}'; if(actual!==expected){console.error('Expected package version '+expected+', got '+actual); process.exit(1)}"
-                    displayName: Validate release tag version
               - template: /build/templates/npmAuthenticate.yml@self
               - task: CmdLine@2
                 displayName: npm install
@@ -225,9 +221,64 @@ extends:
                   Contents: '${{ variables.PACKAGE_NAME }}'
                   TargetFolder: '$(Build.ArtifactStagingDirectory)/${{ variables.ARTIFACT_NAME_PACKAGE }}'
 
+      - stage: RecoverNpmArtifact
+        condition: and(not(canceled()), succeeded(), eq('${{ parameters.releaseMode }}', 'npmOnly'))
+        dependsOn: []
+        jobs:
+          - job: recover_npm_artifact
+            displayName: Recover NPM artifact
+            templateContext:
+              outputs:
+                - output: pipelineArtifact
+                  targetPath: '$(Build.ArtifactStagingDirectory)/$(ARTIFACT_NAME_PACKAGE)'
+                  artifactName: $(ARTIFACT_NAME_PACKAGE)
+            steps:
+              - checkout: none
+              - pwsh: |
+                  if ($env:RELEASE_TAG -notmatch '^1\.1\.\d+$') {
+                      Write-Error 'releaseTag must match 1.1.<patch>'
+                  }
+                  if ([int]$env:SOURCE_BUILD_ID -le 0) {
+                      Write-Error 'sourceBuildId must identify the original release run'
+                  }
+                  $headers = @{ Authorization = "Bearer $env:SYSTEM_ACCESSTOKEN" }
+                  $sourceBuild = Invoke-RestMethod `
+                    -Uri "$(System.CollectionUri)$(System.TeamProjectId)/_apis/build/builds/$env:SOURCE_BUILD_ID?api-version=7.1" `
+                    -Headers $headers
+                  if ($sourceBuild.definition.id -ne [int]"$(System.DefinitionId)") {
+                    Write-Error 'sourceBuildId belongs to a different pipeline'
+                  }
+                  if ($sourceBuild.sourceBranch -ne "refs/tags/$env:RELEASE_TAG") {
+                    Write-Error "Source build used $($sourceBuild.sourceBranch), expected refs/tags/$env:RELEASE_TAG"
+                  }
+                displayName: Validate recovery parameters
+                env:
+                  RELEASE_TAG: ${{ parameters.releaseTag }}
+                  SOURCE_BUILD_ID: ${{ parameters.sourceBuildId }}
+                  SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+              - task: DownloadPipelineArtifact@2
+                displayName: Download original NPM artifact
+                inputs:
+                  buildType: specific
+                  project: $(System.TeamProjectId)
+                  definition: $(System.DefinitionId)
+                  buildVersionToDownload: specific
+                  pipelineId: ${{ parameters.sourceBuildId }}
+                  artifactName: $(ARTIFACT_NAME_PACKAGE)
+                  targetPath: '$(Build.ArtifactStagingDirectory)/$(ARTIFACT_NAME_PACKAGE)'
+
       - stage: ValidateNpm
+        condition: |
+          and(
+            not(canceled()),
+            or(
+              and(eq('${{ parameters.releaseMode }}', 'full'), in(dependencies.BuildNpm.result, 'Succeeded', 'SucceededWithIssues')),
+              and(eq('${{ parameters.releaseMode }}', 'npmOnly'), in(dependencies.RecoverNpmArtifact.result, 'Succeeded', 'SucceededWithIssues'))
+            )
+          )
         dependsOn:
           - BuildNpm
+          - RecoverNpmArtifact
         jobs:
           - job: validate_npm
             displayName: Validate NPM package
@@ -250,8 +301,11 @@ extends:
                   cd pyrightTest
                   yarn
                   yarn add --dev $(Pipeline.Workspace)/$(ARTIFACT_NAME_PACKAGE)/$(PACKAGE_NAME)
+                  node -e "const actual=require('./node_modules/pyright/package.json').version; const expected=process.env.RELEASE_TAG; if(actual!==expected){console.error('Expected package version '+expected+', got '+actual); process.exit(1)}"
                   node_modules/.bin/pyright --version
                 displayName: Validate npm package
+                env:
+                  RELEASE_TAG: $(EXPECTED_RELEASE_TAG)
 
       - stage: CreateRelease
         condition: and(not(canceled()), succeeded(), eq('${{ parameters.releaseMode }}', 'full'))


### PR DESCRIPTION
## Summary

- replaces the removed ESRP npm approver with `brcan@microsoft.com`
- adds an `npmOnly` release mode that republishes the original retained npm artifact
- keeps tagged releases on the existing `full` mode by default

For npm-only recovery, the operator supplies the release tag and original source build ID. The pipeline verifies that the source build belongs to this release pipeline and exact tag, downloads its retained `pyright` artifact, installs it, verifies the embedded package version, and runs only ESRP npm publication. It does not rebuild or republish the VSIX or create another GitHub release.

## Validation

- `npm run check`
- `git diff --check`
- verified `brcan@microsoft.com` resolves to a valid Microsoft Entra identity
- rehearsed recovery against build `14944137`: pipeline `22838`, tag `1.1.412`, commit `fceca4d1`, retained `pyright.tgz` version `1.1.412`

Azure local-YAML preview could not be run because the caller lacks the `EditBuild` permission required for modified-YAML previews.