### PR TITLE
Drop inherited dataclass default when an override assigns a field specifier

### DIFF
--- a/packages/pyright-internal/src/analyzer/dataClasses.ts
+++ b/packages/pyright-internal/src/analyzer/dataClasses.ts
@@ -331,6 +331,7 @@ export function synthesizeDataClassMethods(
             let aliasName: string | undefined;
             let variableTypeEvaluator: EntryTypeEvaluator | undefined;
             let hasDefault = false;
+            let hasAssignedValue = false;
             let isDefaultFactory = false;
             let isKeywordOnly = ClassType.isDataClassKeywordOnly(classType) || sawKeywordOnlySeparator;
             let defaultExpr: ExpressionNode | undefined;
@@ -362,6 +363,7 @@ export function synthesizeDataClassMethods(
                 }
 
                 hasDefault = true;
+                hasAssignedValue = true;
                 defaultExpr = statement.d.rightExpr;
 
                 // If the RHS of the assignment is assigning a field instance where the
@@ -578,7 +580,16 @@ export function synthesizeDataClassMethods(
 
                         // While this isn't documented behavior, it appears that the dataclass implementation
                         // causes overridden variables to "inherit" default values from parent classes.
-                        if (!dataClassEntry.hasDefault && oldEntry.hasDefault && oldEntry.includeInInit) {
+                        // This applies only when the override is a bare annotation (`x: int`). If the
+                        // override assigns a field specifier that supplies no default (`x: int = field()`),
+                        // the runtime replaces the entry outright, so the inherited default is dropped and
+                        // the parameter becomes required.
+                        if (
+                            !dataClassEntry.hasDefault &&
+                            !hasAssignedValue &&
+                            oldEntry.hasDefault &&
+                            oldEntry.includeInInit
+                        ) {
                             dataClassEntry.hasDefault = true;
                             dataClassEntry.defaultExpr = oldEntry.defaultExpr;
                             hasDefault = true;

--- a/packages/pyright-internal/src/tests/samples/dataclass4.py
+++ b/packages/pyright-internal/src/tests/samples/dataclass4.py
@@ -141,3 +141,15 @@ class DC15(DC14):
     # This should generate an error because "b" drops its inherited default
     # and would then follow "a", which still has one.
     b: int = field()
+
+
+@dataclass
+class DC16(DC12):
+    # An assigned field specifier with init=False removes the parameter from
+    # __init__ entirely rather than dropping the inherited default, so the
+    # attribute keeps the base class value.
+    a: int = field(init=False)
+
+
+reveal_type(DC16.__init__, expected_text="(self: DC16) -> None")
+reveal_type(DC16().a, expected_text="int")

--- a/packages/pyright-internal/src/tests/samples/dataclass4.py
+++ b/packages/pyright-internal/src/tests/samples/dataclass4.py
@@ -108,3 +108,36 @@ class DC10:
 class DC11(DC10):
     a: str = field()
     b: bool = field()
+
+
+@dataclass
+class DC12:
+    a: int = 0
+
+
+@dataclass
+class DC13(DC12):
+    # Unlike a bare annotation, an assigned field specifier that supplies no
+    # default replaces the inherited entry rather than inheriting its default,
+    # so "a" becomes a required parameter.
+    a: int = field()
+
+
+reveal_type(DC13.__init__, expected_text="(self: DC13, a: int) -> None")
+
+# This should generate an error because "a" no longer has an
+# inherited default value, so it must be provided.
+DC13()
+
+
+@dataclass
+class DC14:
+    a: int = 0
+    b: int = 1
+
+
+@dataclass
+class DC15(DC14):
+    # This should generate an error because "b" drops its inherited default
+    # and would then follow "a", which still has one.
+    b: int = field()

--- a/packages/pyright-internal/src/tests/typeEvaluator4.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator4.test.ts
@@ -326,7 +326,7 @@ test('DataClass3', () => {
 test('DataClass4', () => {
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['dataclass4.py']);
 
-    TestUtils.validateResults(analysisResults, 6);
+    TestUtils.validateResults(analysisResults, 8);
 });
 
 test('DataClass5', () => {


### PR DESCRIPTION
Fixes #11660.

## The bug

When a dataclass field overrides an inherited field that has a default, `dataClasses.ts` unconditionally re-inherits that default:

```ts
// While this isn't documented behavior, it appears that the dataclass implementation
// causes overridden variables to "inherit" default values from parent classes.
if (!dataClassEntry.hasDefault && oldEntry.hasDefault && oldEntry.includeInInit) {
    dataClassEntry.hasDefault = true;
    dataClassEntry.defaultExpr = oldEntry.defaultExpr;
    ...
}
```

That is correct for a bare annotation, but not when the override assigns a field specifier that supplies no default. I checked the three forms against CPython 3.11 rather than relying on the issue report:

```
Base (self, x: int = 1) -> None

x: int = field()            -> Foo (self, x: int) -> None        Foo() TypeError: missing 1 required positional argument: 'x'
x: int                      -> Bar (self, x: int = 1) -> None    Bar() Bar(x=1)
x: int = field(init=False)  -> Baz (self) -> None                Baz() Baz(x=1)
```

So `x: int = field()` replaces the inherited entry and the parameter becomes required. pyright instead synthesized `(self: Foo, a: int = 0) -> None`, which produced two wrong results at once:

- **False negative:** `Foo()` was accepted, though it raises `TypeError` at runtime.
- **False positive:** the override line was reported with `"x" overrides a field of the same name but is missing a default value`, even though in this form nothing is inherited.

There is a knock-on ordering case too. When a defaulted field precedes the override, dropping the default makes a non-default parameter follow a default one, which CPython rejects at class creation:

```python
@dataclass
class B1:
    a: int = 0
    x: int = 1

@dataclass
class F1(B1):
    x: int = field()   # TypeError: non-default argument 'x' follows default argument
```

pyright did not report that either. With this change the existing "Fields without default values cannot appear after fields with default values" check fires on that line.

## The change

Track whether the entry had an assigned value, and only inherit the base default for bare annotations. Behavior for `x: int` is unchanged: it still inherits the default and still reports the existing diagnostic.

## Tests

Added to `dataclass4.py`, the sample for inherited dataclasses. The new cases pin the synthesized signature so they actually discriminate:

```python
reveal_type(DC13.__init__, expected_text="(self: DC13, a: int) -> None")
```

Without the fix that reports `(self: DC13, a: int = 0) -> None` and the suite fails; with it, it passes. The expected error count for `DataClass4` goes from 6 to 8, covering the now-reported `DC13()` call and the ordering case.

`npx jest typeEvaluator` passes 1212/1212 across all 8 suites, and Prettier reports the changed files clean.
