### PR TITLE
Fix implicit concatenation of t-string literals with str or bytes

### DIFF
--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -1772,6 +1772,22 @@ export function createTypeEvaluator(
 
         const isBytesNode = (node: StringNode | FormatStringNode) =>
             (node.d.token.flags & StringTokenFlags.Bytes) !== 0;
+        const isTemplateNode = (node: StringNode | FormatStringNode) =>
+            (node.d.token.flags & StringTokenFlags.Template) !== 0;
+
+        // Check for mixing of t-string literals with str, bytes, or f-string
+        // literals. CPython reports this as a SyntaxError (PEP 750).
+        const firstTemplateIndex = node.d.strings.findIndex(isTemplateNode);
+        const firstNonTemplateIndex = node.d.strings.findIndex((str) => !isTemplateNode(str));
+        if (firstTemplateIndex >= 0 && firstNonTemplateIndex >= 0) {
+            addDiagnostic(
+                DiagnosticRule.reportGeneralTypeIssues,
+                LocMessage.mixingTemplateAndStr(),
+                node.d.strings[Math.max(firstTemplateIndex, firstNonTemplateIndex)]
+            );
+
+            return { type: UnknownType.create() };
+        }
 
         // Check for mixing of bytes and str, which is not allowed.
         const firstStrIndex = node.d.strings.findIndex((str) => !isBytesNode(str));

--- a/packages/pyright-internal/src/localization/localize.ts
+++ b/packages/pyright-internal/src/localization/localize.ts
@@ -683,6 +683,7 @@ export namespace Localizer {
         export const missingSuperCall = () =>
             new ParameterizedString<{ methodName: string }>(getRawString('Diagnostic.missingSuperCall'));
         export const mixingBytesAndStr = () => getRawString('Diagnostic.mixingBytesAndStr');
+        export const mixingTemplateAndStr = () => getRawString('Diagnostic.mixingTemplateAndStr');
         export const moduleAsType = () => getRawString('Diagnostic.moduleAsType');
         export const moduleNotCallable = () => getRawString('Diagnostic.moduleNotCallable');
         export const moduleUnknownMember = () =>

--- a/packages/pyright-internal/src/localization/package.nls.en-us.json
+++ b/packages/pyright-internal/src/localization/package.nls.en-us.json
@@ -779,6 +779,10 @@
             "message": "Bytes and str values cannot be concatenated",
             "comment": ["{Locked='str'}", "{StrContains=i'bytes'}", "'bytes' is a keyword and should not be localized. It is only capitalized here because it is the first word in the sentence"]
         },
+        "mixingTemplateAndStr": {
+            "message": "Template string literals (t-strings) cannot be concatenated with string or bytes literals",
+            "comment": ["'t-string' is the common English slang for a Python template string", "{Locked='bytes'}"]
+        },
         "moduleAsType": "Module cannot be used as a type",
         "moduleNotCallable": "Module is not callable",
         "moduleUnknownMember": "\"{memberName}\" is not a known attribute of module \"{moduleName}\"",

--- a/packages/pyright-internal/src/tests/samples/tstring2.py
+++ b/packages/pyright-internal/src/tests/samples/tstring2.py
@@ -11,10 +11,29 @@ reveal_type(t2, expected_text="Template")
 t3 = Tr""
 reveal_type(t3, expected_text="Template")
 
-t4 = "" tR"" T"" r"" RT"""{age}""" """x"""
+# Implicit concatenation of t-string literals is allowed.
+t4 = t"Hello " t"{age}"
 reveal_type(t4, expected_text="Template")
 
 t4.strings
 t4.interpolations
 t4.values
 
+# This should generate an error because t-string literals cannot be
+# mixed with string literals.
+t5 = "" t"x"
+
+# This should generate an error.
+t6 = t"x" "y"
+
+# This should generate an error.
+t7 = t"x" f"y"
+
+# This should generate an error.
+t8 = t"x" b"y"
+
+t9 = t"a" + t"b"
+reveal_type(t9, expected_text="Template")
+
+# This should generate an error because Template and str cannot be added.
+t10 = t"a" + "b"

--- a/packages/pyright-internal/src/tests/typeEvaluator4.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator4.test.ts
@@ -140,7 +140,7 @@ test('TString2', () => {
 
     configOptions.defaultPythonVersion = pythonVersion3_14;
     const analysisResults1 = TestUtils.typeAnalyzeSampleFiles(['tstring2.py'], configOptions);
-    TestUtils.validateResults(analysisResults1, 1);
+    TestUtils.validateResults(analysisResults1, 6);
 });
 
 test('MemberAccess1', () => {


### PR DESCRIPTION
## Summary
- CPython 3.14 and [PEP 750](https://peps.python.org/pep-0750/) reject implicit concatenation of a t-string literal with a `str`, `bytes`, or f-string literal (`SyntaxError: cannot mix t-string literals with string or bytes literals`).
- Pyright previously accepted mixes such as `t"x" "y"` and `"" t"x"`, and inferred `Template`. Adjacent t-string literals (`t"a" t"b"`) remain valid.
- The check is implemented next to the existing bytes/str implicit-concatenation diagnostic, so mixed t-string concatenations are reported and typed as `Unknown`.

## Reproduction (Python 3.14)

```python
t1 = t"Hello " t"World"  # valid Template
t2 = t"Hello " "World"   # SyntaxError at runtime; Pyright now reports an error
t3 = t"x" + t"y"         # valid
t4 = t"x" + "y"          # TypeError at runtime; already reported via Template.__add__
```

CPython:

```text
>>> t"a" "b"
SyntaxError: cannot mix t-string literals with string or bytes literals
```

## Root cause
`getTypeOfStringList` treated any string list containing a t-string as `Template`, including mixed implicit concatenations. That matched an earlier draft of PEP 750; the final spec and CPython 3.14 disallow `Template`/`str` (and `Template`/`bytes`) implicit concatenation.

## Test plan
- [x] `tstring2.py`: valid t-string implicit concat; mix with `str`, f-string, and `bytes`; explicit `Template + Template` vs `Template + str`
- [x] `npx jest typeEvaluator4.test.ts -t TString --forceExit` (pass)
- [x] `npx jest typeEvaluator4.test.ts --forceExit` (155 passed)
- [x] `npx jest localizer.test.ts --forceExit` (pass)
- [x] `npx jest typeEvaluator8.test.ts -t Strings2 --forceExit` from `packages/pyright-internal` (pass)
- [x] `ESLINT_USE_FLAT_CONFIG=false npx eslint` on changed TS files (pass)
- [x] `npx prettier -c` on changed TS/JSON files (pass)
- [x] `npx lerna exec --stream --no-bail --ignore=pyright -- "tsc --noEmit"` (pass)
- [x] `git diff --check` (pass)

Full `packages/pyright-internal` `npm test` was not run (includes webpack test server + entire Jest suite). Analyzer coverage for this change is the TString / string-concatenation sample tests.
