### PR TITLE
Fix overload override matching order

### DIFF
--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -29129,20 +29129,37 @@ export function createTypeEvaluator(
             });
         }
 
-        // For an overloaded method overriding an overloaded method, the overrides
-        // must all match and be in the correct order. It is OK if the base method
-        // has additional overloads that are not present in the override.
+        // For an overloaded method overriding an overloaded method, all base overloads
+        // must match in the correct order. The override can have additional overloads.
 
         let previousMatchIndex = -1;
         const baseOverloads = OverloadedType.getOverloads(baseMethod);
+        const matchedBaseOverloadIndices = new Set<number>();
+        const getCallDomainType = (overload: FunctionType) => {
+            // Remove the implicit receiver because it belongs to different classes
+            // and isn't part of the overload's call domain.
+            return FunctionType.clone(
+                overload,
+                FunctionType.isInstanceMethod(overload) ||
+                    FunctionType.isClassMethod(overload) ||
+                    FunctionType.isConstructorMethod(overload)
+            );
+        };
+        const baseCallDomainTypes = baseOverloads.map(getCallDomainType);
+        const overlapFlags =
+            AssignTypeFlags.SkipReturnTypeCheck |
+            AssignTypeFlags.OverloadOverlap |
+            AssignTypeFlags.DisallowExtraKwargsForTd;
 
         for (const overrideOverload of OverloadedType.getOverloads(overrideMethod)) {
-            let possibleMatchIndex: number | undefined;
+            const compatibleBaseOverloadIndices: number[] = [];
+            const incompatibleOverlappingBaseIndices: number[] = [];
+            const overrideCallDomainType = getCallDomainType(overrideOverload);
 
-            let matchIndex = baseOverloads.findIndex((baseOverload, index) => {
+            baseOverloads.forEach((baseOverload, index) => {
                 // If the override isn't applicable for this base class, skip the check.
                 if (baseClass && !isOverrideMethodApplicable(baseOverload, baseClass)) {
-                    return false;
+                    return;
                 }
 
                 const isCompatible = validateOverrideMethodInternal(
@@ -29152,47 +29169,86 @@ export function createTypeEvaluator(
                     enforceParamNames
                 );
 
-                // If the override is compatible but the match is one that is below the previous
-                // matched index, keep looking for additional matches. Record the fact that
-                // we found at least one match.
-                if (isCompatible && index <= previousMatchIndex && possibleMatchIndex === undefined) {
-                    possibleMatchIndex = index;
+                if (isCompatible) {
+                    compatibleBaseOverloadIndices.push(index);
+                } else {
+                    if (
+                        assignType(
+                            baseCallDomainTypes[index],
+                            overrideCallDomainType,
+                            /* diag */ undefined,
+                            /* constraints */ undefined,
+                            overlapFlags | AssignTypeFlags.PartialOverloadOverlap
+                        ) ||
+                        assignType(
+                            overrideCallDomainType,
+                            baseCallDomainTypes[index],
+                            /* diag */ undefined,
+                            /* constraints */ undefined,
+                            overlapFlags | AssignTypeFlags.PartialOverloadOverlap
+                        )
+                    ) {
+                        incompatibleOverlappingBaseIndices.push(index);
+                    }
+                }
+            });
+
+            const hasUnshadowedIncompatibleOverlap = incompatibleOverlappingBaseIndices.some((overlapIndex) => {
+                // A prior override already handles this base domain, so it shadows
+                // the overlapping portion of the current override.
+                if (matchedBaseOverloadIndices.has(overlapIndex)) {
                     return false;
                 }
 
-                return isCompatible;
+                // An earlier compatible base overload shadows a later base overload
+                // if it covers the entire call domain of the current override.
+                return !compatibleBaseOverloadIndices.some((compatibleIndex) => {
+                    return (
+                        compatibleIndex < overlapIndex &&
+                        assignType(
+                            overrideCallDomainType,
+                            baseCallDomainTypes[compatibleIndex],
+                            /* diag */ undefined,
+                            /* constraints */ undefined,
+                            overlapFlags
+                        )
+                    );
+                });
             });
 
-            if (matchIndex < 0 && possibleMatchIndex !== undefined) {
-                matchIndex = possibleMatchIndex;
+            if (hasUnshadowedIncompatibleOverlap) {
+                diag.addMessage(LocAddendum.overrideOverloadNoMatch());
+                return false;
             }
 
-            if (matchIndex < 0) {
-                break;
+            const newlyCoveredBaseIndices = compatibleBaseOverloadIndices.filter(
+                (index) => !matchedBaseOverloadIndices.has(index)
+            );
+
+            if (newlyCoveredBaseIndices.length === 0) {
+                continue;
             }
 
-            if (matchIndex < previousMatchIndex) {
+            if (newlyCoveredBaseIndices.some((index) => index < previousMatchIndex)) {
                 diag.addMessage(LocAddendum.overrideOverloadOrder());
                 return false;
             }
 
-            previousMatchIndex = matchIndex;
+            previousMatchIndex = Math.max(...newlyCoveredBaseIndices);
+            newlyCoveredBaseIndices.forEach((index) => matchedBaseOverloadIndices.add(index));
         }
 
-        if (previousMatchIndex < baseOverloads.length - 1) {
-            const unmatchedOverloads = baseOverloads.slice(previousMatchIndex + 1);
-
-            // See if all of the remaining overrides are nonapplicable.
-            if (
-                !baseClass ||
-                unmatchedOverloads.some((overload) => {
-                    return isOverrideMethodApplicable(overload, baseClass);
-                })
-            ) {
-                // We didn't find matches for all of the base overloads.
-                diag.addMessage(LocAddendum.overrideOverloadNoMatch());
-                return false;
-            }
+        if (
+            baseOverloads.some((overload, index) => {
+                return (
+                    !matchedBaseOverloadIndices.has(index) &&
+                    (!baseClass || isOverrideMethodApplicable(overload, baseClass))
+                );
+            })
+        ) {
+            // We didn't find matches for all of the base overloads.
+            diag.addMessage(LocAddendum.overrideOverloadNoMatch());
+            return false;
         }
 
         return true;

--- a/packages/pyright-internal/src/tests/samples/overloadOverride2.py
+++ b/packages/pyright-internal/src/tests/samples/overloadOverride2.py
@@ -1,0 +1,166 @@
+# This sample tests overloaded methods that add mutually exclusive overloads
+# when overriding another overloaded method.
+
+# pyright: reportIncompatibleMethodOverride=true, reportOverlappingOverload=false
+
+from typing import Literal, overload
+
+
+class Base:
+    @overload
+    def map(self, x: str, wrap: Literal[True]) -> tuple[str]: ...
+
+    @overload
+    def map(self, x: int, wrap: Literal[True]) -> tuple[int]: ...
+
+    def map(self, x: str | int, wrap: Literal[True]) -> tuple[str] | tuple[int]:
+        raise NotImplementedError
+
+
+class ExtrasFirst(Base):
+    @overload
+    def map(self, x: str, wrap: Literal[False] = False) -> str: ...
+
+    @overload
+    def map(self, x: int, wrap: Literal[False] = False) -> int: ...
+
+    @overload
+    def map(self, x: str, wrap: Literal[True]) -> tuple[str]: ...
+
+    @overload
+    def map(self, x: int, wrap: Literal[True]) -> tuple[int]: ...
+
+    def map(self, x: str | int, wrap: bool = False) -> str | int | tuple[str] | tuple[int]:
+        raise NotImplementedError
+
+
+class ExtrasLast(Base):
+    @overload
+    def map(self, x: str, wrap: Literal[True]) -> tuple[str]: ...
+
+    @overload
+    def map(self, x: int, wrap: Literal[True]) -> tuple[int]: ...
+
+    @overload
+    def map(self, x: str, wrap: Literal[False] = False) -> str: ...
+
+    @overload
+    def map(self, x: int, wrap: Literal[False] = False) -> int: ...
+
+    def map(self, x: str | int, wrap: bool = False) -> str | int | tuple[str] | tuple[int]:
+        raise NotImplementedError
+
+
+class ReorderedMatches(Base):
+    @overload
+    def map(self, x: int, wrap: Literal[True]) -> tuple[int]: ...
+
+    @overload
+    def map(self, x: str, wrap: Literal[True]) -> tuple[str]: ...
+
+    # This should generate an error because matching overloads remain ordered.
+    def map(self, x: str | int, wrap: Literal[True]) -> tuple[str] | tuple[int]:
+        raise NotImplementedError
+
+
+class IncompatibleOverlap(Base):
+    @overload
+    def map(self, x: str, wrap: bool) -> str: ...
+
+    @overload
+    def map(self, x: str, wrap: Literal[True]) -> tuple[str]: ...
+
+    @overload
+    def map(self, x: int, wrap: Literal[True]) -> tuple[int]: ...
+
+    # This should generate an error because the additional overload overlaps
+    # incompatibly even though later overloads match all base overloads.
+    def map(self, x: str | int, wrap: bool) -> str | tuple[str] | tuple[int]:
+        raise NotImplementedError
+
+
+class BroadOverlapHidesBase(Base):
+    @overload
+    def map(self, x: str | int, wrap: Literal[True]) -> tuple[str]: ...
+
+    @overload
+    def map(self, x: str, wrap: Literal[True]) -> tuple[str]: ...
+
+    @overload
+    def map(self, x: int, wrap: Literal[True]) -> tuple[int]: ...
+
+    # This should generate an error because the first override is compatible
+    # with the string base overload but overlaps the integer overload incompatibly.
+    def map(self, x: str | int, wrap: Literal[True]) -> tuple[str] | tuple[int]:
+        raise NotImplementedError
+
+
+class SameReturnBase:
+    @overload
+    def convert(self, x: str) -> object: ...
+
+    @overload
+    def convert(self, x: int) -> object: ...
+
+    def convert(self, x: str | int) -> object:
+        raise NotImplementedError
+
+
+class BroadCoversMultiple(SameReturnBase):
+    @overload
+    def convert(self, x: str | int) -> object: ...
+
+    @overload
+    def convert(self, x: bytes) -> object: ...
+
+    def convert(self, x: str | int | bytes) -> object:
+        raise NotImplementedError
+
+
+class OrderedOverlapBase:
+    @overload
+    def select(self, x: int) -> int: ...
+
+    @overload
+    def select(self, x: object) -> object: ...
+
+    def select(self, x: object) -> object:
+        raise NotImplementedError
+
+
+class IdenticalOrderedOverlap(OrderedOverlapBase):
+    @overload
+    def select(self, x: int) -> int: ...
+
+    @overload
+    def select(self, x: object) -> object: ...
+
+    def select(self, x: object) -> object:
+        raise NotImplementedError
+
+
+class SplitDomainBase:
+    @overload
+    def choose(self, x: str) -> str: ...
+
+    @overload
+    def choose(self, x: float) -> float: ...
+
+    @overload
+    def choose(self, x: bytes) -> str: ...
+
+    def choose(self, x: str | float | bytes) -> str | float:
+        raise NotImplementedError
+
+
+class ReorderedSplitDomain(SplitDomainBase):
+    @overload
+    def choose(self, x: float) -> float: ...
+
+    @overload
+    def choose(self, x: str | bytes) -> str: ...
+
+    # This should generate an error because this overload newly covers base
+    # overloads on both sides of the previously matched float overload.
+    def choose(self, x: str | float | bytes) -> str | float:
+        raise NotImplementedError

--- a/packages/pyright-internal/src/tests/typeEvaluator6.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator6.test.ts
@@ -109,6 +109,11 @@ test('OverloadOverride1', () => {
     TestUtils.validateResults(analysisResults, 1);
 });
 
+test('OverloadOverride2', () => {
+    const analysisResults = TestUtils.typeAnalyzeSampleFiles(['overloadOverride2.py']);
+    TestUtils.validateResults(analysisResults, 4);
+});
+
 test('OverloadImpl1', () => {
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['overloadImpl1.py']);
     TestUtils.validateResults(analysisResults, 6);


### PR DESCRIPTION
## Description

Accept overloaded overrides that add disjoint extra overloads or cover multiple base domains without spurious ordering failures, while continuing to reject incompatible overlaps and genuinely reordered matches.

## How you figured out what to do

I traced overloaded override comparison in `typeEvaluator.ts` and added a focused matrix of positive and negative subclass cases. The prior implementation selected one best match, which made compatibility depend on the placement of otherwise valid additional overloads.

## Implementation

Compare override overloads against base call domains rather than selecting a single match. The new logic tracks newly covered base overload indices, preserves monotonic base ordering, and rejects incompatible overlapping extras unless an earlier compatible match already shadows the overlap.

Screenshots or GIFs are not applicable because this change affects analyzer or language-service behavior and has no visual UI.

## Testing

Added `overloadOverride2.py` and its evaluator test with positive cases for extras before and after base overloads and broad compatible coverage, plus negative cases for reordered matches and incompatible broad overlaps. The evaluator regression suite passed.

## Addresses

Fixes #11549
