### PR TITLE
Bind slot attributes initialized in __new__

### DIFF
--- a/packages/pyright-internal/src/analyzer/binder.ts
+++ b/packages/pyright-internal/src/analyzer/binder.ts
@@ -121,7 +121,7 @@ import {
 import { ImplicitImport, ImportResult, ImportType } from './importResult';
 import { getWildcardImportNames } from './importStatementUtils';
 import * as ParseTreeUtils from './parseTreeUtils';
-import { ParseTreeWalker } from './parseTreeWalker';
+import { ParseTreeWalker, getChildNodes } from './parseTreeWalker';
 import { CellChainIndexProvider } from './cellChainIndex';
 import {
     ChainedModuleLevelLookupContext,
@@ -140,6 +140,12 @@ interface MemberAccessInfo {
     methodNode: FunctionNode;
     classScope: Scope;
     isInstanceMember: boolean;
+}
+
+interface NewMethodInstanceAnalysis {
+    instanceAssignment: AssignmentNode | undefined;
+    writeCount: number;
+    returnedInstanceNodes: ReturnNode[];
 }
 
 interface DeferredBindingTask {
@@ -318,6 +324,8 @@ export class Binder extends ParseTreeWalker {
 
     // List of string nodes associated with the "__all__" symbol.
     private _dunderAllStringNodes: StringNode[] = [];
+
+    private _newMethodInstanceAnalysisCache = new WeakMap<FunctionNode, Map<string, NewMethodInstanceAnalysis>>();
 
     // One or more statements are manipulating __all__ in a manner that a
     // static analyzer doesn't understand.
@@ -4450,6 +4458,11 @@ export class Binder extends ParseTreeWalker {
 
         if (leftSymbolName === className) {
             isInstanceMember = false;
+        } else if (
+            leftSymbolName !== firstParamName &&
+            this._isConcreteInstanceNameInNewMethod(node, methodNode, leftSymbolName, firstParamName)
+        ) {
+            isInstanceMember = true;
         } else {
             if (leftSymbolName !== firstParamName) {
                 return undefined;
@@ -4501,6 +4514,159 @@ export class Binder extends ParseTreeWalker {
             classScope,
             isInstanceMember,
         };
+    }
+
+    private _isConcreteInstanceNameInNewMethod(
+        node: MemberAccessNode,
+        methodNode: FunctionNode,
+        instanceName: string,
+        classParamName: string
+    ) {
+        if (methodNode.d.name.d.value !== '__new__') {
+            return false;
+        }
+
+        let memberAssignment: ParseNode | undefined = node;
+        while (memberAssignment && memberAssignment.nodeType !== ParseNodeType.Assignment) {
+            memberAssignment = memberAssignment.parent;
+        }
+
+        if (
+            !memberAssignment ||
+            memberAssignment.parent?.nodeType !== ParseNodeType.StatementList ||
+            memberAssignment.parent.parent !== methodNode.d.suite
+        ) {
+            return false;
+        }
+
+        const analysis = this._getNewMethodInstanceAnalysis(methodNode, instanceName);
+
+        if (
+            analysis.writeCount !== 1 ||
+            !analysis.instanceAssignment ||
+            analysis.instanceAssignment.parent?.nodeType !== ParseNodeType.StatementList ||
+            analysis.instanceAssignment.parent.parent !== methodNode.d.suite ||
+            analysis.instanceAssignment.start >= memberAssignment.start ||
+            !this._isConcreteInstanceCreationCall(analysis.instanceAssignment.d.rightExpr, classParamName)
+        ) {
+            return false;
+        }
+
+        return (
+            analysis.returnedInstanceNodes.length > 0 &&
+            analysis.returnedInstanceNodes.every((returnNode) => returnNode.start > memberAssignment.start) &&
+            analysis.returnedInstanceNodes.some(
+                (returnNode) =>
+                    returnNode.parent?.nodeType === ParseNodeType.StatementList &&
+                    returnNode.parent.parent === methodNode.d.suite
+            )
+        );
+    }
+
+    private _getNewMethodInstanceAnalysis(methodNode: FunctionNode, instanceName: string) {
+        let methodCache = this._newMethodInstanceAnalysisCache.get(methodNode);
+        if (methodCache) {
+            return (
+                methodCache.get(instanceName) ?? {
+                    instanceAssignment: undefined,
+                    writeCount: 0,
+                    returnedInstanceNodes: [],
+                }
+            );
+        }
+
+        methodCache = this._analyzeNewMethodInstanceNames(methodNode);
+        this._newMethodInstanceAnalysisCache.set(methodNode, methodCache);
+        return (
+            methodCache.get(instanceName) ?? {
+                instanceAssignment: undefined,
+                writeCount: 0,
+                returnedInstanceNodes: [],
+            }
+        );
+    }
+
+    private _analyzeNewMethodInstanceNames(methodNode: FunctionNode) {
+        const analysisByName = new Map<string, NewMethodInstanceAnalysis>();
+
+        const getAnalysis = (name: string) => {
+            let analysis = analysisByName.get(name);
+            if (!analysis) {
+                analysis = {
+                    instanceAssignment: undefined,
+                    writeCount: 0,
+                    returnedInstanceNodes: [],
+                };
+                analysisByName.set(name, analysis);
+            }
+            return analysis;
+        };
+
+        const visitNode = (curNode: ParseNode) => {
+            if (
+                curNode !== methodNode &&
+                (curNode.nodeType === ParseNodeType.Function ||
+                    curNode.nodeType === ParseNodeType.Class ||
+                    curNode.nodeType === ParseNodeType.Lambda)
+            ) {
+                return;
+            }
+
+            if (
+                curNode.nodeType === ParseNodeType.Name &&
+                !(curNode.parent?.nodeType === ParseNodeType.MemberAccess && curNode.parent.d.member === curNode) &&
+                ParseTreeUtils.isWriteAccess(curNode)
+            ) {
+                const analysis = getAnalysis(curNode.d.value);
+                analysis.writeCount++;
+
+                let assignmentNode: ParseNode | undefined = curNode;
+                while (assignmentNode && assignmentNode.nodeType !== ParseNodeType.Assignment) {
+                    assignmentNode = assignmentNode.parent;
+                }
+
+                if (assignmentNode?.nodeType === ParseNodeType.Assignment) {
+                    analysis.instanceAssignment = assignmentNode;
+                }
+            } else if (curNode.nodeType === ParseNodeType.Return && curNode.d.expr?.nodeType === ParseNodeType.Name) {
+                getAnalysis(curNode.d.expr.d.value).returnedInstanceNodes.push(curNode);
+            }
+
+            getChildNodes(curNode).forEach((child) => {
+                if (child) {
+                    visitNode(child);
+                }
+            });
+        };
+
+        visitNode(methodNode);
+        return analysisByName;
+    }
+
+    private _isConcreteInstanceCreationCall(node: ExpressionNode, classParamName: string) {
+        if (
+            node.nodeType !== ParseNodeType.Call ||
+            node.d.args.length !== 1 ||
+            node.d.args[0].d.argCategory !== ArgCategory.Simple ||
+            node.d.args[0].d.name ||
+            node.d.args[0].d.valueExpr.nodeType !== ParseNodeType.Name ||
+            node.d.args[0].d.valueExpr.d.value !== classParamName ||
+            node.d.leftExpr.nodeType !== ParseNodeType.MemberAccess ||
+            node.d.leftExpr.d.member.d.value !== '__new__'
+        ) {
+            return false;
+        }
+
+        const newBaseExpr = node.d.leftExpr.d.leftExpr;
+        if (newBaseExpr.nodeType === ParseNodeType.Name) {
+            return newBaseExpr.d.value === 'object';
+        }
+
+        return (
+            newBaseExpr.nodeType === ParseNodeType.Call &&
+            newBaseExpr.d.leftExpr.nodeType === ParseNodeType.Name &&
+            newBaseExpr.d.leftExpr.d.value === 'super'
+        );
     }
 
     private _addImplicitImportsToLoaderActions(importResult: ImportResult, loaderActions: ModuleLoaderActions) {

--- a/packages/pyright-internal/src/analyzer/checker.ts
+++ b/packages/pyright-internal/src/analyzer/checker.ts
@@ -5328,7 +5328,7 @@ export class Checker extends ParseTreeWalker {
             const decls = localSymbol.getDeclarations();
 
             // If the symbol is assigned (or at least declared) within the
-            // class body or within the __init__ method, it can be ignored.
+            // class body or within the __init__ or __new__ method, it can be ignored.
             if (
                 decls.find((decl) => {
                     const containingClass = ParseTreeUtils.getEnclosingClassOrFunction(decl.node);
@@ -5364,7 +5364,7 @@ export class Checker extends ParseTreeWalker {
                         }
                     }
 
-                    if (containingClass.d.name.d.value === '__init__') {
+                    if (['__init__', '__new__'].includes(containingClass.d.name.d.value)) {
                         return true;
                     }
 

--- a/packages/pyright-internal/src/tests/checker.test.ts
+++ b/packages/pyright-internal/src/tests/checker.test.ts
@@ -553,6 +553,13 @@ test('UninitializedVariable3', () => {
     TestUtils.validateResults(analysisResults, 0);
 });
 
+test('UninitializedVariable4', () => {
+    const configOptions = new ConfigOptions(Uri.empty());
+    configOptions.diagnosticRuleSet.reportUninitializedInstanceVariable = 'error';
+    const analysisResults = TestUtils.typeAnalyzeSampleFiles(['uninitializedVariable4.py'], configOptions);
+    TestUtils.validateResults(analysisResults, 1);
+});
+
 test('DeprecatedAlias1', () => {
     const configOptions = new ConfigOptions(Uri.empty());
 

--- a/packages/pyright-internal/src/tests/samples/slots5.py
+++ b/packages/pyright-internal/src/tests/samples/slots5.py
@@ -1,0 +1,120 @@
+# This sample tests instance variables initialized in __new__.
+
+from contextlib import AbstractContextManager
+from typing import Self
+
+
+class TupleAssignment:
+    __slots__ = ("_spam", "_ham")
+
+    def __new__(
+        cls, value: tuple[int, AbstractContextManager[None]]
+    ) -> Self:
+        self = super().__new__(cls)
+        self._spam, self._ham = value
+        return self
+
+    def use(self):
+        reveal_type(self._spam, expected_text="int")
+        with self._ham:
+            pass
+
+
+class DirectAssignment:
+    __slots__ = ("value",)
+
+    def __new__(cls, value: str) -> Self:
+        instance = object.__new__(cls)
+        instance.value = value
+        return instance
+
+    def use(self):
+        reveal_type(self.value, expected_text="str")
+
+
+class AnnotatedSlot:
+    __slots__ = ("value",)
+    value: int
+
+    def __new__(cls, value: int) -> Self:
+        self = super().__new__(cls)
+        self.value = value
+        return self
+
+    def use(self):
+        reveal_type(self.value, expected_text="int")
+
+
+class ConditionalAssignment:
+    __slots__ = ("value",)
+
+    def __new__(
+        cls, value: AbstractContextManager[None], initialize: bool
+    ) -> Self:
+        self = super().__new__(cls)
+        if initialize:
+            self.value = value
+        return self
+
+    def use(self):
+        with self.value:  # This should generate two errors
+            pass
+
+
+class Other:
+    value: int
+
+
+class ReturnsOther:
+    __slots__ = ("value",)
+
+    def __new__(cls) -> Other:
+        self = super().__new__(cls)
+        self.value = 1
+        return Other()
+
+    def use(self):
+        reveal_type(self.value, expected_text="Unbound")
+
+
+class EarlyReturn:
+    __slots__ = ("value",)
+
+    def __new__(
+        cls, value: AbstractContextManager[None], skip: bool
+    ) -> Self:
+        self = super().__new__(cls)
+        if skip:
+            return self
+        self.value = value
+        return self
+
+    def use(self):
+        with self.value:  # This should generate two errors
+            pass
+
+
+class Base:
+    __slots__ = ()
+
+
+class Child(Base):
+    __slots__ = ("value",)
+
+    def __new__(cls, value: bytes) -> Self:
+        self = super().__new__(cls)
+        self.value = value
+        return self
+
+    def use(self):
+        reveal_type(self.value, expected_text="bytes")
+
+
+class NormalInit:
+    __slots__ = ("value",)
+
+    def __init__(self, value: float):
+        self.value = value
+
+    def use(self):
+        reveal_type(self.value, expected_text="float")

--- a/packages/pyright-internal/src/tests/samples/uninitializedVariable4.py
+++ b/packages/pyright-internal/src/tests/samples/uninitializedVariable4.py
@@ -1,0 +1,14 @@
+# This sample tests instance variables initialized in __new__.
+
+from typing import Self
+
+
+class A:
+    __slots__ = ("initialized", "conditional")
+
+    def __new__(cls, value: int, initialize: bool) -> Self:
+        self = super().__new__(cls)
+        self.initialized = value
+        if initialize:
+            self.conditional = value
+        return self

--- a/packages/pyright-internal/src/tests/typeEvaluator8.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator8.test.ts
@@ -712,6 +712,12 @@ test('Slots4', () => {
     TestUtils.validateResults(analysisResults, 0);
 });
 
+test('Slots5', () => {
+    const analysisResults = TestUtils.typeAnalyzeSampleFiles(['slots5.py']);
+
+    TestUtils.validateResults(analysisResults, 4);
+});
+
 test('Parameters1', () => {
     const configOptions = new ConfigOptions(Uri.empty());
 


### PR DESCRIPTION
## Description

Bind slot-backed instance attributes assigned inside `__new__`, including tuple unpacking and direct writes, while keeping conditional initialization and alternate-return paths conservative.

## How you figured out what to do

I traced member binding and uninitialized-variable checks for concrete instances created by `object.__new__(cls)` and `super().__new__(cls)`. Assignments to the returned instance were not treated like initialization, leaving declared slot members inferred as `Unbound`.

## Implementation

Recognize member writes in `__new__` when they target a concrete instance created once at top level and returned from the method. Cache the per-function analysis, support tuple unpacking and direct assignment, and treat declarations initialized there like `__init__` assignments for uninitialized-member checks.

Screenshots or GIFs are not applicable because this change affects analyzer or language-service behavior and has no visual UI.

## Testing

Added `slots5.py`, `uninitializedVariable4.py`, and checker/evaluator coverage for tuple and direct assignment, annotated and inherited slots, normal `__init__`, conditional writes, early returns, and returning a different object. The focused checker/evaluator regressions passed.

## Addresses

Fixes #11373
