### PR TITLE
Retain Sentinel types for non-CONSTANT_NAME bindings

### DIFF
--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -4011,7 +4011,8 @@ export function createTypeEvaluator(
                 if (
                     TypeBase.isInstance(destType) &&
                     !isConstantName(nameValue) &&
-                    !isFinalVariable(symbolWithScope.symbol)
+                    !isFinalVariable(symbolWithScope.symbol) &&
+                    !isSentinelLiteral(destType)
                 ) {
                     destType = stripTypeForm(stripLiteralValue(destType));
                 }
@@ -24654,6 +24655,12 @@ export function createTypeEvaluator(
                                 ClassType.isEnumClass(type) &&
                                 isDeclInEnumClass(evaluatorInterface, decl)
                             ) {
+                                isConstant = true;
+                            }
+
+                            // Sentinel objects are singletons; retaining the literal is sound
+                            // even when the binding is not a CONSTANT_NAME or Final.
+                            if (isSentinelLiteral(type)) {
                                 isConstant = true;
                             }
 

--- a/packages/pyright-internal/src/tests/samples/sentinel3.py
+++ b/packages/pyright-internal/src/tests/samples/sentinel3.py
@@ -1,0 +1,44 @@
+# This sample tests that Sentinel values retain their literal type
+# even when the binding is not a CONSTANT_NAME.
+
+from dataclasses import dataclass
+from typing_extensions import Sentinel  # pyright: ignore[reportMissingModuleSource]
+
+
+Empty = Sentinel("Empty")
+MISSING = Sentinel("MISSING")
+
+
+def func1(value: int | Empty) -> None:
+    if value is Empty:
+        reveal_type(value, expected_text="Empty")
+    else:
+        reveal_type(value, expected_text="int")
+
+
+def func2(value: int | Empty) -> None:
+    if value is not Empty:
+        reveal_type(value, expected_text="int")
+    else:
+        reveal_type(value, expected_text="Empty")
+
+
+@dataclass
+class Address:
+    email: str
+    name: str | None
+
+
+def update_not_empty(address: Address, email: str | Empty, name: str | None | Empty) -> None:
+    if email is not Empty:
+        address.email = email
+        reveal_type(email, expected_text="str")
+    if name is not Empty:
+        address.name = name
+        reveal_type(name, expected_text="str | None")
+
+
+def update_not_missing(address: Address, email: str | MISSING) -> None:
+    if email is not MISSING:
+        address.email = email
+        reveal_type(email, expected_text="str")

--- a/packages/pyright-internal/src/tests/typeEvaluator2.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator2.test.ts
@@ -1013,3 +1013,8 @@ test('Sentinel2', () => {
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['sentinel2.py'], configOptions);
     TestUtils.validateResults(analysisResults, 5);
 });
+
+test('Sentinel3', () => {
+    const analysisResults = TestUtils.typeAnalyzeSampleFiles(['sentinel3.py']);
+    TestUtils.validateResults(analysisResults, 0);
+});


### PR DESCRIPTION
## Summary
- Sentinel objects are unique singletons, so pyright can keep their literal types even when the binding is not a `CONSTANT_NAME` or `Final`.
- That makes `is` / `is not` narrowing work for names like `Empty = Sentinel("Empty")`, matching the behavior already used for all-caps sentinels.

Fixes #10744

## Test plan
- [x] `pnpm exec jest typeEvaluator2.test.ts -t "Sentinel" --forceExit` in `packages/pyright-internal`