### PR TITLE
Do not eliminate a TypedDict with extra items on a negative key check

### DIFF
--- a/packages/pyright-internal/src/analyzer/typeGuards.ts
+++ b/packages/pyright-internal/src/analyzer/typeGuards.ts
@@ -2281,7 +2281,8 @@ function narrowTypeForTypedDictKey(
 
             if (isClassInstance(subtype) && ClassType.isTypedDictClass(subtype)) {
                 const entries = getTypedDictMembersForClass(evaluator, subtype, /* allowNarrowed */ true);
-                const tdEntry = entries.knownItems.get(literalKey.priv.literalValue as string) ?? entries.extraItems;
+                const knownEntry = entries.knownItems.get(literalKey.priv.literalValue as string);
+                const tdEntry = knownEntry ?? entries.extraItems;
 
                 if (isPositiveTest) {
                     // The code that is commented out below implements the behavior that is technically
@@ -2335,7 +2336,15 @@ function narrowTypeForTypedDictKey(
                         )
                     );
                 } else {
-                    return tdEntry !== undefined && (tdEntry.isRequired || tdEntry.isProvided) ? undefined : subtype;
+                    if (!knownEntry) {
+                        // The key is not one of the known items, so it can be supplied
+                        // only through an "extra items" entry, which says nothing about
+                        // whether this particular key is present. Its absence is therefore
+                        // consistent with the type, and the subtype cannot be eliminated.
+                        return subtype;
+                    }
+
+                    return knownEntry.isRequired || knownEntry.isProvided ? undefined : subtype;
                 }
             }
 

--- a/packages/pyright-internal/src/tests/samples/typedDictClosed11.py
+++ b/packages/pyright-internal/src/tests/samples/typedDictClosed11.py
@@ -97,3 +97,26 @@ def func7(td: Right) -> None:
     if "right" in td:
         reveal_type(td, expected_text="Right")
         reveal_type(td["right"], expected_text="int")
+
+
+def func8(td: Baz) -> None:
+    # "extra_items" constrains the type of the extra keys, not which of them
+    # are present, so an "in" check for a key that is not a known item cannot
+    # eliminate the type in either branch.
+    if "other" in td:
+        reveal_type(td, expected_text="Baz")
+    else:
+        reveal_type(td, expected_text="Baz")
+
+        # This should generate an error because "baz" is an int.
+        td["baz"] = ""
+
+
+def func9(td: Baz) -> None:
+    if "other" not in td:
+        reveal_type(td, expected_text="Baz")
+
+        # This should generate an error because "baz" is an int.
+        td["baz"] = ""
+    else:
+        reveal_type(td, expected_text="Baz")

--- a/packages/pyright-internal/src/tests/typeEvaluator5.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator5.test.ts
@@ -410,7 +410,7 @@ test('TypedDictClosed10', () => {
 
 test('TypedDictClosed11', () => {
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['typedDictClosed11.py']);
-    TestUtils.validateResults(analysisResults, 0);
+    TestUtils.validateResults(analysisResults, 2);
 });
 
 test('DataclassTransform1', () => {


### PR DESCRIPTION
Fixes #11438.

`narrowTypeForTypedDictKey` looks the tested key up in the known items and falls back to the "extra items" entry when it is not there. That entry is built in `typedDicts.ts` with `isProvided` set to true, so on the negative side of an `in` check the key is treated as definitely present and the type is eliminated. Everything after the check becomes unreachable:

```python
class Typed(TypedDict, extra_items=str):
    a: str

def test(d: Typed) -> None:
    if "b" in d:
        return
    print("here")  # not analyzed
```

The same function without `extra_items` keeps the last line reachable, which is what pointed at the fallback.

An `extra_items` declaration constrains the type of the extra keys, not which of them are present, so the absence of `"b"` is consistent with `Typed` and the subtype has to survive the negative branch. A known item behaves as before, and a closed TypedDict is unaffected because its synthesized entry has `isProvided` false.

`typedDictClosed11.py` already states the rule in a comment on `func3`, "Baz allows extra items, so it cannot be eliminated here", with `reveal_type(u, expected_text="Baz")` in the else branch. That assertion is vacuous today: I swapped the expected text for a string that cannot match and the test still passed, because the branch is unreachable and `reveal_type` is never evaluated. With this change the same probe fails with `expected "..." but received "Baz"`, so the branch runs and reveals what the comment says it should.

The two functions added to that sample each carry one intentional error in the branch that has to be reachable, so the test fails on main with `Expected 2 errors, got 0` and passes with the change. No existing expected type was weakened.

Full jest run here: 2696 passed. The 28 failures are all in `languageServer.test.ts` and fail the same way on a clean checkout on this machine, so they are my setup and not the change. `check:prettier`, `check:eslint` and `tsc --noEmit` are clean.
