### PR TITLE
Preserve sentinel identity during TypeVar inference

### DIFF
--- a/packages/pyright-internal/src/analyzer/constraintSolver.ts
+++ b/packages/pyright-internal/src/analyzer/constraintSolver.ts
@@ -60,6 +60,7 @@ import {
     isEffectivelyInstantiable,
     isLiteralTypeOrUnion,
     isPartlyUnknown,
+    isSentinelLiteral,
     makePacked,
     makeUnpacked,
     mapSubtypes,
@@ -511,10 +512,17 @@ export function addConstraintsForExpectedType(
     return false;
 }
 
+// Sentinels identify singleton types, so widening a TypeVar must preserve them.
+function stripLiteralsForInference(evaluator: TypeEvaluator, type: Type): Type {
+    return stripTypeForm(
+        mapSubtypes(type, (subtype) => (isSentinelLiteral(subtype) ? subtype : evaluator.stripLiteralValue(subtype)))
+    );
+}
+
 function stripLiteralsForLowerBound(evaluator: TypeEvaluator, typeVar: TypeVarType, lowerBound: Type) {
     return isTypeVarTuple(typeVar)
         ? stripLiteralValueForUnpackedTuple(evaluator, lowerBound)
-        : stripTypeForm(evaluator.stripLiteralValue(lowerBound));
+        : stripLiteralsForInference(evaluator, lowerBound);
 }
 
 function getTypeVarType(
@@ -1442,7 +1450,7 @@ function stripLiteralValueForUnpackedTuple(evaluator: TypeEvaluator, type: Type)
 
     let strippedLiteral = false;
     const tupleTypeArgs: TupleTypeArg[] = type.priv.tupleTypeArgs.map((arg) => {
-        const strippedType = stripTypeForm(evaluator.stripLiteralValue(arg.type));
+        const strippedType = stripLiteralsForInference(evaluator, arg.type);
 
         if (strippedType !== arg.type) {
             strippedLiteral = true;

--- a/packages/pyright-internal/src/analyzer/constraintSolver.ts
+++ b/packages/pyright-internal/src/analyzer/constraintSolver.ts
@@ -514,6 +514,11 @@ export function addConstraintsForExpectedType(
 
 // Sentinels identify singleton types, so widening a TypeVar must preserve them.
 function stripLiteralsForInference(evaluator: TypeEvaluator, type: Type): Type {
+    // Preserve stripLiteralValue's fast path for unions that don't contain sentinels.
+    if (isUnion(type) && !type.priv.subtypes.some(isSentinelLiteral)) {
+        return stripTypeForm(evaluator.stripLiteralValue(type));
+    }
+
     return stripTypeForm(
         mapSubtypes(type, (subtype) => (isSentinelLiteral(subtype) ? subtype : evaluator.stripLiteralValue(subtype)))
     );

--- a/packages/pyright-internal/src/tests/samples/sentinel1.py
+++ b/packages/pyright-internal/src/tests/samples/sentinel1.py
@@ -1,7 +1,7 @@
 # This sample tests the handling of Sentinel as described in PEP 661.
 
 from dataclasses import dataclass
-from typing import Literal, TypeAlias
+from typing import Literal, TypeAlias, assert_type
 from typing_extensions import Sentinel, TypeForm  # pyright: ignore[reportMissingModuleSource]
 
 # This should generate an error because the names don't match.
@@ -94,3 +94,30 @@ def func4(dc: DC1, a: ClassA) -> None:
 
     if a.value is not MISSING:
         reveal_type(a.value, expected_text="int")
+
+
+def identity[T](value: T) -> T:
+    return value
+
+
+result = identity(MISSING)
+reveal_type(result, expected_text="MISSING")
+assert_type(result, MISSING)
+
+
+def round_trip(value: int | MISSING) -> None:
+    result = identity(value)
+    assert_type(result, int | MISSING)
+    if result is MISSING:
+        assert_type(result, MISSING)
+    else:
+        assert_type(result, int)
+
+
+def variadic_identity[*Ts](*values: *Ts) -> tuple[*Ts]:
+    return values
+
+
+assert_type(variadic_identity(MISSING, 1, "text"), tuple[MISSING, int, str])
+assert_type(identity(1), int)
+assert_type(identity("text"), str)

--- a/packages/pyright-internal/src/tests/samples/sentinel2.py
+++ b/packages/pyright-internal/src/tests/samples/sentinel2.py
@@ -1,7 +1,7 @@
 # This sample tests the handling of the sentinel builtin added in Python 3.15.
 
 from dataclasses import dataclass
-from typing import Literal, TypeAlias
+from typing import Literal, TypeAlias, assert_type
 
 # This should generate an error because the names don't match.
 BAD_NAME1 = sentinel("OTHER")
@@ -68,3 +68,19 @@ def func4(dc: DC1, a: ClassA) -> None:
 
     if a.value is not MISSING:
         reveal_type(a.value, expected_text="int")
+
+
+def identity[T](value: T) -> T:
+    return value
+
+
+assert_type(identity(MISSING), MISSING)
+
+
+def round_trip(value: int | MISSING) -> None:
+    result = identity(value)
+    assert_type(result, int | MISSING)
+    if result is not MISSING:
+        assert_type(result, int)
+    else:
+        assert_type(result, MISSING)


### PR DESCRIPTION
Fixes #11728.

Preserve sentinel literal identity when widening TypeVar and TypeVarTuple lower bounds, including union members. Ordinary literals still widen normally, and `type(MISSING)` behavior is unchanged.

Regression coverage includes `typing_extensions.Sentinel`, the Python 3.15 builtin, `assert_type`, `is`/`is not` narrowing, and variadic inference. The new cases fail against the unmodified solver.

This is separate from #11655, which handles non-constant-name bindings rather than constraint solving.

Validation:
- 1,228 tests passed across typeEvaluator1-8, typePrinter, and typeUtils.
- Core TypeScript build passed.
- ESLint and Prettier checks passed for the changed solver.
