### PR TITLE
Do not inherit dataclass defaults from field() overrides without a default

### DIFF
--- a/packages/pyright-internal/src/analyzer/dataClasses.ts
+++ b/packages/pyright-internal/src/analyzer/dataClasses.ts
@@ -332,6 +332,7 @@ export function synthesizeDataClassMethods(
             let variableTypeEvaluator: EntryTypeEvaluator | undefined;
             let hasDefault = false;
             let isDefaultFactory = false;
+            let isFieldSpecifierWithoutDefault = false;
             let isKeywordOnly = ClassType.isDataClassKeywordOnly(classType) || sawKeywordOnlySeparator;
             let defaultExpr: ExpressionNode | undefined;
             let includeInInit = true;
@@ -436,6 +437,8 @@ export function synthesizeDataClassMethods(
                         if (defaultFactoryArg?.d.valueExpr) {
                             defaultExpr = defaultFactoryArg.d.valueExpr;
                         }
+
+                        isFieldSpecifierWithoutDefault = !hasDefault;
 
                         const aliasArg = statement.d.rightExpr.d.args.find((arg) => arg.d.name?.d.value === 'alias');
                         if (aliasArg) {
@@ -576,9 +579,15 @@ export function synthesizeDataClassMethods(
                     if (insertIndex >= 0) {
                         const oldEntry = fullDataClassEntries[insertIndex];
 
-                        // While this isn't documented behavior, it appears that the dataclass implementation
-                        // causes overridden variables to "inherit" default values from parent classes.
-                        if (!dataClassEntry.hasDefault && oldEntry.hasDefault && oldEntry.includeInInit) {
+                        // A bare annotation (`x: int`) inherits a parent field's default at
+                        // runtime. An explicit `field()` with no default or default_factory
+                        // does not, so the synthesized __init__ parameter is required.
+                        if (
+                            !dataClassEntry.hasDefault &&
+                            oldEntry.hasDefault &&
+                            oldEntry.includeInInit &&
+                            !isFieldSpecifierWithoutDefault
+                        ) {
                             dataClassEntry.hasDefault = true;
                             dataClassEntry.defaultExpr = oldEntry.defaultExpr;
                             hasDefault = true;

--- a/packages/pyright-internal/src/tests/samples/dataclass19.py
+++ b/packages/pyright-internal/src/tests/samples/dataclass19.py
@@ -1,0 +1,38 @@
+# This sample tests that overriding a dataclass field with field()
+# and no default does not inherit the parent default.
+
+from dataclasses import dataclass, field
+
+
+@dataclass
+class Base:
+    x: int = 1
+
+
+@dataclass
+class Foo(Base):
+    # This should not generate an error. field() with no default
+    # removes the inherited default at runtime.
+    x: int = field()
+
+
+# This should generate an error because x is required.
+Foo()
+
+foo = Foo(2)
+reveal_type(foo.x, expected_text="int")
+
+
+@dataclass
+class Base2:
+    a: int = 0
+
+
+@dataclass
+class BareOverride(Base2):
+    # This should generate an error because a bare annotation still
+    # inherits the parent default at runtime.
+    a: int
+
+    # This should generate an error because a still has a default.
+    b: str

--- a/packages/pyright-internal/src/tests/typeEvaluator4.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator4.test.ts
@@ -413,6 +413,12 @@ test('DataClass18', () => {
     TestUtils.validateResults(analysisResults, 0);
 });
 
+test('DataClass19', () => {
+    const analysisResults = TestUtils.typeAnalyzeSampleFiles(['dataclass19.py']);
+
+    TestUtils.validateResults(analysisResults, 3);
+});
+
 test('DataClassReplace1', () => {
     const configOptions = new ConfigOptions(Uri.empty());
 


### PR DESCRIPTION
## Summary
- Fixes #11660.
- Overriding a dataclass field with `x: int = field()` removes the parent default at runtime, so `Foo()` is missing a required argument.
- Pyright previously copied the parent default (and warned on the override). Bare annotations like `x: int` still inherit, matching CPython.

## Test plan
- [x] `npx jest typeEvaluator4.test.ts -t "DataClass" --forceExit` (from `packages/pyright-internal`)
- [ ] Confirm `Foo()` is reported as missing `x` when `Foo` overrides `x: int = field()` in the language server