### PR TITLE
Fix constrained TypeVar inference for Never

### DIFF
--- a/packages/pyright-internal/src/analyzer/constraintSolver.ts
+++ b/packages/pyright-internal/src/analyzer/constraintSolver.ts
@@ -1136,7 +1136,8 @@ function assignConstrainedTypeVar(
         });
 
         const isExplicitNeverConstraint =
-            isNever(concreteSrcType) && destType.shared.constraints.some((constraint) => isNever(constraint));
+            isNever(concreteSrcType) &&
+            destType.shared.constraints.some((constraint) => isTypeSame(constraint, concreteSrcType));
         if ((isNever(constrainedType) && !isExplicitNeverConstraint) || !isCompatible) {
             constrainedType = undefined;
         }

--- a/packages/pyright-internal/src/analyzer/constraintSolver.ts
+++ b/packages/pyright-internal/src/analyzer/constraintSolver.ts
@@ -1137,6 +1137,7 @@ function assignConstrainedTypeVar(
 
         const isExplicitNeverConstraint =
             isNever(concreteSrcType) &&
+            destType.shared.hasExplicitNeverConstraint &&
             destType.shared.constraints.some((constraint) => isTypeSame(constraint, concreteSrcType));
         if ((isNever(constrainedType) && !isExplicitNeverConstraint) || !isCompatible) {
             constrainedType = undefined;

--- a/packages/pyright-internal/src/analyzer/constraintSolver.ts
+++ b/packages/pyright-internal/src/analyzer/constraintSolver.ts
@@ -1067,12 +1067,14 @@ function assignConstrainedTypeVar(
         // must all map to the same constraint. For example, Union[str, bytes]
         // cannot be assigned to AnyStr.
         let unconditionalConstraintIndex: number | undefined;
+        let foundCompatibleConstraint = false;
 
         // Find the narrowest constrained type that is compatible.
         constrainedType = mapSubtypes(concreteSrcType, (srcSubtype) => {
             let constrainedSubtype: Type | undefined;
 
             if (isAnyOrUnknown(srcSubtype)) {
+                foundCompatibleConstraint = true;
                 return srcSubtype;
             }
 
@@ -1117,6 +1119,8 @@ function assignConstrainedTypeVar(
                 if ((flags & AssignTypeFlags.Contravariant) === 0) {
                     isCompatible = false;
                 }
+            } else {
+                foundCompatibleConstraint = true;
             }
 
             // If this subtype isn't conditional, make sure it maps to the same
@@ -1135,7 +1139,7 @@ function assignConstrainedTypeVar(
             return constrainedSubtype;
         });
 
-        if (isNever(constrainedType) || !isCompatible) {
+        if (!foundCompatibleConstraint || !isCompatible) {
             constrainedType = undefined;
         }
 

--- a/packages/pyright-internal/src/analyzer/constraintSolver.ts
+++ b/packages/pyright-internal/src/analyzer/constraintSolver.ts
@@ -1067,14 +1067,12 @@ function assignConstrainedTypeVar(
         // must all map to the same constraint. For example, Union[str, bytes]
         // cannot be assigned to AnyStr.
         let unconditionalConstraintIndex: number | undefined;
-        let foundCompatibleConstraint = false;
 
         // Find the narrowest constrained type that is compatible.
         constrainedType = mapSubtypes(concreteSrcType, (srcSubtype) => {
             let constrainedSubtype: Type | undefined;
 
             if (isAnyOrUnknown(srcSubtype)) {
-                foundCompatibleConstraint = true;
                 return srcSubtype;
             }
 
@@ -1119,8 +1117,6 @@ function assignConstrainedTypeVar(
                 if ((flags & AssignTypeFlags.Contravariant) === 0) {
                     isCompatible = false;
                 }
-            } else {
-                foundCompatibleConstraint = true;
             }
 
             // If this subtype isn't conditional, make sure it maps to the same
@@ -1139,7 +1135,9 @@ function assignConstrainedTypeVar(
             return constrainedSubtype;
         });
 
-        if (!foundCompatibleConstraint || !isCompatible) {
+        const isExplicitNeverConstraint =
+            isNever(concreteSrcType) && destType.shared.constraints.some((constraint) => isNever(constraint));
+        if ((isNever(constrainedType) && !isExplicitNeverConstraint) || !isCompatible) {
             constrainedType = undefined;
         }
 

--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -24270,6 +24270,7 @@ export function createTypeEvaluator(
                     );
                 } else if (node.d.typeParamKind === TypeParamKind.TypeVar) {
                     typeVar.shared.constraints = constraints;
+                    typeVar.shared.hasExplicitNeverConstraint = constraints.some((constraint) => isNever(constraint));
                 }
             } else {
                 const boundType = getTypeOfExpressionExpectingType(node.d.boundExpr, {

--- a/packages/pyright-internal/src/analyzer/types.ts
+++ b/packages/pyright-internal/src/analyzer/types.ts
@@ -2850,6 +2850,7 @@ export interface TypeVarDetailsShared {
     kind: TypeVarKind;
     name: string;
     constraints: Type[];
+    hasExplicitNeverConstraint: boolean;
     boundType: Type | undefined;
     isDefaultExplicit: boolean;
     defaultType: Type;
@@ -3185,6 +3186,7 @@ export namespace TypeVarType {
                 kind,
                 name,
                 constraints: [],
+                hasExplicitNeverConstraint: false,
                 boundType: undefined,
                 isDefaultExplicit: false,
                 defaultType: UnknownType.create(),
@@ -3203,6 +3205,9 @@ export namespace TypeVarType {
 
     export function addConstraint(type: TypeVarType, constraintType: Type) {
         type.shared.constraints.push(constraintType);
+        if (isNever(constraintType)) {
+            type.shared.hasExplicitNeverConstraint = true;
+        }
     }
 
     export function getNameWithScope(typeVarType: TypeVarType) {

--- a/packages/pyright-internal/src/tests/samples/constrainedTypeVar21.py
+++ b/packages/pyright-internal/src/tests/samples/constrainedTypeVar21.py
@@ -21,6 +21,10 @@ class ClassC(Generic[T3]):
     pass
 
 
+class ClassD[T5: (int, Never)]:
+    pass
+
+
 def func1(value: ClassA[T1]) -> T1:
     raise NotImplementedError
 
@@ -53,6 +57,10 @@ def func8(value: T4) -> T4:
     raise NotImplementedError
 
 
+def func9[T5: (int, Never)](value: ClassD[T5]) -> T5:
+    raise NotImplementedError
+
+
 def accepts_never(value: Never) -> None:
     pass
 
@@ -64,6 +72,7 @@ def get_never() -> Never:
 assert_type(func1(ClassA[Never]()), Never)
 assert_type(func2(ClassB[Never]()), Never)
 assert_type(func3(ClassC[Never]()), Never)
+assert_type(func9(ClassD[Never]()), Never)
 assert_type(func4((ClassA[Never](),)), Never)
 assert_type(func5(ClassA[Never](), ClassA[Never]()), Never)
 

--- a/packages/pyright-internal/src/tests/samples/constrainedTypeVar21.py
+++ b/packages/pyright-internal/src/tests/samples/constrainedTypeVar21.py
@@ -1,0 +1,87 @@
+# This sample tests a constrained TypeVar that includes Never as one of its
+# constraints.
+
+from typing import Any, Callable, Generic, Never, NoReturn, TypeAlias, TypeVar, assert_type
+
+T1 = TypeVar("T1", int, Never)
+T2 = TypeVar("T2", Never, int)
+T3 = TypeVar("T3", str, Never, int)
+T4 = TypeVar("T4", int, str)
+
+
+class ClassA(Generic[T1]):
+    pass
+
+
+class ClassB(Generic[T2]):
+    pass
+
+
+class ClassC(Generic[T3]):
+    pass
+
+
+def func1(value: ClassA[T1]) -> T1:
+    raise NotImplementedError
+
+
+def func2(value: ClassB[T2]) -> T2:
+    raise NotImplementedError
+
+
+def func3(value: ClassC[T3]) -> T3:
+    raise NotImplementedError
+
+
+def func4(value: tuple[ClassA[T1], ...]) -> T1:
+    raise NotImplementedError
+
+
+def func5(value1: ClassA[T1], value2: ClassA[T1]) -> T1:
+    raise NotImplementedError
+
+
+def func6(value: T1) -> T1:
+    raise NotImplementedError
+
+
+def func7(value: Callable[[T1], None]) -> T1:
+    raise NotImplementedError
+
+
+def func8(value: T4) -> T4:
+    raise NotImplementedError
+
+
+def accepts_never(value: Never) -> None:
+    pass
+
+
+def get_never() -> Never:
+    raise NotImplementedError
+
+
+assert_type(func1(ClassA[Never]()), Never)
+assert_type(func2(ClassB[Never]()), Never)
+assert_type(func3(ClassC[Never]()), Never)
+assert_type(func4((ClassA[Never](),)), Never)
+assert_type(func5(ClassA[Never](), ClassA[Never]()), Never)
+
+Bottom: TypeAlias = Never
+assert_type(func1(ClassA[Bottom]()), Never)
+assert_type(func1(ClassA[NoReturn]()), Never)
+
+# Never is compatible with the int solution because it is the bottom type.
+assert_type(func5(ClassA[Never](), ClassA[int]()), int)
+assert_type(func5(ClassA[int](), ClassA[Never]()), int)
+
+assert_type(func7(accepts_never), Never)
+
+any_value: Any = 1
+assert_type(func6(any_value), Any)
+
+# This should generate an error because str doesn't satisfy any constraint.
+func6("not compatible")
+
+# Preserve the existing behavior when Never is not an explicit constraint.
+assert_type(func8(get_never()), int)

--- a/packages/pyright-internal/src/tests/typeEvaluator2.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator2.test.ts
@@ -599,6 +599,12 @@ test('ConstrainedTypeVar20', () => {
     TestUtils.validateResults(analysisResults, 0);
 });
 
+test('ConstrainedTypeVar21', () => {
+    const analysisResults = TestUtils.typeAnalyzeSampleFiles(['constrainedTypeVar21.py']);
+
+    TestUtils.validateResults(analysisResults, 1);
+});
+
 test('MissingTypeArg1', () => {
     const configOptions = new ConfigOptions(Uri.empty());
 


### PR DESCRIPTION
## Summary

- distinguish a matched `Never` constraint from the `Never` sentinel returned when no constrained TypeVar option matches
- preserve existing handling for `Any`, incompatible inputs, and `Never` passed to TypeVars without an explicit `Never` constraint
- add regression coverage for constraint ordering, aliases, nested and contravariant uses, and repeated inference

Fixes #11736

## Tests

- `pnpm --dir packages/pyright-internal exec jest typeEvaluator2.test --forceExit`
- `pnpm --dir packages/pyright-internal run build`
- targeted ESLint and Prettier checks