### PR TITLE
Do not narrow enum equality comparisons when member values are not statically known

### DIFF
--- a/packages/pyright-internal/src/analyzer/typeGuards.ts
+++ b/packages/pyright-internal/src/analyzer/typeGuards.ts
@@ -2799,9 +2799,11 @@ function isPrimitiveBackedEnumAndPrimitive(enumType: ClassType, primitiveType: C
 }
 
 // If the specified type is a literal member of a primitive-backed enum class,
-// returns the corresponding primitive literal type. Otherwise returns the type
+// returns the corresponding primitive literal type. If the member's underlying
+// primitive value is not known statically (e.g. it was assigned with auto() or
+// a computed expression), returns undefined. Otherwise returns the type
 // unmodified.
-function unwrapPrimitiveBackedEnumLiteral(classType: ClassType): ClassType {
+function unwrapPrimitiveBackedEnumLiteral(classType: ClassType): ClassType | undefined {
     const literalValue = classType.priv.literalValue;
     if (!(literalValue instanceof EnumLiteral) || !isPrimitiveBackedEnumClass(classType)) {
         return classType;
@@ -2812,18 +2814,24 @@ function unwrapPrimitiveBackedEnumLiteral(classType: ClassType): ClassType {
         return itemType;
     }
 
-    return classType;
+    return undefined;
 }
 
 // Determines whether two literal types compare equal using the `==` operator at
 // runtime. This differs from ClassType.isLiteralValueSame only for members of
 // primitive-backed enum classes, which compare equal to their underlying
-// primitive values.
-function isLiteralValueEqualAtRuntime(type1: ClassType, type2: ClassType): boolean {
-    return ClassType.isLiteralValueSame(
-        unwrapPrimitiveBackedEnumLiteral(type1),
-        unwrapPrimitiveBackedEnumLiteral(type2)
-    );
+// primitive values. Returns undefined if the result of the comparison cannot
+// be determined statically because an enum member's underlying primitive
+// value is unknown.
+function isLiteralValueEqualAtRuntime(type1: ClassType, type2: ClassType): boolean | undefined {
+    const unwrappedType1 = unwrapPrimitiveBackedEnumLiteral(type1);
+    const unwrappedType2 = unwrapPrimitiveBackedEnumLiteral(type2);
+
+    if (!unwrappedType1 || !unwrappedType2) {
+        return undefined;
+    }
+
+    return ClassType.isLiteralValueSame(unwrappedType1, unwrappedType2);
 }
 
 // Attempts to narrow a type (make it more constrained) based on a comparison
@@ -2865,6 +2873,14 @@ function narrowTypeForLiteralComparison(
                 const literalValueMatches = isPrimitiveBackedEnumComparison
                     ? isLiteralValueEqualAtRuntime(subtype, literalType)
                     : ClassType.isLiteralValueSame(subtype, literalType);
+
+                if (literalValueMatches === undefined) {
+                    // The outcome of the comparison cannot be determined statically
+                    // because an enum member's underlying primitive value is unknown,
+                    // so no narrowing can be applied in either direction.
+                    return subtype;
+                }
+
                 if (isPositiveTest) {
                     return literalValueMatches ? subtype : undefined;
                 }
@@ -2888,8 +2904,28 @@ function narrowTypeForLiteralComparison(
                     // to the primitive literal type.
                     if (ClassType.isEnumClass(subtype)) {
                         const allLiteralTypes = enumerateLiteralsForType(evaluator, subtype);
-                        const match = allLiteralTypes?.find((type) => isLiteralValueEqualAtRuntime(type, literalType));
-                        return match ?? subtype;
+
+                        if (allLiteralTypes) {
+                            let match: ClassType | undefined;
+                            let isIndeterminate = false;
+
+                            for (const type of allLiteralTypes) {
+                                const isEqual = isLiteralValueEqualAtRuntime(type, literalType);
+                                if (isEqual === undefined) {
+                                    // The member's underlying primitive value is unknown,
+                                    // so it cannot be safely eliminated.
+                                    isIndeterminate = true;
+                                } else if (isEqual && !match) {
+                                    match = type;
+                                }
+                            }
+
+                            if (!isIndeterminate && match) {
+                                return match;
+                            }
+                        }
+
+                        return subtype;
                     }
 
                     // The reference type is the primitive type, so narrowing it to the
@@ -2908,7 +2944,9 @@ function narrowTypeForLiteralComparison(
                 return combineTypes(
                     allLiteralTypes.filter((type) =>
                         isPrimitiveBackedEnumComparison
-                            ? !isLiteralValueEqualAtRuntime(type, literalType)
+                            ? // Eliminate a member only if it definitely compares equal;
+                              // an indeterminate result must retain the member.
+                              isLiteralValueEqualAtRuntime(type, literalType) !== true
                             : !ClassType.isLiteralValueSame(type, literalType)
                     )
                 );

--- a/packages/pyright-internal/src/tests/samples/enumNarrowing1.py
+++ b/packages/pyright-internal/src/tests/samples/enumNarrowing1.py
@@ -137,3 +137,23 @@ def test_computed_enum_var_equals_int_literal(v: ComputedValue):
         assert_type(v, ComputedValue)
     else:
         assert_type(v, Literal[ComputedValue.FIRST])
+
+
+def test_match_int_literal_pattern(v: ComputedValue):
+    # A literal pattern goes through the same comparison. SECOND has a known
+    # value that matches, but FIRST's value is unknown and could be 40 too,
+    # so FIRST must survive into the matching case and the fallback.
+    match v:
+        case 40:
+            assert_type(v, ComputedValue)
+        case _:
+            assert_type(v, ComputedValue)
+
+
+def test_match_auto_int_literal_pattern(v: AutoValue):
+    # Neither member's value is known, so a literal pattern narrows nothing.
+    match v:
+        case 1:
+            assert_type(v, AutoValue)
+        case _:
+            assert_type(v, AutoValue)

--- a/packages/pyright-internal/src/tests/samples/enumNarrowing1.py
+++ b/packages/pyright-internal/src/tests/samples/enumNarrowing1.py
@@ -1,7 +1,7 @@
 # This sample tests type narrowing for equality (== and !=) comparisons
 # between IntEnum/StrEnum members and primitive literals or literal unions.
 
-from enum import IntEnum, IntFlag, StrEnum
+from enum import IntEnum, IntFlag, StrEnum, auto
 from typing import Literal, Union, assert_type
 
 class Priority(IntEnum):
@@ -77,3 +77,63 @@ def test_plain_enum(e: Priority, y: int):
     # declared type rather than narrowing to the enum literal.
     if y == Priority.HIGH:
         assert_type(y, int)
+
+
+def get_int() -> int:
+    return 30
+
+
+class AutoValue(IntEnum):
+    # The underlying primitive values of these members are not known
+    # statically, so equality comparisons with int literals cannot be
+    # used for narrowing in either direction.
+    RED = auto()
+    GREEN = auto()
+
+
+class ComputedValue(IntEnum):
+    FIRST = get_int()
+    SECOND = 40
+
+
+def test_auto_member_equals_int_literal():
+    v = AutoValue.RED
+    if v == 1:
+        # At runtime AutoValue.RED == 1 is True, so this branch is reachable.
+        assert_type(v, Literal[AutoValue.RED])
+    else:
+        assert_type(v, Literal[AutoValue.RED])
+
+
+def test_int_var_equals_auto_member(x: Literal[1, 3]):
+    if x == AutoValue.RED:
+        # At runtime x == AutoValue.RED is True when x is 1, so this branch
+        # is reachable and x cannot be narrowed.
+        assert_type(x, Literal[1, 3])
+    else:
+        assert_type(x, Literal[1, 3])
+
+
+def test_auto_enum_var_equals_int_literal(v: AutoValue):
+    if v == 1:
+        assert_type(v, AutoValue)
+    else:
+        assert_type(v, Literal[AutoValue.RED, AutoValue.GREEN])
+
+
+def test_computed_member_equals_int_literal():
+    v = ComputedValue.FIRST
+    if v == 30:
+        # At runtime this branch is reachable when get_int() returns 30.
+        assert_type(v, Literal[ComputedValue.FIRST])
+    else:
+        assert_type(v, Literal[ComputedValue.FIRST])
+
+
+def test_computed_enum_var_equals_int_literal(v: ComputedValue):
+    if v == 40:
+        # SECOND has a known value that matches, but FIRST's value is
+        # unknown and could also be 40, so no narrowing can occur.
+        assert_type(v, ComputedValue)
+    else:
+        assert_type(v, Literal[ComputedValue.FIRST])


### PR DESCRIPTION
## Bug

#11622 added equality narrowing for primitive-backed enums, so a member of an `IntEnum` or `StrEnum` correctly compares equal to its underlying value. When a member's value is not statically known, though, `unwrapPrimitiveBackedEnumLiteral` falls back to returning the enum literal unchanged. `isLiteralValueEqualAtRuntime` then compares an `EnumLiteral` against an `int` or `str` literal, which is never equal, so the comparison is treated as statically false and the positive branch is eliminated.

`auto()` is the common way to hit this:

```python
from enum import IntEnum, auto

class Color(IntEnum):
    RED = auto()
    GREEN = auto()

c: Color = Color.RED
if c == 1:
    reveal_type(c)  # Never, but Color.RED == 1 is True at runtime
```

The same happens in reverse (`x: Literal[1, 3]` compared against `x == Color.RED`), and in a match statement a case on a member whose value is known can unsoundly eliminate siblings whose values are not.

Any computed member value has the same effect, `auto()` is just the most common form.

## Change

`isLiteralValueEqualAtRuntime` now returns `boolean | undefined`, where `undefined` means the comparison cannot be decided statically because a member's underlying value is unknown. An indeterminate result narrows nothing in either direction and eliminates no members, which is the conservative behaviour these narrowing paths already use elsewhere.

All determinate behaviour from #11622 is unchanged: members with explicit values still narrow exactly as before.

## Tests

Cases added to `enumNarrowing1.py` covering `auto()` members in both comparison directions and the match-statement elimination case. They report 3 errors without the change and 0 with it.

`typeEvaluator1` (159 tests) and `typeEvaluator3` including `EnumNarrowing1` pass, and `tsc --noEmit` is clean.
