### PR TITLE
Fix protocol Self specialization for class properties

### DIFF
--- a/packages/pyright-internal/src/analyzer/protocols.ts
+++ b/packages/pyright-internal/src/analyzer/protocols.ts
@@ -41,6 +41,7 @@ import {
     applySolvedTypeVars,
     ClassMember,
     containsLiteralType,
+    derivesFromClassRecursive,
     lookUpClassMember,
     makeFunctionTypeVarsBound,
     MemberAccessFlags,
@@ -378,9 +379,19 @@ function assignToProtocolInternal(
 
     let selfType: ClassType | TypeVarType | undefined;
     if (isClass(srcType)) {
-        // If the srcType is conditioned on "self", use "Self" as the selfType.
-        // Otherwise use the class type for selfType.
-        const synthCond = srcType.props?.condition?.find((c) => TypeVarType.isSelf(c.typeVar));
+        const srcClassType = srcType;
+
+        // If the srcType is conditioned on its own "self", use "Self" as the
+        // selfType. A condition from an enclosing expression's Self type should
+        // not affect the specialization of this class.
+        const synthCond = srcClassType.props?.condition?.find((c) => {
+            const boundType = c.typeVar.shared.boundType;
+            if (!TypeVarType.isSelf(c.typeVar) || !boundType || !isClass(boundType)) {
+                return false;
+            }
+
+            return derivesFromClassRecursive(srcClassType, boundType, /* ignoreUnknown */ true);
+        });
         if (synthCond) {
             selfType = synthesizeTypeVarForSelfCls(
                 TypeBase.cloneForCondition(srcType, undefined),

--- a/packages/pyright-internal/src/tests/samples/self12.py
+++ b/packages/pyright-internal/src/tests/samples/self12.py
@@ -1,0 +1,121 @@
+# This sample tests contextual type inference for constructors passed as
+# callables when the iterable is read through a descriptor.
+
+from collections.abc import Callable, Iterable, Iterator
+from typing import Self
+
+
+class Meta(type):
+    meta_values = [1, 2, 3]
+
+    @property
+    def values(cls) -> list[int]:
+        return [1, 2, 3]
+
+
+class ClassA(metaclass=Meta):
+    class_values = [1, 2, 3]
+
+    def __init__(self, value: int) -> None:
+        self.value = value
+
+    @classmethod
+    @property
+    def property_values(cls) -> list[int]:
+        return [1, 2, 3]
+
+    @property
+    def instance_values(self) -> list[int]:
+        return [1, 2, 3]
+
+    @classmethod
+    def from_metaclass_property(cls) -> Iterator[Self]:
+        values = cls.values
+        return map(cls, values)
+
+    @classmethod
+    def from_class_property(cls) -> Iterator[Self]:
+        values = cls.property_values
+        return map(cls, values)
+
+    @classmethod
+    def from_metaclass_attribute(cls) -> Iterator[Self]:
+        values = cls.meta_values
+        return map(cls, values)
+
+    @classmethod
+    def from_class_attribute(cls) -> Iterator[Self]:
+        values = cls.class_values
+        return map(cls, values)
+
+    @classmethod
+    def from_annotated_local(cls) -> Iterator[Self]:
+        values: list[int] = cls.values
+        return map(cls, values)
+
+    def from_instance_property(self) -> Iterator[Self]:
+        values = self.instance_values
+        return map(type(self), values)
+
+
+class StringMeta(type):
+    @property
+    def values(cls) -> list[str]:
+        return ["a", "b"]
+
+
+class MatchingStringClass(metaclass=StringMeta):
+    def __init__(self, value: str) -> None:
+        self.value = value
+
+    @classmethod
+    def from_metaclass_property(cls) -> Iterator[Self]:
+        values = cls.values
+        return map(cls, values)
+
+
+class CustomIterator[T]:
+    def __init__(self, values: Iterable[T]) -> None:
+        self._values = iter(values)
+
+    def __iter__(self) -> Self:
+        return self
+
+    def __next__(self) -> T:
+        return next(self._values)
+
+
+def apply_constructor[T, R](func: Callable[[T], R], values: Iterable[T]) -> CustomIterator[R]:
+    return CustomIterator(map(func, values))
+
+
+class CustomIteratorClass(metaclass=Meta):
+    def __init__(self, value: int) -> None:
+        self.value = value
+
+    @classmethod
+    def from_metaclass_property(cls) -> Iterator[Self]:
+        values = cls.values
+        return apply_constructor(cls, values)
+
+
+class WrongTypeClass(metaclass=Meta):
+    def __init__(self, value: str) -> None:
+        self.value = value
+
+    @classmethod
+    def from_metaclass_property(cls) -> Iterator[Self]:
+        values = cls.values
+        # This should generate an error because the constructor accepts str.
+        return apply_constructor(cls, values)
+
+
+class WrongArityClass(metaclass=Meta):
+    def __init__(self, value: int, extra: int) -> None:
+        self.value = value + extra
+
+    @classmethod
+    def from_metaclass_property(cls) -> Iterator[Self]:
+        values = cls.values
+        # This should generate an error because the constructor requires two arguments.
+        return apply_constructor(cls, values)

--- a/packages/pyright-internal/src/tests/typeEvaluator8.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator8.test.ts
@@ -790,6 +790,12 @@ test('Self11', () => {
     TestUtils.validateResults(analysisResults, 0);
 });
 
+test('Self12', () => {
+    const analysisResults = TestUtils.typeAnalyzeSampleFiles(['self12.py']);
+
+    TestUtils.validateResults(analysisResults, 2);
+});
+
 test('UnusedVariable1', () => {
     const configOptions = new ConfigOptions(Uri.empty());
 


### PR DESCRIPTION
## Description

Keep `Self`-based constructor inference stable when `map(cls, values)` reads values through class or metaclass properties, preventing unrelated synthetic return types from entering the result.

## How you figured out what to do

I traced protocol assignment and descriptor-backed constructor inference through `assignToProtocolInternal`. A conditioned `Self` from an enclosing expression could be reused even when its bound class was unrelated to the current source-class hierarchy.

## Implementation

Reuse a conditioned `Self` only when its bound class belongs to the current source-class hierarchy. Otherwise fall back to the concrete source class so descriptor access cannot leak an unrelated `Self` into constructor callables.

Screenshots or GIFs are not applicable because this change affects analyzer or language-service behavior and has no visual UI.

## Testing

Added `self12.py` and its evaluator test covering metaclass properties, class properties, class attributes, annotated locals, instance properties, and custom iterators, with negative constructor type and arity cases. The evaluator regression suite and build passed.

## Addresses

Fixes #11519
