### PR TITLE
Fix nested TypeForm alias evaluation

### DIFF
--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -7702,6 +7702,11 @@ export function createTypeEvaluator(
         return type;
     }
 
+    function convertTypeArgToInstance(type: Type, flags: EvalFlags): Type {
+        const contextualType = (flags & EvalFlags.TypeFormArg) !== 0 ? type.props?.typeForm ?? type : type;
+        return convertToInstance(contextualType);
+    }
+
     // Handles index expressions that are providing type arguments for a
     // generic type alias.
     function createSpecializedTypeAlias(
@@ -7896,7 +7901,7 @@ export function createTypeEvaluator(
 
                 let typeArgType: Type;
                 if (index < typeArgs.length) {
-                    typeArgType = convertToInstance(typeArgs[index].type);
+                    typeArgType = convertTypeArgToInstance(typeArgs[index].type, flags);
                 } else if (param.shared.isDefaultExplicit) {
                     typeArgType = solveAndApplyConstraints(param, constraints, {
                         replaceUnsolved: {
@@ -8272,12 +8277,12 @@ export function createTypeEvaluator(
             const isTypeFormArg = (flags & EvalFlags.TypeFormArg) !== 0;
 
             node.d.items.forEach((item) => {
-                const isItemCached =
-                    isTypeCached(item.d.valueExpr) ||
-                    (isTypeFormArg && isTypeFormTypeCached(item.d.valueExpr, /* expectedType */ undefined));
+                const isItemCached = isTypeFormArg
+                    ? isTypeFormTypeCached(item.d.valueExpr, /* expectedType */ undefined)
+                    : isTypeCached(item.d.valueExpr);
 
                 if (!isItemCached) {
-                    getTypeOfExpression(item.d.valueExpr, flags & EvalFlags.ForwardRefs);
+                    getTypeOfExpression(item.d.valueExpr, flags & (EvalFlags.ForwardRefs | EvalFlags.TypeFormArg));
                 }
             });
         }
@@ -9068,12 +9073,18 @@ export function createTypeEvaluator(
 
             if (!isCyclicalTypeVarCall && !isTypeFormCall) {
                 argList.forEach((arg) => {
+                    const valueExpression = arg.valueExpression;
                     if (
-                        arg.valueExpression &&
-                        arg.valueExpression.nodeType !== ParseNodeType.StringList &&
-                        !isTypeCached(arg.valueExpression)
+                        valueExpression &&
+                        valueExpression.nodeType !== ParseNodeType.StringList &&
+                        !isTypeCached(valueExpression)
                     ) {
-                        getTypeOfExpression(arg.valueExpression);
+                        const expectedType = expectedTypeCache.get(valueExpression.id)?.type;
+                        if (isTypeFormTypeCached(valueExpression, expectedType)) {
+                            suppressDiagnostics(valueExpression, () => getTypeOfExpression(valueExpression));
+                        } else {
+                            getTypeOfExpression(valueExpression);
+                        }
                     }
                 });
             }
@@ -22827,7 +22838,7 @@ export function createTypeEvaluator(
                     }
                 }
 
-                const typeArgType = convertToInstance(typeArgs[index].type);
+                const typeArgType = convertTypeArgToInstance(typeArgs[index].type, flags);
                 typeArgTypes.push(typeArgType);
                 constraints.setBounds(typeParam, typeArgType);
                 return;

--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -792,7 +792,14 @@ export function createTypeEvaluator(
     function isTypeCached(node: ParseNode) {
         // This helper is used by runtime-evaluation guards. A contextual TypeForm
         // entry does not prove that the ordinary runtime type was evaluated.
-        const cacheEntry = readTypeCacheEntry(node);
+        return isTypeCacheEntryValid(readTypeCacheEntry(node));
+    }
+
+    function isTypeFormTypeCached(node: ParseNode, expectedType: Type | undefined) {
+        return isTypeCacheEntryValid(readTypeFormTypeCacheEntry(node, expectedType));
+    }
+
+    function isTypeCacheEntryValid(cacheEntry: TypeCacheEntry | undefined) {
         if (!cacheEntry) {
             return false;
         }
@@ -8259,11 +8266,17 @@ export function createTypeEvaluator(
             }
         );
 
-        // In case we didn't walk the list items above, do so now.
-        // If we have, this information will be cached.
+        // In case we didn't walk the list items above, do so now. TypeForm arguments
+        // use a separate cache, so check it when the enclosing expression is a TypeForm.
         if (!baseTypeResult.isIncomplete) {
+            const isTypeFormArg = (flags & EvalFlags.TypeFormArg) !== 0;
+
             node.d.items.forEach((item) => {
-                if (!isTypeCached(item.d.valueExpr)) {
+                const isItemCached =
+                    isTypeCached(item.d.valueExpr) ||
+                    (isTypeFormArg && isTypeFormTypeCached(item.d.valueExpr, /* expectedType */ undefined));
+
+                if (!isItemCached) {
                     getTypeOfExpression(item.d.valueExpr, flags & EvalFlags.ForwardRefs);
                 }
             });

--- a/packages/pyright-internal/src/tests/samples/typeForm9.py
+++ b/packages/pyright-internal/src/tests/samples/typeForm9.py
@@ -131,6 +131,18 @@ literal_codec = codec_for(Literal["int", "list[str]"])
 assert_type(literal_codec, Codec[Literal["int", "list[str]"]])
 
 
+# A PEP 695 type alias used as a nested TypeForm argument should resolve
+# to the alias's target type rather than the runtime TypeAliasType.
+type Foo = int | str
+
+
+class Bar[T: Foo]: ...
+
+
+bar_codec = codec_for(Bar[Foo])
+assert_type(bar_codec, Codec[Bar[Foo]])
+
+
 # Mixed contexts preserve valid non-TypeForm alternatives.
 def accept_string_or_type(value: str | TypeForm[int]) -> None:
     pass

--- a/packages/pyright-internal/src/tests/typeEvaluator8.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator8.test.ts
@@ -1125,6 +1125,95 @@ test('TypeFormCacheRuntimeFirst', () => {
     assert.strictEqual(state.program.evaluator!.getCachedType(node), runtimeType);
 });
 
+test('TypeFormCacheNestedAliasRuntimeFirst', () => {
+    const code = `
+// @filename: test.py
+//// # pyright: reportMissingModuleSource=false
+//// from typing import assert_type
+//// from typing_extensions import TypeForm
+//// class Codec[T]: ...
+//// def codec_for[T](schema: TypeForm[T]) -> Codec[T]: ...
+//// type Foo = int | str
+//// class Bar[T: Foo]: ...
+//// bar_codec = codec_for(Bar[[|/*marker*/Foo|]])
+//// assert_type(bar_codec, Codec[Bar[Foo]])
+    `;
+    const state = parseAndGetTestState(code).state;
+    const node = getNodeAtMarker(state);
+    assert.ok(node.nodeType === ParseNodeType.Name);
+
+    const runtimeType = state.program.evaluator!.getTypeOfExpression(node).type;
+    assert.strictEqual(state.program.evaluator!.getCachedType(node), runtimeType);
+
+    state.verifyDiagnostics({
+        marker: { category: 'none', message: '' },
+    });
+});
+
+test('TypeFormCacheNestedGenericAliasRuntimeFirst', () => {
+    const code = `
+// @filename: test.py
+//// # pyright: reportMissingModuleSource=false
+//// from typing import assert_type
+//// from typing_extensions import TypeForm
+//// class Codec[T]: ...
+//// def codec_for[T](schema: TypeForm[T]) -> Codec[T]: ...
+//// type Foo = int | str
+//// type Bar[T: Foo] = list[T]
+//// bar_codec = codec_for(Bar[[|/*marker*/Foo|]])
+//// assert_type(bar_codec, Codec[list[int | str]])
+    `;
+    const state = parseAndGetTestState(code).state;
+    const node = getNodeAtMarker(state);
+    assert.ok(node.nodeType === ParseNodeType.Name);
+
+    const runtimeType = state.program.evaluator!.getTypeOfExpression(node).type;
+    assert.strictEqual(state.program.evaluator!.getCachedType(node), runtimeType);
+
+    state.verifyDiagnostics({
+        marker: { category: 'none', message: '' },
+    });
+});
+
+test('TypeFormCacheNestedVariadicRuntimeFirst', () => {
+    const code = `
+// @filename: test.py
+//// # pyright: reportMissingModuleSource=false
+//// from collections.abc import Callable
+//// from typing import assert_type
+//// from typing_extensions import TypeForm
+//// class Codec[T]: ...
+//// def codec_for[T](schema: TypeForm[T]) -> Codec[T]: ...
+//// type Foo = int | str
+//// class ParamSpecClass[**P]: ...
+//// type ParamSpecAlias[**P] = Callable[P, None]
+//// class VariadicClass[*Ts]: ...
+//// type VariadicAlias[*Ts] = tuple[*Ts]
+//// param_class_codec = codec_for(ParamSpecClass[[[|/*paramClass*/Foo|]]])
+//// assert_type(param_class_codec, Codec[ParamSpecClass[[Foo]]])
+//// param_alias_codec = codec_for(ParamSpecAlias[[[|/*paramAlias*/Foo|]]])
+//// assert_type(param_alias_codec, Codec[Callable[[Foo], None]])
+//// variadic_class_codec = codec_for(VariadicClass[[|/*variadicClass*/Foo|]])
+//// assert_type(variadic_class_codec, Codec[VariadicClass[Foo]])
+//// variadic_alias_codec = codec_for(VariadicAlias[[|/*variadicAlias*/Foo|]])
+//// assert_type(variadic_alias_codec, Codec[tuple[Foo]])
+    `;
+    const state = parseAndGetTestState(code).state;
+    const markerNames = ['paramClass', 'paramAlias', 'variadicClass', 'variadicAlias'];
+
+    markerNames.forEach((markerName) => {
+        const node = getNodeAtMarker(state, markerName);
+        assert.ok(node.nodeType === ParseNodeType.Name);
+
+        const runtimeType = state.program.evaluator!.getTypeOfExpression(node).type;
+        assert.strictEqual(state.program.evaluator!.getCachedType(node), runtimeType);
+    });
+
+    state.verifyDiagnostics(
+        Object.fromEntries(markerNames.map((markerName) => [markerName, { category: 'none', message: '' }]))
+    );
+});
+
 test('TypeFormCacheRuntimeFirstReassignment', () => {
     const code = `
 // @filename: test.py


### PR DESCRIPTION
## Summary
- consult the TypeForm-specific cache for nested generic arguments evaluated in a TypeForm context
- preserve incomplete-cache generation checks when selecting cached results
- add regression coverage for PEP 695 aliases used as bounded generic arguments

Fixes #11633

## Testing
- `npx jest typeEvaluator8.test --forceExit -t "TypeForm"`
- `npm run build` (packages/pyright-internal)