### PR TITLE
Fix ClassVar Self assignment context

### DIFF
--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -3142,6 +3142,7 @@ export function createTypeEvaluator(
                                 MemberAccessFlags.DeclaredTypesOnly
                             );
 
+                            selfType = isTypeVar(baseType) ? baseType : baseSubtype;
                             classOrObjectBase = baseSubtype;
                             memberAccessClass = classMemberInfo?.classType;
                             symbol = classMemberInfo?.symbol;
@@ -3157,6 +3158,7 @@ export function createTypeEvaluator(
                                 MemberAccessFlags.SkipInstanceMembers | MemberAccessFlags.DeclaredTypesOnly
                             );
 
+                            selfType = isTypeVar(baseType) ? baseType : baseSubtype;
                             classOrObjectBase = baseSubtype;
                             memberAccessClass = classMemberInfo?.classType;
                             symbol = classMemberInfo?.symbol;

--- a/packages/pyright-internal/src/tests/samples/classVar5.py
+++ b/packages/pyright-internal/src/tests/samples/classVar5.py
@@ -14,3 +14,25 @@ class Parent:
     @classmethod
     def __init_subclass__(cls):
         cls.x = {}
+
+
+class Baz:
+    values: ClassVar[list[Self]]
+
+
+Baz.values = []
+Baz.values = [Baz()]
+
+# This should generate an error.
+Baz.values = [1]
+
+
+class Child(Baz):
+    pass
+
+
+Child.values = []
+Child.values = [Child()]
+
+# This should generate an error.
+Child.values = [Baz()]

--- a/packages/pyright-internal/src/tests/typeEvaluator7.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator7.test.ts
@@ -876,7 +876,7 @@ test('ClassVar4', () => {
 test('ClassVar5', () => {
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['classVar5.py']);
 
-    TestUtils.validateResults(analysisResults, 0);
+    TestUtils.validateResults(analysisResults, 2);
 });
 
 test('ClassVar6', () => {


### PR DESCRIPTION
## Description

Allow empty and class-consistent assignments to `ClassVar[list[Self]]` while still rejecting values whose element types do not match the active class specialization.

## How you figured out what to do

I traced member assignment contextual typing in `typeEvaluator.ts` using the `Baz.values = []` reproduction. The declared member type was being specialized with the wrong `Self` context when assigning through a concrete class or subclass.

## Implementation

Refresh `selfType` for each class subtype before resolving the declared member type. Preserve the original type variable when appropriate; otherwise specialize `Self` against the concrete subtype currently being checked.

Screenshots or GIFs are not applicable because this change affects analyzer or language-service behavior and has no visual UI.

## Testing

Expanded `classVar5.py` with empty-list and correctly typed assignments for a base class and subclass, plus mismatched-element negative cases. The updated evaluator test expects only the two intended errors, and the evaluator regression suite passed.

## Addresses

Fixes #11445
