### PR TITLE
Fix TypeForm for nested classes with metaclass descriptors

### DIFF
--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -7228,12 +7228,23 @@ export function createTypeEvaluator(
             }
         }
 
+        const memberClass = memberInfo && isInstantiableClass(memberInfo.classType) ? memberInfo.classType : undefined;
+
+        let effectiveSelfType = selfType;
+        if (
+            effectiveSelfType &&
+            isClass(effectiveSelfType) &&
+            !(memberName === '__get__' && memberClass && isInstantiableMetaclass(memberClass))
+        ) {
+            effectiveSelfType = ClassType.cloneIncludeSubclasses(effectiveSelfType);
+        }
+
         const boundType = bindFunctionToClassOrObject(
             classType,
             concreteType,
-            memberInfo && isInstantiableClass(memberInfo.classType) ? memberInfo.classType : undefined,
+            memberClass,
             (flags & MemberAccessFlags.TreatConstructorAsClassMethod) !== 0,
-            selfType && isClass(selfType) ? ClassType.cloneIncludeSubclasses(selfType) : selfType,
+            effectiveSelfType,
             diag,
             recursionCount
         );

--- a/packages/pyright-internal/src/tests/samples/typeForm10.py
+++ b/packages/pyright-internal/src/tests/samples/typeForm10.py
@@ -1,0 +1,25 @@
+# pyright: reportMissingModuleSource=false
+
+from typing_extensions import TypeForm
+
+
+class Meta(type):
+    def __get__[T: Meta](
+        cls: T,
+        instance: object | None,
+        owner: type | None = None,
+    ) -> T:
+        return cls
+
+
+class Owner:
+    class A(metaclass=Meta):
+        pass
+
+    class B(metaclass=Meta):
+        pass
+
+
+t1: TypeForm[Owner.A | Owner.B] = Owner.A
+t2: TypeForm[Owner.A | Owner.B] = Owner.B
+t3: TypeForm[Owner.A | Owner.B] = Owner.A | Owner.B

--- a/packages/pyright-internal/src/tests/typeEvaluator8.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator8.test.ts
@@ -13,7 +13,7 @@ import * as assert from 'assert';
 import { EvalFlags } from '../analyzer/typeEvaluatorTypes';
 import { ClassType, isClassInstance, isInstantiableClass, UnknownType } from '../analyzer/types';
 import { ConfigOptions } from '../common/configOptions';
-import { pythonVersion3_10, pythonVersion3_11, pythonVersion3_8, pythonVersion3_12 } from '../common/pythonVersion';
+import { pythonVersion3_10, pythonVersion3_11, pythonVersion3_12, pythonVersion3_8 } from '../common/pythonVersion';
 import { Uri } from '../common/uri/uri';
 import { ParseNodeType } from '../parser/parseNodes';
 import { getNodeAtMarker, parseAndGetTestState } from './harness/fourslash/testState';
@@ -1489,4 +1489,10 @@ test('TypeForm9', () => {
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['typeForm9.py']);
 
     TestUtils.validateResults(analysisResults, 10);
+});
+
+test('TypeForm10', () => {
+    const analysisResults = TestUtils.typeAnalyzeSampleFiles(['typeForm10.py']);
+
+    TestUtils.validateResults(analysisResults, 0);
 });


### PR DESCRIPTION
## Summary

Fixes #11741.

When a nested class uses a metaclass that defines `__get__`, binding the descriptor method was widening the class `selfType` to include subclasses. That caused the generic return type of `__get__` to lose the exact class identity needed for `TypeForm` metadata, so unions such as `Owner.A | Owner.B` were treated as ordinary unions and rejected when assigned to `TypeForm[Owner.A | Owner.B]`.

This change preserves the exact `selfType` specifically when binding a metaclass `__get__`, while retaining the existing subclass-inclusive behavior for other member bindings. A regression test was added for nested classes using a generic metaclass `__get__`.

Classification: B (Pyright limitation). No typeshed change is involved, and the change preserves type precision by retaining the exact class identity in this descriptor-binding path.

## Testing

- `pnpm check`
- `pnpm typecheck`
- `typeEvaluator8.test.ts`: 175 passed
- `checker.test.ts`: 74 passed