### PR TITLE
Benchmark pull request merge commits

### DIFF
--- a/.github/workflows/typecheck_benchmark_comment.yml
+++ b/.github/workflows/typecheck_benchmark_comment.yml
@@ -37,6 +37,7 @@ jobs:
             let issueNumber
             let expectedHeadSha
             let expectedBaseSha
+            let expectedMergeSha
             let report
             if (workflowRun.event === 'pull_request') {
               const pullRequests = workflowRun.pull_requests
@@ -53,10 +54,18 @@ jobs:
             } else {
               const dispatchedReports = artifacts.data.artifacts.flatMap((artifact) => {
                 const match = artifact.name.match(
-                  /^typecheck-benchmark-linux-x64-pr-(\d+)-head-([0-9a-f]{40})-base-([0-9a-f]{40})$/
+                  /^typecheck-benchmark-linux-x64-pr-(\d+)-head-([0-9a-f]{40})-base-([0-9a-f]{40})-merge-([0-9a-f]{40})$/
                 )
                 return match
-                  ? [{ artifact, issueNumber: Number(match[1]), headSha: match[2], baseSha: match[3] }]
+                  ? [
+                      {
+                        artifact,
+                        issueNumber: Number(match[1]),
+                        headSha: match[2],
+                        baseSha: match[3],
+                        mergeSha: match[4],
+                      },
+                    ]
                   : []
               })
               if (dispatchedReports.length !== 1) {
@@ -67,6 +76,7 @@ jobs:
               issueNumber = dispatchedReports[0].issueNumber
               expectedHeadSha = dispatchedReports[0].headSha
               expectedBaseSha = dispatchedReports[0].baseSha
+              expectedMergeSha = dispatchedReports[0].mergeSha
             }
             if (!report) {
               core.setFailed('The benchmark report artifact was not found')
@@ -83,6 +93,10 @@ jobs:
             }
             if (pullRequest.data.base.sha !== expectedBaseSha) {
               core.setFailed('The workflow run base does not match the pull request base')
+              return
+            }
+            if (expectedMergeSha && pullRequest.data.merge_commit_sha !== expectedMergeSha) {
+              core.setFailed('The workflow run merge commit does not match the pull request merge commit')
               return
             }
             const download = await github.rest.actions.downloadArtifact({

--- a/.github/workflows/typecheck_benchmark_pr.yml
+++ b/.github/workflows/typecheck_benchmark_pr.yml
@@ -1,9 +1,10 @@
 name: Type checker benchmark
-run-name: Type checker benchmark for PR #${{ inputs.pr_number }}
+run-name: 'Type checker benchmark for PR #${{ inputs.pr_number }}'
 
 env:
   BENCHMARK_RUNNER_CLASS: 'github-ubuntu-latest'
   NODE_VERSION: '24.15.0'
+  PNPM_VERSION: '10.12.2'
   PYTHON_VERSION: '3.14.6'
 
 on:
@@ -17,12 +18,12 @@ on:
         description: Pull request head commit
         required: true
         type: string
-      head_repository:
-        description: Pull request head repository
-        required: true
-        type: string
       base_sha:
         description: Pull request base commit
+        required: true
+        type: string
+      merge_sha:
+        description: Pull request merge commit
         required: true
         type: string
 
@@ -41,8 +42,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
-          repository: ${{ inputs.head_repository }}
-          ref: ${{ inputs.head_sha }}
+          ref: ${{ inputs.merge_sha }}
           persist-credentials: false
 
       - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
@@ -50,6 +50,8 @@ jobs:
           python-version: ${{ env.PYTHON_VERSION }}
 
       - uses: pnpm/action-setup@f520eceda224fe1a4aed5a2a27a194379a409996 # v6
+        with:
+          version: ${{ env.PNPM_VERSION }}
 
       - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
         with:
@@ -122,7 +124,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: typecheck-benchmark-linux-x64-pr-${{ inputs.pr_number }}-head-${{ inputs.head_sha }}-base-${{ inputs.base_sha }}
+          name: typecheck-benchmark-linux-x64-pr-${{ inputs.pr_number }}-head-${{ inputs.head_sha }}-base-${{ inputs.base_sha }}-merge-${{ inputs.merge_sha }}
           path: build/benchmark/results/
 
       - name: Fail on benchmark regressions

--- a/.github/workflows/typecheck_benchmark_trigger.yml
+++ b/.github/workflows/typecheck_benchmark_trigger.yml
@@ -41,6 +41,10 @@ jobs:
               repo: context.repo.repo,
               pull_number: context.issue.number,
             })
+            if (!pullRequest.data.merge_commit_sha) {
+              core.setFailed('The pull request does not have a merge commit to benchmark')
+              return
+            }
             await github.rest.actions.createWorkflowDispatch({
               owner: context.repo.owner,
               repo: context.repo.repo,
@@ -49,7 +53,7 @@ jobs:
               inputs: {
                 pr_number: String(context.issue.number),
                 head_sha: pullRequest.data.head.sha,
-                head_repository: pullRequest.data.head.repo.full_name,
                 base_sha: pullRequest.data.base.sha,
+                merge_sha: pullRequest.data.merge_commit_sha,
               },
             })

--- a/build/benchmark/README.md
+++ b/build/benchmark/README.md
@@ -108,13 +108,14 @@ result contract, and the comparator rejects mismatched environments.
 The hosted pull-request benchmark runs only when a maintainer comments exactly `/benchmark` on an
 open pull request. The command must be the entire comment. The trusted command workflow checks that
 the commenter has `write`, `maintain`, or `admin` repository permission and then explicitly dispatches
-the benchmark with the pull request's current head and base commits. Users without one of these
-permissions cannot start the benchmark.
+the benchmark with the pull request's current head, base, and synthetic merge commits. Users without
+one of these permissions cannot start the benchmark.
 
-The dispatched workflow runs the pull request's current head with read-only repository permissions.
-When the run completes, a separate trusted workflow validates that the result belongs to the pull
-request's current head, renders it using default-branch code, and creates or updates one benchmark
-comment. The Actions job summary and benchmark artifact contain the same candidate results.
+The dispatched workflow runs the pull request's synthetic merge commit, so all mergeable open pull
+requests use the current pnpm build metadata from the base branch. It uses read-only repository
+permissions. When the run completes, a separate trusted workflow validates the result's head, base,
+and merge commits, renders it using default-branch code, and creates or updates one benchmark comment.
+The Actions job summary and benchmark artifact contain the same candidate results.
 
 Comment `/benchmark` again after pushing a new commit or when rerunning the same head. No benchmark is
 started automatically for later commits. The command workflow must already exist on the repository's

--- a/build/benchmark/test_compare_benchmarks.py
+++ b/build/benchmark/test_compare_benchmarks.py
@@ -505,6 +505,16 @@ Regression threshold: `10.0%`
         )
         self.assertNotIn("actions/download-artifact@v4", weekly_workflow)
 
+        pr_workflow = (
+            REPO_ROOT / ".github" / "workflows" / "typecheck_benchmark_pr.yml"
+        ).read_text(encoding="utf-8")
+        self.assertIn(
+            "run-name: 'Type checker benchmark for PR #${{ inputs.pr_number }}'",
+            pr_workflow,
+        )
+        self.assertIn("PNPM_VERSION: '10.12.2'", pr_workflow)
+        self.assertIn("version: ${{ env.PNPM_VERSION }}", pr_workflow)
+
     def test_pr_benchmark_requires_authorized_comment(self) -> None:
         trigger_workflow = (
             REPO_ROOT
@@ -534,6 +544,7 @@ Regression threshold: `10.0%`
         self.assertIn("createWorkflowDispatch", trigger_workflow)
         self.assertIn("workflow_id: 'typecheck_benchmark_pr.yml'", trigger_workflow)
         self.assertIn("base_sha: pullRequest.data.base.sha", trigger_workflow)
+        self.assertIn("merge_sha: pullRequest.data.merge_commit_sha", trigger_workflow)
         self.assertNotIn("actions/checkout", trigger_workflow)
         self.assertIn(
             "actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0",
@@ -557,8 +568,12 @@ Regression threshold: `10.0%`
         self.assertNotIn("cache: 'pnpm'", benchmark_workflow)
         self.assertIn("persist-credentials: false", benchmark_workflow)
         self.assertIn("inputs.base_sha", benchmark_workflow)
-        self.assertIn("-base-${{ inputs.base_sha }}", benchmark_workflow)
+        self.assertIn("ref: ${{ inputs.merge_sha }}", benchmark_workflow)
+        self.assertIn("-merge-${{ inputs.merge_sha }}", benchmark_workflow)
         self.assertIn("pullRequest.data.base.sha !== expectedBaseSha", comment_workflow)
+        self.assertIn(
+            "pullRequest.data.merge_commit_sha !== expectedMergeSha", comment_workflow
+        )
 
     def test_pr_workflow_prefers_trusted_baseline_with_bootstrap_fallback(self) -> None:
         workflow = (


### PR DESCRIPTION
## Summary

- benchmark GitHub's synthetic PR merge commit so every mergeable open PR inherits current `main` pnpm metadata
- pin pnpm 10.12.2 rather than relying on the PR head's package metadata
- bind head, base, and merge SHAs into artifact provenance and validate all three before commenting
- quote the dynamic run name so the PR number is displayed

## Failure addressed

The dispatched benchmark for PR #11420 checked out its pre-pnpm raw head and failed in `pnpm/action-setup`:
https://github.com/microsoft/pyright/actions/runs/32779866239/job/97599332118

Its synthetic merge commit contains current `main` build metadata (`pnpm@10.12.2`, lockfile v9) while preserving the PR changes.

## Validation

- `python -m unittest test_compare_benchmarks` (26 tests)
- Prettier on all changed workflows and benchmark README
- editor diagnostics clean
- verified PR #11420 merge-ref parents and pnpm metadata