### PR TITLE
Preserve explicit unbounded tuple annotations

### DIFF
--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -29110,6 +29110,22 @@ export function createTypeEvaluator(
                     return undefined;
                 }
 
+                // Preserve the declared unbounded form when a tuple literal is
+                // assigned to it. Narrowing an explicitly annotated
+                // tuple[T, ...] to a fixed tuple of literals can make otherwise
+                // valid operations fail because the literal tuple's element
+                // types are bound independently for each operand.
+                if (
+                    isClassInstance(declaredSubtype) &&
+                    isTupleClass(declaredSubtype) &&
+                    isUnboundedTupleClass(declaredSubtype) &&
+                    isClassInstance(assignedSubtype) &&
+                    isTupleClass(assignedSubtype) &&
+                    !isUnboundedTupleClass(assignedSubtype)
+                ) {
+                    return declaredSubtype;
+                }
+
                 // Retain unknowns for code flow analysis convergence and for
                 // unknown type reporting in strict mode.
                 if (isUnknown(assignedSubtype)) {

--- a/packages/pyright-internal/src/tests/samples/tuple24.py
+++ b/packages/pyright-internal/src/tests/samples/tuple24.py
@@ -1,0 +1,7 @@
+t1: tuple[int, ...] = (1, 2, 3)
+t2: tuple[int, ...] = (1, 2, 4)
+
+reveal_type(t1, expected_text="tuple[int, ...]")
+reveal_type(t2, expected_text="tuple[int, ...]")
+
+_ = t1 >= t2

--- a/packages/pyright-internal/src/tests/typeEvaluator8.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator8.test.ts
@@ -392,6 +392,12 @@ test('Operator1', () => {
     TestUtils.validateResults(analysisResults, 5);
 });
 
+test('Tuple24', () => {
+    const analysisResults = TestUtils.typeAnalyzeSampleFiles(['tuple24.py']);
+
+    TestUtils.validateResults(analysisResults, 0, 0, 2);
+});
+
 test('Operator2', () => {
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['operator2.py']);
 


### PR DESCRIPTION
Fixes #11381

## Summary
- preserve an explicitly annotated `tuple[T, ...]` when a tuple literal is assigned to it
- add a regression test covering tuple comparison and revealed types

## Validation
- `pnpm --dir packages/pyright-internal build`
- `pnpm --dir packages/pyright-internal exec jest typeEvaluator8.test --runInBand --forceExit` (175 passed)
- `git diff --check`

The targeted test was failing before the fix because the annotated tuples were narrowed to fixed literal tuples and `>=` was rejected.