### PR TITLE
Allow equivalent generic function redeclarations

### DIFF
--- a/packages/pyright-internal/src/analyzer/checker.ts
+++ b/packages/pyright-internal/src/analyzer/checker.ts
@@ -3748,11 +3748,15 @@ export class Checker extends ParseTreeWalker {
 
                     let parameterOptionalityMatches = true;
                     if (isFunction(primaryType) && isFunction(adjustedOtherType)) {
-                        parameterOptionalityMatches = primaryType.shared.parameters.every(
-                            (_param, index) =>
-                                !!FunctionType.getParamDefaultType(primaryType, index) ===
-                                !!FunctionType.getParamDefaultType(adjustedOtherType, index)
-                        );
+                        const primaryParameters = primaryType.shared.parameters;
+                        const otherParameters = adjustedOtherType.shared.parameters;
+                        parameterOptionalityMatches =
+                            primaryParameters.length === otherParameters.length &&
+                            primaryParameters.every(
+                                (_param, index) =>
+                                    !!FunctionType.getParamDefaultType(primaryType, index) ===
+                                    !!FunctionType.getParamDefaultType(adjustedOtherType, index)
+                            );
                     }
 
                     if (typeParamsMatch && parameterOptionalityMatches && isTypeSame(primaryType, adjustedOtherType)) {

--- a/packages/pyright-internal/src/analyzer/checker.ts
+++ b/packages/pyright-internal/src/analyzer/checker.ts
@@ -92,6 +92,7 @@ import { UnescapeError, UnescapeErrorType, getUnescapedString } from '../parser/
 import { OperatorType, StringTokenFlags, TokenType } from '../parser/tokenizerTypes';
 import { AnalyzerFileInfo } from './analyzerFileInfo';
 import * as AnalyzerNodeInfo from './analyzerNodeInfo';
+import { ConstraintSolution } from './constraintSolution';
 import { ConstraintTracker } from './constraintTracker';
 import { getBoundCallMethod, getBoundInitMethod, getBoundNewMethod } from './constructors';
 import { addInheritedDataClassEntries } from './dataClasses';
@@ -3647,8 +3648,36 @@ export class Checker extends ParseTreeWalker {
 
                 // If both declarations are functions, it's OK if they
                 // both have the same signatures.
-                if (!isInSameStatementList && primaryType && otherType && isTypeSame(primaryType, otherType)) {
-                    duplicateIsOk = true;
+                if (!isInSameStatementList && primaryType && otherType) {
+                    let adjustedOtherType = otherType;
+                    if (
+                        isFunction(primaryType) &&
+                        isFunction(otherType) &&
+                        primaryType.shared.typeVarScopeId &&
+                        otherType.shared.typeParams.length > 0
+                    ) {
+                        // The declarations bind their own generic parameters in different scopes.
+                        // Align only those local scopes; captured TypeVars must remain distinct.
+                        const solution = new ConstraintSolution();
+                        otherType.shared.typeParams.forEach((typeParam) => {
+                            if (typeParam.priv.scopeId === otherType.shared.typeVarScopeId) {
+                                solution.setType(
+                                    typeParam,
+                                    TypeVarType.cloneForScopeId(
+                                        typeParam,
+                                        primaryType.shared.typeVarScopeId!,
+                                        typeParam.priv.scopeName,
+                                        typeParam.priv.scopeType
+                                    )
+                                );
+                            }
+                        });
+                        adjustedOtherType = applySolvedTypeVars(otherType, solution);
+                    }
+
+                    if (isTypeSame(primaryType, adjustedOtherType)) {
+                        duplicateIsOk = true;
+                    }
                 }
 
                 if (primaryDecl.type === DeclarationType.TypeParam) {

--- a/packages/pyright-internal/src/analyzer/checker.ts
+++ b/packages/pyright-internal/src/analyzer/checker.ts
@@ -3746,7 +3746,16 @@ export class Checker extends ParseTreeWalker {
                         }
                     }
 
-                    if (typeParamsMatch && isTypeSame(primaryType, adjustedOtherType)) {
+                    let parameterOptionalityMatches = true;
+                    if (isFunction(primaryType) && isFunction(adjustedOtherType)) {
+                        parameterOptionalityMatches = primaryType.shared.parameters.every(
+                            (_param, index) =>
+                                !!FunctionType.getParamDefaultType(primaryType, index) ===
+                                !!FunctionType.getParamDefaultType(adjustedOtherType, index)
+                        );
+                    }
+
+                    if (typeParamsMatch && parameterOptionalityMatches && isTypeSame(primaryType, adjustedOtherType)) {
                         duplicateIsOk = true;
                     }
                 }

--- a/packages/pyright-internal/src/analyzer/checker.ts
+++ b/packages/pyright-internal/src/analyzer/checker.ts
@@ -3650,32 +3650,103 @@ export class Checker extends ParseTreeWalker {
                 // both have the same signatures.
                 if (!isInSameStatementList && primaryType && otherType) {
                     let adjustedOtherType = otherType;
+                    let typeParamsMatch = true;
                     if (
                         isFunction(primaryType) &&
                         isFunction(otherType) &&
                         primaryType.shared.typeVarScopeId &&
-                        otherType.shared.typeParams.length > 0
+                        otherType.shared.typeVarScopeId
                     ) {
-                        // The declarations bind their own generic parameters in different scopes.
-                        // Align only those local scopes; captured TypeVars must remain distinct.
-                        const solution = new ConstraintSolution();
-                        otherType.shared.typeParams.forEach((typeParam) => {
-                            if (typeParam.priv.scopeId === otherType.shared.typeVarScopeId) {
-                                solution.setType(
-                                    typeParam,
-                                    TypeVarType.cloneForScopeId(
-                                        typeParam,
-                                        primaryType.shared.typeVarScopeId!,
-                                        typeParam.priv.scopeName,
-                                        typeParam.priv.scopeType
+                        const primaryTypeParams = primaryType.shared.typeParams.filter(
+                            (typeParam) => typeParam.priv.scopeId === primaryType.shared.typeVarScopeId
+                        );
+                        const otherTypeParams = otherType.shared.typeParams.filter(
+                            (typeParam) => typeParam.priv.scopeId === otherType.shared.typeVarScopeId
+                        );
+                        typeParamsMatch = primaryTypeParams.length === otherTypeParams.length;
+
+                        if (typeParamsMatch && otherTypeParams.length > 0) {
+                            // Local type parameter names are not part of a generic function signature.
+                            // Align parameters by position, but verify their metadata before substitution.
+                            const solution = new ConstraintSolution();
+                            otherTypeParams.forEach((typeParam, index) => {
+                                solution.setType(typeParam, primaryTypeParams[index]);
+                            });
+
+                            for (let index = 0; index < primaryTypeParams.length; index++) {
+                                const primaryTypeParam = primaryTypeParams[index];
+                                const otherTypeParam = otherTypeParams[index];
+
+                                if (
+                                    primaryTypeParam.shared.kind !== otherTypeParam.shared.kind ||
+                                    primaryTypeParam.shared.isSynthesized !== otherTypeParam.shared.isSynthesized ||
+                                    primaryTypeParam.shared.declaredVariance !== otherTypeParam.shared.declaredVariance
+                                ) {
+                                    typeParamsMatch = false;
+                                    break;
+                                }
+
+                                const primaryBound = primaryTypeParam.shared.boundType;
+                                const otherBound = otherTypeParam.shared.boundType
+                                    ? applySolvedTypeVars(otherTypeParam.shared.boundType, solution)
+                                    : undefined;
+                                if (
+                                    !!primaryBound !== !!otherBound ||
+                                    (primaryBound && otherBound && !isTypeSame(primaryBound, otherBound))
+                                ) {
+                                    typeParamsMatch = false;
+                                    break;
+                                }
+
+                                if (
+                                    primaryTypeParam.shared.constraints.length !==
+                                    otherTypeParam.shared.constraints.length
+                                ) {
+                                    typeParamsMatch = false;
+                                    break;
+                                }
+                                if (
+                                    primaryTypeParam.shared.constraints.some(
+                                        (constraint, constraintIndex) =>
+                                            !isTypeSame(
+                                                constraint,
+                                                applySolvedTypeVars(
+                                                    otherTypeParam.shared.constraints[constraintIndex],
+                                                    solution
+                                                )
+                                            )
                                     )
-                                );
+                                ) {
+                                    typeParamsMatch = false;
+                                    break;
+                                }
+
+                                if (
+                                    primaryTypeParam.shared.isDefaultExplicit !==
+                                    otherTypeParam.shared.isDefaultExplicit
+                                ) {
+                                    typeParamsMatch = false;
+                                    break;
+                                }
+                                if (
+                                    primaryTypeParam.shared.isDefaultExplicit &&
+                                    !isTypeSame(
+                                        primaryTypeParam.shared.defaultType,
+                                        applySolvedTypeVars(otherTypeParam.shared.defaultType, solution)
+                                    )
+                                ) {
+                                    typeParamsMatch = false;
+                                    break;
+                                }
                             }
-                        });
-                        adjustedOtherType = applySolvedTypeVars(otherType, solution);
+
+                            if (typeParamsMatch) {
+                                adjustedOtherType = applySolvedTypeVars(otherType, solution);
+                            }
+                        }
                     }
 
-                    if (isTypeSame(primaryType, adjustedOtherType)) {
+                    if (typeParamsMatch && isTypeSame(primaryType, adjustedOtherType)) {
                         duplicateIsOk = true;
                     }
                 }

--- a/packages/pyright-internal/src/tests/checker.test.ts
+++ b/packages/pyright-internal/src/tests/checker.test.ts
@@ -468,7 +468,7 @@ test('DuplicateDeclaration3', () => {
 
 test('DuplicateDeclaration4', () => {
     const results = TestUtils.typeAnalyzeSampleFiles(['duplicateDeclaration4.py']);
-    TestUtils.validateResults(results, 8, 0);
+    TestUtils.validateResults(results, 10, 0);
 });
 
 test('Strings1', () => {

--- a/packages/pyright-internal/src/tests/checker.test.ts
+++ b/packages/pyright-internal/src/tests/checker.test.ts
@@ -468,7 +468,7 @@ test('DuplicateDeclaration3', () => {
 
 test('DuplicateDeclaration4', () => {
     const results = TestUtils.typeAnalyzeSampleFiles(['duplicateDeclaration4.py']);
-    TestUtils.validateResults(results, 7, 0);
+    TestUtils.validateResults(results, 8, 0);
 });
 
 test('Strings1', () => {

--- a/packages/pyright-internal/src/tests/checker.test.ts
+++ b/packages/pyright-internal/src/tests/checker.test.ts
@@ -461,6 +461,16 @@ test('DuplicateDeclaration2', () => {
     TestUtils.validateResults(analysisResults, 4);
 });
 
+test('DuplicateDeclaration3', () => {
+    const results = TestUtils.typeAnalyzeSampleFiles(['duplicateDeclaration3.py']);
+    TestUtils.validateResults(results, 0, 0);
+});
+
+test('DuplicateDeclaration4', () => {
+    const results = TestUtils.typeAnalyzeSampleFiles(['duplicateDeclaration4.py']);
+    TestUtils.validateResults(results, 7, 0);
+});
+
 test('Strings1', () => {
     const configOptions = new ConfigOptions(Uri.empty());
     const analysisResults1 = TestUtils.typeAnalyzeSampleFiles(['strings1.py'], configOptions);

--- a/packages/pyright-internal/src/tests/samples/duplicateDeclaration3.py
+++ b/packages/pyright-internal/src/tests/samples/duplicateDeclaration3.py
@@ -1,0 +1,67 @@
+# This sample tests generic function redeclarations in separate statement suites.
+
+from collections.abc import Callable
+from typing import ParamSpec, TypeVar, assert_type
+
+P = ParamSpec("P")
+R = TypeVar("R")
+T = TypeVar("T")
+
+try:
+    import sys
+except ImportError:
+    def fgen(func: Callable[P, R]) -> Callable[P, R]:
+        return func
+
+    def identity(value: T) -> T:
+        return value
+else:
+    def fgen(func: Callable[P, R]) -> Callable[P, R]:
+        return func
+
+    def identity(value: T) -> T:
+        return value
+
+
+def example(value: int, *, label: str) -> bool:
+    return bool(value and label)
+
+
+assert_type(fgen(example)(1, label="test"), bool)
+assert_type(identity(1), int)
+
+
+def conditional_generics(condition: bool) -> None:
+    if condition:
+        def pep695[T](value: T) -> list[T]:
+            return [value]
+
+        def decorate[**P, R](func: Callable[P, R]) -> Callable[P, R]:
+            return func
+
+        def pack[*Ts](*values: *Ts) -> tuple[*Ts]:
+            return values
+    else:
+        def pep695[T](value: T) -> list[T]:
+            return [value]
+
+        def decorate[**P, R](func: Callable[P, R]) -> Callable[P, R]:
+            return func
+
+        def pack[*Ts](*values: *Ts) -> tuple[*Ts]:
+            return values
+
+    assert_type(pep695(1), list[int])
+    assert_type(decorate(example)(1, label="test"), bool)
+    assert_type(pack(1, "text"), tuple[int, str])
+
+
+class GenericMethods[U]:
+    def define(self, condition: bool, outer: U) -> None:
+        if condition:
+            def captured[T](value: T) -> tuple[U, T]:
+                return outer, value
+        else:
+            def captured[T](value: T) -> tuple[U, T]:
+                return outer, value
+        assert_type(captured(1), tuple[U, int])

--- a/packages/pyright-internal/src/tests/samples/duplicateDeclaration3.py
+++ b/packages/pyright-internal/src/tests/samples/duplicateDeclaration3.py
@@ -42,13 +42,13 @@ def conditional_generics(condition: bool) -> None:
         def pack[*Ts](*values: *Ts) -> tuple[*Ts]:
             return values
     else:
-        def pep695[T](value: T) -> list[T]:
+        def pep695[U](value: U) -> list[U]:
             return [value]
 
-        def decorate[**P, R](func: Callable[P, R]) -> Callable[P, R]:
+        def decorate[**Q, S](func: Callable[Q, S]) -> Callable[Q, S]:
             return func
 
-        def pack[*Ts](*values: *Ts) -> tuple[*Ts]:
+        def pack[*Us](*values: *Us) -> tuple[*Us]:
             return values
 
     assert_type(pep695(1), list[int])
@@ -62,6 +62,6 @@ class GenericMethods[U]:
             def captured[T](value: T) -> tuple[U, T]:
                 return outer, value
         else:
-            def captured[T](value: T) -> tuple[U, T]:
+            def captured[V](value: V) -> tuple[U, V]:
                 return outer, value
         assert_type(captured(1), tuple[U, int])

--- a/packages/pyright-internal/src/tests/samples/duplicateDeclaration3.py
+++ b/packages/pyright-internal/src/tests/samples/duplicateDeclaration3.py
@@ -41,6 +41,9 @@ def conditional_generics(condition: bool) -> None:
 
         def pack[*Ts](*values: *Ts) -> tuple[*Ts]:
             return values
+
+        def defaulted[T = int](value: T | None = None) -> T | None:
+            return value
     else:
         def pep695[U](value: U) -> list[U]:
             return [value]
@@ -50,6 +53,9 @@ def conditional_generics(condition: bool) -> None:
 
         def pack[*Us](*values: *Us) -> tuple[*Us]:
             return values
+
+        def defaulted[U = int](value: U | None = None) -> U | None:
+            return value
 
     assert_type(pep695(1), list[int])
     assert_type(decorate(example)(1, label="test"), bool)

--- a/packages/pyright-internal/src/tests/samples/duplicateDeclaration4.py
+++ b/packages/pyright-internal/src/tests/samples/duplicateDeclaration4.py
@@ -1,0 +1,52 @@
+# Generic redeclarations must still reject incompatible signatures and scopes.
+
+
+def incompatible(condition: bool) -> None:
+    if condition:
+        # This should generate an error because the return type differs.
+        def result[T](value: T) -> list[T]:
+            return [value]
+
+        # This should generate an error because the TypeVar bound differs.
+        def bounded[T: int](value: T) -> T:
+            return value
+
+        # This should generate an error because the TypeVar constraints differ.
+        def constrained[T: (int, str)](value: T) -> T:
+            return value
+
+        # This should generate an error because the parameter names differ.
+        def named[T](value: T) -> T:
+            return value
+    else:
+        def result[T](value: T) -> set[T]:
+            return {value}
+
+        def bounded[T: str](value: T) -> T:
+            return value
+
+        def constrained[T: (int, bytes)](value: T) -> T:
+            return value
+
+        def named[T](other: T) -> T:
+            return other
+
+
+def outer[T](condition: bool) -> None:
+    if condition:
+        # This should generate an error because T belongs to the outer function.
+        def captured(value: T) -> T:
+            return value
+    else:
+        # This should also generate an error because T shadows the outer type parameter.
+        def captured[T](value: T) -> T:
+            return value
+
+
+# This should generate an error because the functions share a statement suite.
+def repeated[T](value: T) -> T:
+    return value
+
+
+def repeated[T](value: T) -> T:
+    return value

--- a/packages/pyright-internal/src/tests/samples/duplicateDeclaration4.py
+++ b/packages/pyright-internal/src/tests/samples/duplicateDeclaration4.py
@@ -18,6 +18,10 @@ def incompatible(condition: bool) -> None:
         # This should generate an error because the parameter names differ.
         def named[T](value: T) -> T:
             return value
+
+        # This should generate an error because the type parameter default differs.
+        def defaulted[T = int](value: T | None = None) -> T | None:
+            return value
     else:
         def result[T](value: T) -> set[T]:
             return {value}
@@ -30,6 +34,9 @@ def incompatible(condition: bool) -> None:
 
         def named[T](other: T) -> T:
             return other
+
+        def defaulted[U = str](value: U | None = None) -> U | None:
+            return value
 
 
 def outer[T](condition: bool) -> None:

--- a/packages/pyright-internal/src/tests/samples/duplicateDeclaration4.py
+++ b/packages/pyright-internal/src/tests/samples/duplicateDeclaration4.py
@@ -39,6 +39,21 @@ def incompatible(condition: bool) -> None:
             return value
 
 
+def parameter_optionality(condition: bool) -> None:
+    if condition:
+        def required_first[T](value: T, required: int) -> T:
+            return value
+
+        def optional_first[T](value: T, optional: int = 0) -> T:
+            return value
+    else:
+        def required_first[U](value: U, required: int = 0) -> U:
+            return value
+
+        def optional_first[U](value: U, optional: int) -> U:
+            return value
+
+
 def outer[T](condition: bool) -> None:
     if condition:
         # This should generate an error because T belongs to the outer function.


### PR DESCRIPTION
Fixes #11729.

Align function-local TypeVar scopes when comparing declarations in separate statement suites. The existing signature comparison still checks parameter names, return types, bounds, and constraints; captured outer TypeVars and same-suite redeclarations remain distinct. Inferred types are unchanged.

Adds coverage for the reported try/except/else case, legacy and PEP 695 generics, ParamSpec, TypeVarTuple, captured outer types, and incompatible signatures. The positive sample produces six false redeclaration errors with the original checker and none with the fix; the negative sample retains its expected diagnostics.

Validation:
- 1,302 tests passed across 11 checker, type-evaluator, type-printer, and type-utility suites.
- Core TypeScript build passed.
- ESLint, Prettier, and `git diff --check` passed.
- Existing test expectations and typeshed files are unchanged.
