### PR TITLE
Fix variadic overload implementation validation

### DIFF
--- a/packages/pyright-internal/src/analyzer/checker.ts
+++ b/packages/pyright-internal/src/analyzer/checker.ts
@@ -2819,7 +2819,8 @@ export class Checker extends ParseTreeWalker {
             AssignTypeFlags.SkipReturnTypeCheck |
                 AssignTypeFlags.Contravariant |
                 AssignTypeFlags.SkipSelfClsTypeCheck |
-                AssignTypeFlags.DisallowExtraKwargsForTd
+                AssignTypeFlags.DisallowExtraKwargsForTd |
+                AssignTypeFlags.EnforceOverloadImplCallDomain
         );
 
         // Now check the return types.

--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -28143,7 +28143,9 @@ export function createTypeEvaluator(
         let canAssign = true;
         const checkReturnType = (flags & AssignTypeFlags.SkipReturnTypeCheck) === 0;
         const isContra = (flags & AssignTypeFlags.Contravariant) !== 0;
+        const enforceOverloadImplCallDomain = (flags & AssignTypeFlags.EnforceOverloadImplCallDomain) !== 0;
         flags &= ~AssignTypeFlags.SkipReturnTypeCheck;
+        flags &= ~AssignTypeFlags.EnforceOverloadImplCallDomain;
 
         const destParamSpec = FunctionType.getParamSpecFromArgsKwargs(destType);
         if (destParamSpec) {
@@ -28188,6 +28190,25 @@ export function createTypeEvaluator(
 
             // Skip over the *args parameter since it's handled separately below.
             if (paramIndex === destParamDetails.argsIndex) {
+                const srcParam = srcParamDetails.params[paramIndex];
+
+                // An unbounded *args parameter can consume zero arguments. It therefore
+                // cannot satisfy a required parameter in the source callable, even
+                // though it can provide the parameter's type when arguments are present.
+                if (
+                    enforceOverloadImplCallDomain &&
+                    !destParamDetails.hasUnpackedTypeVarTuple &&
+                    srcParam.param.category === ParamCategory.Simple &&
+                    !srcParam.defaultType
+                ) {
+                    diag?.createAddendum().addMessage(
+                        LocAddendum.functionParamDefaultMissing().format({
+                            name: srcParam.param.name ?? '',
+                        })
+                    );
+                    canAssign = false;
+                }
+
                 if (!isUnpackedTypeVarTuple(destParamDetails.params[destParamDetails.argsIndex].type)) {
                     skippedPosParamIndices.push(paramIndex);
                 }

--- a/packages/pyright-internal/src/analyzer/typeEvaluatorTypes.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluatorTypes.ts
@@ -649,6 +649,10 @@ export const enum AssignTypeFlags {
     // When assigning callables, should a kwargs with an unpacked TypedDict
     // disallow additional named arguments if it does not have extraItems?
     DisallowExtraKwargsForTd = 1 << 17,
+
+    // When validating an overload implementation, ensure that an unbounded
+    // *args parameter doesn't mask a required implementation parameter.
+    EnforceOverloadImplCallDomain = 1 << 18,
 }
 
 export interface TypeEvaluator {

--- a/packages/pyright-internal/src/tests/samples/overloadImpl4.py
+++ b/packages/pyright-internal/src/tests/samples/overloadImpl4.py
@@ -1,0 +1,81 @@
+# This sample tests overload implementation compatibility for variadic
+# parameter lists.
+
+# pyright: reportOverlappingOverload=false
+
+from typing import Any, Callable, ParamSpec, TypeVarTuple, overload
+
+
+class Base:
+    @overload
+    def get(self, key: str) -> Any: ...
+
+    @overload
+    def get(self, *keys: str) -> Any: ...
+
+    # This should generate an error because the second overload allows no keys.
+    def get(self, key: str, *keys: str) -> Any: ...
+
+
+class Derived(Base):
+    # This should continue to generate an override error. The issue does not
+    # require suppressing truthful diagnostics on subclasses.
+    def get(self, key: str, *keys: str) -> Any: ...
+
+
+class IncompatibleDerived(Base):
+    # This should generate an additional override error for incompatible types,
+    # even though the base implementation is itself invalid.
+    def get(self, key: int, *keys: int) -> Any: ...
+
+
+@overload
+def with_default(key: str) -> Any: ...
+
+
+@overload
+def with_default(*keys: str) -> Any: ...
+
+
+def with_default(key: str = "", *keys: str) -> Any: ...
+
+
+@overload
+def keyword_only(*values: int, flag: bool) -> int: ...
+
+
+@overload
+def keyword_only(*values: str, flag: bool) -> str: ...
+
+
+def keyword_only(*values: int | str, flag: bool) -> int | str: ...
+
+
+P = ParamSpec("P")
+
+
+@overload
+def paramspec(func: Callable[P, int], *args: P.args, **kwargs: P.kwargs) -> int: ...
+
+
+@overload
+def paramspec(func: None, *args: Any, **kwargs: Any) -> None: ...
+
+
+def paramspec(
+    func: Callable[P, int] | None, *args: P.args, **kwargs: P.kwargs
+) -> int | None: ...
+
+
+Ts = TypeVarTuple("Ts")
+
+
+@overload
+def variadic_tuple() -> tuple[()]: ...
+
+
+@overload
+def variadic_tuple(*values: *tuple[*Ts]) -> tuple[*Ts]: ...
+
+
+def variadic_tuple(*values: *tuple[*Ts]) -> tuple[*Ts]: ...

--- a/packages/pyright-internal/src/tests/typeEvaluator6.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator6.test.ts
@@ -124,6 +124,11 @@ test('OverloadImpl3', () => {
     TestUtils.validateResults(analysisResults, 2);
 });
 
+test('OverloadImpl4', () => {
+    const analysisResults = TestUtils.typeAnalyzeSampleFiles(['overloadImpl4.py']);
+    TestUtils.validateResults(analysisResults, 3);
+});
+
 test('OverloadOverlap1', () => {
     const configOptions = new ConfigOptions(Uri.empty());
 


### PR DESCRIPTION
## Description

Reject overload implementations whose required leading parameter is masked by an unbounded `*args`, while preserving valid variadic patterns and existing override diagnostics.

## How you figured out what to do

I traced overload implementation validation through `Checker.validateOverloadImplementation` and function assignment. An unbounded `*args` parameter was incorrectly treated as satisfying a required source parameter even though it can consume zero arguments.

## Implementation

Introduce an assignment flag for overload implementation call-domain validation. Under that flag, an unbounded `*args` cannot satisfy a required simple source parameter, so invalid base implementations are reported consistently with equivalent subclass overrides.

Screenshots or GIFs are not applicable because this change affects analyzer or language-service behavior and has no visual UI.

## Testing

Added `overloadImpl4.py` and its evaluator test with invalid base and derived implementations and valid controls using defaults, keyword-only variadics, `ParamSpec`, and `TypeVarTuple`. The evaluator regression suite passed.

## Addresses

Fixes #11533
