### PR TITLE
Report illegal zero-argument super() in nested functions and lambdas

### DIFF
--- a/packages/pyright-internal/src/analyzer/parseTreeUtils.ts
+++ b/packages/pyright-internal/src/analyzer/parseTreeUtils.ts
@@ -704,6 +704,65 @@ export function getEnclosingFunction(node: ParseNode): FunctionNode | undefined 
     return undefined;
 }
 
+// Zero-argument super() is valid only in a method (or a comprehension
+// nested in that method). Nested functions and lambdas raise
+// RuntimeError at runtime because they do not receive the compiler-inserted
+// __class__ cell used by the zero-argument form.
+export function isZeroArgumentSuperCallAllowed(node: ParseNode): boolean {
+    let prevNode: ParseNode | undefined;
+    let curNode = node.parent;
+
+    while (curNode) {
+        if (curNode.nodeType === ParseNodeType.Lambda) {
+            return false;
+        }
+
+        if (curNode.nodeType === ParseNodeType.Function) {
+            // Don't treat a decorator as being "enclosed" in the function.
+            if (curNode.d.decorators.some((decorator) => decorator === prevNode)) {
+                prevNode = curNode;
+                curNode = curNode.parent;
+                continue;
+            }
+
+            let parent: ParseNode | undefined = curNode.parent;
+            while (parent) {
+                if (parent.nodeType === ParseNodeType.Class) {
+                    return true;
+                }
+                if (parent.nodeType === ParseNodeType.Function) {
+                    return false;
+                }
+                parent = parent.parent;
+            }
+
+            return false;
+        }
+
+        if (curNode.nodeType === ParseNodeType.Class) {
+            // super() in a class decorator, type parameter, or base-class
+            // argument is still evaluated in the enclosing scope, not the
+            // class body.
+            if (
+                curNode.d.decorators.some((decorator) => decorator === prevNode) ||
+                curNode.d.arguments.some((arg) => arg === prevNode) ||
+                curNode.d.typeParams === prevNode
+            ) {
+                prevNode = curNode;
+                curNode = curNode.parent;
+                continue;
+            }
+
+            return false;
+        }
+
+        prevNode = curNode;
+        curNode = curNode.parent;
+    }
+
+    return false;
+}
+
 // This is similar to getEnclosingFunction except that it uses evaluation
 // scopes rather than the parse tree to determine whether the specified node
 // is within the scope. That means if the node is within a class decorator

--- a/packages/pyright-internal/src/analyzer/parseTreeUtils.ts
+++ b/packages/pyright-internal/src/analyzer/parseTreeUtils.ts
@@ -11,6 +11,7 @@ import * as AnalyzerNodeInfo from '../analyzer/analyzerNodeInfo';
 import { containsOnlyWhitespace } from '../common/core';
 import { assert, assertNever, fail } from '../common/debug';
 import { convertPositionToOffset, convertTextRangeToRange } from '../common/positionUtils';
+import { PythonVersion, pythonVersion3_12 } from '../common/pythonVersion';
 import { Position, Range, TextRange } from '../common/textRange';
 import { TextRangeCollection, getIndexContaining } from '../common/textRangeCollection';
 import {
@@ -704,60 +705,52 @@ export function getEnclosingFunction(node: ParseNode): FunctionNode | undefined 
     return undefined;
 }
 
-// Zero-argument super() is valid only in a method (or a comprehension
-// nested in that method). Nested functions and lambdas raise
-// RuntimeError at runtime because they do not receive the compiler-inserted
-// __class__ cell used by the zero-argument form.
-export function isZeroArgumentSuperCallAllowed(node: ParseNode): boolean {
-    let prevNode: ParseNode | undefined;
-    let curNode = node.parent;
+// Determines whether a zero-argument `super()` call at the specified node
+// can succeed at runtime. The zero-argument form uses the first argument of
+// the frame that is executing the call along with the compiler-provided
+// `__class__` cell, so the caller must separately verify that an enclosing
+// class is present. This routine verifies only that the executing frame is
+// one that receives a first argument.
+export function isZeroArgSuperCallAllowed(node: ParseNode, pythonVersion: PythonVersion): boolean {
+    // Use the evaluation scope machinery to determine which frame executes
+    // the call. This handles decorators, parameter default values, class
+    // headers, lambdas, and comprehensions.
+    let curNode: ParseNode | undefined = getEvaluationScopeNode(node).node;
 
     while (curNode) {
-        if (curNode.nodeType === ParseNodeType.Lambda) {
-            return false;
-        }
-
-        if (curNode.nodeType === ParseNodeType.Function) {
-            // Don't treat a decorator as being "enclosed" in the function.
-            if (curNode.d.decorators.some((decorator) => decorator === prevNode)) {
-                prevNode = curNode;
-                curNode = curNode.parent;
-                continue;
+        switch (curNode.nodeType) {
+            case ParseNodeType.Function:
+            case ParseNodeType.Lambda: {
+                // The zero-argument form requires that the executing frame
+                // accept a first positional argument.
+                const firstParam = curNode.d.params.length > 0 ? curNode.d.params[0] : undefined;
+                return firstParam?.d.category === ParamCategory.Simple && firstParam.d.name !== undefined;
             }
 
-            let parent: ParseNode | undefined = curNode.parent;
-            while (parent) {
-                if (parent.nodeType === ParseNodeType.Class) {
-                    return true;
-                }
-                if (parent.nodeType === ParseNodeType.Function) {
+            case ParseNodeType.Comprehension: {
+                // A generator expression always executes in its own frame whose
+                // first argument is the implicit iterator, not the method's
+                // "self" argument. List, set, and dict comprehensions likewise
+                // used a separate frame prior to Python 3.12 (PEP 709).
+                if (curNode.d.isGenerator || PythonVersion.isLessThan(pythonVersion, pythonVersion3_12)) {
                     return false;
                 }
-                parent = parent.parent;
+                break;
             }
 
-            return false;
-        }
-
-        if (curNode.nodeType === ParseNodeType.Class) {
-            // super() in a class decorator, type parameter, or base-class
-            // argument is still evaluated in the enclosing scope, not the
-            // class body.
-            if (
-                curNode.d.decorators.some((decorator) => decorator === prevNode) ||
-                curNode.d.arguments.some((arg) => arg === prevNode) ||
-                curNode.d.typeParams === prevNode
-            ) {
-                prevNode = curNode;
-                curNode = curNode.parent;
-                continue;
+            case ParseNodeType.TypeParameterList: {
+                // A type parameter scope is a proxy scope, so continue
+                // searching for the enclosing execution frame.
+                break;
             }
 
-            return false;
+            default: {
+                // A class body or module frame receives no first argument.
+                return false;
+            }
         }
 
-        prevNode = curNode;
-        curNode = curNode.parent;
+        curNode = curNode.parent ? getEvaluationScopeNode(curNode.parent).node : undefined;
     }
 
     return false;

--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -9636,9 +9636,15 @@ export function createTypeEvaluator(
             if (enclosingClassType) {
                 targetClassType = enclosingClassType ?? UnknownType.create();
 
-                // Zero-argument forms of super are not allowed within static methods.
-                // This results in a runtime exception.
-                if (enclosingFunction) {
+                // Zero-argument forms of super are not allowed within nested
+                // functions or lambdas. This results in a runtime exception.
+                if (!ParseTreeUtils.isZeroArgumentSuperCallAllowed(node)) {
+                    addDiagnostic(
+                        DiagnosticRule.reportGeneralTypeIssues,
+                        LocMessage.superCallZeroArgForm(),
+                        node.d.leftExpr
+                    );
+                } else if (enclosingFunction) {
                     const functionInfo = getFunctionInfoFromDecorators(
                         evaluatorInterface,
                         enclosingFunction,

--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -9636,28 +9636,31 @@ export function createTypeEvaluator(
             if (enclosingClassType) {
                 targetClassType = enclosingClassType ?? UnknownType.create();
 
-                // Zero-argument forms of super are not allowed within nested
-                // functions or lambdas. This results in a runtime exception.
-                if (!ParseTreeUtils.isZeroArgumentSuperCallAllowed(node)) {
+                const functionInfo = enclosingFunction
+                    ? getFunctionInfoFromDecorators(evaluatorInterface, enclosingFunction, /* isInClass */ true)
+                    : undefined;
+
+                // Zero-argument forms of super are not allowed within static methods.
+                // This results in a runtime exception.
+                if (functionInfo !== undefined && (functionInfo.flags & FunctionTypeFlags.StaticMethod) !== 0) {
+                    addDiagnostic(
+                        DiagnosticRule.reportGeneralTypeIssues,
+                        LocMessage.superCallZeroArgFormStaticMethod(),
+                        node.d.leftExpr
+                    );
+                } else if (
+                    !ParseTreeUtils.isZeroArgSuperCallAllowed(
+                        node,
+                        AnalyzerNodeInfo.getFileInfo(node).executionEnvironment.pythonVersion
+                    )
+                ) {
+                    // The frame that executes the call doesn't receive a first
+                    // argument, so the zero-argument form raises at runtime.
                     addDiagnostic(
                         DiagnosticRule.reportGeneralTypeIssues,
                         LocMessage.superCallZeroArgForm(),
                         node.d.leftExpr
                     );
-                } else if (enclosingFunction) {
-                    const functionInfo = getFunctionInfoFromDecorators(
-                        evaluatorInterface,
-                        enclosingFunction,
-                        /* isInClass */ true
-                    );
-
-                    if ((functionInfo?.flags & FunctionTypeFlags.StaticMethod) !== 0) {
-                        addDiagnostic(
-                            DiagnosticRule.reportGeneralTypeIssues,
-                            LocMessage.superCallZeroArgFormStaticMethod(),
-                            node.d.leftExpr
-                        );
-                    }
                 }
             } else {
                 addDiagnostic(

--- a/packages/pyright-internal/src/tests/samples/super1.py
+++ b/packages/pyright-internal/src/tests/samples/super1.py
@@ -47,7 +47,16 @@ class ClassD(ClassB, ClassC):
 
     def method(self):
         def inner():
+            # This should generate an error because the zero-arg form
+            # of super is illegal in a nested function.
             super().method1()
+
+        # This should generate an error because the zero-arg form
+        # of super is illegal in a lambda.
+        lambda: super().method1()
+
+        # Comprehensions execute in the enclosing method and are valid.
+        [super().method1() for _ in [1]]
 
 
 super(ClassD)

--- a/packages/pyright-internal/src/tests/samples/super1.py
+++ b/packages/pyright-internal/src/tests/samples/super1.py
@@ -46,17 +46,46 @@ class ClassD(ClassB, ClassC):
         super().non_method1()
 
     def method(self):
-        def inner():
-            # This should generate an error because the zero-arg form
-            # of super is illegal in a nested function.
+        def inner1():
+            # This should generate an error because the frame that executes
+            # the zero-arg form of super receives no first argument.
             super().method1()
 
-        # This should generate an error because the zero-arg form
-        # of super is illegal in a lambda.
+        def inner2(obj):
+            # This is allowed because the frame receives a first argument,
+            # so `inner2(self)` succeeds at runtime.
+            super().method1()
+
+        def inner3(value=super().method1()):
+            # Parameter default values are evaluated in the enclosing
+            # method's frame, so this is allowed.
+            pass
+
+        async def inner4():
+            # This should generate an error because the frame that executes
+            # the zero-arg form of super receives no first argument.
+            super().method1()
+
+        async def inner5(obj):
+            # This is allowed because the frame receives a first argument.
+            super().method1()
+
+        # This should generate an error because a lambda with no parameters
+        # receives no first argument.
         lambda: super().method1()
 
-        # Comprehensions execute in the enclosing method and are valid.
+        # This is allowed because the lambda receives a first argument.
+        lambda obj: super().method1()
+
+        # As of Python 3.12, list, set, and dict comprehensions are inlined
+        # into the enclosing frame, so these are allowed.
         [super().method1() for _ in [1]]
+        {super().method1() for _ in [1]}
+        {0: super().method1() for _ in [1]}
+
+        # This should generate an error because a generator expression always
+        # executes in its own frame whose first argument is the iterator.
+        list(super().method1() for _ in [1])
 
 
 super(ClassD)

--- a/packages/pyright-internal/src/tests/samples/super14.py
+++ b/packages/pyright-internal/src/tests/samples/super14.py
@@ -1,0 +1,28 @@
+# This sample tests the handling of the zero-argument form of super()
+# within a comprehension when the target Python version is older than 3.12.
+# Prior to PEP 709, list, set, and dict comprehensions each executed in
+# their own frame whose first argument was the implicit iterator.
+
+
+class ClassA:
+    def method1(self):
+        pass
+
+
+class ClassB(ClassA):
+    def method2(self):
+        # This should generate an error because a list comprehension
+        # executes in its own frame prior to Python 3.12.
+        [super().method1() for _ in [1]]
+
+        # This should generate an error because a set comprehension
+        # executes in its own frame prior to Python 3.12.
+        {super().method1() for _ in [1]}
+
+        # This should generate an error because a dict comprehension
+        # executes in its own frame prior to Python 3.12.
+        {0: super().method1() for _ in [1]}
+
+        # This should generate an error because a generator expression
+        # executes in its own frame.
+        list(super().method1() for _ in [1])

--- a/packages/pyright-internal/src/tests/typeEvaluator2.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator2.test.ts
@@ -177,7 +177,7 @@ test('AugmentedAssignment3', () => {
 test('Super1', () => {
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['super1.py']);
 
-    TestUtils.validateResults(analysisResults, 6);
+    TestUtils.validateResults(analysisResults, 8);
 });
 
 test('Super2', () => {

--- a/packages/pyright-internal/src/tests/typeEvaluator2.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator2.test.ts
@@ -9,7 +9,13 @@
  */
 
 import { ConfigOptions } from '../common/configOptions';
-import { pythonVersion3_10, pythonVersion3_13, pythonVersion3_15, pythonVersion3_9 } from '../common/pythonVersion';
+import {
+    pythonVersion3_10,
+    pythonVersion3_11,
+    pythonVersion3_13,
+    pythonVersion3_15,
+    pythonVersion3_9,
+} from '../common/pythonVersion';
 import { Uri } from '../common/uri/uri';
 import * as TestUtils from './testUtils';
 
@@ -177,7 +183,7 @@ test('AugmentedAssignment3', () => {
 test('Super1', () => {
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['super1.py']);
 
-    TestUtils.validateResults(analysisResults, 8);
+    TestUtils.validateResults(analysisResults, 10);
 });
 
 test('Super2', () => {
@@ -250,6 +256,14 @@ test('Super13', () => {
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['super13.py']);
 
     TestUtils.validateResults(analysisResults, 0);
+});
+
+test('Super14', () => {
+    const configOptions = new ConfigOptions(Uri.empty());
+    configOptions.defaultPythonVersion = pythonVersion3_11;
+    const analysisResults = TestUtils.typeAnalyzeSampleFiles(['super14.py'], configOptions);
+
+    TestUtils.validateResults(analysisResults, 4);
 });
 
 test('MissingSuper1', () => {


### PR DESCRIPTION
## Summary
- Zero-argument `super()` is valid only in a method (and in comprehensions that run in that method). Nested `def`/`async def` and lambdas raise `RuntimeError: super(): no arguments` because they do not get the compiler-inserted `__class__` cell.
- Pyright previously treated `super()` inside a nested function as if it were in the enclosing method (`super1.py` even contained this case with no expected error).
- Reuses the existing `superCallZeroArgForm` diagnostic. Nested class *bases* evaluated in a method remain allowed; nested class *bodies* still error.

## Test plan
- [x] `npx jest typeEvaluator2.test.ts -t Super --forceExit` (from `packages/pyright-internal`)
- [x] Runtime check: nested `def`/`lambda` raise; `[super() for _ in [1]]` inside a method succeeds
- [ ] Confirm nested `super().method()` in an editor shows the zero-argument diagnostic