### PR TITLE
Optimize recursive sequence protocol rejection

### DIFF
--- a/packages/pyright-internal/src/analyzer/protocols.ts
+++ b/packages/pyright-internal/src/analyzer/protocols.ts
@@ -921,10 +921,6 @@ export function tryFastRejectSequenceProtocol(
     flags: AssignTypeFlags,
     recursionCount: number
 ): '__getitem__' | undefined {
-    if ((flags & AssignTypeFlags.ArgAssignmentFirstPass) !== 0) {
-        return undefined;
-    }
-
     if (!isClassInstance(srcType) || !ClassType.isBuiltIn(srcType, 'list')) {
         return undefined;
     }

--- a/packages/pyright-internal/src/analyzer/protocols.ts
+++ b/packages/pyright-internal/src/analyzer/protocols.ts
@@ -30,8 +30,8 @@ import {
     isFunctionOrOverloaded,
     isInstantiableClass,
     isOverloaded,
-    isTypeVar,
     isTypeSame,
+    isTypeVar,
     ModuleType,
     OverloadedType,
     Type,
@@ -940,16 +940,12 @@ export function tryFastRejectSequenceProtocol(
 
     const srcElementType = srcType.priv.typeArgs?.[0];
 
-    if (
-        !srcElementType ||
-        isAnyOrUnknown(srcElementType) ||
-        (isTypeVar(srcElementType) && TypeVarType.isUnification(srcElementType))
-    ) {
+    if (!srcElementType || isAnyOrUnknown(srcElementType) || isTypeVar(srcElementType)) {
         return undefined;
     }
 
     const destElementType = destType.priv.typeArgs[0];
-    if (isAnyOrUnknown(destElementType)) {
+    if (isAnyOrUnknown(destElementType) || isTypeVar(destElementType)) {
         return undefined;
     }
 

--- a/packages/pyright-internal/src/analyzer/protocols.ts
+++ b/packages/pyright-internal/src/analyzer/protocols.ts
@@ -921,6 +921,10 @@ export function tryFastRejectSequenceProtocol(
     flags: AssignTypeFlags,
     recursionCount: number
 ): '__getitem__' | undefined {
+    if ((flags & AssignTypeFlags.ArgAssignmentFirstPass) !== 0) {
+        return undefined;
+    }
+
     if (!isClassInstance(srcType) || !ClassType.isBuiltIn(srcType, 'list')) {
         return undefined;
     }

--- a/packages/pyright-internal/src/analyzer/protocols.ts
+++ b/packages/pyright-internal/src/analyzer/protocols.ts
@@ -30,6 +30,7 @@ import {
     isFunctionOrOverloaded,
     isInstantiableClass,
     isOverloaded,
+    isTypeVar,
     isTypeSame,
     ModuleType,
     OverloadedType,
@@ -912,7 +913,7 @@ function assignToProtocolInternal(
 // return type is exactly `Leaf | Protocol[Leaf]`. This makes element compatibility a necessary
 // condition of the full protocol assignment. If that condition fails, the source sequence cannot
 // satisfy __getitem__. Every uncertain case falls back to the normal structural protocol walk.
-function tryFastRejectSequenceProtocol(
+export function tryFastRejectSequenceProtocol(
     evaluator: TypeEvaluator,
     destType: ClassType,
     srcType: ClassType | ModuleType,
@@ -939,7 +940,11 @@ function tryFastRejectSequenceProtocol(
 
     const srcElementType = srcType.priv.typeArgs?.[0];
 
-    if (!srcElementType || isAnyOrUnknown(srcElementType)) {
+    if (
+        !srcElementType ||
+        isAnyOrUnknown(srcElementType) ||
+        (isTypeVar(srcElementType) && TypeVarType.isUnification(srcElementType))
+    ) {
         return undefined;
     }
 

--- a/packages/pyright-internal/src/analyzer/protocols.ts
+++ b/packages/pyright-internal/src/analyzer/protocols.ts
@@ -21,7 +21,9 @@ import { getLastTypedDeclarationForSymbol, isEffectivelyClassVar } from './symbo
 import { AssignTypeFlags, TypeEvaluator } from './typeEvaluatorTypes';
 import {
     ClassType,
+    combineTypes,
     FunctionType,
+    isAnyOrUnknown,
     isClass,
     isClassInstance,
     isFunction,
@@ -57,6 +59,16 @@ interface ProtocolAssignmentStackEntry {
     destType: ClassType;
 }
 
+const sequenceProtocolMemberNames = new Set([
+    '__len__',
+    '__getitem__',
+    '__contains__',
+    '__iter__',
+    '__reversed__',
+    'count',
+    'index',
+]);
+
 interface ProtocolCompatibility {
     // Specialized source type or undefined if this entry applies
     // to all specializations
@@ -73,6 +85,8 @@ interface ProtocolCompatibility {
 
 interface ProtocolCompatibilityCheckState {
     isOverloadedTypeBindingFailure: boolean;
+    isFastRejection: boolean;
+    isUniversalCompatibilityCheck: boolean;
 }
 
 const protocolAssignmentStack: ProtocolAssignmentStackEntry[] = [];
@@ -134,9 +148,23 @@ export function assignClassToProtocol(
     protocolAssignmentStack.push({ srcType, destType });
     let isCompatible = true;
     const clonedConstraints = constraints?.clone();
+    const checkState: ProtocolCompatibilityCheckState = {
+        isOverloadedTypeBindingFailure: false,
+        isFastRejection: false,
+        isUniversalCompatibilityCheck: false,
+    };
 
     try {
-        isCompatible = assignToProtocolInternal(evaluator, destType, srcType, diag, constraints, flags, recursionCount);
+        isCompatible = assignToProtocolInternal(
+            evaluator,
+            destType,
+            srcType,
+            diag,
+            constraints,
+            flags,
+            recursionCount,
+            checkState
+        );
     } catch (e) {
         // We'd normally use "finally" here, but the TS debugger does such
         // a poor job dealing with finally, we'll use a catch instead.
@@ -156,6 +184,7 @@ export function assignClassToProtocol(
             clonedConstraints,
             constraints?.clone(),
             isCompatible,
+            checkState.isFastRejection,
             recursionCount
         );
     }
@@ -292,6 +321,7 @@ function setProtocolCompatibility(
     preConstraints: ConstraintTracker | undefined,
     postConstraints: ConstraintTracker | undefined,
     isCompatible: boolean,
+    isFastRejection: boolean,
     recursionCount: number
 ) {
     let map = srcType.shared.protocolCompatibility as Map<string, ProtocolCompatibility[]> | undefined;
@@ -313,6 +343,7 @@ function setProtocolCompatibility(
 
     if (
         !isCompatible &&
+        !isFastRejection &&
         !entries.some((entry) => entry.flags === flags && ClassType.isSameGenericClass(entry.destType, destType))
     ) {
         const genericDestType = requiresTypeArgs(destType)
@@ -323,6 +354,8 @@ function setProtocolCompatibility(
             : srcType;
         const checkState: ProtocolCompatibilityCheckState = {
             isOverloadedTypeBindingFailure: false,
+            isFastRejection: false,
+            isUniversalCompatibilityCheck: true,
         };
 
         // An overload can use its "self" annotation to filter by specialization,
@@ -417,6 +450,27 @@ function assignToProtocolInternal(
         const typedDictClassType = evaluator.getTypedDictClassType();
         if (typedDictClassType && isInstantiableClass(typedDictClassType)) {
             srcType = typedDictClassType;
+        }
+    }
+
+    if (
+        !checkState?.isUniversalCompatibilityCheck &&
+        (!diag || evaluator.isSpeculativeModeInUse(/* node */ undefined))
+    ) {
+        const mismatchedMember = tryFastRejectSequenceProtocol(
+            evaluator,
+            destType,
+            srcType,
+            constraints,
+            flags,
+            recursionCount
+        );
+        if (mismatchedMember) {
+            if (checkState) {
+                checkState.isFastRejection = true;
+            }
+            diag?.createAddendum().addMessage(LocAddendum.memberTypeMismatch().format({ name: mismatchedMember }));
+            return false;
         }
     }
 
@@ -848,6 +902,147 @@ function assignToProtocolInternal(
     }
 
     return typesAreConsistent;
+}
+
+// Some recursive sequence protocols describe an element as either a leaf value or another
+// instance of the same protocol. Proving that a list of complex element types does not match
+// such a protocol through the normal member-by-member walk can be disproportionately expensive.
+//
+// This is a negative-only fast path. It first verifies the protocol's specialized __getitem__
+// return type is exactly `Leaf | Protocol[Leaf]`. This makes element compatibility a necessary
+// condition of the full protocol assignment. If that condition fails, the source sequence cannot
+// satisfy __getitem__. Every uncertain case falls back to the normal structural protocol walk.
+function tryFastRejectSequenceProtocol(
+    evaluator: TypeEvaluator,
+    destType: ClassType,
+    srcType: ClassType | ModuleType,
+    constraints: ConstraintTracker | undefined,
+    flags: AssignTypeFlags,
+    recursionCount: number
+): '__getitem__' | undefined {
+    if (!isClassInstance(srcType) || !ClassType.isBuiltIn(srcType, 'list')) {
+        return undefined;
+    }
+
+    if (destType.shared.typeParams.length !== 1 || !destType.priv.typeArgs || destType.priv.typeArgs.length !== 1) {
+        return undefined;
+    }
+
+    const destTypeParam = destType.shared.typeParams[0];
+    if (TypeVarType.getVariance(destTypeParam) !== Variance.Covariant) {
+        return undefined;
+    }
+
+    if (!isSequenceLikeProtocol(destType)) {
+        return undefined;
+    }
+
+    const srcElementType = srcType.priv.typeArgs?.[0];
+
+    if (!srcElementType || isAnyOrUnknown(srcElementType)) {
+        return undefined;
+    }
+
+    const destElementType = destType.priv.typeArgs[0];
+    if (isAnyOrUnknown(destElementType)) {
+        return undefined;
+    }
+
+    const recursiveDestElementType = combineTypes([destElementType, ClassType.cloneAsInstance(destType)]);
+    if (!hasRecursiveSequenceGetItem(evaluator, destType, recursiveDestElementType)) {
+        return undefined;
+    }
+
+    // The reduced check can solve TypeVars while testing a generic overload. Keep those speculative
+    // solutions isolated; a fast rejection must not modify constraints observable by the caller.
+    const constraintsClone = constraints?.clone();
+    let assignTypeFlags = flags & (AssignTypeFlags.OverloadOverlap | AssignTypeFlags.PartialOverloadOverlap);
+    if (containsLiteralType(srcElementType, /* includeTypeArgs */ true)) {
+        assignTypeFlags |= AssignTypeFlags.RetainLiteralsForTypeVar;
+    }
+
+    if (
+        !evaluator.assignType(
+            recursiveDestElementType,
+            srcElementType,
+            /* diag */ undefined,
+            constraintsClone,
+            assignTypeFlags,
+            recursionCount
+        )
+    ) {
+        return '__getitem__';
+    }
+
+    return undefined;
+}
+
+function hasRecursiveSequenceGetItem(
+    evaluator: TypeEvaluator,
+    classType: ClassType,
+    expectedReturnType: Type
+): boolean {
+    const memberInfo = lookUpClassMember(classType, '__getitem__');
+    if (!memberInfo || !isInstantiableClass(memberInfo.classType)) {
+        return false;
+    }
+
+    let memberType = evaluator.getDeclaredTypeOfSymbol(memberInfo.symbol)?.type;
+    if (!memberType) {
+        return false;
+    }
+
+    memberType = partiallySpecializeType(memberType, classType, evaluator.getTypeClassType());
+    if (!isFunction(memberType)) {
+        return false;
+    }
+
+    const boundMemberType = evaluator.bindFunctionToClassOrObject(
+        ClassType.cloneAsInstance(classType),
+        memberType,
+        classType,
+        /* treatConstructorAsClassMethod */ undefined,
+        /* firstParamType */ undefined,
+        /* diag */ undefined,
+        /* recursionCount */ 0
+    );
+    if (!boundMemberType || !isFunction(boundMemberType)) {
+        return false;
+    }
+
+    const returnType = FunctionType.getEffectiveReturnType(boundMemberType);
+    return !!returnType && isTypeSame(returnType, expectedReturnType);
+}
+
+// Restrict the semantic check above to the standard read-only sequence protocol surface. This is
+// a scope guard rather than the correctness proof: protocols with these names but different
+// __getitem__ semantics are rejected by hasRecursiveSequenceGetItem and use normal matching.
+function isSequenceLikeProtocol(classType: ClassType): boolean {
+    const requiredMemberNames = new Set<string>();
+
+    classType.shared.mro.forEach((mroClass) => {
+        if (!isInstantiableClass(mroClass) || !ClassType.isProtocolClass(mroClass)) {
+            return;
+        }
+
+        ClassType.getSymbolTable(mroClass).forEach((symbol, name) => {
+            if (!symbol.isClassMember() || symbol.isIgnoredForProtocolMatch()) {
+                return;
+            }
+
+            requiredMemberNames.add(name);
+        });
+    });
+
+    if (
+        !requiredMemberNames.has('__len__') ||
+        !requiredMemberNames.has('__getitem__') ||
+        !requiredMemberNames.has('__iter__')
+    ) {
+        return false;
+    }
+
+    return Array.from(requiredMemberNames).every((name) => sequenceProtocolMemberNames.has(name));
 }
 
 // Given a (possibly-specialized) destType and an optional constraint tracker,

--- a/packages/pyright-internal/src/analyzer/protocols.ts
+++ b/packages/pyright-internal/src/analyzer/protocols.ts
@@ -82,6 +82,7 @@ interface ProtocolCompatibility {
     preConstraints: ConstraintTracker | undefined;
     postConstraints: ConstraintTracker | undefined;
     isCompatible: boolean;
+    isFastRejection: boolean;
 }
 
 interface ProtocolCompatibilityCheckState {
@@ -176,7 +177,7 @@ export function assignClassToProtocol(
     protocolAssignmentStack.pop();
 
     // Cache the results for next time.
-    if (!compat) {
+    if (!compat || (compat.isFastRejection && !checkState.isFastRejection)) {
         setProtocolCompatibility(
             evaluator,
             destType,
@@ -345,7 +346,12 @@ function setProtocolCompatibility(
     if (
         !isCompatible &&
         !isFastRejection &&
-        !entries.some((entry) => entry.flags === flags && ClassType.isSameGenericClass(entry.destType, destType))
+        !entries.some(
+            (entry) =>
+                !entry.isFastRejection &&
+                entry.flags === flags &&
+                ClassType.isSameGenericClass(entry.destType, destType)
+        )
     ) {
         const genericDestType = requiresTypeArgs(destType)
             ? selfSpecializeClass(destType, { overrideTypeArgs: true })
@@ -378,6 +384,21 @@ function setProtocolCompatibility(
         }
     }
 
+    if (!isFastRejection) {
+        const fastEntryIndex = entries.findIndex(
+            (entry) =>
+                entry.isFastRejection &&
+                entry.flags === flags &&
+                isTypeSame(entry.destType, destType, { honorIsTypeArgExplicit: true, honorTypeForm: true }) &&
+                entry.srcType !== undefined &&
+                isTypeSame(entry.srcType, srcType, { honorIsTypeArgExplicit: true, honorTypeForm: true }) &&
+                isConstraintTrackerSame(preConstraints, entry.preConstraints)
+        );
+        if (fastEntryIndex >= 0) {
+            entries.splice(fastEntryIndex, 1);
+        }
+    }
+
     const newEntry: ProtocolCompatibility = {
         destType,
         srcType: isAlwaysIncompatible ? undefined : srcType,
@@ -385,6 +406,7 @@ function setProtocolCompatibility(
         preConstraints,
         postConstraints,
         isCompatible,
+        isFastRejection,
     };
 
     entries.push(newEntry);

--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -2485,6 +2485,10 @@ export function createTypeEvaluator(
         applyOptions?: ApplyTypeVarOptions,
         solveOptions?: SolveConstraintsOptions
     ): Type {
+        if (!type.props?.typeAliasInfo && !requiresSpecialization(type)) {
+            return type;
+        }
+
         const solution = solveConstraints(evaluatorInterface, constraints, solveOptions);
         return applySolvedTypeVars(type, solution, applyOptions);
     }

--- a/packages/pyright-internal/src/tests/samples/protocol36.py
+++ b/packages/pyright-internal/src/tests/samples/protocol36.py
@@ -1,8 +1,11 @@
 # This sample tests the handling of nested protocols.
 
-from typing import Protocol, TypeVar, overload
+from collections.abc import Callable, Iterator
+from typing import Any, Protocol, TypeVar, overload
 
 _T_co = TypeVar("_T_co", covariant=True)
+_T_constrained = TypeVar("_T_constrained", int, str)
+_T_array = TypeVar("_T_array", bound="SupportsArray")
 
 
 class NestedSequence(Protocol[_T_co]):
@@ -16,3 +19,121 @@ class NestedSequence(Protocol[_T_co]):
 def func(v1: list[list[list[int]]]):
     a: NestedSequence[int] = v1
     b: NestedSequence[int] = [[[3, 4]]]
+
+
+class SupportsArray(Protocol):
+    def __array__(self) -> object: ...
+
+
+class FullNestedSequence(Protocol[_T_co]):
+    def __len__(self, /) -> int: ...
+
+    def __getitem__(self, index: int, /) -> _T_co | "FullNestedSequence[_T_co]": ...
+
+    def __contains__(self, value: object, /) -> bool: ...
+
+    def __iter__(self, /) -> Iterator[_T_co | "FullNestedSequence[_T_co]"]: ...
+
+    def __reversed__(self, /) -> Iterator[_T_co | "FullNestedSequence[_T_co]"]: ...
+
+    def count(self, value: Any, /) -> int: ...
+
+    def index(self, value: Any, /) -> int: ...
+
+
+def func2(v1: list[list[int]], v2: list[Callable[[], int]]):
+    a: FullNestedSequence[int] = v1
+
+    # This should generate an error because function values do not
+    # implement SupportsArray and are not recursively nested sequences.
+    b: FullNestedSequence[SupportsArray] = v2
+
+
+class SequenceNamedProtocol(Protocol[_T_co]):
+    def __len__(self, /) -> int: ...
+
+    def __getitem__(self, index: int, /) -> object: ...
+
+    def __iter__(self, /) -> Iterator[object]: ...
+
+
+def func3(v: list[Callable[[], int]]):
+    # Sequence-like member names alone do not imply that the type parameter
+    # describes the element returned by __getitem__ or __iter__.
+    a: SequenceNamedProtocol[int] = v
+
+
+def func4(
+    callback: Callable[[int], int]
+    | Callable[[FullNestedSequence[SupportsArray]], int]
+    | Callable[[list[str]], int],
+    value: list[Callable[[], int]],
+):
+    # This should generate an error that identifies the incompatible __getitem__
+    # even though the protocol callable is checked in a speculative union branch.
+    callback(value)
+
+
+def constrained_value(
+    value: _T_constrained, sequence: FullNestedSequence[_T_constrained]
+) -> _T_constrained:
+    return value
+
+
+def func5(
+    values: tuple[int, ...],
+    empty: tuple[()],
+    nested_any: tuple[tuple[Any, Any], tuple[Any, Any]],
+):
+    reveal_type(constrained_value(1, [1, 2]), expected_text="int")
+
+    # This should generate an error because the first argument constrains the
+    # protocol element type to str.
+    constrained_value("", [1, 2])
+
+    valid_heterogeneous: FullNestedSequence[int | str] = (1, "")
+    valid_unbounded: FullNestedSequence[int] = values
+    valid_empty: FullNestedSequence[int] = empty
+
+    # Fixed tuples containing Any must use normal protocol matching. Reducing
+    # their element types can be stricter than the overloaded tuple __getitem__.
+    valid_nested_any: FullNestedSequence[SupportsArray] = nested_any
+
+    # This should generate an error because neither tuple element satisfies
+    # the recursive protocol element type.
+    invalid_heterogeneous: FullNestedSequence[SupportsArray] = (lambda: 1, lambda: 2)
+
+
+class ArrayImpl:
+    def __array__(self) -> object:
+        return object()
+
+
+def preserve_array_subtype(
+    sequence: FullNestedSequence[_T_array], fallback: _T_array
+) -> _T_array:
+    return fallback
+
+
+reveal_type(preserve_array_subtype([ArrayImpl()], ArrayImpl()), expected_text="ArrayImpl")
+
+
+class OverloadedNestedSequence(FullNestedSequence[_T_co], Protocol[_T_co]):
+    @overload
+    def __getitem__(self, index: int, /) -> _T_co | "OverloadedNestedSequence[_T_co]": ...
+
+    @overload
+    def __getitem__(self, index: slice, /) -> "OverloadedNestedSequence[_T_co]": ...
+
+
+def func6(value: list[int]):
+    # An overloaded __getitem__ is outside the fast-path proof and must fall
+    # back to normal structural protocol matching.
+    sequence: OverloadedNestedSequence[int] = value
+
+
+def func7(invalid: list[Callable[[], int]], valid: list[list[int]]):
+    # This should generate an error, but it must not cache list as universally
+    # incompatible with other specializations of the recursive protocol.
+    invalid_sequence: FullNestedSequence[SupportsArray] = invalid
+    valid_sequence: FullNestedSequence[int] = valid

--- a/packages/pyright-internal/src/tests/samples/protocol36Overloads.py
+++ b/packages/pyright-internal/src/tests/samples/protocol36Overloads.py
@@ -1,0 +1,64 @@
+from collections.abc import Callable, Iterator
+from typing import Literal, Protocol, TypeVar, overload
+
+
+T_co = TypeVar("T_co", covariant=True)
+
+
+class SupportsArray(Protocol):
+    def __array__(self) -> object: ...
+
+
+class NestedSequence(Protocol[T_co]):
+    def __len__(self, /) -> int: ...
+    def __getitem__(self, index: int, /) -> T_co | "NestedSequence[T_co]": ...
+    def __iter__(self, /) -> Iterator[T_co | "NestedSequence[T_co]"]: ...
+
+
+class ArrayImpl:
+    def __array__(self) -> object:
+        return object()
+
+
+@overload
+def choose(value: NestedSequence[SupportsArray]) -> Literal["array"]: ...
+@overload
+def choose(value: object) -> str: ...
+def choose(value: object) -> str:
+    return "array"
+
+
+@overload
+def operation(value: int) -> int: ...
+@overload
+def operation(value: str) -> str: ...
+def operation(value: int | str) -> int | str:
+    return value
+
+
+def generic[T](values: list[T], nested: list[tuple[T, int]]) -> None:
+    reveal_type(choose(values), expected_text="str")
+    reveal_type(choose(nested), expected_text="str")
+
+
+def callable_params[**Params, Result](value: Callable[Params, Result]) -> None:
+    reveal_type(choose([value]), expected_text="str")
+    reveal_type(choose([[value]]), expected_text="str")
+
+
+def variadic[*Shape](values: list[tuple[*Shape]]) -> None:
+    reveal_type(choose(values), expected_text="str")
+
+
+def negative_first() -> None:
+    reveal_type(choose([operation]), expected_text="str")
+    reveal_type(choose([[operation]]), expected_text="str")
+    reveal_type(choose([ArrayImpl()]), expected_text="Literal['array']")
+    reveal_type(choose([[ArrayImpl()]]), expected_text="Literal['array']")
+
+
+def positive_first() -> None:
+    reveal_type(choose([ArrayImpl()]), expected_text="Literal['array']")
+    reveal_type(choose([[ArrayImpl()]]), expected_text="Literal['array']")
+    reveal_type(choose([operation]), expected_text="str")
+    reveal_type(choose([[operation]]), expected_text="str")

--- a/packages/pyright-internal/src/tests/typeEvaluator7.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator7.test.ts
@@ -12,7 +12,7 @@ import * as assert from 'assert';
 
 import { tryFastRejectSequenceProtocol } from '../analyzer/protocols';
 import { AssignTypeFlags } from '../analyzer/typeEvaluatorTypes';
-import { ClassType, isClassInstance, TypeVarType } from '../analyzer/types';
+import { AnyType, ClassType, isClassInstance, TypeVarType, UnknownType } from '../analyzer/types';
 import { ConfigOptions } from '../common/configOptions';
 import {
     pythonVersion3_10,
@@ -533,7 +533,7 @@ test('Protocol36', () => {
     expect(protocolErrors.some((error) => error.message.includes('__reversed__'))).toBe(true);
 });
 
-test('Protocol36UnificationTypeVar', () => {
+test('Protocol36UncertainElementType', () => {
     const code = `
 // @filename: test.py
 //// from collections.abc import Iterator
@@ -553,33 +553,92 @@ test('Protocol36UnificationTypeVar', () => {
 ////     def count(self, value: Any, /) -> int: ...
 ////     def index(self, value: Any, /) -> int: ...
 ////
-//// source = /*source*/[1]
-//// destination = /*destination*/cast(FullNestedSequence[SupportsArray], None)
+//// def identity[T](value: T) -> T:
+////     return value
+////
+//// def check[T](value: T):
+////     source = /*source*/[value]
+////     nested_source = /*nestedSource*/[[value]]
+////     concrete_source = /*concreteSource*/[1]
+////     generic_callable_source = /*genericCallableSource*/[identity]
+////     destination = /*destination*/cast(FullNestedSequence[SupportsArray], None)
     `;
     const state = parseAndGetTestState(code).state;
     const sourceNode = getNodeAtMarker(state, 'source');
+    const nestedSourceNode = getNodeAtMarker(state, 'nestedSource');
+    const concreteSourceNode = getNodeAtMarker(state, 'concreteSource');
+    const genericCallableSourceNode = getNodeAtMarker(state, 'genericCallableSource');
     const destinationNode = getNodeAtMarker(state, 'destination');
     assert.strictEqual(sourceNode.nodeType, ParseNodeType.List);
+    assert.strictEqual(nestedSourceNode.nodeType, ParseNodeType.List);
+    assert.strictEqual(concreteSourceNode.nodeType, ParseNodeType.List);
+    assert.strictEqual(genericCallableSourceNode.nodeType, ParseNodeType.List);
     assert.strictEqual(destinationNode.nodeType, ParseNodeType.Name);
     assert.strictEqual(destinationNode.parent?.nodeType, ParseNodeType.Call);
 
     const sourceType = state.program.evaluator!.getTypeOfExpression(sourceNode).type;
+    const nestedSourceType = state.program.evaluator!.getTypeOfExpression(nestedSourceNode).type;
+    const concreteSourceType = state.program.evaluator!.getTypeOfExpression(concreteSourceNode).type;
+    const genericCallableSourceType = state.program.evaluator!.getTypeOfExpression(genericCallableSourceNode).type;
     const destinationType = state.program.evaluator!.getTypeOfExpression(destinationNode.parent).type;
     assert.ok(isClassInstance(sourceType));
+    assert.ok(isClassInstance(nestedSourceType));
+    assert.ok(isClassInstance(concreteSourceType));
+    assert.ok(isClassInstance(genericCallableSourceType));
     assert.ok(isClassInstance(destinationType));
 
     const typeVar = TypeVarType.cloneAsUnificationVar(TypeVarType.createInstance('T'));
-    const sourceWithUnificationTypeVar = ClassType.specialize(sourceType, [typeVar]);
+    const sourceWithUnificationTypeVar = ClassType.specialize(concreteSourceType, [typeVar]);
+    const listOfAny = ClassType.specialize(concreteSourceType, [AnyType.create()]);
+    const listOfUnknown = ClassType.specialize(concreteSourceType, [UnknownType.create()]);
+    const uncertainSources = [sourceType, sourceWithUnificationTypeVar, listOfAny, listOfUnknown];
+
+    for (const uncertainSource of uncertainSources) {
+        assert.strictEqual(
+            tryFastRejectSequenceProtocol(
+                state.program.evaluator!,
+                destinationType,
+                uncertainSource,
+                undefined,
+                AssignTypeFlags.Default,
+                0
+            ),
+            undefined
+        );
+    }
+
     assert.strictEqual(
         tryFastRejectSequenceProtocol(
             state.program.evaluator!,
             destinationType,
-            sourceWithUnificationTypeVar,
+            concreteSourceType,
             undefined,
             AssignTypeFlags.Default,
             0
         ),
-        undefined
+        '__getitem__'
+    );
+    assert.strictEqual(
+        tryFastRejectSequenceProtocol(
+            state.program.evaluator!,
+            destinationType,
+            nestedSourceType,
+            undefined,
+            AssignTypeFlags.Default,
+            0
+        ),
+        '__getitem__'
+    );
+    assert.strictEqual(
+        tryFastRejectSequenceProtocol(
+            state.program.evaluator!,
+            destinationType,
+            genericCallableSourceType,
+            undefined,
+            AssignTypeFlags.Default,
+            0
+        ),
+        '__getitem__'
     );
 });
 

--- a/packages/pyright-internal/src/tests/typeEvaluator7.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator7.test.ts
@@ -80,6 +80,13 @@ test('SolveAndApplyConstraintsConcreteType', () => {
     expect(visitConstraints).toHaveBeenCalled();
     visitConstraints.mockClear();
 
+    const boundAlias = evaluator.solveAndApplyConstraints(aliasType, constraints);
+    const boundAliasArg = boundAlias.props?.typeAliasInfo?.typeArgs?.[0];
+    assert.ok(boundAliasArg && isTypeVar(boundAliasArg));
+    assert.ok(TypeVarType.isBound(boundAliasArg));
+    expect(visitConstraints).toHaveBeenCalled();
+    visitConstraints.mockClear();
+
     const freeAliasType = makeTypeVarsFree(aliasType, [freeTypeVar.priv.scopeId]);
     const specializedAlias = evaluator.solveAndApplyConstraints(freeAliasType, constraints);
     assert.ok(specializedAlias.props?.typeAliasInfo?.typeArgs);
@@ -87,6 +94,32 @@ test('SolveAndApplyConstraintsConcreteType', () => {
     expect(visitConstraints).toHaveBeenCalled();
     visitConstraints.mockRestore();
 });
+
+test.each(['int | str', 'tuple[int, str]', 'Callable[[int], str]', 'None', 'Never'])(
+    'SolveAndApplyConstraintsConcreteTarget %s',
+    (annotation) => {
+        const code = `
+// @filename: test.py
+//// from collections.abc import Callable
+//// from typing import Never
+////
+//// def check(value: ${annotation}):
+////     /*value*/value
+        `;
+        const state = parseAndGetTestState(code).state;
+        const evaluator = state.program.evaluator!;
+        const valueNode = getNodeAtMarker(state, 'value');
+        assert.strictEqual(valueNode.nodeType, ParseNodeType.Name);
+        const valueType = evaluator.getTypeOfExpression(valueNode).type;
+        const constraints = new ConstraintTracker();
+        constraints.setBounds(TypeVarType.createInstance('Unrelated'), UnknownType.create());
+        const visitConstraints = jest.spyOn(constraints, 'doForEachConstraintSet');
+
+        assert.strictEqual(evaluator.solveAndApplyConstraints(valueType, constraints), valueType);
+        expect(visitConstraints).not.toHaveBeenCalled();
+        visitConstraints.mockRestore();
+    }
+);
 
 test('GenericType1', () => {
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['genericType1.py']);
@@ -594,6 +627,12 @@ test('Protocol36', () => {
     expect(protocolErrors.some((error) => error.message.includes('__reversed__'))).toBe(true);
 });
 
+test('Protocol36Overloads', () => {
+    const analysisResults = TestUtils.typeAnalyzeSampleFiles(['protocol36Overloads.py']);
+
+    TestUtils.validateResults(analysisResults, 0);
+});
+
 test('Protocol36UncertainElementType', () => {
     const code = `
 // @filename: test.py
@@ -666,6 +705,25 @@ test('Protocol36UncertainElementType', () => {
             ),
             undefined
         );
+    }
+
+    const uncertainElements = [sourceType.priv.typeArgs![0], typeVar, AnyType.create(), UnknownType.create()];
+    for (const uncertainElement of uncertainElements) {
+        const constraints = new ConstraintTracker();
+        constraints.setBounds(typeVar, concreteSourceType.priv.typeArgs![0]);
+        const originalConstraints = constraints.clone();
+        assert.strictEqual(
+            tryFastRejectSequenceProtocol(
+                state.program.evaluator!,
+                ClassType.specialize(destinationType, [uncertainElement]),
+                concreteSourceType,
+                constraints,
+                AssignTypeFlags.Default,
+                0
+            ),
+            undefined
+        );
+        assert.ok(constraints.isSame(originalConstraints));
     }
 
     assert.strictEqual(
@@ -741,6 +799,71 @@ test('Protocol36UncertainElementType', () => {
         false
     );
     assert.strictEqual(getFastCacheEntryCount(), 0);
+});
+
+test.each([false, true])('Protocol36CacheReuse positiveFirst=%s', (positiveFirst) => {
+    const code = `
+// @filename: test.py
+//// from collections.abc import Iterator
+//// from typing import Protocol, TypeVar
+////
+//// T_co = TypeVar("T_co", covariant=True)
+////
+//// class NestedSequence(Protocol[T_co]):
+////     def __len__(self, /) -> int: ...
+////     def __getitem__(self, index: int, /) -> T_co | "NestedSequence[T_co]": ...
+////     def __iter__(self, /) -> Iterator[T_co | "NestedSequence[T_co]"]: ...
+////
+//// def check(source: list[int], destination: NestedSequence[str]):
+////     /*source*/source
+////     /*destination*/destination
+    `;
+    const state = parseAndGetTestState(code).state;
+    const evaluator = state.program.evaluator!;
+    const sourceNode = getNodeAtMarker(state, 'source');
+    const destinationNode = getNodeAtMarker(state, 'destination');
+    assert.strictEqual(sourceNode.nodeType, ParseNodeType.Name);
+    assert.strictEqual(destinationNode.nodeType, ParseNodeType.Name);
+    const sourceType = evaluator.getTypeOfExpression(sourceNode).type;
+    const destinationType = evaluator.getTypeOfExpression(destinationNode).type;
+    assert.ok(isClassInstance(sourceType));
+    assert.ok(isClassInstance(destinationType));
+    const elementType = sourceType.priv.typeArgs![0];
+    const rejectedType = ClassType.cloneAsInstantiable(destinationType);
+    const acceptedType = ClassType.specialize(rejectedType, [elementType]);
+    const typeParam = destinationType.shared.typeParams[0];
+    const genericType = ClassType.specialize(rejectedType, [typeParam]);
+    const constraints = new ConstraintTracker();
+    constraints.setBounds(typeParam, elementType);
+    const originalConstraints = constraints.clone();
+    const assign = (destination: ClassType, diag?: DiagnosticAddendum, tracker = constraints) =>
+        assignClassToProtocol(evaluator, destination, sourceType, diag, tracker, AssignTypeFlags.Default, 0);
+
+    if (positiveFirst) {
+        assert.strictEqual(assign(acceptedType), true);
+    }
+
+    assert.strictEqual(assign(rejectedType), false);
+    assert.ok(constraints.isSame(originalConstraints));
+    assert.strictEqual(assign(rejectedType), false);
+    assert.ok(constraints.isSame(originalConstraints));
+    assert.strictEqual(assign(acceptedType), true);
+
+    const diagnostics = new DiagnosticAddendum();
+    assert.strictEqual(assign(rejectedType, diagnostics), false);
+    expect(diagnostics.getString()).toContain('"int" is not assignable to "str"');
+    assert.ok(constraints.isSame(originalConstraints));
+    assert.strictEqual(assign(rejectedType), false);
+    assert.strictEqual(assign(acceptedType), true);
+
+    for (let attempt = 0; attempt < 2; attempt++) {
+        const inferredConstraints = new ConstraintTracker();
+        assert.strictEqual(assign(genericType, undefined, inferredConstraints), true);
+        assert.strictEqual(
+            evaluator.printType(evaluator.solveAndApplyConstraints(typeParam, inferredConstraints)),
+            'int'
+        );
+    }
 });
 
 test('Protocol37', () => {

--- a/packages/pyright-internal/src/tests/typeEvaluator7.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator7.test.ts
@@ -8,6 +8,11 @@
  * arbitrarily among multiple files so they can run in parallel.
  */
 
+import * as assert from 'assert';
+
+import { tryFastRejectSequenceProtocol } from '../analyzer/protocols';
+import { AssignTypeFlags } from '../analyzer/typeEvaluatorTypes';
+import { ClassType, isClassInstance, TypeVarType } from '../analyzer/types';
 import { ConfigOptions } from '../common/configOptions';
 import {
     pythonVersion3_10,
@@ -18,6 +23,8 @@ import {
     pythonVersion3_8,
 } from '../common/pythonVersion';
 import { Uri } from '../common/uri/uri';
+import { ParseNodeType } from '../parser/parseNodes';
+import { getNodeAtMarker, parseAndGetTestState } from './harness/fourslash/testState';
 import * as TestUtils from './testUtils';
 
 test('GenericType1', () => {
@@ -524,6 +531,56 @@ test('Protocol36', () => {
     expect(unionCallError[0].message).not.toContain('__iter__');
     expect(protocolErrors.some((error) => error.message.includes('__iter__'))).toBe(true);
     expect(protocolErrors.some((error) => error.message.includes('__reversed__'))).toBe(true);
+});
+
+test('Protocol36UnificationTypeVar', () => {
+    const code = `
+// @filename: test.py
+//// from collections.abc import Iterator
+//// from typing import Any, cast, Protocol, TypeVar
+////
+//// T_co = TypeVar("T_co", covariant=True)
+////
+//// class SupportsArray(Protocol):
+////     def __array__(self) -> object: ...
+////
+//// class FullNestedSequence(Protocol[T_co]):
+////     def __len__(self, /) -> int: ...
+////     def __getitem__(self, index: int, /) -> T_co | "FullNestedSequence[T_co]": ...
+////     def __contains__(self, value: object, /) -> bool: ...
+////     def __iter__(self, /) -> Iterator[T_co | "FullNestedSequence[T_co]"]: ...
+////     def __reversed__(self, /) -> Iterator[T_co | "FullNestedSequence[T_co]"]: ...
+////     def count(self, value: Any, /) -> int: ...
+////     def index(self, value: Any, /) -> int: ...
+////
+//// source = /*source*/[1]
+//// destination = /*destination*/cast(FullNestedSequence[SupportsArray], None)
+    `;
+    const state = parseAndGetTestState(code).state;
+    const sourceNode = getNodeAtMarker(state, 'source');
+    const destinationNode = getNodeAtMarker(state, 'destination');
+    assert.strictEqual(sourceNode.nodeType, ParseNodeType.List);
+    assert.strictEqual(destinationNode.nodeType, ParseNodeType.Name);
+    assert.strictEqual(destinationNode.parent?.nodeType, ParseNodeType.Call);
+
+    const sourceType = state.program.evaluator!.getTypeOfExpression(sourceNode).type;
+    const destinationType = state.program.evaluator!.getTypeOfExpression(destinationNode.parent).type;
+    assert.ok(isClassInstance(sourceType));
+    assert.ok(isClassInstance(destinationType));
+
+    const typeVar = TypeVarType.cloneAsUnificationVar(TypeVarType.createInstance('T'));
+    const sourceWithUnificationTypeVar = ClassType.specialize(sourceType, [typeVar]);
+    assert.strictEqual(
+        tryFastRejectSequenceProtocol(
+            state.program.evaluator!,
+            destinationType,
+            sourceWithUnificationTypeVar,
+            undefined,
+            AssignTypeFlags.Default,
+            0
+        ),
+        undefined
+    );
 });
 
 test('Protocol37', () => {

--- a/packages/pyright-internal/src/tests/typeEvaluator7.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator7.test.ts
@@ -10,10 +10,13 @@
 
 import * as assert from 'assert';
 
-import { tryFastRejectSequenceProtocol } from '../analyzer/protocols';
+import { ConstraintTracker } from '../analyzer/constraintTracker';
+import { assignClassToProtocol, tryFastRejectSequenceProtocol } from '../analyzer/protocols';
 import { AssignTypeFlags } from '../analyzer/typeEvaluatorTypes';
-import { AnyType, ClassType, isClassInstance, TypeVarType, UnknownType } from '../analyzer/types';
+import { AnyType, ClassType, isClassInstance, isTypeVar, TypeVarType, UnknownType } from '../analyzer/types';
+import { makeTypeVarsFree } from '../analyzer/typeUtils';
 import { ConfigOptions } from '../common/configOptions';
+import { DiagnosticAddendum } from '../common/diagnostic';
 import {
     pythonVersion3_10,
     pythonVersion3_11,
@@ -26,6 +29,64 @@ import { Uri } from '../common/uri/uri';
 import { ParseNodeType } from '../parser/parseNodes';
 import { getNodeAtMarker, parseAndGetTestState } from './harness/fourslash/testState';
 import * as TestUtils from './testUtils';
+
+test('SolveAndApplyConstraintsConcreteType', () => {
+    const code = `
+// @filename: test.py
+//// type Alias[T] = int
+////
+//// concrete = /*concrete*/[1]
+////
+//// def check[T](value: list[tuple[T, int]], alias: Alias[T]):
+////     /*generic*/value
+////     /*alias*/alias
+    `;
+    const state = parseAndGetTestState(code).state;
+    const evaluator = state.program.evaluator!;
+    const concreteNode = getNodeAtMarker(state, 'concrete');
+    const genericNode = getNodeAtMarker(state, 'generic');
+    const aliasNode = getNodeAtMarker(state, 'alias');
+    assert.strictEqual(concreteNode.nodeType, ParseNodeType.List);
+    assert.strictEqual(genericNode.nodeType, ParseNodeType.Name);
+    assert.strictEqual(aliasNode.nodeType, ParseNodeType.Name);
+    const concreteType = evaluator.getTypeOfExpression(concreteNode).type;
+    const genericType = evaluator.getTypeOfExpression(genericNode).type;
+    const aliasType = evaluator.getTypeOfExpression(aliasNode).type;
+    assert.ok(isClassInstance(concreteType));
+    assert.ok(isClassInstance(genericType));
+    const tupleType = genericType.priv.typeArgs![0];
+    assert.ok(isClassInstance(tupleType));
+    const typeVar = tupleType.priv.tupleTypeArgs![0].type;
+    assert.ok(isTypeVar(typeVar));
+    const freeTypeVar = typeVar.priv.freeTypeVar;
+    assert.ok(freeTypeVar?.priv.scopeId);
+    const elementType = concreteType.priv.typeArgs![0];
+    const constraints = new ConstraintTracker();
+    constraints.setBounds(freeTypeVar, elementType);
+    const visitConstraints = jest.spyOn(constraints, 'doForEachConstraintSet');
+
+    for (const type of [concreteType, AnyType.create(), UnknownType.create()]) {
+        assert.strictEqual(evaluator.solveAndApplyConstraints(type, constraints), type);
+    }
+    expect(visitConstraints).not.toHaveBeenCalled();
+
+    assert.strictEqual(
+        evaluator.printType(evaluator.solveAndApplyConstraints(genericType, constraints)),
+        'list[tuple[T@check, int]]'
+    );
+    const freeGenericType = makeTypeVarsFree(genericType, [freeTypeVar.priv.scopeId]);
+    const specializedType = evaluator.solveAndApplyConstraints(freeGenericType, constraints);
+    assert.strictEqual(evaluator.printType(specializedType), 'list[tuple[int, int]]');
+    expect(visitConstraints).toHaveBeenCalled();
+    visitConstraints.mockClear();
+
+    const freeAliasType = makeTypeVarsFree(aliasType, [freeTypeVar.priv.scopeId]);
+    const specializedAlias = evaluator.solveAndApplyConstraints(freeAliasType, constraints);
+    assert.ok(specializedAlias.props?.typeAliasInfo?.typeArgs);
+    assert.strictEqual(evaluator.printType(specializedAlias.props.typeAliasInfo.typeArgs[0]), 'int');
+    expect(visitConstraints).toHaveBeenCalled();
+    visitConstraints.mockRestore();
+});
 
 test('GenericType1', () => {
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['genericType1.py']);
@@ -640,6 +701,46 @@ test('Protocol36UncertainElementType', () => {
         ),
         '__getitem__'
     );
+
+    const getFastCacheEntryCount = () => {
+        const protocolCache = concreteSourceType.shared.protocolCompatibility as
+            | Map<string, { isFastRejection?: boolean }[]>
+            | undefined;
+        return protocolCache
+            ? Array.from(protocolCache.values()).reduce(
+                  (count, entries) => count + entries.filter((entry) => entry.isFastRejection).length,
+                  0
+              )
+            : 0;
+    };
+
+    assert.strictEqual(
+        assignClassToProtocol(
+            state.program.evaluator!,
+            ClassType.cloneAsInstantiable(destinationType),
+            concreteSourceType,
+            undefined,
+            undefined,
+            AssignTypeFlags.Default,
+            0
+        ),
+        false
+    );
+    assert.strictEqual(getFastCacheEntryCount(), 1);
+
+    assert.strictEqual(
+        assignClassToProtocol(
+            state.program.evaluator!,
+            ClassType.cloneAsInstantiable(destinationType),
+            concreteSourceType,
+            new DiagnosticAddendum(),
+            undefined,
+            AssignTypeFlags.Default,
+            0
+        ),
+        false
+    );
+    assert.strictEqual(getFastCacheEntryCount(), 0);
 });
 
 test('Protocol37', () => {

--- a/packages/pyright-internal/src/tests/typeEvaluator7.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator7.test.ts
@@ -622,17 +622,6 @@ test('Protocol36UncertainElementType', () => {
         tryFastRejectSequenceProtocol(
             state.program.evaluator!,
             destinationType,
-            concreteSourceType,
-            undefined,
-            AssignTypeFlags.ArgAssignmentFirstPass,
-            0
-        ),
-        undefined
-    );
-    assert.strictEqual(
-        tryFastRejectSequenceProtocol(
-            state.program.evaluator!,
-            destinationType,
             nestedSourceType,
             undefined,
             AssignTypeFlags.Default,

--- a/packages/pyright-internal/src/tests/typeEvaluator7.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator7.test.ts
@@ -622,6 +622,17 @@ test('Protocol36UncertainElementType', () => {
         tryFastRejectSequenceProtocol(
             state.program.evaluator!,
             destinationType,
+            concreteSourceType,
+            undefined,
+            AssignTypeFlags.ArgAssignmentFirstPass,
+            0
+        ),
+        undefined
+    );
+    assert.strictEqual(
+        tryFastRejectSequenceProtocol(
+            state.program.evaluator!,
+            destinationType,
             nestedSourceType,
             undefined,
             AssignTypeFlags.Default,

--- a/packages/pyright-internal/src/tests/typeEvaluator7.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator7.test.ts
@@ -513,7 +513,17 @@ test('Protocol35', () => {
 test('Protocol36', () => {
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['protocol36.py']);
 
-    TestUtils.validateResults(analysisResults, 0);
+    TestUtils.validateResults(analysisResults, 7);
+    const protocolErrors = analysisResults[0].errors.filter((error) =>
+        error.message.includes('FullNestedSequence[SupportsArray]')
+    );
+    expect(protocolErrors).toHaveLength(4);
+    const unionCallError = protocolErrors.filter((error) => error.message.startsWith('Argument of type'));
+    expect(unionCallError).toHaveLength(1);
+    expect(unionCallError[0].message).toContain('__getitem__');
+    expect(unionCallError[0].message).not.toContain('__iter__');
+    expect(protocolErrors.some((error) => error.message.includes('__iter__'))).toBe(true);
+    expect(protocolErrors.some((error) => error.message.includes('__reversed__'))).toBe(true);
 });
 
 test('Protocol37', () => {


### PR DESCRIPTION
## Summary

Improve checking performance for lists of overloaded callables, including NumPy's `np.array([np.sum, np.mean])` and pandas' `test_series_apply.py`, without adding NumPy-specific logic.

### Recursive sequence rejection

- Add a negative-only shortcut for built-in `list` assignments to a recognized recursive sequence protocol with one covariant type parameter. Tuples use ordinary protocol matching.
- Require the specialized, non-overloaded `__getitem__` return type to be exactly `Leaf | Protocol[Leaf]`. Similar member names alone are not sufficient.
- Decline top-level source/destination element TypeVars, Any, and Unknown, and unsupported protocol shapes. This is not a recursive exclusion of all nested TypeVars or gradual types.
- Clone caller constraints for the reduced element check. A successful reduced check does not establish protocol compatibility; ordinary structural matching still runs.

### Constraint solving

- Skip `solveAndApplyConstraints` when the target type requires no specialization and has no alias metadata, avoiding full constraint solves whose results would not transform the target.
- Preserve the normal path for alias metadata because the transformer processes generic aliases before its ordinary no-op check.

### Protocol cache provenance

- Record whether a cached result came from fast rejection.
- Allow a subsequent full check to replace the matching fast-rejection entry and exclude fast entries from the entry-existence check used when considering universal incompatibility.
- This does not provide transactional cache isolation: cached negatives can still be reused before a diagnostic-bearing full check replaces them. Behavioral validation of inference and reuse remains an open gate below.

## Problem and Correctness Argument

### Why checking is slow

For `np.array([np.sum, np.mean])`, Pyright must determine which NumPy overload accepts a list of overloaded functions. Some candidates describe recursive sequences: each element can be a supported leaf value or another sequence. Rejecting an unsuitable candidate can trigger expensive recursive protocol matching, overloaded-function comparison, and repeated constraint solving. Profiling also identified substantial work solving constraints even when the particular type being transformed could not change.

The goal is to eliminate unnecessary work without rejecting valid candidates, accepting invalid ones, or losing inferred type precision. There are two independent changes: skip solving when substitution cannot transform the target (excluding alias metadata), and reject narrowly recognized recursive-sequence candidates using an element-compatibility condition. A successful element check never establishes full protocol compatibility; ordinary structural matching still runs.

### Necessary-condition argument

Suppose the source is `list[E]` and protocol `P[L]` promises:

```python
def __getitem__(self, index: int, /) -> L | P[L]: ...
```

For integer indexing, the built-in list signature returns `E`. Implementing the protocol therefore requires that this return type be assignable to the promised return type. Writing $\preceq$ for assignability:

$$
\mathrm{list}[E] \preceq P[L] \implies E \preceq L \cup P[L]
$$

Taking the contrapositive gives the early-rejection rule:

$$
E \not\preceq L \cup P[L] \implies \mathrm{list}[E] \not\preceq P[L]
$$

This justifies rejection, not acceptance: other protocol members can still be incompatible.

**The integer-index premise is essential.** A slice returns another list, not an element. A slice-only recursive protocol supplied a real counterexample to the return-type-only guard: the shortcut selected fallback `str`, whereas full matching selected `Literal['slice']`. A local follow-up adds a built-in-integer parameter guard and a precise slice regression. As of this description update (2026-09-04), that fix is in local commit `ea13f4cc3`, not the published PR head `34179d476`. The published implementation therefore does not yet enforce this premise. The approximately 4.1-second post-fix pandas measurements and additional local tests must not be mistaken for validation of a published integer-index fix.

### What an exception-free proof still requires

The implication above is not a complete proof of the implementation. The remaining obligations are:

1. **Eligibility establishes every premise.** Binding, specialization, actual list signatures, parameter domains, and return types must have the meaning assumed by the argument.
2. **Reduced failure means genuine incompatibility.** A false result must not merely mean that inference could not solve the relation in this context. Nested generics, conditional types, recursive assumptions, and incomplete inference matter; excluding only top-level Any, Unknown, and TypeVars does not prove this.
3. **Inference assumptions are appropriate.** The reduced check must not reject a candidate that the full check could accept after solving relevant variables.
4. **The probe cannot corrupt later decisions.** Cloning constraints protects the caller tracker, not every nested cache effect. Fast-rejection provenance prevents direct promotion to universal incompatibility, but is not a complete state-isolation proof.
5. **Skipping constraint solving is observationally harmless.** Returning the same type is necessary; omitted solving must also have no required effects on subsequent inference. Alias metadata remains on the normal path because it can require transformation.

The proof target is that every early rejection is justified under the applicable typing rules and inference state, and subsequent decisions remain unaffected. Each obligation needs a code-backed argument or an explicit fallback when its premises cannot be established. Passing suites, adversarial cases, performance measurements, and no-shortcut comparisons provide evidence, not a universal guarantee. The discovered slice counterexample demonstrates the distinction. These obligations remain merge gates, not completed claims of correctness.

## Performance

Latest local measurements used Node 26.5.0, Python 3.12.3, NumPy 2.4.6, and pandas revision `82a712a52a55e9ac99c59a818e36c4d400bc5dbe`. The core was compiled before each CLI bundle. Base checker: `c77393240247e017db6538d35876e723c518e06c`; measured implementation revision: `9577c1663acf0751c858a8cd63d4b36c4145b911`. The subsequent test-only commit `34179d47639970e3d8be13ca21949bde2af2f6a6` does not change production code; benchmarks have not been rerun for it.

| Configuration | Combined NumPy check time | Combined NumPy wall time | pandas file wall time |
| --- | ---: | ---: | ---: |
| Base | 79.75 s | 80.69 s | Historical: about 4 minutes |
| Solver guard alone, without sequence shortcut | 24.68 s | 25.66 s | 78.53 s |
| Current integrated changes | 0.27 s | 1.22 s | 4.18 s |

The base singleton lists containing only `np.sum` or only `np.mean` checked in 0.32 and 0.34 seconds. The combined trigger revealed `ndarray[tuple[Any, ...], dtype[Any]]` with no errors or warnings across these measurements. The final pandas runs also reported no errors or warnings.

These are single-run local observations, not statistical benchmarks or Node 24 CI comparisons. The historical pandas base timing is not a fresh paired baseline. The independent solver guard provides a substantial partial improvement; it does not by itself retain the approximately four-second pandas result.

## Tests and Local Validation

- Existing sequence coverage includes positive nested sequences, incompatible callables, similar member names with different semantics, constrained generic results, tuple fallback, and subsequent valid list specializations after a rejection.
- Direct helper tests cover scoped/unification TypeVars, Any/Unknown, concrete and generic-callable sources, and fast-cache replacement after a full diagnostic-bearing check.
- Added `SolveAndApplyConstraintsConcreteType`: concrete types, Any, and Unknown avoid constraint-set traversal; bound TypeVars stay bound; free TypeVars specialize precisely through nested `list[tuple[T, int]]` and generic alias metadata.
- Added eight test cases in `34179d476`, plus expanded existing assertions:
  - Fresh evaluators exercise positive-first and negative-first protocol assignments, repeated rejection, diagnostic details, preserved caller constraints, and subsequent generic assignments inferring `int` with fresh constraint trackers.
  - A dependency-free overload sample asserts precise `Literal['array']` selection for valid array-like sequences and `str` fallback for overloaded callables, scoped `list[T]`, nested `list[tuple[T, int]]`, ParamSpec callables, and TypeVarTuple tuples.
  - Uncertain destination elements (scoped/unification TypeVars, Any, Unknown) decline the helper without changing constraints.
  - Concrete unions, tuples, callables, None, and Never avoid solver traversal; alias assertions distinguish bound preservation from free-TypeVar substitution.
- Full internal suite: **77 suites, 2,795 tests passed** for the implementation preceding this test-only commit. The full suite has not been rerun after the new tests.
- Latest pre-push targeted shard: **180 tests passed**, with core TypeScript build, targeted ESLint/Prettier, and `git diff --check` also passing on `34179d476`.
- The earlier implementation validation also included a CLI development build. Jest emitted worker-exit/listener warnings; the latest targeted run emitted the force-exit notice.
- No existing expected types or diagnostic expectations were weakened for performance.

## Coverage Progress and Remaining Before Merge

- [x] Add focused protocol cache-reuse tests in both assignment orders, asserting results, caller constraints, diagnostic element incompatibility, and subsequent generic inference.
- [ ] Validate broader inference-context and cross-candidate cache reuse beyond these focused scenarios; these tests do not establish general transactional cache isolation.
- [x] Add dependency-free recursive-protocol overload regressions for scoped `list[T]` and nested `list[tuple[T, int]]`, callable fallback, and precise positive overload selection. These model the relevant matching behavior rather than importing NumPy.
- [x] Cover ParamSpec callables and TypeVarTuple tuple inputs in overload selection, and uncertain top-level destination elements in direct helper tests.
- [ ] Add remaining nested Any/Unknown and incomplete-inference coverage at the shortcut boundary.
- [ ] Repeat pandas measurements at least three times, targeting median wall time below five seconds in the pinned environment, and add stable small-trigger work/scaling coverage.
- [ ] Validate the relevant hydra-zen, pandas-stubs, JAX, and frozen scikit-learn cases, then run the broader primer comparison with recorded revisions.
- [ ] Resolve the reported SymPy `dict[Dummy, Basic | Unknown] -> dict[Dummy, Basic]` change with a reproducible, semantically justified expectation. Repeated unchanged-base full-project runs produced different diagnostics, so those broad diffs do not yet establish causality.

Correct typing behavior is the acceptance criterion, not exact parity with every old diagnostic. Any reproducible semantic change needs an explanation and focused coverage; passing local tests and having pushed the code do not close the remaining cache/inference gates.
