### PR TITLE
Fix reflected operator priority when the right operand is a subclass

### DIFF
--- a/packages/pyright-internal/src/analyzer/operations.ts
+++ b/packages/pyright-internal/src/analyzer/operations.ts
@@ -28,7 +28,9 @@ import { evaluateStaticBoolExpression } from './staticExpressions';
 import { EvalFlags, MagicMethodDeprecationInfo, TypeEvaluator, TypeResult } from './typeEvaluatorTypes';
 import {
     InferenceContext,
+    MemberAccessFlags,
     convertToInstantiable,
+    derivesFromClassRecursive,
     getLiteralTypeClassName,
     getTypeCondition,
     getUnionSubtypeCount,
@@ -38,6 +40,7 @@ import {
     isUnboundedTupleClass,
     isUnionableType,
     lookUpClassMember,
+    lookUpObjectMember,
     makeInferenceContext,
     mapSubtypes,
     preserveUnknown,
@@ -1245,6 +1248,60 @@ function validateContainmentOperation(
     return { type, magicMethodDeprecationInfo: deprecatedInfo };
 }
 
+// Python evaluates a binary operation by calling the left operand's magic
+// method first, but there is an exception to this rule: if the right operand's
+// type is a proper subclass of the left operand's type and it overrides the
+// reflected magic method, the reflected method is called first.
+function isReflectedOperatorPrioritized(
+    leftType: Type,
+    rightType: Type,
+    magicMethodName: string,
+    altMagicMethodName: string
+): boolean {
+    if (!isClassInstance(leftType) || !isClassInstance(rightType)) {
+        return false;
+    }
+
+    // The right operand's class must be a proper subclass of the left operand's class.
+    if (ClassType.isSameGenericClass(leftType, rightType)) {
+        return false;
+    }
+
+    if (
+        !derivesFromClassRecursive(
+            ClassType.cloneAsInstantiable(rightType),
+            ClassType.cloneAsInstantiable(leftType),
+            /* ignoreUnknown */ true
+        )
+    ) {
+        return false;
+    }
+
+    // The right operand's class must override the reflected magic method.
+    const rightAltMember = lookUpObjectMember(rightType, altMagicMethodName, MemberAccessFlags.SkipInstanceMembers);
+    if (!rightAltMember) {
+        return false;
+    }
+
+    const leftAltMember = lookUpObjectMember(leftType, altMagicMethodName, MemberAccessFlags.SkipInstanceMembers);
+    if (
+        leftAltMember &&
+        isClass(leftAltMember.classType) &&
+        isClass(rightAltMember.classType) &&
+        ClassType.isSameGenericClass(leftAltMember.classType, rightAltMember.classType)
+    ) {
+        return false;
+    }
+
+    // If the left operand's class doesn't implement the normal form of the
+    // operator, there's nothing to prioritize over.
+    if (!lookUpObjectMember(leftType, magicMethodName, MemberAccessFlags.SkipInstanceMembers)) {
+        return false;
+    }
+
+    return true;
+}
+
 function validateArithmeticOperation(
     evaluator: TypeEvaluator,
     operator: OperatorType,
@@ -1304,7 +1361,29 @@ function validateArithmeticOperation(
                     }
 
                     const magicMethodName = binaryOperatorMap[operator][0];
-                    let resultTypeResult = evaluator.getTypeOfMagicMethodCall(
+                    let resultTypeResult: TypeResult | undefined;
+
+                    // If the right operand's type is a proper subclass of the left
+                    // operand's type and overrides the reflected magic method, Python
+                    // gives the reflected form of the operator priority.
+                    if (
+                        isReflectedOperatorPrioritized(
+                            leftSubtypeExpanded,
+                            rightSubtypeExpanded,
+                            magicMethodName,
+                            binaryOperatorMap[operator][1]
+                        )
+                    ) {
+                        resultTypeResult = evaluator.getTypeOfMagicMethodCall(
+                            convertFunctionToObject(evaluator, rightSubtypeUnexpanded),
+                            binaryOperatorMap[operator][1],
+                            [{ type: leftSubtypeUnexpanded, isIncomplete: leftTypeResult.isIncomplete }],
+                            errorNode,
+                            inferenceContext
+                        );
+                    }
+
+                    resultTypeResult ??= evaluator.getTypeOfMagicMethodCall(
                         convertFunctionToObject(evaluator, leftSubtypeUnexpanded),
                         magicMethodName,
                         [{ type: rightSubtypeUnexpanded, isIncomplete: rightTypeResult.isIncomplete }],

--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -6579,6 +6579,12 @@ export function createTypeEvaluator(
         };
     }
 
+    // Determines whether all of the symbol's typed declarations are methods.
+    function isDeclaredAsMethod(symbol: Symbol): boolean {
+        const decls = symbol.getTypedDeclarations();
+        return decls.length > 0 && decls.every((decl) => decl.type === DeclarationType.Function);
+    }
+
     function getTypeOfClassMemberName(
         errorNode: ExpressionNode | undefined,
         classType: ClassType,
@@ -6598,6 +6604,13 @@ export function createTypeEvaluator(
         // a symbol with an inferred type.
         if (!memberInfo) {
             memberInfo = lookUpClassMember(classType, memberName, flags);
+        } else if (memberInfo.skippedUndeclaredType && isDeclaredAsMethod(memberInfo.symbol)) {
+            // A symbol without a declared type was skipped in a class that appears
+            // earlier in the MRO, and the declared symbol we found is a method.
+            // A class-scoped assignment that aliases a method (a common idiom for
+            // defining reflected dunder methods) overrides the base class method,
+            // so use the overriding symbol instead.
+            memberInfo = lookUpClassMember(classType, memberName, flags) ?? memberInfo;
         }
 
         if (!memberInfo) {

--- a/packages/pyright-internal/src/tests/samples/operator13.py
+++ b/packages/pyright-internal/src/tests/samples/operator13.py
@@ -1,0 +1,62 @@
+# This sample tests that the reflected form of a binary operator is given
+# priority when the right operand's type is a proper subclass of the left
+# operand's type and it overrides the reflected magic method.
+
+from enum import IntFlag, auto
+from typing import Self
+
+
+class Flags(IntFlag):
+    A = auto()
+    B = auto()
+
+
+reveal_type(int() & Flags.A, expected_text="Flags")
+reveal_type(int() | Flags.A, expected_text="Flags")
+reveal_type(int() ^ Flags.A, expected_text="Flags")
+
+# The left operand's own method is used when both operands have the same type.
+reveal_type(int() & int(), expected_text="int")
+
+
+class Base:
+    def __add__(self, other: "Base") -> "Base": ...
+
+    def __radd__(self, other: "Base") -> "Base": ...
+
+
+class Derived(Base):
+    def __radd__(self, other: Base) -> Self:
+        return self
+
+
+class DerivedNoOverride(Base): ...
+
+
+def func1(base: Base, derived: Derived, no_override: DerivedNoOverride):
+    # The subclass overrides __radd__, so it takes priority.
+    reveal_type(base + derived, expected_text="Derived")
+
+    # The subclass doesn't override __radd__, so the normal order applies.
+    reveal_type(base + no_override, expected_text="Base")
+
+    # The right operand isn't a subclass of the left operand.
+    reveal_type(derived + base, expected_text="Base")
+
+
+# A class-scoped assignment that aliases a method overrides a method of the
+# same name in a base class rather than adopting its declared signature.
+class Base2:
+    def __and__(self, other: "Base2") -> "Base2": ...
+
+    def __rand__(self, other: "Base2") -> "Base2": ...
+
+
+class Derived2(Base2):
+    def __and__(self, other: "Base2") -> "Derived2": ...
+
+    __rand__ = __and__
+
+
+def func2(base: Base2, derived: Derived2):
+    reveal_type(base & derived, expected_text="Derived2")

--- a/packages/pyright-internal/src/tests/typeEvaluator8.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator8.test.ts
@@ -458,6 +458,12 @@ test('Operator12', () => {
     TestUtils.validateResults(analysisResults, 0);
 });
 
+test('Operator13', () => {
+    const analysisResults = TestUtils.typeAnalyzeSampleFiles(['operator13.py']);
+
+    TestUtils.validateResults(analysisResults, 0);
+});
+
 test('Optional1', () => {
     const configOptions = new ConfigOptions(Uri.empty());
 


### PR DESCRIPTION
Fixes #11515

### Root cause

There are two separate problems behind the reported symptom.

**1. The reflected form of the operator is never given priority.**

Python evaluates `x op y` by calling `type(x).__op__` first, except in one case: if `type(y)` is a proper subclass of `type(x)` and it overrides the reflected method `__rop__`, then `type(y).__rop__` is called first. `validateArithmeticOperation` in `operations.ts` always tried the left operand's method first and only fell back to the reflected form if that failed. Since `int.__and__` accepts any `int`, it always won, and the more precise result from `IntFlag.__rand__` was never considered.

**2. An undeclared class member does not override a declared method in a base class.**

`getTypeOfClassMemberName` looks for a member with a declared type first, walking the whole MRO before falling back to a lookup that also accepts inferred types. When a derived class defines a member through a plain assignment, that member has no declared type, so the lookup skipped it and returned a declared member from a base class instead.

typeshed defines `IntFlag`'s reflected methods with the alias idiom:

```python
class IntFlag(int, ReprEnum, Flag, boundary=KEEP):
    def __and__(self, other: int) -> Self: ...
    __rand__ = __and__
```

`int` already declares `__rand__`, so `Flags.A.__rand__` resolved to `int.__rand__` (`(value: int, /) -> int`) rather than the alias. Even with the operator ordering fixed, the reflected call would still have produced `int`.

### Fix

`operations.ts` now checks, before calling the left operand's magic method, whether the right operand's type is a proper subclass of the left operand's type and overrides the reflected magic method. If so, the reflected method is tried first, with the existing evaluation order used as a fallback so nothing regresses when the reflected call doesn't apply.

`typeEvaluator.ts` uses the existing but previously unused `skippedUndeclaredType` flag on `ClassMember`. When the declared-types-only lookup skipped an undeclared symbol in a class earlier in the MRO and the declared symbol it found is a method, the overriding symbol is used instead. This is deliberately limited to methods so that `reportIncompatibleVariableOverride` behavior for variable overrides is unchanged.

### Verification

New sample `operator13.py` registered in `typeEvaluator8.test.ts` covers:

- `int() & Flags.A`, `|` and `^` now evaluate to `Flags`
- `int() & int()` still evaluates to `int`
- a subclass that overrides `__radd__` takes priority over the base class `__add__`
- a subclass that does not override `__radd__` keeps the normal evaluation order
- a right operand that is not a subclass keeps the normal evaluation order
- a method alias assignment overriding a base class method of the same name

Reverting either source change makes the new test fail. With both applied, all 1285 tests across the `typeEvaluator*` and `checker` suites pass with no regressions.
