### PR TITLE
Fix incomplete builtin completions

### DIFF
--- a/packages/pyright-internal/src/languageServerBase.ts
+++ b/packages/pyright-internal/src/languageServerBase.ts
@@ -25,7 +25,6 @@ import {
     CompletionItem,
     CompletionList,
     CompletionParams,
-    CompletionTriggerKind,
     ConfigurationItem,
     Connection,
     Declaration,
@@ -174,8 +173,6 @@ export abstract class LanguageServerBase implements LanguageServerInterface, Dis
 
     private _progressReporter: ProgressReporter;
     private _progressReportCounter = 0;
-
-    private _lastTriggerKind: CompletionTriggerKind | undefined = CompletionTriggerKind.Invoked;
 
     private _initialized = false;
     private _workspaceFoldersChangedDisposable: Disposable | undefined;
@@ -936,26 +933,6 @@ export abstract class LanguageServerBase implements LanguageServerInterface, Dis
         }, token);
     }
 
-    protected setCompletionIncomplete(params: CompletionParams, completions: CompletionList | null) {
-        // We set completion incomplete for the first invocation and next consecutive call,
-        // but after that we mark it as completed so the client doesn't repeatedly call back.
-        // We mark the first one as incomplete because completion could be invoked without
-        // any meaningful character provided, such as an explicit completion invocation (ctrl+space)
-        // or a period. That might cause us to not include some items (e.g., auto-imports).
-        // The next consecutive call provides some characters to help us to pick
-        // better completion items. After that, we are not going to introduce new items,
-        // so we can let the client to do the filtering and caching.
-        const completionIncomplete =
-            this._lastTriggerKind !== CompletionTriggerKind.TriggerForIncompleteCompletions ||
-            params.context?.triggerKind !== CompletionTriggerKind.TriggerForIncompleteCompletions;
-
-        this._lastTriggerKind = params.context?.triggerKind;
-
-        if (completions) {
-            completions.isIncomplete = completionIncomplete;
-        }
-    }
-
     protected async onCompletion(params: CompletionParams, token: CancellationToken): Promise<CompletionList | null> {
         const uri = this.convertLspUriStringToUri(params.textDocument.uri);
         const workspace = await this.getWorkspaceForFile(uri);
@@ -978,7 +955,6 @@ export abstract class LanguageServerBase implements LanguageServerInterface, Dis
                 token
             ).getCompletions();
 
-            this.setCompletionIncomplete(params, completions);
             return completions;
         }, token);
     }

--- a/packages/pyright-internal/src/languageService/completionProvider.ts
+++ b/packages/pyright-internal/src/languageService/completionProvider.ts
@@ -373,6 +373,8 @@ const maxRecentCompletions = 128;
 export class CompletionProvider {
     private static _mostRecentCompletions: RecentCompletionInfo[] = [];
 
+    private _isIncomplete = false;
+
     // Indicates whether invocation position is inside of string literal
     // token or an f-string expression.
     private _stringLiteralContainer: StringToken | FStringStartToken | undefined = undefined;
@@ -406,7 +408,7 @@ export class CompletionProvider {
         }
 
         const completionMap = this._getCompletions();
-        const completionList = CompletionList.create(completionMap?.toArray());
+        const completionList = CompletionList.create(completionMap?.toArray(), this._isIncomplete);
         if (this.options.completionItemDataDefault) {
             hoistCompletionItemDataDefault(completionList, this.fileUri, this.position);
         }
@@ -992,6 +994,13 @@ export class CompletionProvider {
         if (!this.configOptions.autoImportCompletions) {
             // If auto import on the server is turned off or this particular invocation
             // is turned off (ex, notebook), don't do any thing.
+            return;
+        }
+
+        // Auto-import candidates require a nonempty filter. Avoid the expensive index scan
+        // until the client has one, and tell it that a later request can add candidates.
+        if (!priorWord) {
+            this._isIncomplete = true;
             return;
         }
 

--- a/packages/pyright-internal/src/tests/completions.test.ts
+++ b/packages/pyright-internal/src/tests/completions.test.ts
@@ -861,6 +861,95 @@ test('completion quote trigger - middle', async () => {
     assert.strictEqual(result?.items.length, 0);
 });
 
+test('completion incomplete only while auto-import candidates are deferred', () => {
+    const code = `
+// @filename: test.py
+//// import os
+//// /*empty*/
+//// pri/*module*/
+//// def func():
+////     private_value = 1
+////     pri/*function*/
+//// Pri/*autoImport*/
+
+// @filename: unused.py
+//// class PriorityAutoImport:
+////     pass
+    `;
+
+    const state = parseAndGetTestState(code).state;
+    state.openFiles(state.testData.files.map((f) => f.fileName));
+
+    while (state.workspace.service.test_program.analyze());
+
+    const getCompletions = (markerName: string) => {
+        const marker = state.getMarkerByName(markerName);
+        const uri = Uri.file(marker.fileName, state.serviceProvider);
+        const position = state.convertOffsetToPosition(marker.fileName, marker.position);
+        const options: CompletionOptions = {
+            format: 'markdown',
+            snippet: false,
+            lazyEdit: false,
+        };
+
+        return new CompletionProvider(state.program, uri, position, options, CancellationToken.None).getCompletions();
+    };
+
+    const emptyResult = getCompletions('empty');
+    assert(emptyResult);
+    assert.strictEqual(emptyResult.isIncomplete, true);
+    assert(emptyResult.items.some((item) => item.label === 'print'));
+    assert(!emptyResult.items.some((item) => item.label === 'PriorityAutoImport'));
+
+    for (const markerName of ['module', 'function']) {
+        const result = getCompletions(markerName);
+        assert(result);
+        assert.strictEqual(result.isIncomplete, false);
+        assert(result.items.some((item) => item.label === 'print'));
+    }
+
+    const functionResult = getCompletions('function')!;
+    assert(functionResult.items.some((item) => item.label === 'private_value'));
+
+    const autoImportResult = getCompletions('autoImport');
+    assert(autoImportResult);
+    assert.strictEqual(autoImportResult.isIncomplete, false);
+    assert(autoImportResult.items.some((item) => item.label === 'PriorityAutoImport'));
+});
+
+test('completion list is complete when auto-import is disabled', () => {
+    const code = `
+// @filename: pyrightconfig.json
+//// {
+////   "autoImportCompletions": false
+//// }
+
+// @filename: test.py
+//// /*marker*/
+    `;
+
+    const state = parseAndGetTestState(code).state;
+    const marker = state.getMarkerByName('marker');
+    const uri = Uri.file(marker.fileName, state.serviceProvider);
+    const position = state.convertOffsetToPosition(marker.fileName, marker.position);
+    const options: CompletionOptions = {
+        format: 'markdown',
+        snippet: false,
+        lazyEdit: false,
+    };
+
+    const result = new CompletionProvider(
+        state.program,
+        uri,
+        position,
+        options,
+        CancellationToken.None
+    ).getCompletions();
+
+    assert(result);
+    assert.strictEqual(result.isIncomplete, false);
+});
+
 test('auto import sort text', async () => {
     const code = `
 // @filename: test.py

--- a/packages/pyright-internal/src/tests/fourslash/completions.builtinPrefix.fourslash.ts
+++ b/packages/pyright-internal/src/tests/fourslash/completions.builtinPrefix.fourslash.ts
@@ -1,0 +1,23 @@
+/// <reference path="typings/fourslash.d.ts" />
+
+// @filename: test.py
+//// import os
+////
+//// pri[|/*module*/|]
+////
+//// def func():
+////     private_value = 1
+////     pri[|/*function*/|]
+
+// @ts-ignore
+await helper.verifyCompletion('included', 'markdown', {
+    module: {
+        completions: [{ label: 'print', kind: Consts.CompletionItemKind.Function }],
+    },
+    function: {
+        completions: [
+            { label: 'print', kind: Consts.CompletionItemKind.Function },
+            { label: 'private_value', kind: Consts.CompletionItemKind.Variable },
+        ],
+    },
+});

--- a/packages/pyright-internal/src/tests/languageServer.test.ts
+++ b/packages/pyright-internal/src/tests/languageServer.test.ts
@@ -11,6 +11,7 @@ import {
     CancellationToken,
     CompletionItem,
     CompletionRequest,
+    CompletionTriggerKind,
     ConfigurationItem,
     DidChangeWorkspaceFoldersNotification,
     DidCloseTextDocumentNotification,
@@ -176,6 +177,50 @@ describe(`Basic language server tests`, () => {
 
         const completionItem = completionResult.items.find((i: CompletionItem) => i.label === 'path')!;
         assert(completionItem);
+        assert.strictEqual(completionResult.isIncomplete, false);
+    });
+
+    test('Completion incompleteness reflects deferred auto-imports', async () => {
+        const code = `
+// @filename: test.py
+//// import os
+//// [|/*empty*/|]
+//// [|pri/*prefix*/|]
+
+// @filename: unused.py
+//// class PriorityAutoImport:
+////     pass
+        `;
+        const info = await runLanguageServer(DEFAULT_WORKSPACE_ROOT, code, /* callInitialize */ true);
+
+        openFile(info, 'empty');
+
+        const getCompletions = async (markerName: string, triggerKind: CompletionTriggerKind) => {
+            const marker = info.testData.markerPositions.get(markerName)!;
+            const text = info.testData.files.find((d) => d.fileName === marker.fileName)!.content;
+            const parseResult = getParseResults(text);
+            const result = await info.connection.sendRequest(
+                CompletionRequest.type,
+                {
+                    textDocument: { uri: marker.fileUri.toString() },
+                    position: convertOffsetToPosition(marker.position, parseResult.tokenizerOutput.lines),
+                    context: { triggerKind },
+                },
+                CancellationToken.None
+            );
+
+            assert(result);
+            assert(!isArray(result));
+            return result;
+        };
+
+        const emptyResult = await getCompletions('empty', CompletionTriggerKind.Invoked);
+        assert.strictEqual(emptyResult.isIncomplete, true);
+        assert(!emptyResult.items.some((item) => item.label === 'PriorityAutoImport'));
+
+        const prefixResult = await getCompletions('prefix', CompletionTriggerKind.TriggerForIncompleteCompletions);
+        assert.strictEqual(prefixResult.isIncomplete, false);
+        assert(prefixResult.items.some((item) => item.label === 'print'));
     });
 
     [false, true].forEach((supportsPullDiagnostics) => {


### PR DESCRIPTION
## Description

Fix incomplete completion lists for deferred auto-imports without dropping builtins, so names like `print` remain available in module and function completions while the list stays incomplete only until a usable prefix exists.

## How you figured out what to do

I traced request-level incompleteness handling through `LanguageServerBase`, `CompletionProvider`, and the completion tests. The existing logic tied incompleteness to the previous trigger kind rather than whether auto-import results were deferred, which allowed builtins to disappear from prefix completions.

## Implementation

Move completion incompleteness ownership into `CompletionProvider` and track it per request. The provider marks a list incomplete only when auto-import completions are enabled and the request has no filter text, removing the cross-request trigger heuristic from `LanguageServerBase`.

Screenshots or GIFs are not applicable because this change affects analyzer or language-service behavior and has no visual UI.

## Testing

Added provider, fourslash, and language-server regressions covering empty invocations, `print` at module and function scope, disabled auto-imports, and request-path consistency. Public and hidden checks and the Pyright build passed.

## Addresses

Fixes #11659
