### PR TITLE
Fix equivalent generic redeclarations in try/except branches

### DIFF
--- a/packages/pyright-internal/src/analyzer/checker.ts
+++ b/packages/pyright-internal/src/analyzer/checker.ts
@@ -3647,7 +3647,20 @@ export class Checker extends ParseTreeWalker {
 
                 // If both declarations are functions, it's OK if they
                 // both have the same signatures.
-                if (!isInSameStatementList && primaryType && otherType && isTypeSame(primaryType, otherType)) {
+                // Generic functions in alternate branches have distinct local type
+                // variables, so compare their assignability in both directions.
+                if (
+                    !isInSameStatementList &&
+                    primaryType &&
+                    otherType &&
+                    (isTypeSame(primaryType, otherType) ||
+                        (isFunction(primaryType) &&
+                            isFunction(otherType) &&
+                            primaryType.shared.typeParams.length > 0 &&
+                            primaryType.shared.typeParams.length === otherType.shared.typeParams.length &&
+                            this._evaluator.assignType(primaryType, otherType) &&
+                            this._evaluator.assignType(otherType, primaryType)))
+                ) {
                     duplicateIsOk = true;
                 }
 

--- a/packages/pyright-internal/src/tests/samples/tryExcept13.py
+++ b/packages/pyright-internal/src/tests/samples/tryExcept13.py
@@ -1,0 +1,34 @@
+# This sample verifies that equivalent generic functions in try/except branches
+# are not reported as redeclarations.
+
+from collections.abc import Callable
+from typing import ParamSpec, TypeVar
+
+P = ParamSpec("P")
+R = TypeVar("R")
+
+
+try:
+    from rich import print  # pyright: ignore[reportMissingImports]
+except ImportError:
+
+    def fgen(func: Callable[P, R]) -> Callable[P, R]:
+        return func
+
+else:
+
+    def fgen(func: Callable[P, R]) -> Callable[P, R]:
+        return func
+
+
+try:
+    from rich import print  # pyright: ignore[reportMissingImports]
+except ImportError:
+
+    def hgen(func: Callable[P, R]) -> Callable[P, R]:
+        ...
+
+else:
+
+    def hgen(func: Callable[P, R]) -> Callable[[str], R]:
+        ...

--- a/packages/pyright-internal/src/tests/typeEvaluator7.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator7.test.ts
@@ -1075,6 +1075,11 @@ test('TryExcept12', () => {
     TestUtils.validateResults(analysisResults2, 1);
 });
 
+test('TryExcept13', () => {
+    const analysisResults = TestUtils.typeAnalyzeSampleFiles(['tryExcept13.py']);
+    TestUtils.validateResults(analysisResults, 1);
+});
+
 test('exceptionGroup1', () => {
     const configOptions = new ConfigOptions(Uri.empty());
 


### PR DESCRIPTION
Fixes #10457

## Summary
- Treat equivalent generic function declarations in alternate branches as the same declaration.
- Keep reporting redeclarations when the generic signatures are genuinely different.

## Checks
- `pnpm --dir packages/pyright-internal exec jest --runInBand src/tests/typeEvaluator7.test.ts --forceExit`
- `pnpm --dir packages/pyright-internal run build`
- `pnpm exec prettier -c packages/pyright-internal/src/analyzer/checker.ts packages/pyright-internal/src/tests/typeEvaluator7.test.ts`
- `git diff --check`
