### PR TITLE
Fix exhaustive match checking for final class objects

### DIFF
--- a/packages/pyright-internal/src/analyzer/patternMatching.ts
+++ b/packages/pyright-internal/src/analyzer/patternMatching.ts
@@ -1339,9 +1339,20 @@ function narrowTypeBasedOnValuePattern(
                                 isInstantiableClass(valueSubtypeExpanded) &&
                                 isSameWithoutLiteralValue(subjectSubtypeExpanded, valueSubtypeExpanded)
                             ) {
+                                // A value pattern compares with ==, not identity. Ensure that the
+                                // class has standard equality semantics by checking if its metaclass
+                                // is the standard type (or ABCMeta) and hasn't been overridden with a
+                                // custom metaclass that might implement a custom __eq__.
+                                const metaclass = subjectSubtypeExpanded.shared.effectiveMetaclass;
+                                const isStandardEquality =
+                                    !metaclass ||
+                                    (isClass(metaclass) &&
+                                        ClassType.isBuiltIn(metaclass, ['type', 'ABCMeta', 'EnumMeta']));
+
                                 if (
-                                    ClassType.isFinal(subjectSubtypeExpanded) ||
-                                    !subjectSubtypeExpanded.priv.includeSubclasses
+                                    isStandardEquality &&
+                                    (ClassType.isFinal(subjectSubtypeExpanded) ||
+                                        !subjectSubtypeExpanded.priv.includeSubclasses)
                                 ) {
                                     return undefined;
                                 }

--- a/packages/pyright-internal/src/analyzer/patternMatching.ts
+++ b/packages/pyright-internal/src/analyzer/patternMatching.ts
@@ -1339,15 +1339,17 @@ function narrowTypeBasedOnValuePattern(
                                 isInstantiableClass(valueSubtypeExpanded) &&
                                 isSameWithoutLiteralValue(subjectSubtypeExpanded, valueSubtypeExpanded)
                             ) {
-                                // A value pattern compares with ==, not identity. Ensure that the
-                                // class has standard equality semantics by checking if its metaclass
-                                // is the standard type (or ABCMeta) and hasn't been overridden with a
-                                // custom metaclass that might implement a custom __eq__.
                                 const metaclass = subjectSubtypeExpanded.shared.effectiveMetaclass;
+                                let eqClass: ClassType | undefined;
+                                if (metaclass && isInstantiableClass(metaclass)) {
+                                    const eqMember = lookUpClassMember(metaclass, '__eq__');
+                                    if (eqMember && isClass(eqMember.classType)) {
+                                        eqClass = eqMember.classType;
+                                    }
+                                }
+
                                 const isStandardEquality =
-                                    !metaclass ||
-                                    (isClass(metaclass) &&
-                                        ClassType.isBuiltIn(metaclass, ['type', 'ABCMeta', 'EnumMeta']));
+                                    !eqClass || ClassType.isBuiltIn(eqClass, ['type', 'object', 'ABCMeta', 'EnumMeta']);
 
                                 if (
                                     isStandardEquality &&

--- a/packages/pyright-internal/src/analyzer/patternMatching.ts
+++ b/packages/pyright-internal/src/analyzer/patternMatching.ts
@@ -1335,6 +1335,15 @@ function narrowTypeBasedOnValuePattern(
                         // If this is a negative test, see if it's an enum value.
                         if (!isPositiveTest) {
                             if (
+                                isInstantiableClass(subjectSubtypeExpanded) &&
+                                isInstantiableClass(valueSubtypeExpanded) &&
+                                isSameWithoutLiteralValue(subjectSubtypeExpanded, valueSubtypeExpanded)
+                            ) {
+                                if (ClassType.isFinal(subjectSubtypeExpanded) || !subjectSubtypeExpanded.priv.includeSubclasses) {
+                                    return undefined;
+                                }
+                            }
+                            if (
                                 isClassInstance(subjectSubtypeExpanded) &&
                                 isClassInstance(valueSubtypeExpanded) &&
                                 isSameWithoutLiteralValue(subjectSubtypeExpanded, valueSubtypeExpanded)

--- a/packages/pyright-internal/src/analyzer/patternMatching.ts
+++ b/packages/pyright-internal/src/analyzer/patternMatching.ts
@@ -1339,7 +1339,10 @@ function narrowTypeBasedOnValuePattern(
                                 isInstantiableClass(valueSubtypeExpanded) &&
                                 isSameWithoutLiteralValue(subjectSubtypeExpanded, valueSubtypeExpanded)
                             ) {
-                                if (ClassType.isFinal(subjectSubtypeExpanded) || !subjectSubtypeExpanded.priv.includeSubclasses) {
+                                if (
+                                    ClassType.isFinal(subjectSubtypeExpanded) ||
+                                    !subjectSubtypeExpanded.priv.includeSubclasses
+                                ) {
                                     return undefined;
                                 }
                             }

--- a/packages/pyright-internal/src/tests/samples/matchClassFinal.py
+++ b/packages/pyright-internal/src/tests/samples/matchClassFinal.py
@@ -63,3 +63,25 @@ def non_exhaustive_custom_meta(inst: C1 | D1):
             pass
         case NS3.D1:
             pass
+
+class MetaNoOverride(type):
+    pass
+
+@final
+class E1(metaclass=MetaNoOverride):
+    pass
+
+@final
+class F1(metaclass=MetaNoOverride):
+    pass
+
+class NS4:
+    E1 = E1
+    F1 = F1
+
+def exhaustive_custom_meta_no_override(inst: E1 | F1):
+    match type(inst):
+        case NS4.E1:
+            pass
+        case NS4.F1:
+            pass

--- a/packages/pyright-internal/src/tests/samples/matchClassFinal.py
+++ b/packages/pyright-internal/src/tests/samples/matchClassFinal.py
@@ -1,0 +1,42 @@
+# pyright: reportMatchNotExhaustive=true
+
+from typing import final
+
+class Base:
+    pass
+
+@final
+class A1(Base):
+    pass
+
+@final
+class B1(Base):
+    pass
+
+class NS1:
+    A1 = A1
+    B1 = B1
+
+def exhaustive_final(inst: A1 | B1):
+    match type(inst):
+        case NS1.A1:
+            pass
+        case NS1.B1:
+            pass
+
+class A2(Base):
+    pass
+
+class B2(Base):
+    pass
+
+class NS2:
+    A2 = A2
+    B2 = B2
+
+def non_exhaustive_non_final(inst: A2 | B2):
+    match type(inst):
+        case NS2.A2:
+            pass
+        case NS2.B2:
+            pass

--- a/packages/pyright-internal/src/tests/samples/matchClassFinal.py
+++ b/packages/pyright-internal/src/tests/samples/matchClassFinal.py
@@ -40,3 +40,26 @@ def non_exhaustive_non_final(inst: A2 | B2):
             pass
         case NS2.B2:
             pass
+
+class Meta(type):
+    def __eq__(self, other):
+        return False
+
+@final
+class C1(metaclass=Meta):
+    pass
+
+@final
+class D1(metaclass=Meta):
+    pass
+
+class NS3:
+    C1 = C1
+    D1 = D1
+
+def non_exhaustive_custom_meta(inst: C1 | D1):
+    match type(inst):
+        case NS3.C1:
+            pass
+        case NS3.D1:
+            pass

--- a/packages/pyright-internal/src/tests/typeEvaluator6.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator6.test.ts
@@ -623,6 +623,14 @@ test('MatchMapping1', () => {
     TestUtils.validateResults(analysisResults, 2);
 });
 
+test('MatchClassFinal', () => {
+    const configOptions = new ConfigOptions(Uri.empty());
+
+    configOptions.defaultPythonVersion = pythonVersion3_12;
+    const analysisResults = TestUtils.typeAnalyzeSampleFiles(['matchClassFinal.py'], configOptions);
+    TestUtils.validateResults(analysisResults, 1); // 1 error for the non-exhaustive match
+});
+
 test('MatchLiteral1', () => {
     const configOptions = new ConfigOptions(Uri.empty());
 

--- a/packages/pyright-internal/src/tests/typeEvaluator6.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator6.test.ts
@@ -628,7 +628,7 @@ test('MatchClassFinal', () => {
 
     configOptions.defaultPythonVersion = pythonVersion3_12;
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['matchClassFinal.py'], configOptions);
-    TestUtils.validateResults(analysisResults, 1); // 1 error for the non-exhaustive match
+    TestUtils.validateResults(analysisResults, 2); // 1 error for non-final, 1 error for custom metaclass
 });
 
 test('MatchLiteral1', () => {


### PR DESCRIPTION
What was the issue?
In Python, checking type(inst) for exhaustiveness is challenging because class types are "open" by default—meaning inst could be an instance of a subclass, not necessarily the exact base class. Therefore, Pyright correctly flags that subclasses are left "unhandled" if you simply check for the exact class itself.

However, Pyright was not properly narrowing class types when matched against case statements if those classes were explicitly marked as @final (which guarantees they cannot have subclasses). While type(inst) is NS.A worked correctly with @final classes, the match statement was lacking this @final check in its narrowing logic.

The Fix
I added logic to packages/pyright-internal/src/analyzer/patternMatching.ts to check if a class object pattern match involves a @final class. Now, if you match against a @final class in a match statement, Pyright correctly removes that exact type from the unhandled options, leading to properly passing exhaustiveness checks.