### PR TITLE
Install pinned pnpm on Azure DevOps build agents

### DIFF
--- a/build/azuredevops/azure-pipelines-release.yml
+++ b/build/azuredevops/azure-pipelines-release.yml
@@ -103,6 +103,11 @@ extends:
                 displayName: Use Node 24.15.0
                 inputs:
                   version: 24.15.0
+              # The 1ES agent image ships Node but not pnpm, and corepack cannot
+              # fetch it in the restricted-network build, so install the pinned pnpm
+              # via npm (which honors NPM_CONFIG_USERCONFIG for the authenticated feed).
+              - script: npm run installPinnedPackageManager
+                displayName: Install pinned pnpm
               - task: CmdLine@2
                 displayName: pnpm install
                 inputs:
@@ -127,10 +132,6 @@ extends:
                   SourceFolder: packages/vscode-pyright
                   Contents: '$(VSIX_NAME)'
                   TargetFolder: build_output
-
-              - script: |
-                  pnpm install -g @vscode/vsce
-                displayName: 'Install vsce and dependencies'
 
               - script: pnpm exec vsce generate-manifest -i $(VSIX_NAME) -o extension.manifest
                 displayName: 'Generate extension manifest'
@@ -210,6 +211,11 @@ extends:
                 displayName: Use Node 24.15.0
                 inputs:
                   version: 24.15.0
+              # The 1ES agent image ships Node but not pnpm, and corepack cannot
+              # fetch it in the restricted-network build, so install the pinned pnpm
+              # via npm (which honors NPM_CONFIG_USERCONFIG for the authenticated feed).
+              - script: npm run installPinnedPackageManager
+                displayName: Install pinned pnpm
               - task: CmdLine@2
                 displayName: pnpm install
                 inputs:
@@ -438,8 +444,12 @@ extends:
               # Install dependencies and VS Code Extension Manager (vsce >= v2.26.1 needed)
               # Generate + authenticate the CFS feed .npmrc at runtime (ICM 839806358).
               - template: /build/templates/npmAuthenticate.yml@self
+              # This checkout: none job has no workspace to run `pnpm exec` from, so
+              # install the pinned vsce globally; the bare `vsce publish` step below
+              # then finds it on PATH. npm honors NPM_CONFIG_USERCONFIG for the
+              # authenticated feed.
               - script: |
-                  pnpm install -g @vscode/vsce
+                  npm install --ignore-scripts=false -g @vscode/vsce@3.9.2
                 displayName: 'Install vsce and dependencies'
               # https://code.visualstudio.com/api/working-with-extensions/publishing-extension#get-a-personal-access-token
               # Publish to Marketplace

--- a/build/azuredevops/azure-pipelines.yml
+++ b/build/azuredevops/azure-pipelines.yml
@@ -53,6 +53,11 @@ extends:
                 displayName: Use Node 24.15.0
                 inputs:
                   version: 24.15.0
+              # The 1ES agent image ships Node but not pnpm, and corepack cannot
+              # fetch it in the restricted-network build, so install the pinned pnpm
+              # via npm (which honors NPM_CONFIG_USERCONFIG for the authenticated feed).
+              - script: npm run installPinnedPackageManager
+                displayName: Install pinned pnpm
               - task: CmdLine@2
                 displayName: pnpm install
                 inputs:

--- a/build/installPinnedPackageManager.js
+++ b/build/installPinnedPackageManager.js
@@ -1,0 +1,40 @@
+const { spawnSync } = require('child_process');
+const path = require('path');
+
+const repoRoot = path.resolve(__dirname, '..');
+const { packageManager } = require(path.join(repoRoot, 'package.json'));
+
+if (!/^pnpm@\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?$/.test(packageManager)) {
+    throw new Error(`Unsupported packageManager value: ${packageManager}`);
+}
+
+console.log(`Installing pinned package manager: ${packageManager}`);
+
+const result = spawnSync(`npm install --global ${packageManager}`, {
+    cwd: repoRoot,
+    shell: true,
+    stdio: 'inherit',
+});
+
+if (result.error) {
+    throw result.error;
+}
+if (result.status !== 0) {
+    process.exitCode = result.status ?? 1;
+} else {
+    const versionResult = spawnSync('pnpm --version', {
+        cwd: repoRoot,
+        shell: true,
+        encoding: 'utf8',
+    });
+
+    if (versionResult.error) {
+        throw versionResult.error;
+    }
+    if (versionResult.status !== 0) {
+        process.stderr.write(versionResult.stderr);
+        process.exitCode = versionResult.status ?? 1;
+    } else {
+        console.log(`Installed pnpm version: ${versionResult.stdout.trim()}`);
+    }
+}

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
     "packageManager": "pnpm@10.12.2",
     "scripts": {
         "clean": "lerna run --no-bail --stream clean",
+        "installPinnedPackageManager": "node ./build/installPinnedPackageManager.js",
         "install:all": "pnpm install",
         "test": "pnpm --dir packages/pyright-internal test",
         "update:all": "node ./build/updateDeps.js",


### PR DESCRIPTION
## Problem

PR #11652 migrated CI package installation from npm to pnpm, but the Azure DevOps agent image ships Node **without** pnpm. Since it merged, every ADO build fails at `pnpm run install:all` with:

```
pnpm: command not found   (exit 127)
```

`package.json` pins `"packageManager": "pnpm@10.12.2"`, but `UseNode@1` does not enable corepack, and corepack can't fetch pnpm in the restricted-network build anyway.

## Fix

**Provision the pinned pnpm before it is used.** Add `npm run installPinnedPackageManager` (a thin `npm install --global pnpm@<pinned>` wrapper that reads the version from `package.json`) after `UseNode@1` in every `checkout: self` job that runs the pnpm workspace install:
- `azure-pipelines.yml` (build)
- `azure-pipelines-release.yml` (`build_vsix`, `build_npm`)

npm is used for this bootstrap because it honors the pipeline's `NPM_CONFIG_USERCONFIG` for the authenticated feed. corepack is intentionally not used — it cannot reach the registry in the restricted-network build.

**Fix `@vscode/vsce` invocations** that #11652 left broken on a fresh agent (`pnpm install -g` fails with `ERR_PNPM_NO_GLOBAL_BIN_DIR`):
- Manifest generation → `pnpm exec vsce generate-manifest` (vsce is already a workspace devDependency, so no global install needed).
- Marketplace publish job (`checkout: none`, no workspace) → `npm install --ignore-scripts=false -g @vscode/vsce@3.9.2`, so its bare `vsce publish` step finds vsce on PATH.

## Testing

- Both pipeline YAML files parse.
- `installPinnedPackageManager.js` mirrors the existing helper pattern; `npm install --global pnpm@10.12.2` succeeds under the restricted network.
- `pnpm exec vsce` resolves the workspace devDependency; `pnpm install -g` / bare `pnpm exec` outside a workspace were confirmed to fail, which is why they are replaced.
