### PR TITLE
Report async comprehensions inside lambdas

### DIFF
--- a/packages/pyright-internal/src/analyzer/binder.ts
+++ b/packages/pyright-internal/src/analyzer/binder.ts
@@ -2444,7 +2444,15 @@ export class Binder extends ParseTreeWalker {
     }
 
     override visitComprehension(node: ComprehensionNode): boolean {
-        const enclosingFunction = ParseTreeUtils.getEnclosingFunction(node);
+        // Use evaluation scopes so lambda and class bodies act as non-async boundaries,
+        // while lambda defaults and class headers retain their enclosing context.
+        let enclosingScopeNode = ParseTreeUtils.getEvaluationScopeNode(node, this._nodeInfo).node;
+        while (
+            enclosingScopeNode.nodeType === ParseNodeType.Comprehension ||
+            enclosingScopeNode.nodeType === ParseNodeType.TypeParameterList
+        ) {
+            enclosingScopeNode = ParseTreeUtils.getEvaluationScopeNode(enclosingScopeNode.parent!, this._nodeInfo).node;
+        }
 
         // The first iterable is executed outside of the comprehension scope.
         if (node.d.forIfNodes.length > 0 && node.d.forIfNodes[0].nodeType === ParseNodeType.ComprehensionFor) {
@@ -2474,7 +2482,10 @@ export class Binder extends ParseTreeWalker {
                         // Async for is not allowed outside of an async function
                         // unless we're in ipython mode.
                         if (compr.d.asyncToken && !this._fileInfo.ipythonMode) {
-                            if (!enclosingFunction || !enclosingFunction.d.isAsync) {
+                            if (
+                                enclosingScopeNode.nodeType !== ParseNodeType.Function ||
+                                !enclosingScopeNode.d.isAsync
+                            ) {
                                 // Allow if it's within a generator expression. Execution of
                                 // generator expressions is deferred and therefore can be
                                 // run within the context of an async function later.

--- a/packages/pyright-internal/src/tests/parser.test.ts
+++ b/packages/pyright-internal/src/tests/parser.test.ts
@@ -67,6 +67,122 @@ test('Parser2', () => {
     assert.strictEqual(diagSink.getErrors().length, 0);
 });
 
+test('Async comprehensions respect lambda function boundaries', () => {
+    const testCases = [
+        {
+            name: 'direct async comprehensions',
+            source: `from typing import Any
+async def func(values: Any):
+    [value async for value in values]
+    {value async for value in values}
+    {value: value async for value in values}
+    (value async for value in values)`,
+            expectedErrors: 0,
+        },
+        {
+            name: 'list comprehension in lambda',
+            source: `from typing import Any
+async def func(values: Any):
+    return lambda: [value async for value in values]`,
+            expectedErrors: 1,
+        },
+        {
+            name: 'set comprehension in lambda',
+            source: `from typing import Any
+async def func(values: Any):
+    return lambda: {value async for value in values}`,
+            expectedErrors: 1,
+        },
+        {
+            name: 'dict comprehension in lambda',
+            source: `from typing import Any
+async def func(values: Any):
+    return lambda: {value: value async for value in values}`,
+            expectedErrors: 1,
+        },
+        {
+            name: 'generator expression in lambda',
+            source: `from typing import Any
+async def func(values: Any):
+    return lambda: (value async for value in values)`,
+            expectedErrors: 0,
+        },
+        {
+            name: 'nested lambda body',
+            source: `from typing import Any
+async def func(values: Any):
+    return lambda: lambda: [value async for value in values]`,
+            expectedErrors: 1,
+        },
+        {
+            name: 'nested lambda default in lambda body',
+            source: `from typing import Any
+async def func(values: Any):
+    return lambda: (lambda default=[value async for value in values]: default)`,
+            expectedErrors: 1,
+        },
+        {
+            name: 'lambda default in async function',
+            source: `from typing import Any
+async def func(values: Any):
+    return lambda default=[value async for value in values]: default`,
+            expectedErrors: 0,
+        },
+        {
+            name: 'eager comprehensions in sync function',
+            source: `from typing import Any
+def func(values: Any):
+    [value async for value in values]
+    {value async for value in values}
+    {value: value async for value in values}`,
+            expectedErrors: 3,
+        },
+        {
+            name: 'generator expression in sync function',
+            source: `from typing import Any
+def func(values: Any):
+    return (value async for value in values)`,
+            expectedErrors: 0,
+        },
+        {
+            name: 'nested sync function',
+            source: `from typing import Any
+async def func(values: Any):
+    def nested():
+        return [value async for value in values]`,
+            expectedErrors: 1,
+        },
+        {
+            name: 'nested class body',
+            source: `from typing import Any
+class_values: Any
+async def func():
+    class Nested:
+        values = [value async for value in class_values]`,
+            expectedErrors: 1,
+        },
+    ];
+
+    for (const testCase of testCases) {
+        const code = testCase.source
+            .split('\n')
+            .map((line) => `//// ${line}`)
+            .join('\n');
+        const state = parseAndGetTestState(code).state;
+        while (state.program.analyze()) {
+            // Analyze until stable.
+        }
+
+        const source = state.program.getBoundSourceFile(state.activeFile.fileUri)!;
+        const diagnostics = source.getDiagnostics(state.configOptions) ?? [];
+        const asyncContextDiagnostics = diagnostics.filter(
+            (diagnostic) => diagnostic.message === LocMessage.asyncNotInAsyncFunction()
+        );
+
+        assert.strictEqual(asyncContextDiagnostics.length, testCase.expectedErrors, testCase.name);
+    }
+});
+
 test('FStringEmptyTuple', () => {
     assert.doesNotThrow(() => {
         const diagSink = new DiagnosticSink();

--- a/packages/pyright-internal/src/tests/samples/comprehension12.py
+++ b/packages/pyright-internal/src/tests/samples/comprehension12.py
@@ -1,0 +1,46 @@
+# This sample tests that lambdas create non-async function boundaries
+# for eager asynchronous comprehensions.
+
+from typing import Any
+
+class_values: Any
+
+
+async def async_function(values: Any):
+    [value async for value in values]
+    {value async for value in values}
+    {value: value async for value in values}
+    (value async for value in values)
+
+    # These should generate errors because a lambda is not async.
+    lambda: [value async for value in values]
+    lambda: {value async for value in values}
+    lambda: {value: value async for value in values}
+
+    # An async generator expression is allowed because its execution is deferred.
+    lambda: (value async for value in values)
+
+    # These should generate errors at the nearest lambda boundary.
+    lambda: lambda: [value async for value in values]
+    lambda: (lambda default=[value async for value in values]: default)
+
+    # A lambda default is evaluated in its enclosing async function.
+    lambda default=[value async for value in values]: default
+
+    def sync_nested():
+        # This should generate an error in a nested sync function.
+        [value async for value in values]
+
+    class Nested:
+        # This should generate an error in a nested class body.
+        values = [value async for value in class_values]
+
+
+def sync_function(values: Any):
+    # These should generate errors in a sync function.
+    [value async for value in values]
+    {value async for value in values}
+    {value: value async for value in values}
+
+    # An async generator expression is allowed in a sync function.
+    (value async for value in values)

--- a/packages/pyright-internal/src/tests/typeEvaluator3.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator3.test.ts
@@ -584,6 +584,12 @@ test('Comprehension11', () => {
     TestUtils.validateResults(analysisResults, 0);
 });
 
+test('Comprehension12', () => {
+    const analysisResults = TestUtils.typeAnalyzeSampleFiles(['comprehension12.py']);
+
+    TestUtils.validateResults(analysisResults, 10);
+});
+
 test('Literals1', () => {
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['literals1.py']);
 


### PR DESCRIPTION
## Description

Pyright did not report an error for eager asynchronous comprehensions inside a lambda body when the lambda was nested in an async function. A lambda body is a separate, non-async function boundary, so list, set, and dictionary async comprehensions there are invalid even when the enclosing `def` is async.

Lambda default expressions and class header expressions are evaluated in their enclosing context and must continue to inherit that context. Async generator expressions also remain allowed because their execution is deferred.

## How you figured out what to do

I reproduced the behavior for every comprehension form and compared the accepted syntax with CPython. I then traced comprehension binding through `Binder.visitComprehension` and found that it used `getEnclosingFunction`, which skipped lambda and class evaluation boundaries and could therefore select an outer async function.

I reviewed the existing evaluation-scope utilities and the binder's handling of comprehension scopes, lambda defaults, nested functions, class bodies, and deferred generator expressions. This identified `getEvaluationScopeNode` as the appropriate way to determine the context where each comprehension is evaluated.

## Implementation

`Binder.visitComprehension` now determines the nearest evaluation scope rather than only the nearest function declaration. It skips the comprehension's own synthetic scope and type-parameter scopes, then requires that the resulting scope be an async function before permitting eager async comprehensions.

This makes lambda and class bodies non-async boundaries while preserving the enclosing context for lambda defaults and class headers. Existing deferred-generator behavior is unchanged.

Screenshots or GIFs are not applicable because this change affects syntax diagnostics and has no visual UI.

## Testing

Added parser coverage for list, set, dictionary, and generator comprehensions in:

- async and synchronous functions
- direct and nested lambda bodies
- lambda default expressions
- nested synchronous functions
- class bodies

Added `comprehension12.py` evaluator coverage with expected diagnostic counts. The targeted parser and evaluator tests, Pyright build and typecheck, Prettier, and ESLint passed.

## Addresses

Fixes #11158