### PR TITLE
Fix npm recovery build lookup URL

### DIFF
--- a/build/azuredevops/azure-pipelines-release.yml
+++ b/build/azuredevops/azure-pipelines-release.yml
@@ -10,6 +10,7 @@ parameters:
     values:
       - full
       - npmOnly
+      - npmValidateOnly
   - name: releaseTag
     displayName: Release tag (required for npmOnly)
     type: string
@@ -40,7 +41,7 @@ variables:
   # Route npm child processes through the runtime-generated authenticated CFS config.
   - name: NPM_CONFIG_USERCONFIG
     value: $(Agent.TempDirectory)/cfs.npmrc
-  - ${{ if eq(parameters.releaseMode, 'npmOnly') }}:
+  - ${{ if ne(parameters.releaseMode, 'full') }}:
       - name: EXPECTED_RELEASE_TAG
         value: ${{ parameters.releaseTag }}
   - ${{ else }}:
@@ -222,7 +223,7 @@ extends:
                   TargetFolder: '$(Build.ArtifactStagingDirectory)/${{ variables.ARTIFACT_NAME_PACKAGE }}'
 
       - stage: RecoverNpmArtifact
-        condition: and(not(canceled()), succeeded(), eq('${{ parameters.releaseMode }}', 'npmOnly'))
+        condition: and(not(canceled()), succeeded(), ne('${{ parameters.releaseMode }}', 'full'))
         dependsOn: []
         jobs:
           - job: recover_npm_artifact
@@ -288,7 +289,7 @@ extends:
             not(canceled()),
             or(
               and(eq('${{ parameters.releaseMode }}', 'full'), in(dependencies.BuildNpm.result, 'Succeeded', 'SucceededWithIssues')),
-              and(eq('${{ parameters.releaseMode }}', 'npmOnly'), in(dependencies.RecoverNpmArtifact.result, 'Succeeded', 'SucceededWithIssues'))
+              and(ne('${{ parameters.releaseMode }}', 'full'), in(dependencies.RecoverNpmArtifact.result, 'Succeeded', 'SucceededWithIssues'))
             )
           )
         dependsOn:

--- a/build/azuredevops/azure-pipelines-release.yml
+++ b/build/azuredevops/azure-pipelines-release.yml
@@ -12,11 +12,11 @@ parameters:
       - npmOnly
       - npmValidateOnly
   - name: releaseTag
-    displayName: Release tag (required for npmOnly)
+    displayName: Release tag (required for npmOnly and npmValidateOnly)
     type: string
     default: ''
   - name: sourceBuildId
-    displayName: Source build ID (required for npmOnly)
+    displayName: Source build ID (required for npmOnly and npmValidateOnly)
     type: number
     default: 0
 resources:
@@ -41,7 +41,7 @@ variables:
   # Route npm child processes through the runtime-generated authenticated CFS config.
   - name: NPM_CONFIG_USERCONFIG
     value: $(Agent.TempDirectory)/cfs.npmrc
-  - ${{ if ne(parameters.releaseMode, 'full') }}:
+  - ${{ if or(eq(parameters.releaseMode, 'npmOnly'), eq(parameters.releaseMode, 'npmValidateOnly')) }}:
       - name: EXPECTED_RELEASE_TAG
         value: ${{ parameters.releaseTag }}
   - ${{ else }}:
@@ -223,7 +223,7 @@ extends:
                   TargetFolder: '$(Build.ArtifactStagingDirectory)/${{ variables.ARTIFACT_NAME_PACKAGE }}'
 
       - stage: RecoverNpmArtifact
-        condition: and(not(canceled()), succeeded(), ne('${{ parameters.releaseMode }}', 'full'))
+        condition: and(not(canceled()), succeeded(), or(eq('${{ parameters.releaseMode }}', 'npmOnly'), eq('${{ parameters.releaseMode }}', 'npmValidateOnly')))
         dependsOn: []
         jobs:
           - job: recover_npm_artifact
@@ -289,7 +289,7 @@ extends:
             not(canceled()),
             or(
               and(eq('${{ parameters.releaseMode }}', 'full'), in(dependencies.BuildNpm.result, 'Succeeded', 'SucceededWithIssues')),
-              and(ne('${{ parameters.releaseMode }}', 'full'), in(dependencies.RecoverNpmArtifact.result, 'Succeeded', 'SucceededWithIssues'))
+              and(or(eq('${{ parameters.releaseMode }}', 'npmOnly'), eq('${{ parameters.releaseMode }}', 'npmValidateOnly')), in(dependencies.RecoverNpmArtifact.result, 'Succeeded', 'SucceededWithIssues'))
             )
           )
         dependsOn:

--- a/build/azuredevops/azure-pipelines-release.yml
+++ b/build/azuredevops/azure-pipelines-release.yml
@@ -256,7 +256,7 @@ extends:
                   if ($sourceBuild.sourceBranch -ne "refs/tags/$env:RELEASE_TAG") {
                     Write-Error "Source build used $($sourceBuild.sourceBranch), expected refs/tags/$env:RELEASE_TAG"
                   }
-                    git fetch origin "refs/tags/$env:RELEASE_TAG:refs/tags/$env:RELEASE_TAG"
+                    git fetch origin "refs/tags/${env:RELEASE_TAG}:refs/tags/${env:RELEASE_TAG}"
                     if ($LASTEXITCODE -ne 0) {
                       Write-Error "Unable to fetch release tag $env:RELEASE_TAG"
                     }

--- a/build/azuredevops/azure-pipelines-release.yml
+++ b/build/azuredevops/azure-pipelines-release.yml
@@ -247,7 +247,7 @@ extends:
                   }
                   $headers = @{ Authorization = "Bearer $env:SYSTEM_ACCESSTOKEN" }
                   $sourceBuild = Invoke-RestMethod `
-                    -Uri "$(System.CollectionUri)$(System.TeamProjectId)/_apis/build/builds/$env:SOURCE_BUILD_ID?api-version=7.1" `
+                    -Uri "$(System.CollectionUri)$(System.TeamProjectId)/_apis/build/builds/${env:SOURCE_BUILD_ID}?api-version=7.1" `
                     -Headers $headers
                   if ($sourceBuild.definition.id -ne [int]"$(System.DefinitionId)") {
                     Write-Error 'sourceBuildId belongs to a different pipeline'


### PR DESCRIPTION
## Summary

- fixes PowerShell parsing of `SOURCE_BUILD_ID` before the Builds API query string
- fixes PowerShell parsing of `RELEASE_TAG` inside the Git fetch refspec
- adds `npmValidateOnly` to exercise artifact recovery and package smoke validation without entering ESRP npm publication

Recovery run `14951826` exposed the Builds API interpolation issue. Pre-merge validation run `14953223` then exposed the same scoped-variable boundary problem in the tag refspec, where PowerShell produced `refs/tags//tags/1.1.412`.

## Validation

- `npm run check`
- `git diff --check`
- verified the Builds API URI contains `builds/14944137?api-version=7.1`
- executed the corrected refspec against tag `1.1.412`; it resolves to `fceca4d1`
- `npmValidateOnly` reaches recovery/validation and cannot enter npm publication