### PR TITLE
Fix Sentinel base type assignability

### DIFF
--- a/packages/pyright-internal/src/analyzer/sentinel.ts
+++ b/packages/pyright-internal/src/analyzer/sentinel.ts
@@ -20,6 +20,7 @@ export function createSentinelType(
     evaluator: TypeEvaluator,
     errorNode: ExpressionNode,
     argList: Arg[],
+    sentinelBaseClass: ClassType,
     nodeInfo: AnalyzerNodeInfoAccessor
 ): Type | undefined {
     let className = '';
@@ -70,10 +71,10 @@ export function createSentinelType(
         ClassTypeFlags.Final | ClassTypeFlags.ValidTypeAliasClass,
         getTypeSourceId(errorNode),
         /* declaredMetaclass */ undefined,
-        evaluator.getTypeClassType()
+        sentinelBaseClass.shared.effectiveMetaclass
     );
 
-    classType.shared.baseClasses.push(evaluator.getObjectType());
+    classType.shared.baseClasses.push(sentinelBaseClass);
     computeMroLinearization(classType);
     classType = ClassType.cloneWithLiteral(classType, new SentinelLiteral(fullClassName, className));
 

--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -11704,7 +11704,9 @@ export function createTypeEvaluator(
                 expandedCallType.shared.fullName === 'typing_extensions.sentinel' ||
                 expandedCallType.shared.fullName === 'typing_extensions.Sentinel'
             ) {
-                return { returnType: createSentinelType(evaluatorInterface, errorNode, argList, nodeInfo) };
+                return {
+                    returnType: createSentinelType(evaluatorInterface, errorNode, argList, expandedCallType, nodeInfo),
+                };
             }
 
             if (ClassType.isSpecialFormClass(expandedCallType)) {

--- a/packages/pyright-internal/src/tests/samples/sentinel1.py
+++ b/packages/pyright-internal/src/tests/samples/sentinel1.py
@@ -17,6 +17,13 @@ BAD_CALL3 = Sentinel(1)
 
 MISSING = Sentinel("MISSING")
 
+
+def accept_sentinel(value: Sentinel) -> None:
+    pass
+
+
+accept_sentinel(MISSING)
+
 type TA1 = int | MISSING
 
 TA2: TypeAlias = int | MISSING

--- a/packages/pyright-internal/src/tests/samples/sentinel2.py
+++ b/packages/pyright-internal/src/tests/samples/sentinel2.py
@@ -17,6 +17,13 @@ BAD_CALL3 = sentinel(1)
 
 MISSING = sentinel("MISSING")
 
+
+def accept_sentinel(value: sentinel) -> None:
+    pass
+
+
+accept_sentinel(MISSING)
+
 type TA1 = int | MISSING
 
 TA2: TypeAlias = int | MISSING


### PR DESCRIPTION
## Summary

- model synthesized sentinel types as nominal subtypes of their `Sentinel` factory class
- preserve the factory class metaclass for synthesized sentinel types
- cover both `typing_extensions.Sentinel` and Python 3.15's built-in `sentinel`

Fixes #11529

## Tests

- `pnpm --dir packages/pyright-internal exec jest typeEvaluator2.test --runInBand --forceExit`
- `pnpm --dir packages/pyright-internal run build`
- `pnpm run check:eslint -- --quiet`
- `pnpm run check:prettier`