### PR TITLE
Preserve abstract classes through identity decorators

### DIFF
--- a/packages/pyright-internal/src/analyzer/decorators.ts
+++ b/packages/pyright-internal/src/analyzer/decorators.ts
@@ -444,7 +444,36 @@ export function applyClassDecorator(
         }
     }
 
-    return getTypeOfDecorator(evaluator, decoratorNode, inputClassType, nodeInfo);
+    const returnType = getTypeOfDecorator(evaluator, decoratorNode, inputClassType, nodeInfo);
+
+    const inputPreservesClassIdentity =
+        isInstantiableClass(inputClassType) &&
+        (ClassType.isSameGenericClass(inputClassType, originalClassType) ||
+            originalClassType.shared.decoratorPreservesClassIdentity === true);
+    const decoratorParamName =
+        isFunction(decoratorType) && decoratorType.shared.parameters.length === 1
+            ? decoratorType.shared.parameters[0].name
+            : undefined;
+    const decoratorDeclaration = isFunction(decoratorType) ? decoratorType.shared.declaration : undefined;
+    const decoratorParamSymbol =
+        decoratorParamName && decoratorDeclaration
+            ? nodeInfo.getScope(decoratorDeclaration.node)?.lookUpSymbol(decoratorParamName)
+            : undefined;
+    originalClassType.shared.decoratorPreservesClassIdentity =
+        inputPreservesClassIdentity &&
+        isFunction(decoratorType) &&
+        isInstantiableClass(returnType) &&
+        decoratorParamName !== undefined &&
+        decoratorParamSymbol?.getDeclarations().every((decl) => decl.type === DeclarationType.Param) === true &&
+        decoratorDeclaration?.node.d.decorators.length === 0 &&
+        !!decoratorDeclaration?.returnStatements?.length &&
+        !evaluator.isAfterNodeReachable(decoratorDeclaration.node.d.suite) &&
+        decoratorDeclaration.returnStatements.every(
+            (returnNode) =>
+                returnNode.d.expr?.nodeType === ParseNodeType.Name && returnNode.d.expr.d.value === decoratorParamName
+        );
+
+    return returnType;
 }
 
 function getTypeOfDecorator(

--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -11743,12 +11743,40 @@ export function createTypeEvaluator(
             };
         }
 
-        if (ClassType.supportsAbstractMethods(expandedCallType)) {
-            const abstractSymbols = getAbstractSymbols(expandedCallType);
+        let concreteDecoratedClassType: ClassType | undefined;
+        if (expandedCallType.priv.includeSubclasses && errorNode.nodeType === ParseNodeType.Call) {
+            const callTargetNode = errorNode.d.leftExpr;
+            const symbolDeclarations =
+                callTargetNode.nodeType === ParseNodeType.Name
+                    ? lookUpSymbolRecursive(callTargetNode, callTargetNode.d.value, /* honorCodeFlow */ true)
+                          ?.symbol.getDeclarations()
+                          .filter((decl) => decl.node.start <= callTargetNode.start)
+                    : undefined;
+            const activeDeclaration =
+                symbolDeclarations?.length === 1
+                    ? resolveAliasDeclaration(symbolDeclarations[0], /* resolveLocalNames */ true)
+                    : undefined;
+            const classDeclaration = activeDeclaration?.type === DeclarationType.Class ? activeDeclaration : undefined;
+
+            if (classDeclaration?.type === DeclarationType.Class) {
+                const classTypeInfo = getTypeOfClass(classDeclaration.node);
+                if (
+                    classTypeInfo?.classType.shared.decoratorPreservesClassIdentity &&
+                    isInstantiableClass(classTypeInfo.decoratedType) &&
+                    ClassType.isSameGenericClass(classTypeInfo.decoratedType, expandedCallType)
+                ) {
+                    concreteDecoratedClassType = classTypeInfo.classType;
+                }
+            }
+        }
+
+        const abstractClassType = concreteDecoratedClassType ?? expandedCallType;
+        if (ClassType.supportsAbstractMethods(abstractClassType)) {
+            const abstractSymbols = getAbstractSymbols(abstractClassType);
 
             if (
                 abstractSymbols.length > 0 &&
-                !expandedCallType.priv.includeSubclasses &&
+                (!expandedCallType.priv.includeSubclasses || concreteDecoratedClassType !== undefined) &&
                 !isTypeVar(unexpandedCallType)
             ) {
                 // If the class is abstract, it can't be instantiated.
@@ -11778,7 +11806,7 @@ export function createTypeEvaluator(
                 addDiagnostic(
                     DiagnosticRule.reportAbstractUsage,
                     LocMessage.instantiateAbstract().format({
-                        type: expandedCallType.shared.name,
+                        type: abstractClassType.shared.name,
                     }) + diagAddendum.getString(),
                     errorNode
                 );

--- a/packages/pyright-internal/src/analyzer/types.ts
+++ b/packages/pyright-internal/src/analyzer/types.ts
@@ -725,6 +725,9 @@ export interface ClassDetailsShared {
     // is used.
     deprecatedMessage?: string | undefined;
 
+    // Indicates that the final class decorator returns its class argument.
+    decoratorPreservesClassIdentity?: boolean;
+
     // A cache of protocol classes (indexed by the class full name)
     // that have been determined to be compatible or incompatible
     // with this class. We use "object" here to avoid a circular dependency.

--- a/packages/pyright-internal/src/tests/checker.test.ts
+++ b/packages/pyright-internal/src/tests/checker.test.ts
@@ -140,6 +140,18 @@ test('AbstractClass11', () => {
     TestUtils.validateResults(analysisResults, 2);
 });
 
+test('AbstractClass12', () => {
+    const analysisResults = TestUtils.typeAnalyzeSampleFiles(['abstractClass12.py']);
+
+    TestUtils.validateResults(analysisResults, 5);
+});
+
+test('AbstractClass13', () => {
+    const analysisResults = TestUtils.typeAnalyzeSampleFiles(['abstractClass13.py']);
+
+    TestUtils.validateResults(analysisResults, 1);
+});
+
 test('Constants1', () => {
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['constants1.py']);
 

--- a/packages/pyright-internal/src/tests/samples/abstractClass12.py
+++ b/packages/pyright-internal/src/tests/samples/abstractClass12.py
@@ -1,0 +1,231 @@
+from abc import ABC, abstractmethod
+from typing import Callable, Generic, Protocol, TypeVar, cast
+
+
+T = TypeVar("T")
+
+
+class Decorator(Generic[T]):
+    def decorate(self, cls: type[T]) -> type[T]:
+        return cls
+
+
+class MethodGenericDecorator:
+    def decorate(self, cls: type[T]) -> type[T]:
+        return cls
+
+
+class ProtocolBase(Protocol):
+    value: str
+
+    @abstractmethod
+    def method(self) -> None: ...
+
+
+protocol_decorator: Decorator[ProtocolBase] = Decorator()
+method_generic_decorator = MethodGenericDecorator()
+
+
+@protocol_decorator.decorate
+class AbstractProtocolImpl(ProtocolBase):
+    pass
+
+
+# This should generate an error because the decorated class is abstract.
+AbstractProtocolImpl()
+reveal_type(AbstractProtocolImpl, expected_text="type[ProtocolBase]")
+
+
+@method_generic_decorator.decorate
+class AbstractMethodGenericProtocolImpl(ProtocolBase):
+    pass
+
+
+# This should generate an error because the decorated class is abstract.
+AbstractMethodGenericProtocolImpl()
+reveal_type(AbstractMethodGenericProtocolImpl, expected_text="type[AbstractMethodGenericProtocolImpl]")
+
+
+@protocol_decorator.decorate
+class ConcreteProtocolImpl(ProtocolBase):
+    value = ""
+
+    def method(self) -> None:
+        pass
+
+
+ConcreteProtocolImpl()
+reveal_type(ConcreteProtocolImpl, expected_text="type[ProtocolBase]")
+
+
+class ABCBase(ABC):
+    @abstractmethod
+    def method(self) -> None: ...
+
+
+abc_decorator: Decorator[ABCBase] = Decorator()
+
+
+@abc_decorator.decorate
+class AbstractABCImpl(ABCBase):
+    pass
+
+
+# This should generate an error because the decorated class is abstract.
+AbstractABCImpl()
+reveal_type(AbstractABCImpl, expected_text="type[ABCBase]")
+
+
+@abc_decorator.decorate
+class ConcreteABCImpl(ABCBase):
+    def method(self) -> None:
+        pass
+
+
+ConcreteABCImpl()
+reveal_type(ConcreteABCImpl, expected_text="type[ABCBase]")
+
+
+@method_generic_decorator.decorate
+class AbstractMethodGenericABCImpl(ABCBase):
+    pass
+
+
+# This should generate an error because the decorated class is abstract.
+AbstractMethodGenericABCImpl()
+reveal_type(AbstractMethodGenericABCImpl, expected_text="type[AbstractMethodGenericABCImpl]")
+
+
+class Replacement:
+    pass
+
+
+def replace(cls: type[object]) -> type[Replacement]:
+    return Replacement
+
+
+@replace
+class ReplacedAbstractClass(ABC):
+    @abstractmethod
+    def method(self) -> None: ...
+
+
+# The decorator intentionally returns a different, concrete class.
+ReplacedAbstractClass()
+reveal_type(ReplacedAbstractClass, expected_text="type[Replacement]")
+
+
+class ConcreteSibling(ABCBase):
+    def method(self) -> None:
+        pass
+
+
+def replace_with_sibling(cls: type[ABCBase]) -> type[ABCBase]:
+    return ConcreteSibling
+
+
+@replace_with_sibling
+class SiblingReplacedAbstractClass(ABCBase):
+    pass
+
+
+# A non-generic decorator can intentionally return another subclass.
+SiblingReplacedAbstractClass()
+reveal_type(SiblingReplacedAbstractClass, expected_text="type[ABCBase]")
+
+
+class Materializer(Generic[T]):
+    def decorate(self, cls: type[T]) -> type[T]:
+        return cast(type[T], ConcreteSibling)
+
+
+materializer: Materializer[ABCBase] = Materializer()
+
+
+@materializer.decorate
+class MaterializedAbstractClass(ABCBase):
+    pass
+
+
+# A generic decorator with an identity-shaped annotation can return another class.
+MaterializedAbstractClass()
+reveal_type(MaterializedAbstractClass, expected_text="type[ABCBase]")
+
+
+class ReassigningMaterializer(Generic[T]):
+    def decorate(self, cls: type[T]) -> type[T]:
+        cls = cast(type[T], ConcreteSibling)
+        return cls
+
+
+reassigning_materializer: ReassigningMaterializer[ABCBase] = ReassigningMaterializer()
+
+
+@reassigning_materializer.decorate
+class ReassignedAbstractClass(ABCBase):
+    pass
+
+
+# Returning a reassigned parameter doesn't preserve the decorated class.
+ReassignedAbstractClass()
+reveal_type(ReassignedAbstractClass, expected_text="type[ABCBase]")
+
+
+@abc_decorator.decorate
+@replace_with_sibling
+class StackedReplacedAbstractClass(ABCBase):
+    pass
+
+
+# An identity decorator above a replacement decorator doesn't restore identity.
+StackedReplacedAbstractClass()
+reveal_type(StackedReplacedAbstractClass, expected_text="type[ABCBase]")
+
+
+candidate: type[ABCBase] = ConcreteSibling
+(AbstractABCImpl if bool() else candidate)()
+
+
+def test_rebound_class_name() -> None:
+    @abc_decorator.decorate
+    class ReboundAbstractClass(ABCBase):
+        pass
+
+    ReboundAbstractClass = candidate
+    ReboundAbstractClass()
+
+
+def test_future_rebound_class_name() -> None:
+    @abc_decorator.decorate
+    class FutureReboundAbstractClass(ABCBase):
+        pass
+
+    # This should generate an error because the later assignment isn't active yet.
+    FutureReboundAbstractClass()
+    FutureReboundAbstractClass = candidate
+
+
+F = TypeVar("F", bound=Callable[..., object])
+
+
+def replace_function(func: F) -> F:
+    return cast(F, materializer.decorate)
+
+
+class FunctionDecoratedDecorator(Generic[T]):
+    @replace_function
+    def decorate(self, cls: type[T]) -> type[T]:
+        return cls
+
+
+function_decorated_decorator: FunctionDecoratedDecorator[ABCBase] = FunctionDecoratedDecorator()
+
+
+@function_decorated_decorator.decorate
+class FunctionDecoratedAbstractClass(ABCBase):
+    pass
+
+
+# The function decorator replaces the apparent identity decorator.
+FunctionDecoratedAbstractClass()
+reveal_type(FunctionDecoratedAbstractClass, expected_text="type[ABCBase]")

--- a/packages/pyright-internal/src/tests/samples/abstractClass13.py
+++ b/packages/pyright-internal/src/tests/samples/abstractClass13.py
@@ -1,0 +1,6 @@
+from abstractClass13Lib import ImportedAbstractClass
+
+
+# This should generate an error because the imported decorated class is abstract.
+ImportedAbstractClass()
+reveal_type(ImportedAbstractClass, expected_text="type[Base]")

--- a/packages/pyright-internal/src/tests/samples/abstractClass13Lib.py
+++ b/packages/pyright-internal/src/tests/samples/abstractClass13Lib.py
@@ -1,0 +1,23 @@
+from abc import ABC, abstractmethod
+from typing import Generic, TypeVar
+
+
+T = TypeVar("T")
+
+
+class Decorator(Generic[T]):
+    def decorate(self, cls: type[T]) -> type[T]:
+        return cls
+
+
+class Base(ABC):
+    @abstractmethod
+    def method(self) -> None: ...
+
+
+decorator: Decorator[Base] = Decorator()
+
+
+@decorator.decorate
+class ImportedAbstractClass(Base):
+    pass


### PR DESCRIPTION
## Description

Preserve abstract-class instantiation diagnostics through proven identity decorators while allowing decorators that genuinely replace a class to return concrete results.

## How you figured out what to do

I traced decorated class evaluation and abstract-use diagnostics through `decorators.ts`, `typeEvaluator.ts`, and the checker. A generic decorator returning `type[T]` obscured the original abstract class, but type signatures alone were insufficient because replacement decorators can have the same apparent shape.

## Implementation

Record class identity preservation only when the applied decorator can be proven from its body and declarations to return its class argument unchanged. Recover the underlying class for abstract-use diagnostics only in that proven case; replacements, casts, reassignments, and function-decorated lookalikes retain existing behavior.

Screenshots or GIFs are not applicable because this change affects analyzer or language-service behavior and has no visual UI.

## Testing

Added checker coverage and local/imported samples for abstract protocols and ABCs, stacked decorators, concrete implementations, replacement returns, casts, reassignments, and false-positive boundaries. A 565-test checker/evaluator selection passed.

## Addresses

Fixes #11411
