### PR TITLE
Fix full release stage conditions

### DIFF
--- a/build/azuredevops/azure-pipelines-release.yml
+++ b/build/azuredevops/azure-pipelines-release.yml
@@ -324,7 +324,13 @@ extends:
                   RELEASE_TAG: $(EXPECTED_RELEASE_TAG)
 
       - stage: CreateRelease
-        condition: and(not(canceled()), succeeded(), eq('${{ parameters.releaseMode }}', 'full'))
+        condition: |
+          and(
+            not(canceled()),
+            eq('${{ parameters.releaseMode }}', 'full'),
+            in(dependencies.BuildVsix.result, 'Succeeded', 'SucceededWithIssues'),
+            in(dependencies.ValidateNpm.result, 'Succeeded', 'SucceededWithIssues')
+          )
         dependsOn:
           - BuildVsix
           - ValidateNpm
@@ -358,7 +364,12 @@ extends:
                     $(Pipeline.Workspace)/$(ARTIFACT_NAME_PACKAGE)/$(PACKAGE_NAME)
 
       - stage: WaitForValidation
-        condition: and(not(canceled()), succeeded(), eq('${{ parameters.releaseMode }}', 'full'))
+        condition: |
+          and(
+            not(canceled()),
+            eq('${{ parameters.releaseMode }}', 'full'),
+            in(dependencies.CreateRelease.result, 'Succeeded', 'SucceededWithIssues')
+          )
         dependsOn:
           - CreateRelease
         jobs:
@@ -378,7 +389,12 @@ extends:
                   onTimeout: 'reject' # require sign-off
 
       - stage: PublishToMarketplace
-        condition: and(not(canceled()), succeeded(), eq('${{ parameters.releaseMode }}', 'full'))
+        condition: |
+          and(
+            not(canceled()),
+            eq('${{ parameters.releaseMode }}', 'full'),
+            in(dependencies.WaitForValidation.result, 'Succeeded', 'SucceededWithIssues')
+          )
         dependsOn:
           - WaitForValidation
         jobs:


### PR DESCRIPTION
## Summary

Fix full Pyright release runs skipping all production stages after npm artifact validation.

`RecoverNpmArtifact` is intentionally skipped in `full` mode. The downstream stages used `succeeded()`, which evaluated false because that skipped stage was a transitive dependency through `ValidateNpm`. Check each stage's explicit prerequisite results instead.

## Validation

- YAML parses successfully and passes Prettier and Syncpack checks.
- Official `Pyright-Release` condition-only run passed in `full` mode: https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=14977419&view=results
- The test run reproduced the intended graph: `RecoverNpmArtifact` skipped, while `CreateRelease`, `WaitForValidation`, `PublishToMarketplace`, and `PublishToNpm` all succeeded.

This unblocks recovery of the tagged but unpublished `1.1.413` release.