### PR TITLE
Avoid work-done progress notifications for document diagnostic pulls

### DIFF
--- a/packages/pyright-internal/src/languageServerBase.ts
+++ b/packages/pyright-internal/src/languageServerBase.ts
@@ -173,7 +173,6 @@ export abstract class LanguageServerBase implements LanguageServerInterface, Dis
     private _pendingCommandCancellationSource: AbstractCancellationTokenSource | undefined;
 
     private _progressReporter: ProgressReporter;
-    private _progressReportCounter = 0;
 
     private _lastTriggerKind: CompletionTriggerKind | undefined = CompletionTriggerKind.Invoked;
 
@@ -1181,50 +1180,43 @@ export abstract class LanguageServerBase implements LanguageServerInterface, Dis
             return result;
         }
 
-        // Send a progress message to the client.
-        this.incrementAnalysisProgress();
+        // Reanalyze the file if it's not up to date.
+        if (params.previousResultId !== diagnosticsVersion.toString() && sourceFile) {
+            let diagnosticsVersionAfter = UncomputedDiagnosticsVersion - 1; // Just has to be different
+            let serverDiagnostics: AnalyzerDiagnostic[] = [];
 
-        try {
-            // Reanalyze the file if it's not up to date.
-            if (params.previousResultId !== diagnosticsVersion.toString() && sourceFile) {
-                let diagnosticsVersionAfter = UncomputedDiagnosticsVersion - 1; // Just has to be different
-                let serverDiagnostics: AnalyzerDiagnostic[] = [];
+            // Loop until we analyze the same version that we started with.
+            while (diagnosticsVersion !== diagnosticsVersionAfter && !token.isCancellationRequested && sourceFile) {
+                // Reset the version we're analyzing
+                sourceFile = workspace.service.getSourceFile(uri);
+                diagnosticsVersion = sourceFile?.getDiagnosticVersion() ?? UncomputedDiagnosticsVersion;
 
-                // Loop until we analyze the same version that we started with.
-                while (diagnosticsVersion !== diagnosticsVersionAfter && !token.isCancellationRequested && sourceFile) {
-                    // Reset the version we're analyzing
-                    sourceFile = workspace.service.getSourceFile(uri);
-                    diagnosticsVersion = sourceFile?.getDiagnosticVersion() ?? UncomputedDiagnosticsVersion;
-
-                    // Then reanalyze the file (this should go to the background thread so this thread can handle other requests).
-                    if (sourceFile) {
-                        serverDiagnostics = await workspace.service.analyzeFileAndGetDiagnostics(uri, token);
-                    }
-
-                    // If any text edits came in, make sure we reanalyze the file. Diagnostics version should be reset to zero
-                    // if a text edit comes in.
-                    const sourceFileAfter = workspace.service.getSourceFile(uri);
-                    diagnosticsVersionAfter = sourceFileAfter?.getDiagnosticVersion() ?? UncomputedDiagnosticsVersion;
+                // Then reanalyze the file (this should go to the background thread so this thread can handle other requests).
+                if (sourceFile) {
+                    serverDiagnostics = await workspace.service.analyzeFileAndGetDiagnostics(uri, token);
                 }
 
-                // Then convert the diagnostics to the LSP format.
-                const lspDiagnostics = this._convertDiagnostics(workspace.service.fs, serverDiagnostics).filter(
-                    (d) => d !== undefined
-                ) as Diagnostic[];
-
-                result.resultId =
-                    diagnosticsVersionAfter === UncomputedDiagnosticsVersion
-                        ? undefined
-                        : diagnosticsVersionAfter.toString();
-                result.items = lspDiagnostics;
-            } else {
-                (result as any).kind = 'unchanged';
-                result.resultId =
-                    diagnosticsVersion === UncomputedDiagnosticsVersion ? undefined : diagnosticsVersion.toString();
-                delete (result as any).items;
+                // If any text edits came in, make sure we reanalyze the file. Diagnostics version should be reset to zero
+                // if a text edit comes in.
+                const sourceFileAfter = workspace.service.getSourceFile(uri);
+                diagnosticsVersionAfter = sourceFileAfter?.getDiagnosticVersion() ?? UncomputedDiagnosticsVersion;
             }
-        } finally {
-            this.decrementAnalysisProgress();
+
+            // Then convert the diagnostics to the LSP format.
+            const lspDiagnostics = this._convertDiagnostics(workspace.service.fs, serverDiagnostics).filter(
+                (d) => d !== undefined
+            ) as Diagnostic[];
+
+            result.resultId =
+                diagnosticsVersionAfter === UncomputedDiagnosticsVersion
+                    ? undefined
+                    : diagnosticsVersionAfter.toString();
+            result.items = lspDiagnostics;
+        } else {
+            (result as any).kind = 'unchanged';
+            result.resultId =
+                diagnosticsVersion === UncomputedDiagnosticsVersion ? undefined : diagnosticsVersion.toString();
+            delete (result as any).items;
         }
 
         return result;
@@ -1371,19 +1363,6 @@ export abstract class LanguageServerBase implements LanguageServerInterface, Dis
 
         // Update progress.
         this.sendProgressMessage(results.requiringAnalysisCount.files, results.requiringAnalysisCount.cells);
-    }
-
-    protected incrementAnalysisProgress() {
-        this._progressReportCounter += 1;
-        this.sendProgressMessage(this._progressReportCounter);
-    }
-
-    protected decrementAnalysisProgress() {
-        this._progressReportCounter -= 1;
-        if (this._progressReportCounter < 0) {
-            this._progressReportCounter = 0;
-        }
-        this.sendProgressMessage(this._progressReportCounter);
     }
 
     protected getAnalysisProgressReporter(): ProgressReporter {

--- a/packages/pyright-internal/src/tests/languageServer.test.ts
+++ b/packages/pyright-internal/src/tests/languageServer.test.ts
@@ -316,6 +316,34 @@ describe(`Basic language server tests`, () => {
             });
 
             if (supportsPullDiagnostics) {
+                // Regression test: document diagnostic pulls can occur after every edit,
+                // so they should not create server-initiated work done progress notifications.
+                test('document diagnostic pull does not create work done progress', async () => {
+                    const code = `
+// @filename: test.py
+//// /*marker*/pass
+        `;
+                    const info = await runLanguageServer(
+                        DEFAULT_WORKSPACE_ROOT,
+                        code,
+                        /* callInitialize */ true,
+                        undefined,
+                        undefined,
+                        /* supportsBackgroundThread */ false,
+                        supportsPullDiagnostics
+                    );
+
+                    await openFile(info, 'marker');
+                    const fileUri = info.testData.markerPositions.get('marker')!.fileUri.toString();
+                    const progressReporterCount = info.progressReporters.length;
+
+                    await info.connection.sendRequest(DocumentDiagnosticRequest.type, {
+                        textDocument: { uri: fileUri },
+                    });
+
+                    assert.strictEqual(info.progressReporters.length, progressReporterCount);
+                });
+
                 // Regression test: in open-files-only mode, diagnostics for a library/out-of-workspace
                 // file that was transiently opened (e.g. via go-to-definition) must clear once the client
                 // closes the file. A re-pull of the now-closed file must return an empty `full` report.

--- a/packages/pyright-internal/src/typeServer/server.ts
+++ b/packages/pyright-internal/src/typeServer/server.ts
@@ -499,53 +499,47 @@ export class TypeServer extends LanguageServerBase {
             return result;
         }
 
-        this.incrementAnalysisProgress();
+        if (params.previousResultId !== diagnosticsVersion.toString() && sourceFile) {
+            let diagnosticsVersionAfter = UncomputedDiagnosticsVersion - 1;
+            let serverDiagnostics: AnalyzerDiagnostic[] = [];
 
-        try {
-            if (params.previousResultId !== diagnosticsVersion.toString() && sourceFile) {
-                let diagnosticsVersionAfter = UncomputedDiagnosticsVersion - 1;
-                let serverDiagnostics: AnalyzerDiagnostic[] = [];
+            while (diagnosticsVersion !== diagnosticsVersionAfter && !token.isCancellationRequested && sourceFile) {
+                sourceFile = workspace.service.getSourceFile(uri);
+                diagnosticsVersion = sourceFile?.getDiagnosticVersion() ?? UncomputedDiagnosticsVersion;
 
-                while (diagnosticsVersion !== diagnosticsVersionAfter && !token.isCancellationRequested && sourceFile) {
-                    sourceFile = workspace.service.getSourceFile(uri);
-                    diagnosticsVersion = sourceFile?.getDiagnosticVersion() ?? UncomputedDiagnosticsVersion;
-
-                    if (sourceFile) {
-                        serverDiagnostics = await workspace.service.analyzeFileAndGetDiagnostics(uri, token);
-                    }
-
-                    const sourceFileAfter = workspace.service.getSourceFile(uri);
-                    diagnosticsVersionAfter = sourceFileAfter?.getDiagnosticVersion() ?? UncomputedDiagnosticsVersion;
+                if (sourceFile) {
+                    serverDiagnostics = await workspace.service.analyzeFileAndGetDiagnostics(uri, token);
                 }
 
-                // Use the type server's converter which handles TaskItem diagnostics. Pass
-                // `true` for the tag-support flags unconditionally: a TSP child doesn't
-                // receive the actual client capabilities, but a foreground server relays
-                // these diagnostics directly and the original client does support them.
-                const lspDiagnostics = serverDiagnostics
-                    .map((d) =>
-                        this.convertDiagnostic(
-                            d,
-                            workspace.service.fs,
-                            /* supportsUnnecessaryDiagnosticTag */ true,
-                            /* supportsTaskItemDiagnosticTag */ true
-                        )
-                    )
-                    .filter((d): d is Diagnostic => d !== undefined);
-
-                result.resultId =
-                    diagnosticsVersionAfter === UncomputedDiagnosticsVersion
-                        ? undefined
-                        : diagnosticsVersionAfter.toString();
-                result.items = lspDiagnostics;
-            } else {
-                (result as any).kind = 'unchanged';
-                result.resultId =
-                    diagnosticsVersion === UncomputedDiagnosticsVersion ? undefined : diagnosticsVersion.toString();
-                delete (result as any).items;
+                const sourceFileAfter = workspace.service.getSourceFile(uri);
+                diagnosticsVersionAfter = sourceFileAfter?.getDiagnosticVersion() ?? UncomputedDiagnosticsVersion;
             }
-        } finally {
-            this.decrementAnalysisProgress();
+
+            // Use the type server's converter which handles TaskItem diagnostics. Pass
+            // `true` for the tag-support flags unconditionally: a TSP child doesn't
+            // receive the actual client capabilities, but a foreground server relays
+            // these diagnostics directly and the original client does support them.
+            const lspDiagnostics = serverDiagnostics
+                .map((d) =>
+                    this.convertDiagnostic(
+                        d,
+                        workspace.service.fs,
+                        /* supportsUnnecessaryDiagnosticTag */ true,
+                        /* supportsTaskItemDiagnosticTag */ true
+                    )
+                )
+                .filter((d): d is Diagnostic => d !== undefined);
+
+            result.resultId =
+                diagnosticsVersionAfter === UncomputedDiagnosticsVersion
+                    ? undefined
+                    : diagnosticsVersionAfter.toString();
+            result.items = lspDiagnostics;
+        } else {
+            (result as any).kind = 'unchanged';
+            result.resultId =
+                diagnosticsVersion === UncomputedDiagnosticsVersion ? undefined : diagnosticsVersion.toString();
+            delete (result as any).items;
         }
 
         return result;


### PR DESCRIPTION
## Summary

Fixes #11408.

Pyright no longer creates a work-done progress notification for each document diagnostic pull request.

## Root cause

When a client requested document diagnostics, Pyright incremented the global analysis progress counter before analyzing the file and decremented it afterward.

For clients that support work-done progress, changing the counter from zero to one caused Pyright to create a new progress reporter and send begin, report, and end notifications. Clients such as Neovim request updated diagnostics after document changes, so this produced a new `lsp.progress` notification on nearly every keystroke.

Document diagnostic pulls are individual client requests and should not be represented as global background-analysis progress.

## Fix

Remove the global analysis progress updates from document diagnostic handling in both the regular language server and the type server.

Background and workspace analysis continue to report progress through the existing progress reporter. Only the per-document diagnostic requests stop creating server-initiated work-done progress notifications.

The now-unused diagnostic progress counter and its helper methods were also removed.

## Tests

Added a regression test that performs a document diagnostic pull and verifies that it does not create a new work-done progress reporter.