### PR TITLE
Do not iterate via __getitem__ when __iter__ is explicitly set

### DIFF
--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -3402,9 +3402,22 @@ export function createTypeEvaluator(
                 const iterReturnType = getTypeOfMagicMethodCall(subtype, iterMethodName, [], errorNode)?.type;
 
                 if (!iterReturnType) {
-                    // There was no __iter__. See if we can fall back to
-                    // the __getitem__ method instead.
+                    // There was no callable __iter__. The legacy sequence protocol
+                    // falls back to __getitem__, but CPython does that only when
+                    // __iter__ is missing. An explicit `__iter__ = None` (or any
+                    // non-callable __iter__) makes the object not iterable.
+                    let hasExplicitIterMember = false;
                     if (!isAsync && isClassInstance(subtype)) {
+                        hasExplicitIterMember = !!lookUpObjectMember(
+                            subtype,
+                            iterMethodName,
+                            MemberAccessFlags.SkipInstanceMembers |
+                                MemberAccessFlags.SkipAttributeAccessOverride |
+                                MemberAccessFlags.SkipObjectBaseClass
+                        );
+                    }
+
+                    if (!isAsync && isClassInstance(subtype) && !hasExplicitIterMember) {
                         const getItemReturnType = getTypeOfMagicMethodCall(
                             subtype,
                             '__getitem__',

--- a/packages/pyright-internal/src/tests/samples/forLoop3.py
+++ b/packages/pyright-internal/src/tests/samples/forLoop3.py
@@ -1,0 +1,44 @@
+# This sample tests that `__iter__ = None` disables iteration even
+# when `__getitem__` is defined. CPython raises TypeError in this case.
+
+
+class SequenceProtocol:
+    def __getitem__(self, item: int) -> int:
+        if item >= 3:
+            raise IndexError
+        return item
+
+
+# The legacy sequence protocol should still be iterable.
+for _ in SequenceProtocol():
+    pass
+
+
+class IterNone:
+    def __getitem__(self, item: int) -> int:
+        return item
+
+    __iter__ = None
+
+
+# This should generate an error because __iter__ is None.
+for _ in IterNone():
+    pass
+
+
+class IterNoneSubclass(IterNone):
+    pass
+
+
+# This should generate an error because __iter__ is None.
+for _ in IterNoneSubclass():
+    pass
+
+
+class IterRestored(IterNone):
+    def __iter__(self):
+        yield 1
+
+
+for _ in IterRestored():
+    pass

--- a/packages/pyright-internal/src/tests/typeEvaluator3.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator3.test.ts
@@ -518,6 +518,12 @@ test('ForLoop2', () => {
     TestUtils.validateResults(analysisResults, 7);
 });
 
+test('ForLoop3', () => {
+    const analysisResults = TestUtils.typeAnalyzeSampleFiles(['forLoop3.py']);
+
+    TestUtils.validateResults(analysisResults, 2);
+});
+
 test('Comprehension1', () => {
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['comprehension1.py']);
 


### PR DESCRIPTION
## Summary
- Fixes #11220.
- CPython treats an object as not iterable when `__iter__` is present but not callable (`__iter__ = None`), even if `__getitem__` exists. Pyright still used the legacy sequence protocol and accepted `for x in Foo()`.
- `__getitem__` fallback now applies only when `__iter__` is missing.

## Test plan
- [x] `npx jest typeEvaluator3.test.ts -t ForLoop --forceExit` (from `packages/pyright-internal`)
- [x] Runtime: `for _ in Foo()` with `__iter__ = None` raises `TypeError`; a `__getitem__`-only class still iterates
- [ ] Confirm a `for` loop over such a class reports a not-iterable error in the language server