### PR TITLE
Fix functools.partial type evaluation for callable class instances

### DIFF
--- a/packages/pyright-internal/src/analyzer/constructorTransform.ts
+++ b/packages/pyright-internal/src/analyzer/constructorTransform.ts
@@ -102,6 +102,18 @@ function applyPartialTransform(
         if (constructor) {
             origFunctionType = constructor;
         }
+    } else if (isClassInstance(origFunctionTypeConcrete)) {
+        const callMethodResult = evaluator.getTypeOfBoundMember(
+            errorNode,
+            origFunctionTypeConcrete,
+            '__call__',
+            /* usage */ undefined,
+            /* diag */ undefined,
+            MemberAccessFlags.SkipInstanceMembers | MemberAccessFlags.SkipAttributeAccessOverride
+        );
+        if (callMethodResult?.type && (isFunction(callMethodResult.type) || isOverloaded(callMethodResult.type))) {
+            origFunctionType = callMethodResult.type;
+        }
     }
 
     // Evaluate the inferred return type if necessary.

--- a/packages/pyright-internal/src/tests/samples/partial9.py
+++ b/packages/pyright-internal/src/tests/samples/partial9.py
@@ -1,0 +1,35 @@
+# This sample tests functools.partial with callable class instances (objects with __call__).
+
+from functools import partial
+from typing import overload
+
+class CallableClass:
+    def __call__(self, a: int, b: str, c: float = 1.0) -> bool:
+        return True
+
+c = CallableClass()
+p1 = partial(c, 1)
+reveal_type(p1("hello"), expected_text="bool")
+reveal_type(p1("hello", c=2.0), expected_text="bool")
+
+# This should generate an error because 'b' must be a str
+p1(123)
+
+# This should generate an error because 'c' must be a float
+p1("hello", c="invalid")
+
+
+class OverloadedCallable:
+    @overload
+    def __call__(self, a: int, b: int) -> int: ...
+    @overload
+    def __call__(self, a: str, b: str) -> str: ...
+    def __call__(self, a: int | str, b: int | str) -> int | str:
+        return a
+
+oc = OverloadedCallable()
+p2 = partial(oc, 1)
+reveal_type(p2(2), expected_text="int")
+
+# This should generate an error because second argument must be int
+p2("invalid")

--- a/packages/pyright-internal/src/tests/typeEvaluator8.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator8.test.ts
@@ -874,6 +874,12 @@ test('Partial8', () => {
     TestUtils.validateResults(analysisResults, 1);
 });
 
+test('Partial9', () => {
+    const analysisResults = TestUtils.typeAnalyzeSampleFiles(['partial9.py']);
+
+    TestUtils.validateResults(analysisResults, 3);
+});
+
 test('TotalOrdering1', () => {
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['totalOrdering1.py']);
 


### PR DESCRIPTION
### Description
This PR fixes type evaluation for `functools.partial` when applied to callable class instances (objects implementing `__call__`).

Previously, `applyPartialTransform` in `constructorTransform.ts` checked if the target callable was an instantiable class (to create a function from its constructor), a plain function, or an overloaded function. When an instance of a callable class was passed to `partial(callable_instance, ...)`, `applyPartialTransform` returned `undefined`, causing the resulting partial object to evaluate as unspecialized `partial[Unknown]`. This resulted in missing parameter type checking, missing argument count validation, and unspecialized return types.

### Changes
- Updated `applyPartialTransform` in `packages/pyright-internal/src/analyzer/constructorTransform.ts` to look up the bound `__call__` method when the target callable argument is a class instance.
- Added regression tests in `packages/pyright-internal/src/tests/samples/partial9.py` and `typeEvaluator8.test.ts` covering partial application with simple and overloaded `__call__` methods on callable objects.

### Validation
- Ran full test suite in `typeEvaluator8.test.ts` (174/174 passing).
- Ran repository checks (`pnpm run check` and `pnpm run typecheck` passing cleanly).
