### PR TITLE
Preserve benchmark result comments

### DIFF
--- a/.github/workflows/typecheck_benchmark_pr.yml
+++ b/.github/workflows/typecheck_benchmark_pr.yml
@@ -271,26 +271,9 @@ jobs:
             const report = fs.readFileSync('report.md', 'utf8')
             const issueNumber = Number(process.env.PR_NUMBER)
             const body = `${marker}\n${report}`
-            const comments = await github.paginate(github.rest.issues.listComments, {
+            await github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: issueNumber,
+              body,
             })
-            const previous = comments.find(
-              (comment) => comment.user?.type === 'Bot' && comment.body?.includes(marker)
-            )
-            if (previous) {
-              await github.rest.issues.updateComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                comment_id: previous.id,
-                body,
-              })
-            } else {
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: issueNumber,
-                body,
-              })
-            }


### PR DESCRIPTION
## Summary

- create a new PR comment for every completed type checker benchmark
- preserve results from earlier benchmark runs instead of updating the first marked comment

Run 33026272768 completed its comment step successfully, but updated comment 5429124029 because the workflow searched for the fixed `typecheck-benchmark-report` marker.

## Validation

- `pnpm exec prettier --check .github/workflows/typecheck_benchmark_pr.yml`
- `git diff --check`