### PR TITLE
Invalidate tuple shape narrowing after mutations

### DIFF
--- a/packages/pyright-internal/src/analyzer/codeFlowEngine.ts
+++ b/packages/pyright-internal/src/analyzer/codeFlowEngine.ts
@@ -14,7 +14,7 @@
 import { ConsoleInterface } from '../common/console';
 import { assert, fail } from '../common/debug';
 import { convertOffsetToPosition } from '../common/positionUtils';
-import { ArgCategory, ExpressionNode, ParseNode, ParseNodeType } from '../parser/parseNodes';
+import { ArgCategory, CallNode, ExpressionNode, ParseNode, ParseNodeType } from '../parser/parseNodes';
 import { AnalyzerNodeInfoAccessor } from './analyzerNodeInfo';
 import {
     CodeFlowReferenceExpressionNode,
@@ -74,6 +74,7 @@ import {
     derivesFromStdlibClass,
     doForEachSubtype,
     isIncompleteUnknown,
+    isTupleClass,
     isTypeAliasPlaceholder,
     mapSubtypes,
 } from './typeUtils';
@@ -113,6 +114,137 @@ export interface CodeFlowAnalyzer {
         reference: CodeFlowReferenceExpressionNode | undefined,
         options?: FlowNodeTypeOptions
     ) => FlowNodeTypeResult;
+}
+
+function isCallPotentiallyMutatingReference(
+    callNode: CallNode,
+    reference: CodeFlowReferenceExpressionNode,
+    antecedent: FlowNode
+) {
+    if (reference.nodeType !== ParseNodeType.MemberAccess && reference.nodeType !== ParseNodeType.Index) {
+        return false;
+    }
+
+    const referenceBase = reference.d.leftExpr;
+    const callTarget = callNode.d.leftExpr;
+    const callReceiver = callTarget.nodeType === ParseNodeType.MemberAccess ? callTarget.d.leftExpr : callTarget;
+
+    if (isExpressionPotentialAliasForReference(callReceiver, referenceBase, antecedent)) {
+        return true;
+    }
+
+    return callNode.d.args.some((arg) =>
+        isExpressionPotentialAliasForReference(arg.d.valueExpr, referenceBase, antecedent)
+    );
+}
+
+function isExpressionPotentialAliasForReference(
+    expression: ExpressionNode,
+    referenceBase: ExpressionNode,
+    flowNode: FlowNode
+): boolean {
+    const pendingStates = [{ expression, flowNode }];
+    const exploredStates = new Set<string>();
+
+    while (pendingStates.length > 0) {
+        const state = pendingStates.pop()!;
+        if (
+            isMatchingExpression(referenceBase, state.expression) ||
+            isPartialMatchingExpression(referenceBase, state.expression)
+        ) {
+            return true;
+        }
+
+        if (state.expression.nodeType !== ParseNodeType.Name) {
+            continue;
+        }
+
+        const stateKey = `${state.expression.id}:${state.flowNode.id}`;
+        if (exploredStates.has(stateKey)) {
+            continue;
+        }
+        exploredStates.add(stateKey);
+
+        if (state.flowNode.flags & FlowFlags.Assignment) {
+            const assignmentFlowNode = state.flowNode as FlowAssignment;
+            if (isMatchingExpression(state.expression, assignmentFlowNode.node)) {
+                // Follow simple local aliases so "alias = obj; alias.mutate()" invalidates "obj.member".
+                const assignmentNode = assignmentFlowNode.node.parent;
+                if (assignmentNode?.nodeType === ParseNodeType.Assignment) {
+                    pendingStates.push({
+                        expression: assignmentNode.d.rightExpr,
+                        flowNode: assignmentFlowNode.antecedent,
+                    });
+                }
+                continue;
+            }
+        }
+
+        if (state.flowNode.flags & (FlowFlags.BranchLabel | FlowFlags.LoopLabel)) {
+            const labelNode = state.flowNode as FlowLabel;
+            labelNode.antecedents.forEach((antecedent) => {
+                pendingStates.push({ expression: state.expression, flowNode: antecedent });
+            });
+            continue;
+        }
+
+        if (
+            state.flowNode.flags &
+            (FlowFlags.Assignment |
+                FlowFlags.Call |
+                FlowFlags.TrueCondition |
+                FlowFlags.FalseCondition |
+                FlowFlags.TrueNeverCondition |
+                FlowFlags.FalseNeverCondition |
+                FlowFlags.VariableAnnotation)
+        ) {
+            const antecedent = (state.flowNode as FlowAssignment | FlowCall | FlowCondition | FlowVariableAnnotation)
+                .antecedent;
+            pendingStates.push({ expression: state.expression, flowNode: antecedent });
+        }
+    }
+
+    return false;
+}
+
+function isTupleShapeNarrowed(typeAtStart: Type, narrowedType: Type) {
+    if (isTypeSame(typeAtStart, narrowedType)) {
+        return false;
+    }
+
+    const originalTupleShapes = new Set<string>();
+    const narrowedTupleShapes = new Set<string>();
+
+    doForEachSubtype(typeAtStart, (subtype) => {
+        if (isClassInstance(subtype) && isTupleClass(subtype)) {
+            originalTupleShapes.add(getTupleShapeKey(subtype));
+        }
+    });
+
+    doForEachSubtype(narrowedType, (subtype) => {
+        if (isClassInstance(subtype) && isTupleClass(subtype)) {
+            narrowedTupleShapes.add(getTupleShapeKey(subtype));
+        }
+    });
+
+    if (originalTupleShapes.size === 0 || narrowedTupleShapes.size === 0) {
+        return false;
+    }
+
+    return (
+        originalTupleShapes.size !== narrowedTupleShapes.size ||
+        [...originalTupleShapes].some((shape) => !narrowedTupleShapes.has(shape))
+    );
+}
+
+function getTupleShapeKey(tupleType: ClassType) {
+    if (!tupleType.priv.tupleTypeArgs) {
+        return 'unspecialized';
+    }
+
+    return tupleType.priv.tupleTypeArgs
+        .map((typeArg) => (typeArg.isUnbounded ? '*' : typeArg.isOptional ? '?' : '1'))
+        .join('');
 }
 
 export interface CodeFlowEngine {
@@ -516,6 +648,31 @@ export function getCodeFlowEngine(
                         // so we can assume that the code before this is unreachable.
                         if (isCallNoReturn(evaluator, callFlowNode)) {
                             return setCacheEntry(curFlowNode, /* type */ undefined, /* isIncomplete */ false);
+                        }
+
+                        if (
+                            reference &&
+                            options?.typeAtStart?.type &&
+                            isCallPotentiallyMutatingReference(callFlowNode.node, reference, callFlowNode.antecedent)
+                        ) {
+                            const flowTypeResult = preventRecursion(curFlowNode, () =>
+                                getTypeFromFlowNode(callFlowNode.antecedent)
+                            );
+
+                            // Preserve normal member narrowing behavior, but discard tuple shape information
+                            // that may have been invalidated by reassignment through the receiver or an argument.
+                            if (
+                                flowTypeResult.type &&
+                                isTupleShapeNarrowed(options.typeAtStart!.type, flowTypeResult.type)
+                            ) {
+                                return setCacheEntry(
+                                    curFlowNode,
+                                    options.typeAtStart.type,
+                                    !!options.typeAtStart.isIncomplete || flowTypeResult.isIncomplete
+                                );
+                            }
+
+                            return setCacheEntry(curFlowNode, flowTypeResult.type, flowTypeResult.isIncomplete);
                         }
 
                         curFlowNode = callFlowNode.antecedent;

--- a/packages/pyright-internal/src/tests/samples/typeNarrowingTupleLength2.py
+++ b/packages/pyright-internal/src/tests/samples/typeNarrowingTupleLength2.py
@@ -1,0 +1,231 @@
+# This sample tests invalidation of tuple length narrowing for attributes
+# across calls that can mutate the object.
+
+from typing import Literal
+
+
+class TupleContainer:
+    values: tuple[int, ...]
+
+    def __init__(self, values: tuple[int, ...]) -> None:
+        self.values = values
+
+    def shorten(self) -> None:
+        self.values = self.values[:-1]
+
+    def test_self_method(self) -> None:
+        assert len(self.values) == 5
+        reveal_type(
+            self.values, expected_text="tuple[int, int, int, int, int]"
+        )
+
+        self.shorten()
+        reveal_type(self.values, expected_text="tuple[int, ...]")
+
+        assert len(self.values) == 4
+        reveal_type(self.values, expected_text="tuple[int, int, int, int]")
+
+
+def shorten(container: TupleContainer) -> None:
+    container.values = container.values[:-1]
+
+
+def consume_tuple(values: tuple[int, ...]) -> None:
+    pass
+
+
+def unrelated_call() -> None:
+    pass
+
+
+def test_external_call(container: TupleContainer) -> None:
+    assert len(container.values) == 5
+    shorten(container)
+    reveal_type(container.values, expected_text="tuple[int, ...]")
+
+    assert len(container.values) == 4
+    reveal_type(container.values, expected_text="tuple[int, int, int, int]")
+
+
+def test_alias(container: TupleContainer) -> None:
+    alias = container
+    assert len(container.values) == 5
+
+    alias.shorten()
+    reveal_type(container.values, expected_text="tuple[int, ...]")
+
+    assert len(container.values) == 4
+    reveal_type(container.values, expected_text="tuple[int, int, int, int]")
+
+
+def test_alias_across_branch(
+    container: TupleContainer, condition: bool
+) -> None:
+    alias = container
+    assert len(container.values) == 5
+
+    if condition:
+        pass
+
+    alias.shorten()
+    reveal_type(container.values, expected_text="tuple[int, ...]")
+
+
+def test_possible_alias_across_branch(
+    container: TupleContainer,
+    other: TupleContainer,
+    condition: bool,
+) -> None:
+    alias = container
+    if condition:
+        alias = other
+
+    assert len(container.values) == 5
+    alias.shorten()
+    reveal_type(container.values, expected_text="tuple[int, ...]")
+
+
+def test_unrelated_aliases_across_branch(
+    container: TupleContainer,
+    other1: TupleContainer,
+    other2: TupleContainer,
+    condition: bool,
+) -> None:
+    if condition:
+        alias = other1
+    else:
+        alias = other2
+
+    assert len(container.values) == 5
+    alias.shorten()
+    reveal_type(
+        container.values, expected_text="tuple[int, int, int, int, int]"
+    )
+
+
+def test_alias_across_many_branches(
+    container: TupleContainer, conditions: tuple[bool, ...]
+) -> None:
+    alias = container
+    assert len(container.values) == 5
+
+    if conditions[0]:
+        pass
+    if conditions[1]:
+        pass
+    if conditions[2]:
+        pass
+    if conditions[3]:
+        pass
+    if conditions[4]:
+        pass
+    if conditions[5]:
+        pass
+    if conditions[6]:
+        pass
+    if conditions[7]:
+        pass
+    if conditions[8]:
+        pass
+    if conditions[9]:
+        pass
+    if conditions[10]:
+        pass
+    if conditions[11]:
+        pass
+
+    alias.shorten()
+    reveal_type(container.values, expected_text="tuple[int, ...]")
+
+
+def test_alias_in_loop(
+    container: TupleContainer, condition: bool
+) -> None:
+    alias = container
+
+    while condition:
+        assert len(container.values) == 5
+        alias.shorten()
+        reveal_type(container.values, expected_text="tuple[int, ...]")
+
+        assert len(container.values) == 4
+        reveal_type(
+            container.values, expected_text="tuple[int, int, int, int]"
+        )
+        condition = False
+
+
+def test_local_variable(container: TupleContainer) -> None:
+    values = container.values
+    assert len(values) == 5
+
+    shorten(container)
+    reveal_type(values, expected_text="tuple[int, int, int, int, int]")
+
+
+def test_direct_assignment(container: TupleContainer) -> None:
+    assert len(container.values) == 5
+    container.values = container.values[:-1]
+
+    assert len(container.values) == 4
+    reveal_type(container.values, expected_text="tuple[int, int, int, int]")
+
+
+def test_unrelated_calls(
+    container: TupleContainer, other: TupleContainer
+) -> None:
+    assert len(container.values) == 5
+
+    unrelated_call()
+    consume_tuple(container.values)
+    other.shorten()
+    reveal_type(
+        container.values, expected_text="tuple[int, int, int, int, int]"
+    )
+
+
+class PropertyContainer:
+    _values: tuple[int, ...]
+
+    def __init__(self, values: tuple[int, ...]) -> None:
+        self._values = values
+
+    @property
+    def values(self) -> tuple[int, ...]:
+        return self._values
+
+
+def mutate_property_container(container: PropertyContainer) -> None:
+    container._values = container._values[:-1]
+
+
+def test_property(container: PropertyContainer) -> None:
+    assert len(container.values) == 5
+
+    unrelated_call()
+    consume_tuple(container.values)
+    reveal_type(
+        container.values, expected_text="tuple[int, int, int, int, int]"
+    )
+
+    mutate_property_container(container)
+    reveal_type(container.values, expected_text="tuple[int, ...]")
+
+    assert len(container.values) == 4
+    reveal_type(container.values, expected_text="tuple[int, int, int, int]")
+
+
+class TaggedTupleContainer:
+    value: tuple[Literal["a"], int] | tuple[Literal["b"], str]
+
+
+def inspect_tagged_tuple(container: TaggedTupleContainer) -> None:
+    pass
+
+
+def test_element_narrowing(container: TaggedTupleContainer) -> None:
+    if container.value[0] == "a":
+        inspect_tagged_tuple(container)
+        reveal_type(
+            container.value, expected_text="tuple[Literal['a'], int]"
+        )

--- a/packages/pyright-internal/src/tests/typeEvaluator1.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator1.test.ts
@@ -531,6 +531,12 @@ test('TypeNarrowingTupleLength1', () => {
     TestUtils.validateResults(analysisResults, 0);
 });
 
+test('TypeNarrowingTupleLength2', () => {
+    const analysisResults = TestUtils.typeAnalyzeSampleFiles(['typeNarrowingTupleLength2.py']);
+
+    TestUtils.validateResults(analysisResults, 0);
+});
+
 test('TypeNarrowingIn1', () => {
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['typeNarrowingIn1.py']);
 


### PR DESCRIPTION
## Description

Invalidate tuple-length shape narrowing for attributes after calls that may mutate the owning object, without discarding unrelated narrowing or unaffected local copies.

## How you figured out what to do

I traced tuple-length narrowing through `codeFlowEngine.ts` across receiver calls, helper calls, aliases, branches, and loops. Existing flow analysis retained an attribute's narrowed tuple shape even after a call could mutate its owner.

## Implementation

Detect calls that may mutate a member or index reference through the receiver or an argument alias. Follow simple aliases backward with a cycle-safe worklist and, when mutation intervenes, revert only tuple-shape narrowing while preserving element-discriminant narrowing and incomplete-loop state.

Screenshots or GIFs are not applicable because this change affects analyzer or language-service behavior and has no visual UI.

## Testing

Added `typeNarrowingTupleLength2.py` and its evaluator test covering self-calls, external helpers, aliases through branches and loops, unrelated aliases and calls, local copies, properties, re-narrowing, and tagged tuples. All 1,212 evaluator tests passed.

## Addresses

Fixes #11437
