### PR TITLE
Allow assigning signature metadata to functions

### DIFF
--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -6111,7 +6111,8 @@ export function createTypeEvaluator(
         node: MemberAccessNode,
         baseTypeResult: TypeResult,
         usage: EvaluatorUsage,
-        flags: EvalFlags
+        flags: EvalFlags,
+        allowFunctionSignatureAssignment = true
     ): TypeResult {
         let baseType = transformPossibleRecursiveTypeAlias(baseTypeResult.type);
         const memberName = node.d.member.d.value;
@@ -6491,6 +6492,11 @@ export function createTypeEvaluator(
             case TypeCategory.Function:
             case TypeCategory.Overloaded: {
                 const hasSelf = isMethodType(baseType);
+                const functionTypes = isFunction(baseType) ? [baseType] : OverloadedType.getOverloads(baseType);
+                const isBuiltinsFunction = functionTypes.some(
+                    (functionType) =>
+                        FunctionType.isBuiltIn(functionType) && functionType.shared.moduleName === 'builtins'
+                );
 
                 if (memberName === '__self__' && hasSelf) {
                     // Handle "__self__" specially because MethodType defines
@@ -6513,7 +6519,8 @@ export function createTypeEvaluator(
                         node,
                         { type: altType ? convertToInstance(altType) : UnknownType.create() },
                         usage,
-                        flags
+                        flags,
+                        !hasSelf && !isBuiltinsFunction
                     ).type;
                 }
                 break;
@@ -6530,7 +6537,15 @@ export function createTypeEvaluator(
                 isFunctionOrOverloaded(baseType) ||
                 (isClassInstance(baseType) && ClassType.isBuiltIn(baseType, ['function', 'FunctionType']));
 
-            if (!baseTypeResult.isIncomplete) {
+            // These signature metadata attributes can be assigned on function objects at runtime.
+            const isFunctionSignatureAssignment =
+                allowFunctionSignatureAssignment &&
+                usage.method === 'set' &&
+                (memberName === '__signature__' || memberName === '__text_signature__') &&
+                isClassInstance(baseType) &&
+                ClassType.isBuiltIn(baseType, ['function', 'FunctionType']);
+
+            if (!baseTypeResult.isIncomplete && !isFunctionSignatureAssignment) {
                 let diagMessage = LocMessage.memberAccess();
                 if (usage.method === 'set') {
                     diagMessage = LocMessage.memberSet();

--- a/packages/pyright-internal/src/tests/samples/functionMember1.py
+++ b/packages/pyright-internal/src/tests/samples/functionMember1.py
@@ -1,5 +1,9 @@
 # This sample tests the reportFunctionMemberAccess diagnostic rule.
 
+from inspect import Signature
+from types import FunctionType
+from typing import cast
+
 
 def func1():
     pass
@@ -7,6 +11,32 @@ def func1():
 
 a = func1.__annotations__
 b = func1.__class__
+
+# These function metadata attributes can be assigned at runtime.
+func1.__signature__ = Signature()
+func1.__text_signature__ = "()"
+
+
+def set_signature(func: FunctionType) -> None:
+    func.__signature__ = Signature()
+    func.__text_signature__ = "()"
+
+
+# Functions implemented in Python remain writable even if they are declared in a core stdlib stub.
+cast.__signature__ = Signature()
+
+# This should generate an error because reads remain unknown.
+d = func1.__signature__
+
+# This should generate an error because deletes remain unknown.
+del func1.__text_signature__
+
+
+# This should generate an error because builtin functions don't allow attribute assignments.
+len.__signature__ = Signature()
+
+# This should generate an error because overloaded builtin functions don't allow attribute assignments.
+open.__text_signature__ = "()"
 
 # This should generate an error
 c = func1.bar

--- a/packages/pyright-internal/src/tests/samples/functionMember2.py
+++ b/packages/pyright-internal/src/tests/samples/functionMember2.py
@@ -4,6 +4,7 @@
 # pyright: reportFunctionMemberAccess=error
 
 
+from inspect import Signature
 from typing import Protocol
 
 
@@ -36,6 +37,12 @@ reveal_type(s3, expected_text="type[A]")
 
 s4 = A().method2.__self__
 reveal_type(s4, expected_text="type[A]")
+
+# This should generate an error because bound methods don't allow attribute assignments.
+A().method1.__signature__ = Signature()
+
+# This should generate an error because bound class methods don't allow attribute assignments.
+A.method2.__text_signature__ = "()"
 
 # This should generate an error because method3 is static.
 s5 = A().method3.__self__

--- a/packages/pyright-internal/src/tests/typeEvaluator1.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator1.test.ts
@@ -1015,13 +1015,13 @@ test('FunctionMember1', () => {
 
     configOptions.diagnosticRuleSet.reportFunctionMemberAccess = 'error';
     const analysisResult2 = TestUtils.typeAnalyzeSampleFiles(['functionMember1.py'], configOptions);
-    TestUtils.validateResults(analysisResult2, 3);
+    TestUtils.validateResults(analysisResult2, 7);
 });
 
 test('FunctionMember2', () => {
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['functionMember2.py']);
 
-    TestUtils.validateResults(analysisResults, 6);
+    TestUtils.validateResults(analysisResults, 8);
 });
 
 test('Annotations1', () => {


### PR DESCRIPTION
Fixes #11435.

Pyright currently reports `reportFunctionMemberAccess` for assignments to function `__signature__` and `__text_signature__`, although these metadata attributes are writable on Python function objects.

Allow these two assignments through the existing function-object fallback. Preserve diagnostics for reads, deletes, arbitrary attributes, bound methods, and known functions from `builtins`, including overloaded builtins. Add coverage for user functions, `types.FunctionType` values, and the Python-implemented `typing.cast` helper.

Classification: B (Pyright limitation). Typeshed commit: N/A. This removes false-positive assignment diagnostics without widening inferred types or removing existing precision checks. Stubs for other modules do not reliably identify whether a function is implemented in Python or C; this follows their existing function-object representation.

Validation:

- The new assignment regression failed before the fix.
- Complete `typeEvaluator1.test.ts`: 160 passed.
- Package build, repository syncpack/ESLint/Prettier checks, and repository typecheck: passed.
- `git diff --check`: passed.