### PR TITLE
Dispatch typecheck benchmark workflow directly

### DIFF
--- a/.github/workflows/typecheck_benchmark_comment.yml
+++ b/.github/workflows/typecheck_benchmark_comment.yml
@@ -16,7 +16,7 @@ jobs:
   comment:
     name: Comment benchmark results
     runs-on: ubuntu-latest
-    if: ${{ github.event.workflow_run.event == 'pull_request' }}
+    if: ${{ github.event.workflow_run.event == 'pull_request' || github.event.workflow_run.event == 'workflow_dispatch' }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
@@ -28,35 +28,52 @@ jobs:
         with:
           script: |
             const fs = require('fs')
-            const pullRequests = context.payload.workflow_run.pull_requests
-            if (pullRequests.length === 0) {
-              core.info('No pull request is associated with this workflow run; skipping comment')
+            const workflowRun = context.payload.workflow_run
+            const artifacts = await github.rest.actions.listWorkflowRunArtifacts({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: workflowRun.id,
+            })
+            let issueNumber
+            let expectedHeadSha
+            let report
+            if (workflowRun.event === 'pull_request') {
+              const pullRequests = workflowRun.pull_requests
+              if (pullRequests.length !== 1) {
+                core.setFailed(`Expected one pull request, found ${pullRequests.length}`)
+                return
+              }
+              issueNumber = pullRequests[0].number
+              expectedHeadSha = workflowRun.head_sha
+              report = artifacts.data.artifacts.find(
+                (artifact) => artifact.name === 'typecheck-benchmark-linux-x64'
+              )
+            } else {
+              const dispatchedReports = artifacts.data.artifacts.flatMap((artifact) => {
+                const match = artifact.name.match(
+                  /^typecheck-benchmark-linux-x64-pr-(\d+)-sha-([0-9a-f]{40})$/
+                )
+                return match ? [{ artifact, issueNumber: Number(match[1]), headSha: match[2] }] : []
+              })
+              if (dispatchedReports.length !== 1) {
+                core.setFailed(`Expected one dispatched benchmark report, found ${dispatchedReports.length}`)
+                return
+              }
+              report = dispatchedReports[0].artifact
+              issueNumber = dispatchedReports[0].issueNumber
+              expectedHeadSha = dispatchedReports[0].headSha
+            }
+            if (!report) {
+              core.setFailed('The benchmark report artifact was not found')
               return
             }
-            if (pullRequests.length > 1) {
-              core.setFailed(`Expected one pull request, found ${pullRequests.length}`)
-              return
-            }
-            const issueNumber = pullRequests[0].number
             const pullRequest = await github.rest.pulls.get({
               owner: context.repo.owner,
               repo: context.repo.repo,
               pull_number: issueNumber,
             })
-            if (pullRequest.data.head.sha !== context.payload.workflow_run.head_sha) {
+            if (pullRequest.data.head.sha !== expectedHeadSha) {
               core.setFailed('The workflow run head does not match the pull request head')
-              return
-            }
-            const artifacts = await github.rest.actions.listWorkflowRunArtifacts({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              run_id: context.payload.workflow_run.id,
-            })
-            const report = artifacts.data.artifacts.find(
-              (artifact) => artifact.name === 'typecheck-benchmark-linux-x64'
-            )
-            if (!report) {
-              core.setFailed('The benchmark report artifact was not found')
               return
             }
             const download = await github.rest.actions.downloadArtifact({

--- a/.github/workflows/typecheck_benchmark_comment.yml
+++ b/.github/workflows/typecheck_benchmark_comment.yml
@@ -36,6 +36,7 @@ jobs:
             })
             let issueNumber
             let expectedHeadSha
+            let expectedBaseSha
             let report
             if (workflowRun.event === 'pull_request') {
               const pullRequests = workflowRun.pull_requests
@@ -45,15 +46,18 @@ jobs:
               }
               issueNumber = pullRequests[0].number
               expectedHeadSha = workflowRun.head_sha
+              expectedBaseSha = pullRequests[0].base.sha
               report = artifacts.data.artifacts.find(
                 (artifact) => artifact.name === 'typecheck-benchmark-linux-x64'
               )
             } else {
               const dispatchedReports = artifacts.data.artifacts.flatMap((artifact) => {
                 const match = artifact.name.match(
-                  /^typecheck-benchmark-linux-x64-pr-(\d+)-sha-([0-9a-f]{40})$/
+                  /^typecheck-benchmark-linux-x64-pr-(\d+)-head-([0-9a-f]{40})-base-([0-9a-f]{40})$/
                 )
-                return match ? [{ artifact, issueNumber: Number(match[1]), headSha: match[2] }] : []
+                return match
+                  ? [{ artifact, issueNumber: Number(match[1]), headSha: match[2], baseSha: match[3] }]
+                  : []
               })
               if (dispatchedReports.length !== 1) {
                 core.setFailed(`Expected one dispatched benchmark report, found ${dispatchedReports.length}`)
@@ -62,6 +66,7 @@ jobs:
               report = dispatchedReports[0].artifact
               issueNumber = dispatchedReports[0].issueNumber
               expectedHeadSha = dispatchedReports[0].headSha
+              expectedBaseSha = dispatchedReports[0].baseSha
             }
             if (!report) {
               core.setFailed('The benchmark report artifact was not found')
@@ -74,6 +79,10 @@ jobs:
             })
             if (pullRequest.data.head.sha !== expectedHeadSha) {
               core.setFailed('The workflow run head does not match the pull request head')
+              return
+            }
+            if (pullRequest.data.base.sha !== expectedBaseSha) {
+              core.setFailed('The workflow run base does not match the pull request base')
               return
             }
             const download = await github.rest.actions.downloadArtifact({

--- a/.github/workflows/typecheck_benchmark_pr.yml
+++ b/.github/workflows/typecheck_benchmark_pr.yml
@@ -1,4 +1,5 @@
 name: Type checker benchmark
+run-name: Type checker benchmark for PR #${{ inputs.pr_number }}
 
 env:
   BENCHMARK_RUNNER_CLASS: 'github-ubuntu-latest'
@@ -6,18 +7,32 @@ env:
   PYTHON_VERSION: '3.14.6'
 
 on:
-  pull_request:
-    types:
-      - labeled
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: Pull request number
+        required: true
+        type: string
+      head_sha:
+        description: Pull request head commit
+        required: true
+        type: string
+      head_repository:
+        description: Pull request head repository
+        required: true
+        type: string
+      base_sha:
+        description: Pull request base commit
+        required: true
+        type: string
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ inputs.pr_number }}
   cancel-in-progress: true
 
 jobs:
   benchmark:
     name: Compare Pyright performance
-    if: ${{ github.event.label.name == 'run-typecheck-benchmark' }}
     runs-on: ubuntu-latest
     timeout-minutes: 180
     permissions:
@@ -25,6 +40,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          repository: ${{ inputs.head_repository }}
+          ref: ${{ inputs.head_sha }}
 
       - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
@@ -55,7 +73,7 @@ jobs:
       - name: Check out trusted baseline
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
-          ref: ${{ github.event.pull_request.base.sha || github.sha }}
+          ref: ${{ inputs.base_sha }}
           path: benchmark-baseline
           sparse-checkout: build/benchmark/baselines
 
@@ -106,7 +124,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: typecheck-benchmark-linux-x64
+          name: typecheck-benchmark-linux-x64-pr-${{ inputs.pr_number }}-sha-${{ inputs.head_sha }}
           path: build/benchmark/results/
 
       - name: Fail on benchmark regressions

--- a/.github/workflows/typecheck_benchmark_pr.yml
+++ b/.github/workflows/typecheck_benchmark_pr.yml
@@ -122,7 +122,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: typecheck-benchmark-linux-x64-pr-${{ inputs.pr_number }}-sha-${{ inputs.head_sha }}
+          name: typecheck-benchmark-linux-x64-pr-${{ inputs.pr_number }}-head-${{ inputs.head_sha }}-base-${{ inputs.base_sha }}
           path: build/benchmark/results/
 
       - name: Fail on benchmark regressions

--- a/.github/workflows/typecheck_benchmark_pr.yml
+++ b/.github/workflows/typecheck_benchmark_pr.yml
@@ -43,20 +43,17 @@ jobs:
         with:
           repository: ${{ inputs.head_repository }}
           ref: ${{ inputs.head_sha }}
+          persist-credentials: false
 
       - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: ${{ env.PYTHON_VERSION }}
-          cache: 'pip'
-          cache-dependency-path: 'build/benchmark/install_envs.json'
 
       - uses: pnpm/action-setup@f520eceda224fe1a4aed5a2a27a194379a409996 # v6
 
       - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
         with:
           node-version: ${{ env.NODE_VERSION }}
-          cache: 'pnpm'
-          cache-dependency-path: 'pnpm-lock.yaml'
 
       - name: Verify build prerequisites
         run: |
@@ -76,6 +73,7 @@ jobs:
           ref: ${{ inputs.base_sha }}
           path: benchmark-baseline
           sparse-checkout: build/benchmark/baselines
+          persist-credentials: false
 
       - name: Select benchmark baseline
         id: baseline

--- a/.github/workflows/typecheck_benchmark_trigger.yml
+++ b/.github/workflows/typecheck_benchmark_trigger.yml
@@ -6,9 +6,9 @@ on:
       - created
 
 permissions:
+  actions: write
   contents: read
-  issues: write
-  pull-requests: write
+  pull-requests: read
 
 jobs:
   trigger:
@@ -36,35 +36,20 @@ jobs:
               return
             }
 
-            const label = 'run-typecheck-benchmark'
-            try {
-              await github.rest.issues.getLabel({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                name: label,
-              })
-            } catch (error) {
-              if (error.status !== 404) throw error
-              await github.rest.issues.createLabel({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                name: label,
-                color: '1d76db',
-                description: 'Run the type checker performance benchmark',
-              })
-            }
-
-            if (context.payload.issue.labels.some((item) => item.name === label)) {
-              await github.rest.issues.removeLabel({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: context.issue.number,
-                name: label,
-              })
-            }
-            await github.rest.issues.addLabels({
+            const pullRequest = await github.rest.pulls.get({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              issue_number: context.issue.number,
-              labels: [label],
+              pull_number: context.issue.number,
+            })
+            await github.rest.actions.createWorkflowDispatch({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: 'typecheck_benchmark_pr.yml',
+              ref: context.payload.repository.default_branch,
+              inputs: {
+                pr_number: String(context.issue.number),
+                head_sha: pullRequest.data.head.sha,
+                head_repository: pullRequest.data.head.repo.full_name,
+                base_sha: pullRequest.data.base.sha,
+              },
             })

--- a/build/benchmark/README.md
+++ b/build/benchmark/README.md
@@ -177,10 +177,10 @@ or otherwise failed, it is reported as `No baseline` until a new hosted baseline
 The pull-request workflow also fails if any candidate package cannot be prepared or any checker
 times out, crashes, or otherwise fails, even when that package has no successful baseline yet.
 
-On pull requests, the benchmark pins Python 3.14.6, caches pip downloads using `install_envs.json` as
-the cache key, runs Pyright with a 6.5 GiB V8 old-space limit, and runs each package once with no
-discarded warmup. Each invocation may take up to 30 minutes. A regression must exceed both a 20%
-relative threshold and an absolute variance guard of 1
+On pull requests, the benchmark pins Python 3.14.6, disables shared dependency caches because it
+executes untrusted pull-request code, runs Pyright with a 6.5 GiB V8 old-space limit, and runs each
+package once with no discarded warmup. Each invocation may take up to 30 minutes. A regression must
+exceed both a 20% relative threshold and an absolute variance guard of 1
 second for time or 100 MB for peak memory. These are the comparator defaults, so the gate and trusted
 comment renderer share one configuration source. Reports and artifacts are published before a failed
 comparison marks the job unsuccessful.

--- a/build/benchmark/README.md
+++ b/build/benchmark/README.md
@@ -107,13 +107,14 @@ result contract, and the comparator rejects mismatched environments.
 
 The hosted pull-request benchmark runs only when a maintainer comments exactly `/benchmark` on an
 open pull request. The command must be the entire comment. The trusted command workflow checks that
-the commenter has `write`, `maintain`, or `admin` repository permission and then toggles the
-`run-typecheck-benchmark` label. Users without one of these permissions cannot start the benchmark.
+the commenter has `write`, `maintain`, or `admin` repository permission and then explicitly dispatches
+the benchmark with the pull request's current head and base commits. Users without one of these
+permissions cannot start the benchmark.
 
-The label event runs the pull request's current head with read-only repository permissions. When the
-run completes, a separate trusted workflow validates that the result belongs to the pull request's
-current head, renders it using default-branch code, and creates or updates one benchmark comment. The
-Actions job summary and `typecheck-benchmark-linux-x64` artifact contain the same candidate results.
+The dispatched workflow runs the pull request's current head with read-only repository permissions.
+When the run completes, a separate trusted workflow validates that the result belongs to the pull
+request's current head, renders it using default-branch code, and creates or updates one benchmark
+comment. The Actions job summary and benchmark artifact contain the same candidate results.
 
 Comment `/benchmark` again after pushing a new commit or when rerunning the same head. No benchmark is
 started automatically for later commits. The command workflow must already exist on the repository's

--- a/build/benchmark/test_compare_benchmarks.py
+++ b/build/benchmark/test_compare_benchmarks.py
@@ -480,8 +480,6 @@ Regression threshold: `10.0%`
                 "actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6",
                 workflow,
             )
-            self.assertIn("cache: 'pnpm'", workflow)
-            self.assertIn("pnpm-lock.yaml", workflow)
             self.assertIn("SKIP_LERNA_BOOTSTRAP: 'yes'", workflow)
             self.assertIn("--max-old-space-size=6656", workflow)
             self.assertIn("timeout-minutes: 10", workflow)
@@ -499,6 +497,8 @@ Regression threshold: `10.0%`
         weekly_workflow = (
             REPO_ROOT / ".github" / "workflows" / "typecheck_benchmark_weekly.yml"
         ).read_text(encoding="utf-8")
+        self.assertIn("cache: 'pnpm'", weekly_workflow)
+        self.assertIn("pnpm-lock.yaml", weekly_workflow)
         self.assertIn(
             "actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1",
             weekly_workflow,
@@ -520,11 +520,20 @@ Regression threshold: `10.0%`
         ).read_text(encoding="utf-8")
 
         self.assertIn("issue_comment:", trigger_workflow)
-        self.assertIn("github.event.comment.body == '/benchmark'", trigger_workflow)
+        self.assertIn(
+            "startsWith(github.event.comment.body, '/benchmark')", trigger_workflow
+        )
+        self.assertIn(
+            "context.payload.comment.body.trim() !== '/benchmark'", trigger_workflow
+        )
         self.assertIn("github.event.issue.state == 'open'", trigger_workflow)
         self.assertIn("getCollaboratorPermissionLevel", trigger_workflow)
         self.assertIn("['admin', 'maintain', 'write']", trigger_workflow)
-        self.assertIn("issues: write", trigger_workflow)
+        self.assertIn("actions: write", trigger_workflow)
+        self.assertIn("pull-requests: read", trigger_workflow)
+        self.assertIn("createWorkflowDispatch", trigger_workflow)
+        self.assertIn("workflow_id: 'typecheck_benchmark_pr.yml'", trigger_workflow)
+        self.assertIn("base_sha: pullRequest.data.base.sha", trigger_workflow)
         self.assertNotIn("actions/checkout", trigger_workflow)
         self.assertIn(
             "actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0",
@@ -541,12 +550,15 @@ Regression threshold: `10.0%`
         )
         self.assertNotIn("actions/checkout@v4", comment_workflow)
         self.assertNotIn("actions/github-script@v7", comment_workflow)
-        self.assertIn("types:\n      - labeled", benchmark_workflow)
+        self.assertIn("workflow_dispatch:", benchmark_workflow)
         self.assertNotIn("paths:", benchmark_workflow)
-        self.assertIn(
-            "github.event.label.name == 'run-typecheck-benchmark'",
-            benchmark_workflow,
-        )
+        self.assertNotIn("pull_request:", benchmark_workflow)
+        self.assertNotIn("cache: 'pip'", benchmark_workflow)
+        self.assertNotIn("cache: 'pnpm'", benchmark_workflow)
+        self.assertIn("persist-credentials: false", benchmark_workflow)
+        self.assertIn("inputs.base_sha", benchmark_workflow)
+        self.assertIn("-base-${{ inputs.base_sha }}", benchmark_workflow)
+        self.assertIn("pullRequest.data.base.sha !== expectedBaseSha", comment_workflow)
 
     def test_pr_workflow_prefers_trusted_baseline_with_bootstrap_fallback(self) -> None:
         workflow = (


### PR DESCRIPTION
This pull request refactors the type checker benchmark GitHub Actions workflows to improve security and reliability. The main change is to replace the label-based trigger for running benchmarks with a workflow dispatch model, where a trusted workflow dispatches the benchmark run with explicit inputs. This ensures that only authorized users can trigger benchmarks and that the correct commits are benchmarked and reported.

Key changes include:

**Workflow Triggering and Permissions:**

* The benchmark is now triggered by a `/benchmark` comment, which causes a trusted workflow to dispatch the benchmark workflow with explicit PR details, rather than toggling a label. This removes the need for the `run-typecheck-benchmark` label and associated label management logic. (`.github/workflows/typecheck_benchmark_trigger.yml`, `build/benchmark/README.md`) [[1]](diffhunk://#diff-c180c0f82bdc3c001d55f8f1aa3b65d62a848f1af854687a9f19cd7b85249b9aL39-R54) [[2]](diffhunk://#diff-19f7a5ce0ed089e77d5d607c65a2ec877d450937154b5e9a62489507955d7ea7L110-R117)
* Permissions on the trigger workflow have been tightened: `actions: write` is now explicitly granted, and unnecessary write permissions for `issues` and `pull-requests` have been removed. (`.github/workflows/typecheck_benchmark_trigger.yml`)

**Benchmark Workflow Refactoring:**

* The benchmark workflow (`typecheck_benchmark_pr.yml`) is now only triggered via `workflow_dispatch` with required inputs for PR number, head SHA, base SHA, and head repository, instead of responding to label events. The workflow checks out the correct PR and baseline commits using these inputs. (`.github/workflows/typecheck_benchmark_pr.yml`) [[1]](diffhunk://#diff-38826ee5568cd83e8d1ca3d53551ebded2b215f45cb4c0f5658fa66a8a3625e0R2-R45) [[2]](diffhunk://#diff-38826ee5568cd83e8d1ca3d53551ebded2b215f45cb4c0f5658fa66a8a3625e0L58-R76)
* Artifact names now include the PR number and head SHA to uniquely identify benchmark results per commit. (`.github/workflows/typecheck_benchmark_pr.yml`)

**Benchmark Result Commenting:**

* The workflow that comments benchmark results has been updated to support both PR and workflow dispatch events, and to correctly locate the relevant artifact and PR for each case. (`.github/workflows/typecheck_benchmark_comment.yml`) [[1]](diffhunk://#diff-6f734ce59a6e8f0a7820c651e18cb12e16153b57caa3b29335f6b9dec020bae5L19-R19) [[2]](diffhunk://#diff-6f734ce59a6e8f0a7820c651e18cb12e16153b57caa3b29335f6b9dec020bae5L31-L61)

These changes collectively make the benchmark process more robust, auditable, and secure by ensuring only trusted users can dispatch benchmarks and by tightly coupling benchmark runs to specific PR commits.