### PR TITLE
Cover two remaining dataclass field() override branches

### DIFF
--- a/packages/pyright-internal/src/tests/samples/dataclass19.py
+++ b/packages/pyright-internal/src/tests/samples/dataclass19.py
@@ -36,3 +36,33 @@ class BareOverride(Base2):
 
     # This should generate an error because a still has a default.
     b: str
+
+
+@dataclass
+class Base3:
+    a: int = 0
+    b: int = 1
+
+
+@dataclass
+class OrderOverride(Base3):
+    # This should generate an error because "b" loses its inherited default
+    # and would then follow "a", which still has one. At runtime this is a
+    # TypeError raised when the class is created.
+    b: int = field()
+
+
+@dataclass
+class Base4:
+    a: int = 0
+
+
+@dataclass
+class InitFalseOverride(Base4):
+    # field(init=False) removes the parameter from __init__ rather than
+    # dropping the inherited default, so the attribute keeps the base value.
+    a: int = field(init=False)
+
+
+reveal_type(InitFalseOverride.__init__, expected_text="(self: InitFalseOverride) -> None")
+reveal_type(InitFalseOverride().a, expected_text="int")

--- a/packages/pyright-internal/src/tests/typeEvaluator4.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator4.test.ts
@@ -416,7 +416,7 @@ test('DataClass18', () => {
 test('DataClass19', () => {
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['dataclass19.py']);
 
-    TestUtils.validateResults(analysisResults, 3);
+    TestUtils.validateResults(analysisResults, 4);
 });
 
 test('DataClassReplace1', () => {


### PR DESCRIPTION
Follow-up to #11665, tests only, no behaviour change.

#11665 fixed the inherited-default behaviour and its sample covers the plain `field()` override and the bare annotation. Two branches of the same behaviour are still unasserted, one of which @rchiodo asked for on #11664.

### The ordering case

When a defaulted field *precedes* the override, dropping the inherited default leaves a required parameter after a defaulted one, which CPython rejects when the class is created:

```python
@dataclass
class Base3:
    a: int = 0
    b: int = 1

@dataclass
class OrderOverride(Base3):
    b: int = field()   # TypeError: non-default argument 'b' follows default argument
```

Pyright already reports this correctly, but nothing pinned it. `dataclass19.py` currently produces a fourth error that the expected count of 3 does not cover:

```
Expected 3 errors, got 4
```

So this is a real, previously unasserted diagnostic rather than a new one.

### The `field(init=False)` case

`field(init=False)` removes the parameter from `__init__` entirely rather than dropping the inherited default, so the attribute keeps the base class value. Verified against CPython:

```
x: int = field()            -> (self, x: int)        Foo() TypeError: missing 1 required positional argument
x: int                      -> (self, x: int = 1)    Bar() Bar(x=1)
x: int = field(init=False)  -> (self)                Baz() Baz(x=1)
```

Both halves are now pinned:

```python
reveal_type(InitFalseOverride.__init__, expected_text="(self: InitFalseOverride) -> None")
reveal_type(InitFalseOverride().a, expected_text="int")
```

### Testing

`npx jest typeEvaluator4` passes 157/157. Expected error count for `DataClass19` goes from 3 to 4, for the ordering diagnostic above.

For context: I had an overlapping PR open at #11664, which I am closing in favour of #11665. These are the two cases its tests covered that the merged sample does not, so I have rebased them onto the merged fix rather than let them go to waste.
