### PR TITLE
fix(analyzer): support member access on Annotated alias values

### DIFF
--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -6136,6 +6136,8 @@ export function createTypeEvaluator(
             return { type: UnknownType.create(/* isIncomplete */ true), isIncomplete: true };
         }
 
+        const baseTypeForm = baseType.props?.typeForm;
+
         if (baseType.props?.specialForm && (flags & EvalFlags.TypeExpression) === 0) {
             baseType = baseType.props.specialForm;
         }
@@ -6283,6 +6285,24 @@ export function createTypeEvaluator(
                         (flags & EvalFlags.TypeExpression) === 0 ? undefined : MemberAccessFlags.TypeExpression,
                         baseTypeResult.bindToSelfType
                     );
+
+                    if (
+                        (!typeResult || typeResult.typeErrors) &&
+                        ClassType.isBuiltIn(baseType, 'Annotated') &&
+                        baseTypeForm
+                    ) {
+                        const fallbackDiag = new DiagnosticAddendum();
+                        const fallbackResult = getTypeOfMemberAccessWithBaseType(
+                            node,
+                            { type: baseTypeForm },
+                            usage,
+                            flags
+                        );
+                        if (fallbackResult && !fallbackResult.typeErrors) {
+                            typeResult = fallbackResult;
+                            diag = fallbackDiag;
+                        }
+                    }
                 }
 
                 if (typeResult) {

--- a/packages/pyright-internal/src/tests/samples/annotated10.py
+++ b/packages/pyright-internal/src/tests/samples/annotated10.py
@@ -1,0 +1,16 @@
+# This sample tests member access on an Annotated alias used as a value.
+
+from typing import Annotated, ClassVar
+
+class Foo:
+    bar: int = 42
+    baz: ClassVar[str] = "hello"
+
+A = Annotated[Foo, "meta"]
+
+reveal_type(A.bar, expected_text="int")
+reveal_type(A.baz, expected_text="str")
+
+def f(x: A) -> int:
+    reveal_type(x.bar, expected_text="int")
+    return x.bar

--- a/packages/pyright-internal/src/tests/typeEvaluator7.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator7.test.ts
@@ -987,6 +987,12 @@ test('Annotated2', () => {
     TestUtils.validateResults(analysisResults, 0);
 });
 
+test('Annotated10', () => {
+    const analysisResults = TestUtils.typeAnalyzeSampleFiles(['annotated10.py']);
+
+    TestUtils.validateResults(analysisResults, 0);
+});
+
 test('Circular1', () => {
     const configOptions = new ConfigOptions(Uri.empty());
 


### PR DESCRIPTION
Closes #11538.

### Summary of Changes
At runtime, `typing._AnnotatedAlias.__getattr__` delegates attribute access to `__origin__` (the underlying annotated type).

In `getTypeOfMemberAccessWithBaseType`:
- Preserved `baseType.props?.typeForm` as `baseTypeForm` before stripping special forms.
- When member lookup on an `Annotated` special form produces an error or no member, falls back to evaluating member access against the underlying `typeForm`.
- Added sample test `annotated10.py` and test suite entry in `typeEvaluator7.test.ts` verifying member access on an `Annotated` alias value.