### PR TITLE
Fix crashes after clearing analyzer caches

### DIFF
--- a/packages/pyright-internal/src/analyzer/analyzerNodeInfo.ts
+++ b/packages/pyright-internal/src/analyzer/analyzerNodeInfo.ts
@@ -152,7 +152,6 @@ export interface AnalyzerNodeInfoContext extends AnalyzerNodeInfoReader {
     registerStore(root: ModuleNode, store: AnalyzerNodeInfoStore): void;
     remove(root: ModuleNode): void;
     retainRemovedStore(root: ModuleNode): void;
-    clearRetainedStores(): void;
     enterOverlay(): void;
     // Preserves an overlay-produced store for a tree that survives the overlay.
     promoteToPreviousLayer(root: ModuleNode): void;
@@ -163,6 +162,12 @@ export interface AnalyzerNodeInfoContext extends AnalyzerNodeInfoReader {
 interface AnalyzerNodeInfoContextLayer {
     readonly stores: WeakMap<object, AnalyzerNodeInfoStore>;
     readonly removedKeys: WeakSet<object>;
+}
+
+const _retiredStores = Symbol('retiredAnalyzerNodeInfoStores');
+
+interface RetiredAnalyzerNodeInfoHost {
+    [_retiredStores]?: WeakMap<AnalyzerNodeInfoContextImpl, AnalyzerNodeInfoStore>;
 }
 
 class AnalyzerNodeInfoBindingSessionImpl implements AnalyzerNodeInfoBindingSession {
@@ -223,7 +228,6 @@ class AnalyzerNodeInfoBindingSessionImpl implements AnalyzerNodeInfoBindingSessi
 
 export class AnalyzerNodeInfoContextImpl implements AnalyzerNodeInfoContext {
     private _layers: AnalyzerNodeInfoContextLayer[] = [this._createLayer()];
-    private _retainedStores = new WeakMap<object, AnalyzerNodeInfoStore>();
     private _disposed = false;
     private readonly _currentLayerReader: AnalyzerNodeInfoReader = {
         get: (node) => this._getFromCurrentLayer(node),
@@ -237,17 +241,17 @@ export class AnalyzerNodeInfoContextImpl implements AnalyzerNodeInfoContext {
 
         // Fast path: no edit-mode overlay is active (the steady-state batch/check
         // case always has just the base layer). Skip the layer-walk loop and the
-        // removedKeys tombstone check, but include any store retained for an
-        // in-progress evaluation during the most recent cache clear.
+        // removedKeys tombstone check, but include metadata retained by a parse
+        // tree that remains reachable after its source file drops it.
         const layers = this._layers;
         if (layers.length === 1) {
-            return (layers[0].stores.get(node.a) ?? this._retainedStores.get(node.a))?.get(node);
+            return (layers[0].stores.get(node.a) ?? this._getRetiredStore(node.a))?.get(node);
         }
 
         for (let index = layers.length - 1; index >= 0; index--) {
             const layer = layers[index];
             if (layer.removedKeys.has(node.a)) {
-                return this._retainedStores.get(node.a)?.get(node);
+                return this._getRetiredStore(node.a)?.get(node);
             }
 
             const store = layer.stores.get(node.a);
@@ -256,7 +260,7 @@ export class AnalyzerNodeInfoContextImpl implements AnalyzerNodeInfoContext {
             }
         }
 
-        return this._retainedStores.get(node.a)?.get(node);
+        return this._getRetiredStore(node.a)?.get(node);
     }
 
     getFileInfo(node: ParseNode): AnalyzerFileInfo | undefined {
@@ -266,13 +270,13 @@ export class AnalyzerNodeInfoContextImpl implements AnalyzerNodeInfoContext {
 
         const layers = this._layers;
         if (layers.length === 1) {
-            return (layers[0].stores.get(node.a) ?? this._retainedStores.get(node.a))?.getFileInfo(node);
+            return (layers[0].stores.get(node.a) ?? this._getRetiredStore(node.a))?.getFileInfo(node);
         }
 
         for (let index = layers.length - 1; index >= 0; index--) {
             const layer = layers[index];
             if (layer.removedKeys.has(node.a)) {
-                return this._retainedStores.get(node.a)?.getFileInfo(node);
+                return this._getRetiredStore(node.a)?.getFileInfo(node);
             }
 
             const store = layer.stores.get(node.a);
@@ -281,7 +285,7 @@ export class AnalyzerNodeInfoContextImpl implements AnalyzerNodeInfoContext {
             }
         }
 
-        return this._retainedStores.get(node.a)?.getFileInfo(node);
+        return this._getRetiredStore(node.a)?.getFileInfo(node);
     }
 
     getCurrentLayerReader(): AnalyzerNodeInfoReader {
@@ -309,7 +313,7 @@ export class AnalyzerNodeInfoContextImpl implements AnalyzerNodeInfoContext {
         const layer = this._layers[this._layers.length - 1];
         layer.removedKeys.delete(root.a);
         layer.stores.set(root.a, store);
-        this._retainedStores.delete(root.a);
+        this._deleteRetiredStore(root.a);
     }
 
     remove(root: ModuleNode): void {
@@ -317,7 +321,7 @@ export class AnalyzerNodeInfoContextImpl implements AnalyzerNodeInfoContext {
         const layer = this._layers[this._layers.length - 1];
         layer.stores.delete(root.a);
         layer.removedKeys.add(root.a);
-        this._retainedStores.delete(root.a);
+        this._deleteRetiredStore(root.a);
     }
 
     retainRemovedStore(root: ModuleNode): void {
@@ -325,15 +329,12 @@ export class AnalyzerNodeInfoContextImpl implements AnalyzerNodeInfoContext {
         const layer = this._layers[this._layers.length - 1];
         const store = layer.stores.get(root.a);
         if (store) {
-            this._retainedStores.set(root.a, store);
+            const host = root.a as RetiredAnalyzerNodeInfoHost;
+            host[_retiredStores] ??= new WeakMap<AnalyzerNodeInfoContextImpl, AnalyzerNodeInfoStore>();
+            host[_retiredStores].set(this, store);
         }
         layer.stores.delete(root.a);
         layer.removedKeys.add(root.a);
-    }
-
-    clearRetainedStores(): void {
-        this._throwIfDisposed();
-        this._retainedStores = new WeakMap<object, AnalyzerNodeInfoStore>();
     }
 
     enterOverlay(): void {
@@ -370,7 +371,6 @@ export class AnalyzerNodeInfoContextImpl implements AnalyzerNodeInfoContext {
 
     dispose(): void {
         this._layers = [];
-        this._retainedStores = new WeakMap<object, AnalyzerNodeInfoStore>();
         this._disposed = true;
     }
 
@@ -379,6 +379,14 @@ export class AnalyzerNodeInfoContextImpl implements AnalyzerNodeInfoContext {
             stores: new WeakMap<object, AnalyzerNodeInfoStore>(),
             removedKeys: new WeakSet<object>(),
         };
+    }
+
+    private _getRetiredStore(key: object) {
+        return (key as RetiredAnalyzerNodeInfoHost)[_retiredStores]?.get(this);
+    }
+
+    private _deleteRetiredStore(key: object) {
+        (key as RetiredAnalyzerNodeInfoHost)[_retiredStores]?.delete(this);
     }
 
     private _getFromCurrentLayer(node: ParseNode): AnalyzerNodeInfo | undefined {

--- a/packages/pyright-internal/src/analyzer/analyzerNodeInfo.ts
+++ b/packages/pyright-internal/src/analyzer/analyzerNodeInfo.ts
@@ -151,6 +151,8 @@ export interface AnalyzerNodeInfoContext extends AnalyzerNodeInfoReader {
     publish(session: AnalyzerNodeInfoBindingSession): AnalyzerNodeInfoStore;
     registerStore(root: ModuleNode, store: AnalyzerNodeInfoStore): void;
     remove(root: ModuleNode): void;
+    retainRemovedStore(root: ModuleNode): void;
+    clearRetainedStores(): void;
     enterOverlay(): void;
     // Preserves an overlay-produced store for a tree that survives the overlay.
     promoteToPreviousLayer(root: ModuleNode): void;
@@ -221,6 +223,7 @@ class AnalyzerNodeInfoBindingSessionImpl implements AnalyzerNodeInfoBindingSessi
 
 export class AnalyzerNodeInfoContextImpl implements AnalyzerNodeInfoContext {
     private _layers: AnalyzerNodeInfoContextLayer[] = [this._createLayer()];
+    private _retainedStores = new WeakMap<object, AnalyzerNodeInfoStore>();
     private _disposed = false;
     private readonly _currentLayerReader: AnalyzerNodeInfoReader = {
         get: (node) => this._getFromCurrentLayer(node),
@@ -234,17 +237,17 @@ export class AnalyzerNodeInfoContextImpl implements AnalyzerNodeInfoContext {
 
         // Fast path: no edit-mode overlay is active (the steady-state batch/check
         // case always has just the base layer). Skip the layer-walk loop and the
-        // removedKeys tombstone check: a tree removed from the base layer also has
-        // its store deleted, so stores.get returns undefined for it anyway.
+        // removedKeys tombstone check, but include any store retained for an
+        // in-progress evaluation during the most recent cache clear.
         const layers = this._layers;
         if (layers.length === 1) {
-            return layers[0].stores.get(node.a)?.get(node);
+            return (layers[0].stores.get(node.a) ?? this._retainedStores.get(node.a))?.get(node);
         }
 
         for (let index = layers.length - 1; index >= 0; index--) {
             const layer = layers[index];
             if (layer.removedKeys.has(node.a)) {
-                return undefined;
+                return this._retainedStores.get(node.a)?.get(node);
             }
 
             const store = layer.stores.get(node.a);
@@ -253,7 +256,7 @@ export class AnalyzerNodeInfoContextImpl implements AnalyzerNodeInfoContext {
             }
         }
 
-        return undefined;
+        return this._retainedStores.get(node.a)?.get(node);
     }
 
     getFileInfo(node: ParseNode): AnalyzerFileInfo | undefined {
@@ -263,13 +266,13 @@ export class AnalyzerNodeInfoContextImpl implements AnalyzerNodeInfoContext {
 
         const layers = this._layers;
         if (layers.length === 1) {
-            return layers[0].stores.get(node.a)?.getFileInfo(node);
+            return (layers[0].stores.get(node.a) ?? this._retainedStores.get(node.a))?.getFileInfo(node);
         }
 
         for (let index = layers.length - 1; index >= 0; index--) {
             const layer = layers[index];
             if (layer.removedKeys.has(node.a)) {
-                return undefined;
+                return this._retainedStores.get(node.a)?.getFileInfo(node);
             }
 
             const store = layer.stores.get(node.a);
@@ -278,7 +281,7 @@ export class AnalyzerNodeInfoContextImpl implements AnalyzerNodeInfoContext {
             }
         }
 
-        return undefined;
+        return this._retainedStores.get(node.a)?.getFileInfo(node);
     }
 
     getCurrentLayerReader(): AnalyzerNodeInfoReader {
@@ -306,6 +309,7 @@ export class AnalyzerNodeInfoContextImpl implements AnalyzerNodeInfoContext {
         const layer = this._layers[this._layers.length - 1];
         layer.removedKeys.delete(root.a);
         layer.stores.set(root.a, store);
+        this._retainedStores.delete(root.a);
     }
 
     remove(root: ModuleNode): void {
@@ -313,6 +317,23 @@ export class AnalyzerNodeInfoContextImpl implements AnalyzerNodeInfoContext {
         const layer = this._layers[this._layers.length - 1];
         layer.stores.delete(root.a);
         layer.removedKeys.add(root.a);
+        this._retainedStores.delete(root.a);
+    }
+
+    retainRemovedStore(root: ModuleNode): void {
+        this._throwIfDisposed();
+        const layer = this._layers[this._layers.length - 1];
+        const store = layer.stores.get(root.a);
+        if (store) {
+            this._retainedStores.set(root.a, store);
+        }
+        layer.stores.delete(root.a);
+        layer.removedKeys.add(root.a);
+    }
+
+    clearRetainedStores(): void {
+        this._throwIfDisposed();
+        this._retainedStores = new WeakMap<object, AnalyzerNodeInfoStore>();
     }
 
     enterOverlay(): void {
@@ -349,6 +370,7 @@ export class AnalyzerNodeInfoContextImpl implements AnalyzerNodeInfoContext {
 
     dispose(): void {
         this._layers = [];
+        this._retainedStores = new WeakMap<object, AnalyzerNodeInfoStore>();
         this._disposed = true;
     }
 

--- a/packages/pyright-internal/src/analyzer/program.ts
+++ b/packages/pyright-internal/src/analyzer/program.ts
@@ -1155,7 +1155,6 @@ export class Program {
     // Discards any cached information associated with this program.
     emptyCache() {
         this._createNewEvaluator();
-        this._analyzerNodeInfoContext.clearRetainedStores();
         this._discardCachedParseResults();
         this._parsedFileCount = 0;
 

--- a/packages/pyright-internal/src/analyzer/program.ts
+++ b/packages/pyright-internal/src/analyzer/program.ts
@@ -1155,6 +1155,7 @@ export class Program {
     // Discards any cached information associated with this program.
     emptyCache() {
         this._createNewEvaluator();
+        this._analyzerNodeInfoContext.clearRetainedStores();
         this._discardCachedParseResults();
         this._parsedFileCount = 0;
 
@@ -1251,7 +1252,10 @@ export class Program {
     // It does not discard cached index results or diagnostics for files.
     private _discardCachedParseResults() {
         for (const sourceFileInfo of this._sourceFileList) {
-            this._dropParseAndBindInfo(sourceFileInfo.sourceFile);
+            const parseTree = sourceFileInfo.sourceFile.dropParseAndBindInfo();
+            if (parseTree) {
+                this._analyzerNodeInfoContext.retainRemovedStore(parseTree);
+            }
         }
     }
 
@@ -1751,10 +1755,10 @@ export class Program {
     }
 
     private _dropParseAndBindInfo(sourceFile: SourceFile) {
-        sourceFile.dropParseAndBindInfo();
-
-        // Types and declarations can retain parse nodes after the source file drops its
-        // parse tree. Keep their analyzer information available until the tree is collected.
+        const parseTree = sourceFile.dropParseAndBindInfo();
+        if (parseTree) {
+            this._analyzerNodeInfoContext.remove(parseTree);
+        }
     }
 
     private _addToSourceFileListAndMap(fileInfo: SourceFileInfo) {

--- a/packages/pyright-internal/src/analyzer/program.ts
+++ b/packages/pyright-internal/src/analyzer/program.ts
@@ -1751,10 +1751,10 @@ export class Program {
     }
 
     private _dropParseAndBindInfo(sourceFile: SourceFile) {
-        const parseTree = sourceFile.dropParseAndBindInfo();
-        if (parseTree) {
-            this._analyzerNodeInfoContext.remove(parseTree);
-        }
+        sourceFile.dropParseAndBindInfo();
+
+        // Types and declarations can retain parse nodes after the source file drops its
+        // parse tree. Keep their analyzer information available until the tree is collected.
     }
 
     private _addToSourceFileListAndMap(fileInfo: SourceFileInfo) {

--- a/packages/pyright-internal/src/analyzer/sourceFile.ts
+++ b/packages/pyright-internal/src/analyzer/sourceFile.ts
@@ -491,6 +491,7 @@ export class SourceFile {
         this._writableData.parsedFileContentsHash = undefined;
         this._writableData.moduleSymbolTable = undefined;
         this._writableData.isBindingNeeded = true;
+        this._writableData.importInfo = [];
         this._writableData.imports = [];
         return parseTree;
     }

--- a/packages/pyright-internal/src/tests/analyzerNodeInfo.test.ts
+++ b/packages/pyright-internal/src/tests/analyzerNodeInfo.test.ts
@@ -87,9 +87,12 @@ test('context retains stores with reachable parse trees', () => {
     const firstFileInfo = {} as AnalyzerFileInfo;
     const secondFileInfo = {} as AnalyzerFileInfo;
 
-    context.registerStore(firstRoot, createStoreWithFileInfo(firstRoot, firstFileInfo));
+    const firstStore = createStoreWithFileInfo(firstRoot, firstFileInfo);
+    firstStore.getOrCreate(firstRoot).codeFlowComplexity = 1;
+    context.registerStore(firstRoot, firstStore);
     context.retainRemovedStore(firstRoot);
     assert.equal(context.getFileInfo(firstRoot), firstFileInfo);
+    assert.equal(context.get(firstRoot)?.codeFlowComplexity, 1);
 
     context.registerStore(secondRoot, createStoreWithFileInfo(secondRoot, secondFileInfo));
     context.retainRemovedStore(secondRoot);

--- a/packages/pyright-internal/src/tests/analyzerNodeInfo.test.ts
+++ b/packages/pyright-internal/src/tests/analyzerNodeInfo.test.ts
@@ -80,7 +80,7 @@ test('context getFileInfo fast path handles base-layer register/remove/reregiste
     assert.equal(context.getFileInfo(root), secondFileInfo);
 });
 
-test('context retains removed stores for one cache generation', () => {
+test('context retains stores with reachable parse trees', () => {
     const firstRoot = parseModule('first = 1');
     const secondRoot = parseModule('second = 2');
     const context = new AnalyzerNodeInfoContextImpl();
@@ -91,15 +91,29 @@ test('context retains removed stores for one cache generation', () => {
     context.retainRemovedStore(firstRoot);
     assert.equal(context.getFileInfo(firstRoot), firstFileInfo);
 
-    context.clearRetainedStores();
-    assert.equal(context.getFileInfo(firstRoot), undefined);
-
     context.registerStore(secondRoot, createStoreWithFileInfo(secondRoot, secondFileInfo));
     context.retainRemovedStore(secondRoot);
+    assert.equal(context.getFileInfo(firstRoot), firstFileInfo);
     assert.equal(context.getFileInfo(secondRoot), secondFileInfo);
 
     context.remove(secondRoot);
     assert.equal(context.getFileInfo(secondRoot), undefined);
+});
+
+test('retired stores remain isolated between contexts sharing a parse tree', () => {
+    const root = parseModule('value = 1');
+    const firstContext = new AnalyzerNodeInfoContextImpl();
+    const secondContext = new AnalyzerNodeInfoContextImpl();
+    const firstFileInfo = {} as AnalyzerFileInfo;
+    const secondFileInfo = {} as AnalyzerFileInfo;
+
+    firstContext.registerStore(root, createStoreWithFileInfo(root, firstFileInfo));
+    secondContext.registerStore(root, createStoreWithFileInfo(root, secondFileInfo));
+    firstContext.retainRemovedStore(root);
+    secondContext.retainRemovedStore(root);
+
+    assert.equal(firstContext.getFileInfo(root), firstFileInfo);
+    assert.equal(secondContext.getFileInfo(root), secondFileInfo);
 });
 
 function parseModule(code: string): ModuleNode {

--- a/packages/pyright-internal/src/tests/analyzerNodeInfo.test.ts
+++ b/packages/pyright-internal/src/tests/analyzerNodeInfo.test.ts
@@ -80,6 +80,28 @@ test('context getFileInfo fast path handles base-layer register/remove/reregiste
     assert.equal(context.getFileInfo(root), secondFileInfo);
 });
 
+test('context retains removed stores for one cache generation', () => {
+    const firstRoot = parseModule('first = 1');
+    const secondRoot = parseModule('second = 2');
+    const context = new AnalyzerNodeInfoContextImpl();
+    const firstFileInfo = {} as AnalyzerFileInfo;
+    const secondFileInfo = {} as AnalyzerFileInfo;
+
+    context.registerStore(firstRoot, createStoreWithFileInfo(firstRoot, firstFileInfo));
+    context.retainRemovedStore(firstRoot);
+    assert.equal(context.getFileInfo(firstRoot), firstFileInfo);
+
+    context.clearRetainedStores();
+    assert.equal(context.getFileInfo(firstRoot), undefined);
+
+    context.registerStore(secondRoot, createStoreWithFileInfo(secondRoot, secondFileInfo));
+    context.retainRemovedStore(secondRoot);
+    assert.equal(context.getFileInfo(secondRoot), secondFileInfo);
+
+    context.remove(secondRoot);
+    assert.equal(context.getFileInfo(secondRoot), undefined);
+});
+
 function parseModule(code: string): ModuleNode {
     return TestUtils.parseText(code, new DiagnosticSink()).parserOutput.parseTree;
 }

--- a/packages/pyright-internal/src/tests/service.test.ts
+++ b/packages/pyright-internal/src/tests/service.test.ts
@@ -360,6 +360,20 @@ test('excluded but still part of program', () => {
     );
 });
 
+test('empty cache preserves analyzer information for retained parse trees', () => {
+    const state = parseAndGetTestState('//// value = 1', '/projectRoot').state;
+    const program = state.workspace.service.test_program;
+
+    while (program.analyze());
+
+    const parseTree = program.getParseResults(state.activeFile.fileUri)!.parserOutput.parseTree;
+    assert.ok(program.analyzerNodeInfoContext.getFileInfo(parseTree));
+
+    program.emptyCache();
+
+    assert.ok(program.analyzerNodeInfoContext.getFileInfo(parseTree));
+});
+
 test('py.typed marker file', () => {
     const code = `
 // @filename: myPkg/__init__.py

--- a/packages/pyright-internal/src/tests/service.test.ts
+++ b/packages/pyright-internal/src/tests/service.test.ts
@@ -378,7 +378,7 @@ test('empty cache preserves analyzer information for retained parse trees', () =
     const nextParseTree = program.getParseResults(state.activeFile.fileUri)!.parserOutput.parseTree;
     program.emptyCache();
 
-    assert.strictEqual(program.analyzerNodeInfoContext.getFileInfo(parseTree), undefined);
+    assert.ok(program.analyzerNodeInfoContext.getFileInfo(parseTree));
     assert.ok(program.analyzerNodeInfoContext.getFileInfo(nextParseTree));
 });
 

--- a/packages/pyright-internal/src/tests/service.test.ts
+++ b/packages/pyright-internal/src/tests/service.test.ts
@@ -372,6 +372,14 @@ test('empty cache preserves analyzer information for retained parse trees', () =
     program.emptyCache();
 
     assert.ok(program.analyzerNodeInfoContext.getFileInfo(parseTree));
+
+    while (program.analyze());
+
+    const nextParseTree = program.getParseResults(state.activeFile.fileUri)!.parserOutput.parseTree;
+    program.emptyCache();
+
+    assert.strictEqual(program.analyzerNodeInfoContext.getFileInfo(parseTree), undefined);
+    assert.ok(program.analyzerNodeInfoContext.getFileInfo(nextParseTree));
 });
 
 test('py.typed marker file', () => {


### PR DESCRIPTION
## Summary

- preserve analyzer-node metadata when parse trees are dropped from source files but remain referenced by cached types and declarations
- prevent the `isStubFile` and `Did not find evaluation scope` crashes seen in recent mypy_primer runs after #11658
- add coverage for retained parse-tree metadata across `Program.emptyCache()`

## Test plan

- `pnpm --dir packages/pyright-internal exec jest service.test --forceExit`
- `pnpm --dir packages/pyright-internal run build`
- Prettier and ESLint on the changed files