### PR TITLE
Fix pnpm setup in benchmark workflow

### DIFF
--- a/.github/workflows/typecheck_benchmark_pr.yml
+++ b/.github/workflows/typecheck_benchmark_pr.yml
@@ -4,7 +4,6 @@ run-name: 'Type checker benchmark for PR #${{ inputs.pr_number }}'
 env:
   BENCHMARK_RUNNER_CLASS: 'github-ubuntu-latest'
   NODE_VERSION: '24.15.0'
-  PNPM_VERSION: '10.12.2'
   PYTHON_VERSION: '3.14.6'
 
 on:
@@ -50,8 +49,6 @@ jobs:
           python-version: ${{ env.PYTHON_VERSION }}
 
       - uses: pnpm/action-setup@f520eceda224fe1a4aed5a2a27a194379a409996 # v6
-        with:
-          version: ${{ env.PNPM_VERSION }}
 
       - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
         with:

--- a/build/benchmark/test_compare_benchmarks.py
+++ b/build/benchmark/test_compare_benchmarks.py
@@ -523,8 +523,11 @@ Regression threshold: `10.0%`
             "run-name: 'Type checker benchmark for PR #${{ inputs.pr_number }}'",
             pr_workflow,
         )
-        self.assertIn("PNPM_VERSION: '10.12.2'", pr_workflow)
-        self.assertIn("version: ${{ env.PNPM_VERSION }}", pr_workflow)
+        self.assertNotIn("PNPM_VERSION:", pr_workflow)
+        self.assertNotRegex(
+            pr_workflow,
+            r"uses: pnpm/action-setup@[^\n]+\n\s+with:\n\s+version:",
+        )
 
     def test_pr_benchmark_requires_authorized_comment(self) -> None:
         trigger_workflow = (


### PR DESCRIPTION
## Summary

- remove the workflow-specific pnpm version from the PR benchmark
- use the `packageManager` version declared in `package.json`
- guard against configuring a second pnpm version source

Fixes the setup failure in https://github.com/microsoft/pyright/actions/runs/34192441400/job/101953077604

## Test

- `python -m unittest test_compare_benchmarks.CompareBenchmarksTest.test_workflows_use_current_pnpm_setup`